### PR TITLE
Join texts with a space

### DIFF
--- a/lib/models/document.js
+++ b/lib/models/document.js
@@ -70,7 +70,7 @@ class Document extends new Record(DEFAULTS) {
   get text() {
     return this.nodes
       .map(node => node.text)
-      .join('')
+      .join(' ')
   }
 
 }


### PR DESCRIPTION
The computed property `text` is incredibly useful. But when it's used in a document to join all texts, those should be separated by a space instead of just concatenated.