### PR TITLE
Fix #194: fix possilbe deletion of "data" property with setBlock transforms

### DIFF
--- a/lib/models/transforms.js
+++ b/lib/models/transforms.js
@@ -527,11 +527,15 @@ const Transforms = {
     if (typeof properties == 'string') {
       properties = { type: properties }
     }
+    if (properties.data) {
+        properties.data = Data.create(properties.data)
+    } else {
+        delete properties.data
+    }
 
     // Update each of the blocks.
     const blocks = node.getBlocksAtRange(range)
     blocks.forEach((block) => {
-      if (properties.data) properties.data = Data.create(properties.data)
       block = block.merge(properties)
       node = node.updateDescendant(block)
     })


### PR DESCRIPTION
This PR prevents the deletion of `data` by passing `{ data: null | undefined }` to `setBlock`.