### PR TITLE
Fix typo in Installing Slate doc

### DIFF
--- a/docs/guides/installing-slate.md
+++ b/docs/guides/installing-slate.md
@@ -54,7 +54,7 @@ And now that we've our initial state, we define our `App` and pass it into Slate
 ```js
 // Import React!
 import React from 'react'
-import { Editor, Raw } from 'state'
+import { Editor, Raw } from 'slate'
 
 const initialState = Raw.deserialize([
   {


### PR DESCRIPTION
`import { Editor, Raw } from 'state'` → `import { Editor, Raw } from 'slate'`