### PR TITLE
undo and redo transform does not return Transform

### DIFF
--- a/docs/reference/models/transform.md
+++ b/docs/reference/models/transform.md
@@ -340,11 +340,11 @@ Wrap the [`Inline`](./inline.md) nodes in a `range` with a new [`Inline`](./inli
 ## History Transforms
 
 ### `redo`
-`redo() => Transform`
+`redo() => State`
 
 Move forward one step in the history.
 
 ### `undo`
-`undo() => Transform`
+`undo() => State`
 
 Move backward one step in the history.


### PR DESCRIPTION
This PR fixes the documentation for `undo` and `redo` transforms, which return a new `State` instead of a `Transform`.