### PR TITLE
Add properties hasUndo and hasRedo to State

### DIFF
--- a/docs/reference/models/state.md
+++ b/docs/reference/models/state.md
@@ -22,6 +22,8 @@ For convenience, in addition to transforms, many of the [`Selection`](./selectio
   - [`fragment`](#fragment)
   - [`inlines`](#inlines)
   - [`texts`](#texts)
+  - [`hasUndo`](#hasundo)
+  - [`hasRedo`](#hasredo)
 - [Selection-like Properties](#selection-like-properties)
   - [`{edge}Key`](#edgekey)
   - [`{edge}Offset`](#edgeoffset)
@@ -32,7 +34,7 @@ For convenience, in addition to transforms, many of the [`Selection`](./selectio
   - [`isFocused`](#isfocused)
   - [`isForward`](#isForward)
 - [Static Methods](#static-methods)
-  - [`State.create`](#statecreate) 
+  - [`State.create`](#statecreate)
 - [Methods](#methods)
   - [`transform`](#transform)
 
@@ -42,7 +44,7 @@ For convenience, in addition to transforms, many of the [`Selection`](./selectio
 ```js
 State({
   document: Document,
-  selection: Selection 
+  selection: Selection
 })
 ```
 
@@ -97,6 +99,15 @@ Get a list of the lowest-depth [`Inline`](./inline.md) nodes in the current sele
 
 Get a list of the [`Text`](./text.md) nodes in the current selection.
 
+### `hasUndo`
+`Boolean`
+
+Whether there are undoable events.
+
+### `hasRedo`
+`Boolean`
+
+Whether there are redoable events.
 
 ## Selection-like Properties
 

--- a/lib/models/state.js
+++ b/lib/models/state.js
@@ -71,7 +71,7 @@ class State extends new Record(DEFAULTS) {
   /**
    * Is there redoable events?
    *
-   * @return {Boolean} hasUndo
+   * @return {Boolean} hasRedo
    */
 
   get hasRedo() {

--- a/lib/models/state.js
+++ b/lib/models/state.js
@@ -59,6 +59,26 @@ class State extends new Record(DEFAULTS) {
   }
 
   /**
+   * Is there undoable events?
+   *
+   * @return {Boolean} hasUndo
+   */
+
+  get hasUndo() {
+    return this.history.undos.size > 0
+  }
+
+  /**
+   * Is there redoable events?
+   *
+   * @return {Boolean} hasUndo
+   */
+
+  get hasRedo() {
+    return this.history.redos.size > 0
+  }
+
+  /**
    * Is the current selection blurred?
    *
    * @return {Boolean} isBlurred


### PR DESCRIPTION
This PR adds two computed properties  to `State`: `hasUndo` and `hasRedo`.

These properties are shortcuts when for example rendering Undo/Redo buttons in a toolbar.

I’ve documented the properties, but I’m not an english native so let me know if the descriptions are not good enough. 