### PR TITLE
fix isBackward in onSelect event selection

### DIFF
--- a/lib/components/content.js
+++ b/lib/components/content.js
@@ -594,13 +594,16 @@ class Content extends React.Component {
         focusNode.nodeType == 3
       )
 
-      data.selection = selection.merge({
+      selection = selection.merge({
         anchorKey: anchor.key,
         anchorOffset: anchor.offset,
         focusKey: focus.key,
         focusOffset: focus.offset,
-        isFocused: true
+        isFocused: true,
+        isBackward: null
       })
+
+      data.selection = selection.normalize(document)
     }
 
     this.props.onSelect(e, data)


### PR DESCRIPTION
I think at some point in the `onSelect` changes the `isBackward` value broke. I mostly just copied how `moveTo` managed to update it, which was the method used before `onSelect` was moved.

Hopefully this is the correct way to do it?