### PR TITLE
Add memoization

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -99,7 +99,6 @@ class RichText extends React.Component {
 
   onChange = (state) => {
     this.setState({ state })
-    console.log(state.document.toJS())
   }
 
   /**

--- a/lib/components/void.js
+++ b/lib/components/void.js
@@ -59,7 +59,7 @@ class Void extends React.Component {
 
   renderLeaf = () => {
     const { node, state } = this.props
-    const child = node.getTextNodes().first()
+    const child = node.getTexts().first()
     const text = ''
     const marks = Mark.createSet()
     const start = 0

--- a/lib/models/node.js
+++ b/lib/models/node.js
@@ -22,29 +22,37 @@ import { List, Map, OrderedSet, Set } from 'immutable'
 const Node = {
 
   /**
-   * Assert that the node has a child by `key`.
+   * Assert that a node has a child by `key` and return it.
    *
    * @param {String or Node} key
+   * @return {Node}
    */
 
-  assertHasChild(key) {
-    key = normalizeKey(key)
-    if (!this.hasChild(key)) {
+  assertChild(key) {
+    const child = this.getChild(key)
+
+    if (!child) {
       throw new Error(`Could not find a child node with key "${key}".`)
     }
+
+    return child
   },
 
   /**
-   * Assert that the node has a descendant by `key`.
+   * Assert that a node has a descendant by `key` and return it.
    *
    * @param {String or Node} key
+   * @return {Node}
    */
 
-  assertHasDescendant(key) {
-    key = normalizeKey(key)
-    if (!this.hasDescendant(key)) {
+  assertDescendant(key) {
+    const descendant = this.getDescendant(key)
+
+    if (!descendant) {
       throw new Error(`Could not find a descendant node with key "${key}".`)
     }
+
+    return descendant
   },
 
   /**
@@ -114,12 +122,9 @@ const Node = {
   getBlocks() {
     return this
       .getTextNodes()
-      .reduce((blocks, text) => {
-        const block = this.getClosestBlock(text)
-        return blocks.includes(block)
-          ? blocks
-          : blocks.push(block)
-      }, Block.createList())
+      .map(text => this.getClosestBlock(text))
+      .toSet()
+      .toList()
   },
 
   /**
@@ -130,7 +135,6 @@ const Node = {
    */
 
   getBlocksAtRange(range) {
-    range = range.normalize(this)
     return this
       .getTextsAtRange(range)
       .map(text => this.getClosestBlock(text))
@@ -144,7 +148,6 @@ const Node = {
    */
 
   getCharactersAtRange(range) {
-    range = range.normalize(this)
     return this
       .getTextsAtRange(range)
       .reduce((characters, text) => {
@@ -161,10 +164,9 @@ const Node = {
    */
 
   getChildrenAfter(key) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
-    const nodes = this.nodes.slice(index + 1)
-    return nodes
+    return this.nodes.slice(index + 1)
   },
 
   /**
@@ -175,10 +177,9 @@ const Node = {
    */
 
   getChildrenAfterIncluding(key) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
-    const nodes = this.nodes.slice(index)
-    return nodes
+    return this.nodes.slice(index)
   },
 
   /**
@@ -189,10 +190,9 @@ const Node = {
    */
 
   getChildrenBefore(key) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
-    const nodes = this.nodes.slice(0, index)
-    return nodes
+    return this.nodes.slice(0, index)
   },
 
   /**
@@ -203,10 +203,9 @@ const Node = {
    */
 
   getChildrenBeforeIncluding(key) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
-    const nodes = this.nodes.slice(0, index + 1)
-    return nodes
+    return this.nodes.slice(0, index + 1)
   },
 
   /**
@@ -218,9 +217,9 @@ const Node = {
    */
 
   getChildrenBetween(start, end) {
-    start = this.getChild(start)
+    start = this.assertChild(start)
     start = this.nodes.indexOf(start)
-    end = this.getChild(end)
+    end = this.assertChild(end)
     end = this.nodes.indexOf(end)
     return this.nodes.slice(start + 1, end)
   },
@@ -234,9 +233,9 @@ const Node = {
    */
 
   getChildrenBetweenIncluding(start, end) {
-    start = this.getChild(start)
+    start = this.assertChild(start)
     start = this.nodes.indexOf(start)
-    end = this.getChild(end)
+    end = this.assertChild(end)
     end = this.nodes.indexOf(end)
     return this.nodes.slice(start, end + 1)
   },
@@ -250,7 +249,7 @@ const Node = {
    */
 
   getClosest(key, iterator) {
-    let node = this.getDescendant(key)
+    let node = this.assertDescendant(key)
 
     while (node = this.getParent(node)) {
       if (node == this) return null
@@ -295,21 +294,6 @@ const Node = {
   },
 
   /**
-   * Get all of the blocks closest to text nodes.
-   *
-   * @return {List} nodes
-   */
-
-  getDeepestBlocks() {
-    const texts = this.getTextNodes()
-    const set = texts.reduce((memo, text) => {
-      return memo.add(this.getClosestBlock(text))
-    }, new OrderedSet())
-
-    return set.toList()
-  },
-
-  /**
    * Get a descendant node by `key`.
    *
    * @param {String} key
@@ -330,12 +314,12 @@ const Node = {
    */
 
   getDepth(key, startAt = 1) {
-    key = normalizeKey(key)
-    this.assertHasDescendant(key)
-    if (this.hasChild(key)) return startAt
-    return this
-      .getHighestChild(key)
-      .getDepth(key, startAt + 1)
+    this.assertDescendant(key)
+    return this.hasChild(key)
+      ? startAt
+      : this
+        .getHighestChild(key)
+        .getDepth(key, startAt + 1)
   },
 
   /**
@@ -354,8 +338,8 @@ const Node = {
 
     // Make sure the children exist.
     const { startKey, startOffset, endKey, endOffset } = range
-    node.assertHasDescendant(startKey)
-    node.assertHasDescendant(endKey)
+    node.assertDescendant(startKey)
+    node.assertDescendant(endKey)
 
     // Split at the start and end.
     const start = range.collapseToStart()
@@ -380,6 +364,25 @@ const Node = {
   },
 
   /**
+   * Get the furthest parent of a node by `key` that matches an `iterator`.
+   *
+   * @param {String or Node} key
+   * @param {Function} iterator
+   * @return {Node or Null}
+   */
+
+  getFurthest(key, iterator) {
+    let node = this.assertDescendant(key)
+    let furthest = null
+
+    while (node = this.getClosest(node, iterator)) {
+      furthest = node
+    }
+
+    return furthest
+  },
+
+  /**
    * Get the furthest block parent of a node by `key`.
    *
    * @param {String or Node} key
@@ -387,14 +390,7 @@ const Node = {
    */
 
   getFurthestBlock(key) {
-    let node = this.getDescendant(key)
-    let furthest = null
-
-    while (node = this.getClosestBlock(node)) {
-      furthest = node
-    }
-
-    return furthest
+    return this.getFurthest(key, node => node.kind == 'block')
   },
 
   /**
@@ -405,14 +401,7 @@ const Node = {
    */
 
   getFurthestInline(key) {
-    let node = this.getDescendant(key)
-    let furthest = null
-
-    while (node = this.getClosestInline(node)) {
-      furthest = node
-    }
-
-    return furthest
+    return this.getFurthest(key, node => node.kind == 'inline')
   },
 
   /**
@@ -439,7 +428,7 @@ const Node = {
    */
 
   getHighestOnlyChildParent(key) {
-    let child = this.getChild(key)
+    let child = this.assertChild(key)
     let match = null
     let parent
 
@@ -458,11 +447,12 @@ const Node = {
    */
 
   getInlinesAtRange(range) {
-    range = range.normalize(this)
     return this
       .getTextsAtRange(range)
       .map(text => this.getClosestInline(text))
       .filter(exists => exists)
+      .toSet()
+      .toList()
   },
 
   /**
@@ -496,7 +486,8 @@ const Node = {
     // Otherwise, get a set of the marks for each character in the range.
     return this
       .getCharactersAtRange(range)
-      .reduce((memo, char) => memo.union(char.marks), marks)
+      .map(char => char.marks)
+      .toSet()
   },
 
   /**
@@ -507,8 +498,7 @@ const Node = {
    */
 
   getNextBlock(key) {
-    key = normalizeKey(key)
-    const child = this.getDescendant(key)
+    const child = this.assertDescendant(key)
     let last
 
     if (child.kind == 'block') {
@@ -532,8 +522,7 @@ const Node = {
    */
 
   getNextSibling(key) {
-    const node = this.getDescendant(key)
-    if (!node) return null
+    const node = this.assertDescendant(key)
     return this
       .getParent(node)
       .nodes
@@ -563,8 +552,7 @@ const Node = {
    */
 
   getOffset(key) {
-    key = normalizeKey(key)
-    this.assertHasDescendant(key)
+    this.assertDescendant(key)
 
     // Calculate the offset of the nodes before the highest child.
     const child = this.getHighestChild(key)
@@ -586,17 +574,13 @@ const Node = {
    */
 
   getOffsetAtRange(range) {
+    range = range.normalize(this)
+
     if (range.isExpanded) {
       throw new Error('The range must be collapsed to calculcate its offset.')
     }
 
     const { startKey, startOffset } = range
-    const startNode = this.getDescendant(startKey)
-
-    if (!startNode) {
-      throw new Error(`Could not find a node by startKey "${startKey}".`)
-    }
-
     return this.getOffset(startKey) + startOffset
   },
 
@@ -608,7 +592,6 @@ const Node = {
    */
 
   getParent(key) {
-    key = normalizeKey(key)
     if (this.hasChild(key)) return this
 
     let node = null
@@ -630,8 +613,7 @@ const Node = {
    */
 
   getPreviousSibling(key) {
-    const node = this.getDescendant(key)
-    if (!node) return null
+    const node = this.assertDescendant(key)
     return this
       .getParent(node)
       .nodes
@@ -661,8 +643,7 @@ const Node = {
    */
 
   getPreviousBlock(key) {
-    key = normalizeKey(key)
-    const child = this.getDescendant(key)
+    const child = this.assertDescendant(key)
     let first
 
     if (child.kind == 'block') {
@@ -735,8 +716,7 @@ const Node = {
    */
 
   hasChild(key) {
-    key = normalizeKey(key)
-    return !!this.nodes.find(node => node.key == key)
+    return !!this.getChild(key)
   },
 
   /**
@@ -747,12 +727,7 @@ const Node = {
    */
 
   hasDescendant(key) {
-    key = normalizeKey(key)
-    return !!this.nodes.find((node) => {
-      return node.kind == 'text'
-        ? node.key == key
-        : node.key == key || node.hasDescendant(key)
-    })
+    return !!this.getDescendant(key)
   },
 
   /**
@@ -763,7 +738,7 @@ const Node = {
    */
 
   hasVoidParent(key) {
-    return !!this.getClosest(key, n => n.isVoid)
+    return !!this.getClosest(key, parent => parent.isVoid)
   },
 
   /**
@@ -775,7 +750,7 @@ const Node = {
    */
 
   insertChildrenAfter(key, nodes) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
 
     nodes = this.nodes
@@ -795,8 +770,7 @@ const Node = {
    */
 
   insertChildrenBefore(key, nodes) {
-    key = normalizeKey(key)
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
 
     nodes = this.nodes
@@ -941,7 +915,7 @@ const Node = {
    */
 
   removeChildrenAfter(key) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
     const nodes = this.nodes.slice(0, index + 1)
     return this.merge({ nodes })
@@ -955,7 +929,7 @@ const Node = {
    */
 
   removeChildrenAfterIncluding(key) {
-    const child = this.getChild(key)
+    const child = this.assertChild(key)
     const index = this.nodes.indexOf(child)
     const nodes = this.nodes.slice(0, index)
     return this.merge({ nodes })
@@ -969,8 +943,7 @@ const Node = {
    */
 
   removeDescendant(key) {
-    key = normalizeKey(key)
-    this.assertHasDescendant(key)
+    this.assertDescendant(key)
 
     const child = this.getChild(key)
 
@@ -991,7 +964,7 @@ const Node = {
    */
 
   updateDescendant(node) {
-    this.assertHasDescendant(node)
+    this.assertDescendant(node)
     return this.mapDescendants(d => d.key == node.key ? node : d)
   }
 

--- a/lib/models/node.js
+++ b/lib/models/node.js
@@ -124,7 +124,7 @@ const Node = {
 
   getBlocks() {
     return this
-      .getTextNodes()
+      .getTexts()
       .map(text => this.getClosestBlock(text))
       .toSet()
       .toList()
@@ -515,10 +515,10 @@ const Node = {
     let last
 
     if (child.kind == 'block') {
-      last = child.getTextNodes().last()
+      last = child.getTexts().last()
     } else {
       const block = this.getClosestBlock(key)
-      last = block.getTextNodes().last()
+      last = block.getTexts().last()
     }
 
     const next = this.getNextText(last)
@@ -552,7 +552,7 @@ const Node = {
 
   getNextText(key) {
     key = normalizeKey(key)
-    return this.getTextNodes()
+    return this.getTexts()
       .skipUntil(text => text.key == key)
       .get(1)
   },
@@ -643,7 +643,7 @@ const Node = {
 
   getPreviousText(key) {
     key = normalizeKey(key)
-    return this.getTextNodes()
+    return this.getTexts()
       .takeUntil(text => text.key == key)
       .last()
   },
@@ -660,10 +660,10 @@ const Node = {
     let first
 
     if (child.kind == 'block') {
-      first = child.getTextNodes().first()
+      first = child.getTexts().first()
     } else {
       const block = this.getClosestBlock(key)
-      first = block.getTextNodes().first()
+      first = block.getTexts().first()
     }
 
     const previous = this.getPreviousText(first)
@@ -682,7 +682,7 @@ const Node = {
   getTextAtOffset(offset) {
     let length = 0
     return this
-      .getTextNodes()
+      .getTexts()
       .find((text) => {
         length += text.length
         return length >= offset
@@ -695,11 +695,11 @@ const Node = {
    * @return {List} nodes
    */
 
-  getTextNodes() {
+  getTexts() {
     return this.nodes.reduce((texts, node) => {
       return node.kind == 'text'
         ? texts.push(node)
-        : texts.concat(node.getTextNodes())
+        : texts.concat(node.getTexts())
     }, Block.createList())
   },
 
@@ -713,7 +713,7 @@ const Node = {
   getTextsAtRange(range) {
     range = range.normalize(this)
     const { startKey, endKey } = range
-    const texts = this.getTextNodes()
+    const texts = this.getTexts()
     const startText = this.getDescendant(startKey)
     const endText = this.getDescendant(endKey)
     const start = texts.indexOf(startText)
@@ -872,7 +872,7 @@ const Node = {
 
       // That void nodes contain no text.
       if (desc.isVoid && desc.length) {
-        let text = desc.getTextNodes().first()
+        let text = desc.getTexts().first()
         let characters = text.characters.clear()
         text = text.merge({ characters })
         const nodes = desc.nodes.clear().push(text)
@@ -1069,7 +1069,7 @@ memoize(Node, [
   'getPreviousText',
   'getPreviousBlock',
   'getTextAtOffset',
-  'getTextNodes',
+  'getTexts',
   'getTextsAtRange',
   'hasChild',
   'hasDescendant',

--- a/lib/models/node.js
+++ b/lib/models/node.js
@@ -9,6 +9,7 @@ import Selection from './selection'
 import Transforms from './transforms'
 import Text from './text'
 import includes from 'lodash/includes'
+import memoize from '../utils/memoize'
 import uid from '../utils/uid'
 import { List, Map, OrderedSet, Set } from 'immutable'
 
@@ -32,6 +33,7 @@ const Node = {
     const child = this.getChild(key)
 
     if (!child) {
+      key = normalizeKey(key)
       throw new Error(`Could not find a child node with key "${key}".`)
     }
 
@@ -49,6 +51,7 @@ const Node = {
     const descendant = this.getDescendant(key)
 
     if (!descendant) {
+      key = normalizeKey(key)
       throw new Error(`Could not find a descendant node with key "${key}".`)
     }
 
@@ -302,7 +305,17 @@ const Node = {
 
   getDescendant(key) {
     key = normalizeKey(key)
-    return this.findDescendant(node => node.key == key)
+
+    let child = this.getChild(key)
+    if (child) return child
+
+    this.nodes.find((node) => {
+      if (node.kind == 'text') return false
+      child = node.getDescendant(key)
+      return child
+    })
+
+    return child
   },
 
   /**
@@ -1013,6 +1026,56 @@ function isInRange(index, text, range) {
 for (const key in Transforms) {
   Node[key] = Transforms[key]
 }
+
+/**
+ * Memoize read methods.
+ */
+
+memoize(Node, [
+  'assertChild',
+  'assertDescendant',
+  'findDescendant',
+  'filterDescendants',
+  'getBlocks',
+  'getBlocksAtRange',
+  'getCharactersAtRange',
+  'getChildrenAfter',
+  'getChildrenAfterIncluding',
+  'getChildrenBefore',
+  'getChildrenBeforeIncluding',
+  'getChildrenBetween',
+  'getChildrenBetweenIncluding',
+  'getClosest',
+  'getClosestBlock',
+  'getClosestInline',
+  'getChild',
+  'getDescendant',
+  'getDepth',
+  'getFragmentAtRange',
+  'getFurthest',
+  'getFurthestBlock',
+  'getFurthestInline',
+  'getHighestChild',
+  'getHighestOnlyChildParent',
+  'getInlinesAtRange',
+  'getMarksAtRange',
+  'getNextBlock',
+  'getNextSibling',
+  'getNextText',
+  'getOffset',
+  'getOffsetAtRange',
+  'getParent',
+  'getPreviousSibling',
+  'getPreviousText',
+  'getPreviousBlock',
+  'getTextAtOffset',
+  'getTextNodes',
+  'getTextsAtRange',
+  'hasChild',
+  'hasDescendant',
+  'hasVoidParent',
+  'isInlineSplitAtRange'
+])
 
 /**
  * Export.

--- a/lib/models/selection.js
+++ b/lib/models/selection.js
@@ -143,7 +143,7 @@ class Selection extends new Record(DEFAULTS) {
    */
 
   hasAnchorAtStartOf(node) {
-    const first = node.kind == 'text' ? node : node.getTextNodes().first()
+    const first = node.kind == 'text' ? node : node.getTexts().first()
     return this.anchorKey == first.key && this.anchorOffset == 0
   }
 
@@ -155,7 +155,7 @@ class Selection extends new Record(DEFAULTS) {
    */
 
   hasAnchorAtEndOf(node) {
-    const last = node.kind == 'text' ? node : node.getTextNodes().last()
+    const last = node.kind == 'text' ? node : node.getTexts().last()
     return this.anchorKey == last.key && this.anchorOffset == last.length
   }
 
@@ -185,7 +185,7 @@ class Selection extends new Record(DEFAULTS) {
    */
 
   hasAnchorIn(node) {
-    const nodes = node.kind == 'text' ? [node] : node.getTextNodes()
+    const nodes = node.kind == 'text' ? [node] : node.getTexts()
     return nodes.some(n => n.key == this.anchorKey)
   }
 
@@ -197,7 +197,7 @@ class Selection extends new Record(DEFAULTS) {
    */
 
   hasFocusAtEndOf(node) {
-    const last = node.kind == 'text' ? node : node.getTextNodes().last()
+    const last = node.kind == 'text' ? node : node.getTexts().last()
     return this.focusKey == last.key && this.focusOffset == last.length
   }
 
@@ -209,7 +209,7 @@ class Selection extends new Record(DEFAULTS) {
    */
 
   hasFocusAtStartOf(node) {
-    const first = node.kind == 'text' ? node : node.getTextNodes().first()
+    const first = node.kind == 'text' ? node : node.getTexts().first()
     return this.focusKey == first.key && this.focusOffset == 0
   }
 
@@ -239,7 +239,7 @@ class Selection extends new Record(DEFAULTS) {
    */
 
   hasFocusIn(node) {
-    const nodes = node.kind == 'text' ? [node] : node.getTextNodes()
+    const nodes = node.kind == 'text' ? [node] : node.getTexts()
     return nodes.some(n => n.key == this.focusKey)
   }
 
@@ -252,7 +252,7 @@ class Selection extends new Record(DEFAULTS) {
 
   isAtStartOf(node) {
     const { startKey, startOffset } = this
-    const first = node.kind == 'text' ? node : node.getTextNodes().first()
+    const first = node.kind == 'text' ? node : node.getTexts().first()
     return this.isCollapsed && startKey == first.key && startOffset == 0
   }
 
@@ -265,7 +265,7 @@ class Selection extends new Record(DEFAULTS) {
 
   isAtEndOf(node) {
     const { endKey, endOffset } = this
-    const last = node.kind == 'text' ? node : node.getTextNodes().last()
+    const last = node.kind == 'text' ? node : node.getTexts().last()
     return this.isCollapsed && endKey == last.key && endOffset == last.length
   }
 
@@ -290,7 +290,7 @@ class Selection extends new Record(DEFAULTS) {
       !node.hasDescendant(anchorKey) ||
       !node.hasDescendant(focusKey)
     ) {
-      const first = node.getTextNodes().first()
+      const first = node.getTexts().first()
       return selection.merge({
         anchorKey: first.key,
         anchorOffset: 0,
@@ -322,7 +322,7 @@ class Selection extends new Record(DEFAULTS) {
 
     // If `isBackward` is not set, derive it.
     if (isBackward == null) {
-      let texts = node.getTextNodes()
+      let texts = node.getTexts()
       let anchorIndex = texts.indexOf(anchorNode)
       let focusIndex = texts.indexOf(focusNode)
       isBackward = anchorIndex == focusIndex

--- a/lib/models/state.js
+++ b/lib/models/state.js
@@ -646,7 +646,7 @@ class State extends new Record(DEFAULTS) {
     if (!fragment.length) return state
 
     // Lookup some nodes for determining the selection next.
-    const texts = fragment.getTextNodes()
+    const texts = fragment.getTexts()
     const lastText = texts.last()
     const lastInline = fragment.getClosestInline(lastText)
     const startText = document.getDescendant(selection.startKey)
@@ -656,14 +656,14 @@ class State extends new Record(DEFAULTS) {
     const nextBlock = nextText ? document.getClosestBlock(nextText) : null
     const nextNextText = nextText ? document.getNextText(nextText) : null
 
-    const docTexts = document.getTextNodes()
+    const docTexts = document.getTexts()
 
     // Insert the fragment.
     document = document.insertFragmentAtRange(selection, fragment)
 
     // Determine what the selection should be after inserting.
     const keys = docTexts.map(text => text.key)
-    const text = document.getTextNodes().findLast(n => !keys.includes(n.key))
+    const text = document.getTexts().findLast(n => !keys.includes(n.key))
 
     after = text
       ? selection.collapseToStartOf(text).moveForward(lastText.length)

--- a/lib/models/transforms.js
+++ b/lib/models/transforms.js
@@ -32,8 +32,8 @@ const Transforms = {
 
     // Make sure the children exist.
     const { startKey, startOffset, endKey, endOffset } = range
-    node.assertHasDescendant(startKey)
-    node.assertHasDescendant(endKey)
+    node.assertDescendant(startKey)
+    node.assertDescendant(endKey)
 
     // If the start and end nodes are the same, just remove characters.
     if (startKey == endKey) {
@@ -231,7 +231,7 @@ const Transforms = {
     }
 
     // Get the first and last block of the fragment.
-    const blocks = fragment.getDeepestBlocks()
+    const blocks = fragment.getBlocks()
     const firstBlock = blocks.first()
     let lastBlock = blocks.last()
 

--- a/lib/models/transforms.js
+++ b/lib/models/transforms.js
@@ -213,11 +213,11 @@ const Transforms = {
     let nextChild
 
     if (range.isAtStartOf(node)) {
-      nextChild = node.getClosestBlock(node.getTextNodes().first())
+      nextChild = node.getClosestBlock(node.getTexts().first())
     }
 
     if (range.isAtStartOf(block)) {
-      nextChild = block.getHighestChild(block.getTextNodes().first())
+      nextChild = block.getHighestChild(block.getTexts().first())
     }
 
     else if (range.isAtStartOf(start)) {
@@ -724,7 +724,7 @@ const Transforms = {
     if (data) data = Data.create(data)
 
     // Find the closest matching inline wrappers of each text node.
-    const texts = this.getTextNodes()
+    const texts = this.getTexts()
     const wrappers = texts.reduce((memo, text) => {
       const match = node.getClosest(text, (parent) => {
         if (parent.kind != 'inline') return false

--- a/lib/utils/memoize.js
+++ b/lib/utils/memoize.js
@@ -1,0 +1,47 @@
+
+import { Map } from 'immutable'
+
+/**
+ * The leaf node of a cache tree.
+ *
+ * An object, so that immutable maps will key it by reference.
+ *
+ * @type {Object}
+ */
+
+const LEAF = {}
+
+/**
+ * Memoize all of the `properties` on a `object`.
+ *
+ * @param {Object} object
+ * @param {Array} properties
+ * @return {Record}
+ */
+
+function memoize(object, properties) {
+  for (const property of properties) {
+    const original = object[property]
+
+    if (!original) {
+      throw new Error(`Object does not have a property named "${property}".`)
+    }
+
+    object[property] = function (...args) {
+      const keys = [property, ...args, LEAF]
+      const cache = this.cache = this.cache || new Map()
+
+      if (cache.hasIn(keys)) return cache.getIn(keys)
+
+      const value = original.apply(this, args)
+      this.cache = cache.setIn(keys, value)
+      return value
+    }
+  }
+}
+
+/**
+ * Export.
+ */
+
+export default memoize

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "cheerio": "^0.20.0",
     "detect-browser": "^1.3.3",
+    "es6-symbol": "^3.1.0",
     "esrever": "^0.2.0",
     "immutable": "^3.8.1",
     "keycode": "^2.1.2",

--- a/test/transforms/fixtures/add-mark-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/add-mark-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/add-mark-at-range/existing-marks/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/existing-marks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark-at-range/first-character/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark-at-range/last-character/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark-at-range/middle-character/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark-at-range/whole-word/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/whole-word/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark-at-range/with-data/index.js
+++ b/test/transforms/fixtures/add-mark-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/add-mark/across-blocks/index.js
+++ b/test/transforms/fixtures/add-mark/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
 

--- a/test/transforms/fixtures/add-mark/across-inlines/index.js
+++ b/test/transforms/fixtures/add-mark/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
 

--- a/test/transforms/fixtures/add-mark/collapsed-selection-off-again/index.js
+++ b/test/transforms/fixtures/add-mark/collapsed-selection-off-again/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/collapsed-selection/index.js
+++ b/test/transforms/fixtures/add-mark/collapsed-selection/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/existing-marks/index.js
+++ b/test/transforms/fixtures/add-mark/existing-marks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/first-character/index.js
+++ b/test/transforms/fixtures/add-mark/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/last-character/index.js
+++ b/test/transforms/fixtures/add-mark/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/middle-character/index.js
+++ b/test/transforms/fixtures/add-mark/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/whole-word/index.js
+++ b/test/transforms/fixtures/add-mark/whole-word/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/with-data-object/index.js
+++ b/test/transforms/fixtures/add-mark/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/add-mark/with-data/index.js
+++ b/test/transforms/fixtures/add-mark/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
 
   return state

--- a/test/transforms/fixtures/delete-at-range/across-blocks-inlines/index.js
+++ b/test/transforms/fixtures/delete-at-range/across-blocks-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const last = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/delete-at-range/first-character/index.js
+++ b/test/transforms/fixtures/delete-at-range/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-at-range/join-blocks-and-trim/index.js
+++ b/test/transforms/fixtures/delete-at-range/join-blocks-and-trim/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/delete-at-range/join-blocks/index.js
+++ b/test/transforms/fixtures/delete-at-range/join-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/delete-at-range/last-character/index.js
+++ b/test/transforms/fixtures/delete-at-range/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-at-range/middle-character/index.js
+++ b/test/transforms/fixtures/delete-at-range/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-at-range/nested-block/index.js
+++ b/test/transforms/fixtures/delete-at-range/nested-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const last = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/delete-at-range/whole-word/index.js
+++ b/test/transforms/fixtures/delete-at-range/whole-word/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-backward-at-range/first-character/index.js
+++ b/test/transforms/fixtures/delete-backward-at-range/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-backward-at-range/join-blocks/index.js
+++ b/test/transforms/fixtures/delete-backward-at-range/join-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const second = texts.last()
   const range = selection.merge({
     anchorKey: second.key,

--- a/test/transforms/fixtures/delete-backward-at-range/join-nested-blocks/index.js
+++ b/test/transforms/fixtures/delete-backward-at-range/join-nested-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const second = texts.last()
   const range = selection.merge({
     anchorKey: second.key,

--- a/test/transforms/fixtures/delete-backward-at-range/last-character/index.js
+++ b/test/transforms/fixtures/delete-backward-at-range/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-backward-at-range/middle-character/index.js
+++ b/test/transforms/fixtures/delete-backward-at-range/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-backward-at-range/start-of-document/index.js
+++ b/test/transforms/fixtures/delete-backward-at-range/start-of-document/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-forward-at-range/end-of-document/index.js
+++ b/test/transforms/fixtures/delete-forward-at-range/end-of-document/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-forward-at-range/first-character/index.js
+++ b/test/transforms/fixtures/delete-forward-at-range/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-forward-at-range/join-blocks/index.js
+++ b/test/transforms/fixtures/delete-forward-at-range/join-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-forward-at-range/join-nested-blocks/index.js
+++ b/test/transforms/fixtures/delete-forward-at-range/join-nested-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-forward-at-range/last-character/index.js
+++ b/test/transforms/fixtures/delete-forward-at-range/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/delete-forward-at-range/middle-character/index.js
+++ b/test/transforms/fixtures/delete-forward-at-range/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/end-block/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/end-block/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/end-inline/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/end-inline/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/middle-block-multiple-fragment-blocks/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/middle-block-multiple-fragment-blocks/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/middle-block/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/middle-block/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/middle-inline-fragment-inline/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/middle-inline-fragment-inline/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/middle-inline/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/middle-inline/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/start-block/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/start-block/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/start-inline/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/start-inline/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/start-second-block/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/start-second-block/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const second = texts.get(1)
   const range = selection.merge({
     anchorKey: second.key,

--- a/test/transforms/fixtures/insert-fragment-at-range/with-delete-across-blocks/index.js
+++ b/test/transforms/fixtures/insert-fragment-at-range/with-delete-across-blocks/index.js
@@ -9,7 +9,7 @@ export default function (state) {
   const fragment = Raw.deserialize(raw).document
 
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const last = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/insert-text-at-range/after-mark/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/after-mark/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/before-mark/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/before-mark/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/during-mark/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/during-mark/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/first-character/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/first-space/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/first-space/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/first-words/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/first-words/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/last-character/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/last-space/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/last-space/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/last-words/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/last-words/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/middle-character/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/middle-space/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/middle-space/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/insert-text-at-range/middle-words/index.js
+++ b/test/transforms/fixtures/insert-text-at-range/middle-words/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/remove-mark-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/remove-mark-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/remove-mark-at-range/existing-marks/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/existing-marks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/remove-mark-at-range/first-character/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/first-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/remove-mark-at-range/last-character/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/last-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/remove-mark-at-range/middle-character/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/middle-character/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/remove-mark-at-range/whole-word/index.js
+++ b/test/transforms/fixtures/remove-mark-at-range/whole-word/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/set-block-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/set-block-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/set-block-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/set-block-at-range/data-only/index.js
+++ b/test/transforms/fixtures/set-block-at-range/data-only/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/nested-block/index.js
+++ b/test/transforms/fixtures/set-block-at-range/nested-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/single-block-string-shorthand/index.js
+++ b/test/transforms/fixtures/set-block-at-range/single-block-string-shorthand/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/single-block/index.js
+++ b/test/transforms/fixtures/set-block-at-range/single-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/set-block-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/with-data/index.js
+++ b/test/transforms/fixtures/set-block-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-block-at-range/with-is-void/index.js
+++ b/test/transforms/fixtures/set-block-at-range/with-is-void/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/set-inline-at-range/data-only/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/data-only/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/nested-inline/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/nested-inline/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/single-inline-string-shorthand/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/single-inline-string-shorthand/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/single-inline/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/single-inline/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/with-data/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/set-inline-at-range/with-is-void/index.js
+++ b/test/transforms/fixtures/set-inline-at-range/with-is-void/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-block-at-range/block-end/index.js
+++ b/test/transforms/fixtures/split-block-at-range/block-end/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-block-at-range/block-middle/index.js
+++ b/test/transforms/fixtures/split-block-at-range/block-middle/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-block-at-range/block-start/index.js
+++ b/test/transforms/fixtures/split-block-at-range/block-start/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const second = texts.get(1)
   const range = selection.merge({
     anchorKey: second.key,

--- a/test/transforms/fixtures/split-block-at-range/depth/index.js
+++ b/test/transforms/fixtures/split-block-at-range/depth/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-block-at-range/with-delete-across-blocks-and-inlines/index.js
+++ b/test/transforms/fixtures/split-block-at-range/with-delete-across-blocks-and-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/split-block-at-range/with-delete-across-blocks/index.js
+++ b/test/transforms/fixtures/split-block-at-range/with-delete-across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/split-block-at-range/with-delete/index.js
+++ b/test/transforms/fixtures/split-block-at-range/with-delete/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-block-at-range/with-inline/index.js
+++ b/test/transforms/fixtures/split-block-at-range/with-inline/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-inline-at-range/block-end/index.js
+++ b/test/transforms/fixtures/split-inline-at-range/block-end/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-inline-at-range/block-middle/index.js
+++ b/test/transforms/fixtures/split-inline-at-range/block-middle/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-inline-at-range/block-start/index.js
+++ b/test/transforms/fixtures/split-inline-at-range/block-start/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-inline-at-range/depth/index.js
+++ b/test/transforms/fixtures/split-inline-at-range/depth/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-inline-at-range/with-delete/index.js
+++ b/test/transforms/fixtures/split-inline-at-range/with-delete/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/split-inline-at-range/with-marks/index.js
+++ b/test/transforms/fixtures/split-inline-at-range/with-marks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-block-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-block-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-block-at-range/ending-child-blocks/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/ending-child-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const fifth = texts.get(4)
   const sixth = texts.get(5)
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-block-at-range/middle-child-blocks/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/middle-child-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const third = texts.get(2)
   const fourth = texts.get(3)
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-block-at-range/nested-block/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/nested-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-block-at-range/single-block/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/single-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-block-at-range/starting-child-blocks/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/starting-child-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.get(0)
   const second = texts.get(1)
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-block-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-block-at-range/with-data/index.js
+++ b/test/transforms/fixtures/unwrap-block-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-inline-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/unwrap-inline-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-inline-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/unwrap-inline-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/unwrap-inline-at-range/nested-block/index.js
+++ b/test/transforms/fixtures/unwrap-inline-at-range/nested-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-inline-at-range/single-block/index.js
+++ b/test/transforms/fixtures/unwrap-inline-at-range/single-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-inline-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/unwrap-inline-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/unwrap-inline-at-range/with-data/index.js
+++ b/test/transforms/fixtures/unwrap-inline-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-block-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/wrap-block-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/wrap-block-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/wrap-block-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/wrap-block-at-range/nested-block/index.js
+++ b/test/transforms/fixtures/wrap-block-at-range/nested-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-block-at-range/single-block/index.js
+++ b/test/transforms/fixtures/wrap-block-at-range/single-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-block-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/wrap-block-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-block-at-range/with-data/index.js
+++ b/test/transforms/fixtures/wrap-block-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-inline-at-range/across-blocks/index.js
+++ b/test/transforms/fixtures/wrap-inline-at-range/across-blocks/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/wrap-inline-at-range/across-inlines/index.js
+++ b/test/transforms/fixtures/wrap-inline-at-range/across-inlines/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const second = texts.last()
   const range = selection.merge({

--- a/test/transforms/fixtures/wrap-inline-at-range/nested-block/index.js
+++ b/test/transforms/fixtures/wrap-inline-at-range/nested-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-inline-at-range/single-block/index.js
+++ b/test/transforms/fixtures/wrap-inline-at-range/single-block/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-inline-at-range/with-data-object/index.js
+++ b/test/transforms/fixtures/wrap-inline-at-range/with-data-object/index.js
@@ -1,7 +1,7 @@
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,

--- a/test/transforms/fixtures/wrap-inline-at-range/with-data/index.js
+++ b/test/transforms/fixtures/wrap-inline-at-range/with-data/index.js
@@ -3,7 +3,7 @@ import { Data } from '../../../../..'
 
 export default function (state) {
   const { document, selection } = state
-  const texts = document.getTextNodes()
+  const texts = document.getTexts()
   const first = texts.first()
   const range = selection.merge({
     anchorKey: first.key,


### PR DESCRIPTION
This pull request:

- cleans up a handful of node methods, removing some extraneous logic.
- including, renaming `Node#getTextNodes` to `Node#getTexts` for consistency with the other `getBlocks`, `getInlines`, etc.
- changes many `getChild` and `getDescendant` internal calls to their new `assert*` equivalents, to throw earlier when weird things happen.

And then it adds memoization to the read-only node methods. Since the objects are all `Immutable.Record`s, it's easy to just keep a `this.cache`property on the instance. When the instance is updated, a new `Record` is created, which doesn't have the `.cache` instance property, thus invalidating all of the return values.