### PR TITLE
Fix signature of Selection.has{Edge}In in documentation

### DIFF
--- a/docs/reference/models/selection.md
+++ b/docs/reference/models/selection.md
@@ -140,7 +140,7 @@ Determine whether a selection has an edge at the end of a `node`. Where `{Edge}`
 Determine whether a selection has an edge in a `node` between its `start` and `end` offset. Where `{Edge}` can be one of: `Anchor`, `Focus`, `Start`, `End` or `Edge` (referring to either point).
 
 ### `has{Edge}In` 
-`has{Edge}In(node: Node, start: Number, end: Number) => Boolean`
+`has{Edge}In(node: Node) => Boolean`
 
 Determine whether a selection has an edge inside a `node`. Where `{Edge}` can be one of: `Anchor`, `Focus`, `Start`, `End` or `Edge` (referring to either point).
 


### PR DESCRIPTION
This PR fixes the signature of `Selection.has{Edge}In` in the documentation.