### PR TITLE
Doc fixes

### DIFF
--- a/docs/reference/models/block.md
+++ b/docs/reference/models/block.md
@@ -20,8 +20,8 @@ Block nodes may contain nested block nodes, inline nodes, and text nodes—just 
   - [`length`](#length)
   - [`text`](#text)
 - [Static Methods](#static-methods)
-  - [`Block.create`](#block-create)
-  - [`Block.createList`](#block-createlist)
+  - [`Block.create`](#blockcreate)
+  - [`Block.createList`](#blockcreatelist)
 - [Node Methods](#node-methods)
 
 

--- a/docs/reference/models/character.md
+++ b/docs/reference/models/character.md
@@ -13,8 +13,8 @@ Characters are how Slate associates [`Marks`](./mark.md) with a range of text, f
   - [`marks`](#marks)
   - [`text`](#text)
 - [Static Methods](#static-methods)
-  - [`Character.create`](#character-create)
-  - [`Character.createList`](#character-createlist)
+  - [`Character.create`](#charactercreate)
+  - [`Character.createList`](#charactercreatelist)
 
 
 ## Properties

--- a/docs/reference/models/data.md
+++ b/docs/reference/models/data.md
@@ -10,7 +10,7 @@ Data is simply a thin wrapper around [`Immutable.Map`](https://facebook.github.i
 A data object can have any properties associated with it.
 
 - [Static Methods](#static-methods)
-  - [`Data.create`](#data-create)
+  - [`Data.create`](#datacreate)
 
 
 ## Static Methods

--- a/docs/reference/models/document.md
+++ b/docs/reference/models/document.md
@@ -16,7 +16,7 @@ Documents are made up of block nodes, inline nodes, and text nodes—just like i
   - [`length`](#length)
   - [`text`](#text)
 - [Static Methods](#static-methods)
-  - [`Document.create`](#document-create)
+  - [`Document.create`](#documentcreate)
 - [Node Methods](#node-methods)
 
 

--- a/docs/reference/models/inline.md
+++ b/docs/reference/models/inline.md
@@ -85,15 +85,15 @@ A concatenated string of all of the descendant [`Text`](./text.md) nodes of this
 
 ## Static Methods
 
-### `Block.create`
-`Block.create(properties: Object) => Block`
+### `Inline.create`
+`Inline.create(properties: Object) => Block`
 
 Create a block from a plain Javascript object of `properties`.
 
-### `Block.createList`
-`Block.createList(array: Array) => List`
+### `Inline.createList`
+`Inline.createList(array: Array) => List`
 
-Create a list of block nodes from a plain Javascript `array`.
+Create a list of inline nodes from a plain Javascript `array`.
 
 
 ## Node Methods

--- a/docs/reference/models/inline.md
+++ b/docs/reference/models/inline.md
@@ -20,8 +20,8 @@ Inline nodes may contain nested inline nodes and text nodes—just like in the D
   - [`length`](#length)
   - [`text`](#text)
 - [Static Methods](#static-methods)
-  - [`Inline.create`](#inline-create)
-  - [`Inline.createList`](#inline-createlist)
+  - [`Inline.create`](#inlinecreate)
+  - [`Inline.createList`](#inlinecreatelist)
 - [Node Methods](#node-methods)
 
 

--- a/docs/reference/models/mark.md
+++ b/docs/reference/models/mark.md
@@ -11,8 +11,8 @@ A formatting mark that can be associated with [`Characters`](./character.md). Ma
   - [`data`](#data)
   - [`type`](#type)
 - [Static Methods](#static-methods)
-  - [`Mark.create`](#mark-create)
-  - [`Mark.createSet`](#mark-createset)
+  - [`Mark.create`](#markcreate)
+  - [`Mark.createSet`](#markcreateset)
 
 
 ## Properties

--- a/docs/reference/models/selection.md
+++ b/docs/reference/models/selection.md
@@ -28,7 +28,7 @@ Often times, you don't need to specifically know which point is the "anchor" and
   - [`startKey`](#startkey)
   - [`startOffset`](#startoffset)
 - [Static Methods](#static-methods)
-  - [`Selection.create`](#create) 
+  - [`Selection.create`](#selectioncreate) 
 - [Checking Methods](#checking-methods)
   - [`has{Edge}AtEndOf`](#hasedgeatendof)
   - [`has{Edge}AtStartOf`](#hasedgeatstartof)

--- a/docs/reference/models/state.md
+++ b/docs/reference/models/state.md
@@ -31,8 +31,8 @@ For convenience, in addition to transforms, many of the [`Selection`](./selectio
   - [`isExpanded`](#isExpanded)
   - [`isFocused`](#isfocused)
   - [`isForward`](#isForward)
-- [Static Methods](#static)
-  - [`State.create`](#create) 
+- [Static Methods](#static-methods)
+  - [`State.create`](#statecreate) 
 - [Methods](#methods)
   - [`transform`](#transform)
 

--- a/docs/reference/models/text.md
+++ b/docs/reference/models/text.md
@@ -15,7 +15,7 @@ A text node in a Slate [`Document`](./document.md). Text nodes are always the bo
   - [`length`](#length)
   - [`text`](#text)
 - [Static Methods](#static-methods)
-  - [`Text.create`](#text-create)
+  - [`Text.create`](#textcreate)
 
 
 ## Properties


### PR DESCRIPTION
- Replace block static methods with inline static methods in inline doc file
- Fix hash link refs for static methods in various model doc files.