### PR TITLE
moved onSelect event handling to core plugin

### DIFF
--- a/lib/components/content.js
+++ b/lib/components/content.js
@@ -557,41 +557,7 @@ class Content extends React.Component {
     if (this.tmp.isCopying) return
     if (this.tmp.isComposing) return
 
-    let { state } = this.props
-    let { document, selection } = state
-    const native = window.getSelection()
-
-    if (!native.rangeCount) {
-      selection = selection.merge({ isFocused: false })
-      state = state.merge({ selection })
-      this.onChange(state)
-      return
-    }
-
-    // Calculate the Slate-specific selection based on the native one.
-    const { anchorNode, anchorOffset, focusNode, focusOffset } = native
-    const anchor = OffsetKey.findPoint(anchorNode, anchorOffset, state)
-    const focus = OffsetKey.findPoint(focusNode, focusOffset, state)
-
-    // If the native selection is inside text nodes, we can trust the native
-    // state and not need to re-render.
-    const isNative = (
-      anchorNode.nodeType == 3 &&
-      focusNode.nodeType == 3
-    )
-
-    state = state
-      .transform()
-      .focus()
-      .moveTo({
-        anchorKey: anchor.key,
-        anchorOffset: anchor.offset,
-        focusKey: focus.key,
-        focusOffset: focus.offset
-      })
-      .apply({ isNative })
-
-    this.onChange(state)
+    this.props.onSelect(e)
   }
 
   /**
@@ -731,4 +697,3 @@ class Content extends React.Component {
  */
 
 export default Content
-

--- a/lib/components/editor.js
+++ b/lib/components/editor.js
@@ -28,6 +28,7 @@ class Editor extends React.Component {
     onDrop: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
     onPaste: React.PropTypes.func,
+    onSelect: React.PropTypes.func,
     onSelectionChange: React.PropTypes.func,
     placeholder: React.PropTypes.any,
     placeholderClassName: React.PropTypes.string,
@@ -202,6 +203,16 @@ class Editor extends React.Component {
   }
 
   /**
+   * On selection.
+   *
+   * @param {Mixed} ...args
+   */
+
+  onSelect = (...args) => {
+    this.onEvent('onSelect', ...args)
+  }
+
+  /**
    * Render the editor.
    *
    * @return {Element} element
@@ -217,6 +228,7 @@ class Editor extends React.Component {
         onDrop={this.onDrop}
         onKeyDown={this.onKeyDown}
         onPaste={this.onPaste}
+        onSelect={this.onSelect}
         readOnly={this.props.readOnly}
         renderMark={this.renderMark}
         renderNode={this.renderNode}

--- a/lib/plugins/core.js
+++ b/lib/plugins/core.js
@@ -5,6 +5,7 @@ import React from 'react'
 import String from '../utils/string'
 import keycode from 'keycode'
 import { IS_WINDOWS, IS_MAC } from '../utils/environment'
+import OffsetKey from '../utils/offset-key'
 
 /**
  * The default plugin.
@@ -306,6 +307,51 @@ function Plugin(options = {}) {
           return transform.apply()
         }
       }
+    },
+
+    /**
+     * The core `onSelect` handler.
+     *
+     * @param {Event} e
+     * @param {State} state
+     * @param {Editor} editor
+     * @return {State or Null}
+     */
+
+    onSelect(e, state, editor) {
+      let { document, selection } = state
+      const native = window.getSelection()
+
+      if (!native.rangeCount) {
+        selection = selection.merge({ isFocused: false })
+        state = state.merge({ selection })
+        return state
+      }
+
+      // Calculate the Slate-specific selection based on the native one.
+      const { anchorNode, anchorOffset, focusNode, focusOffset } = native
+      const anchor = OffsetKey.findPoint(anchorNode, anchorOffset, state)
+      const focus = OffsetKey.findPoint(focusNode, focusOffset, state)
+
+      // If the native selection is inside text nodes, we can trust the native
+      // state and not need to re-render.
+      const isNative = (
+        anchorNode.nodeType == 3 &&
+        focusNode.nodeType == 3
+      )
+
+      state = state
+        .transform()
+        .focus()
+        .moveTo({
+          anchorKey: anchor.key,
+          anchorOffset: anchor.offset,
+          focusKey: focus.key,
+          focusOffset: focus.offset
+        })
+        .apply({ isNative })
+
+      return state
     },
 
     /**


### PR DESCRIPTION
My attempt at #174.

I added an `onSelect` method to the core plugin with the Content component `onSelect` logic and then added an `onSelect` prop to the Editor component.

Tests and linting pass on my machine. I also did a local install into my project and it solves my problem in #173.