### PR TITLE
Fix "initialState" declaration in "Installing Slate" doc

### DIFF
--- a/docs/guides/installing-slate.md
+++ b/docs/guides/installing-slate.md
@@ -31,22 +31,20 @@ To keep things simple, we'll use the `Raw` serializer that ships with Slate to c
 import { Editor, Raw } from 'slate'
 
 // Create our initial state...
-const initialState = Raw.deserialize([
-  {
-    kind: 'block',
-    type: 'paragraph',
-    nodes: [
-      {
-        kind: 'text',
-        ranges: [
-          {
-            text: 'A line of text in a paragraph.'
-          }
-        ]
-      }
-    ]
-  }
-])
+const initialState = Raw.deserialize({
+  kind: 'block',
+  type: 'paragraph',
+  nodes: [
+    {
+      kind: 'text',
+      ranges: [
+        {
+          text: 'A line of text in a paragraph.'
+        }
+      ]
+    }
+  ]
+})
 ```
 
 And now that we've our initial state, we define our `App` and pass it into Slate's `Editor` component, like so:


### PR DESCRIPTION
I tried to use the example however I received errors saying that `map` could not be executed over `undefined`.

It looks like the deserialiser was trying to map over the `nodes` prop of an object, but the example passes in an array of objects.  I removed the wrapping array and all was well again.