### PR TITLE
Add ability for `renderMark` to return a React componen

### DIFF
--- a/lib/components/editor.js
+++ b/lib/components/editor.js
@@ -252,9 +252,10 @@ class Editor extends React.Component {
 
       // plugin.renderMak can return a map of style
       if (!(typeof component === 'function')) {
-          component = (props => <span style={component}>{props.children}</span>)
+          const style = component
+          component = (props => <span style={style}>{props.children}</span>)
       }
-      
+
       if (component) return component
     }
   }

--- a/lib/components/editor.js
+++ b/lib/components/editor.js
@@ -242,17 +242,15 @@ class Editor extends React.Component {
    *
    * @param {Mark} mark
    * @param {Set} marks
-   * @return {Object}
+   * @return {Element}
    */
 
   renderMark = (mark, marks) => {
     for (const plugin of this.state.plugins) {
       if (!plugin.renderMark) continue
-      const style = plugin.renderMark(mark, marks, this.state.state, this)
-      if (style) return style
+      const component = plugin.renderMark(mark, marks, this.state.state, this)
+      if (component) return component
     }
-
-    return {}
   }
 
   /**

--- a/lib/components/editor.js
+++ b/lib/components/editor.js
@@ -248,7 +248,13 @@ class Editor extends React.Component {
   renderMark = (mark, marks) => {
     for (const plugin of this.state.plugins) {
       if (!plugin.renderMark) continue
-      const component = plugin.renderMark(mark, marks, this.state.state, this)
+      let component = plugin.renderMark(mark, marks, this.state.state, this)
+
+      // plugin.renderMak can return a map of style
+      if (!(typeof component === 'function')) {
+          component = (props => <span style={component}>{props.children}</span>)
+      }
+      
       if (component) return component
     }
   }

--- a/lib/components/editor.js
+++ b/lib/components/editor.js
@@ -251,7 +251,7 @@ class Editor extends React.Component {
       let component = plugin.renderMark(mark, marks, this.state.state, this)
 
       // plugin.renderMak can return a map of style
-      if (!(typeof component === 'function')) {
+      if (component && !(typeof component === 'function')) {
           const style = component
           component = (props => <span style={style}>{props.children}</span>)
       }

--- a/lib/components/leaf.js
+++ b/lib/components/leaf.js
@@ -195,6 +195,9 @@ class Leaf extends React.Component {
       })
 
       const MarkComponent = renderMark(mark, marks)
+      if (!MarkComponent) {
+          return inner
+      }
 
       return (
           <MarkComponent

--- a/lib/components/leaf.js
+++ b/lib/components/leaf.js
@@ -176,9 +176,13 @@ class Leaf extends React.Component {
       const text = this.renderText()
 
       const element = marks.reduce((inner, mark) => {
-          const Component = renderMark(mark, marks)
+          const MarkComponent = renderMark(mark, marks)
 
-          return <Component mark={mark}>{inner}</Component>
+          if (!MarkComponent) {
+              return inner
+          }
+
+          return <MarkComponent mark={mark}>{inner}</MarkComponent>
       }, text)
 
       return element

--- a/lib/components/leaf.js
+++ b/lib/components/leaf.js
@@ -151,9 +151,8 @@ class Leaf extends React.Component {
       <span
         key={this.tmp.renders}
         data-offset-key={offsetKey}
-        style={this.renderStyle()}
       >
-        {this.renderText()}
+        {this.renderWithMarks()}
       </span>
     )
   }
@@ -172,21 +171,18 @@ class Leaf extends React.Component {
     return text
   }
 
-  renderStyle() {
-    const { marks, renderMark } = this.props
-    const style = marks.reduce((memo, mark) => {
-      const styles = renderMark(mark, marks)
+  renderWithMarks() {
+      const { marks, renderMark } = this.props
+      const text = this.renderText()
 
-      for (const key in styles) {
-        memo[key] = styles[key]
-      }
+      const element = marks.reduce((inner, mark) => {
+          const Component = renderMark(mark, marks)
 
-      return memo
-    }, {})
+          return <Component mark={mark}>{inner}</Component>
+      }, text)
 
-    return style
+      return element
   }
-
 }
 
 /**

--- a/lib/components/leaf.js
+++ b/lib/components/leaf.js
@@ -4,6 +4,22 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 /**
+ * Find the deepest child (text node) of a DOM node
+ * @param  {DOMNode} node
+ * @return {DOMNode}
+ */
+
+function findDeepestNode(node) {
+    let child = node.firstChild
+
+    if (child) {
+        return findDeepestNode(child)
+    }
+
+    return node
+}
+
+/**
  * Leaf.
  */
 
@@ -86,7 +102,7 @@ class Leaf extends React.Component {
 
     // We have a selection to render, so prepare a few things...
     const native = window.getSelection()
-    const el = ReactDOM.findDOMNode(this).firstChild
+    const el = findDeepestNode(ReactDOM.findDOMNode(this))
 
     // If both the start and end are here, set the selection all at once.
     if (hasAnchor && hasFocus) {
@@ -171,19 +187,27 @@ class Leaf extends React.Component {
     return text
   }
 
+  renderMark(inner, mark) {
+      const { node, index, renderMark, marks } = this.props
+      const offsetKey = OffsetKey.stringify({
+        key: node.key,
+        index
+      })
+
+      const MarkComponent = renderMark(mark, marks)
+
+      return (
+          <MarkComponent
+              mark={mark}
+          >
+            {inner}
+          </MarkComponent>
+      )
+  }
+
   renderWithMarks() {
       const { marks, renderMark } = this.props
-      const text = this.renderText()
-
-      const element = marks.reduce((inner, mark) => {
-          const MarkComponent = renderMark(mark, marks)
-
-          if (!MarkComponent) {
-              return inner
-          }
-
-          return <MarkComponent mark={mark}>{inner}</MarkComponent>
-      }, text)
+      const element = marks.reduce(this.renderMark, this.renderText(), this)
 
       return element
   }

--- a/lib/components/void.js
+++ b/lib/components/void.js
@@ -175,7 +175,7 @@ class Void extends React.Component {
    */
 
   renderLeafMark = (mark) => {
-    return {}
+    return
   }
 
 }

--- a/test/rendering/fixtures/custom-decorator/output.html
+++ b/test/rendering/fixtures/custom-decorator/output.html
@@ -3,7 +3,7 @@
   <div style="position:relative;">
     <span>
       <span>o</span>
-      <span style="font-weight:bold;">n</span>
+      <span><span style="font-weight:bold;">n</span></span>
       <span>e</span>
     </span>
   </div>

--- a/test/rendering/fixtures/custom-mark-combine/index.js
+++ b/test/rendering/fixtures/custom-mark-combine/index.js
@@ -1,0 +1,13 @@
+
+import React from 'react'
+
+const BOLD = {
+  fontWeight: 'bold'
+}
+
+const ITALIC = (props => <i>{props.children}</i>)
+
+export function renderMark(mark, marks) {
+  if (mark.type == 'bold') return BOLD
+  if (mark.type == 'italic') return ITALIC
+}

--- a/test/rendering/fixtures/custom-mark-combine/input.yaml
+++ b/test/rendering/fixtures/custom-mark-combine/input.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: default
+    nodes:
+      - kind: text
+        ranges:
+          - text: one
+            marks:
+              - type: bold
+          - text: two
+            marks:
+              - type: italic
+          - text: three
+            marks:
+              - type: bold
+              - type: italic

--- a/test/rendering/fixtures/custom-mark-combine/output.html
+++ b/test/rendering/fixtures/custom-mark-combine/output.html
@@ -3,8 +3,8 @@
   <div style="position:relative;">
     <span>
       <span><span style="font-weight:bold;">one</span></span>
-      <span><span style="font-style:italic;">two</span></span>
-      <span><span style="font-family:bold-italic;">three</span></span>
+      <span><i>two</i></span>
+      <span><i><span style="font-weight:bold;">three</span></i></span>
     </span>
   </div>
 </div>

--- a/test/rendering/fixtures/custom-mark-multiple/index.js
+++ b/test/rendering/fixtures/custom-mark-multiple/index.js
@@ -16,10 +16,10 @@ const BOLD_ITALIC = {
 export function renderMark(mark, marks) {
   if (
     marks.size > 1 &&
-    marks.some(m => m.type == 'bold') &&
-    marks.some(m => m.type == 'italic')
+    marks.some(m => m.type == 'italic') &&
+    marks.some(m => m.type == 'bold')
   ) {
-    return BOLD_ITALIC
+    return mark.type == 'bold' ? BOLD_ITALIC : undefined
   }
 
   if (mark.type == 'bold') return BOLD

--- a/test/rendering/fixtures/custom-mark/output.html
+++ b/test/rendering/fixtures/custom-mark/output.html
@@ -3,7 +3,7 @@
   <div style="position:relative;">
     <span>
       <span>one</span>
-      <span style="font-weight:bold;">two</span>
+      <span><span style="font-weight:bold;">two</span></span>
       <span>three</span>
     </span>
   </div>


### PR DESCRIPTION
This PR fixes #201 

Basically, it allows `renderMarks` to return React components:

```js
const BoldSpan = (props => <b>{this.props.children}</b>)

renderMarks(mark) {
     if (mark.type == 'bold') return BoldSpan
}
```

Currently, if a leaf has 2 marks (`bold` and `italic`), it will result in one `span` with `style={ { fontWight: 'bold', fontStyle: 'italic' }}`; with this PR it will result in `<b><em>{text}</em></b>`.

### TODOs

- [x] Change rendering of marks to use a component
- [x] Backward compatibility if `renderMark` returns an Object, build it as `<span style={style}>{props.children}</span>
- [x] Adapt unit tests
- [x] Ensure that examples are working


--- 

@ianstormtaylor I'm posting this PR while it's still a WIP so that you can review it and tell if it looks like the right implementation for you.