### PR TITLE
add tests for calling wrapInline twice

### DIFF
--- a/test/transforms/fixtures/wrap-inline/twice/index.js
+++ b/test/transforms/fixtures/wrap-inline/twice/index.js
@@ -1,0 +1,23 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const text = texts.first()
+  const range = selection.merge({
+    anchorKey: text.key,
+    anchorOffset: 7,
+    focusKey: text.key,
+    focusOffset: 11
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .wrapInline('inner')
+    .wrapInline('outer')
+    .apply()
+
+  return next
+}

--- a/test/transforms/fixtures/wrap-inline/twice/input.yaml
+++ b/test/transforms/fixtures/wrap-inline/twice/input.yaml
@@ -1,0 +1,7 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: before word after

--- a/test/transforms/fixtures/wrap-inline/twice/output.yaml
+++ b/test/transforms/fixtures/wrap-inline/twice/output.yaml
@@ -1,0 +1,16 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "before "
+      - kind: inline
+        type: outer
+        nodes:
+          - kind: inline
+            type: inner
+            nodes:
+              - kind: text
+                text: word
+      - kind: text
+        text: " after"


### PR DESCRIPTION
So unfortunately it looks like the `0.8.0` release did not fix #185. I added a small test to show this.

I hope calling the folder `twice` is clear enough. Please let know if I should change anything.