### PR TITLE
remove dangling comma in rich-text example state.json

### DIFF
--- a/examples/rich-text/state.json
+++ b/examples/rich-text/state.json
@@ -55,7 +55,7 @@
           "kind": "text",
           "ranges": [
             {
-              "text": "Since it's rich text, you can do things like turn a selection of text ",
+              "text": "Since it's rich text, you can do things like turn a selection of text "
             },
             {
               "text": "bold",


### PR DESCRIPTION
After simply copy and pasting the rich-text component and locally, ran into this error:

```bash
ERROR in ./client/components/HomeView/state.json
Module build failed: SyntaxError: Unexpected token } in JSON at position 1206
    at Object.parse (native)
    at Object.module.exports (/Users/jaredpalmer/workspace/github/jaredpalmer/slateTest/node_modules/json-loader/index.js:7:48)
 @ ./client/components/HomeView/index.js 13:13-36
```

Just a dangler.