### PR TITLE
Add/render to iframe

### DIFF
--- a/examples/iframe-rendering/Readme.md
+++ b/examples/iframe-rendering/Readme.md
@@ -1,7 +1,14 @@
-
 # IFrame rendering example
 
 This example shows how to render Slate into IFrame, preserving single react component tree.
 You may need this if you want to have separate styles for editor content & application.
+
+In example this exmaple you can see, 
+that editor is using bootstrap styles, while they are not included to parent page. 
+
+## React onSelect problem
+Current react version has a problem with onSelect event handling, if input is rendered from parent component tree to iframe.
+
+This problem is solved by custom SelectEventPlugin - [react-frame-aware-selection-plugin](https://www.npmjs.com/package/react-frame-aware-selection-plugin)
 
 Check out the [Examples readme](..) to see how to run it!

--- a/examples/iframe-rendering/Readme.md
+++ b/examples/iframe-rendering/Readme.md
@@ -1,0 +1,7 @@
+
+# IFrame rendering example
+
+This example shows how to render Slate into IFrame, preserving single react component tree.
+You may need this if you want to have separate styles for editor content & application.
+
+Check out the [Examples readme](..) to see how to run it!

--- a/examples/iframe-rendering/index.js
+++ b/examples/iframe-rendering/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-
 import injector from 'react-frame-aware-selection-plugin'
-injector();
+
+injector()
 
 import { Editor, Mark, Raw } from '../..'
 import initialState from './state.json'
@@ -124,14 +124,16 @@ class IFrameRendering extends React.Component {
         return MARKS[mark.type]
     }
 
-    render () {
-        const bootstrapCDN =
+    render() {
+        const bootstrapCDN = (
             <link
                 href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
                 rel="stylesheet"
                 integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
-                crossOrigin="anonymous">
+                crossOrigin="anonymous"
+            >
             </link>
+        )
 
         return (
             <Frame head={bootstrapCDN} style={{width: `100%`, height: '300px'}}>

--- a/examples/iframe-rendering/index.js
+++ b/examples/iframe-rendering/index.js
@@ -1,0 +1,93 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+function resolveDocument (reactIFrameElementNode) {
+    const iFrame = ReactDOM.findDOMNode(reactIFrameElementNode);
+    return iFrame.contentDocument
+}
+
+//appending context to body > div, to suppress react warning
+function getRootDiv (doc) {
+    let rootDiv = doc.querySelector('div#root')
+    if (!rootDiv) {
+        rootDiv = doc.createElement('div')
+        rootDiv.setAttribute('id', 'root')
+        rootDiv.id = 'root'
+        rootDiv.setAttribute('style', 'width: 100%; height: 100%')
+
+        doc.body.appendChild(rootDiv)
+    }
+    return rootDiv
+}
+
+class IFrame extends React.Component {
+
+    static propTypes = {
+        head: React.PropTypes.node,
+        children: React.PropTypes.node,
+    }
+
+    //rendering plain frame.
+    render () {
+        return <iframe style={{border: 'solid 1px black', width: '100%'}}></iframe>
+    }
+
+    componentDidMount = () => {
+        this.renderContents()
+    }
+
+    componentDidUpdate = () => {
+        this.renderContents()
+    }
+
+    componentWillUnmount = () => this.getDocument().then((doc) => {
+        ReactDOM.unmountComponentAtNode(doc.body)
+        if (this.props.head) {
+            ReactDOM.unmountComponentAtNode(doc.head)
+        }
+    })
+
+    renderContents = () => this.getDocument().then((doc) => {
+        if (this.props.head) {
+            ReactDOM.unstable_renderSubtreeIntoContainer(this, this.props.head, doc.head)
+        }
+        const rootDiv = getRootDiv(doc)
+        ReactDOM.unstable_renderSubtreeIntoContainer(this, this.props.children, rootDiv)
+    })
+
+
+    getDocument = () => new Promise((resolve) => {
+        const resolveTick = () => { //using arrow function to preserve `this` context
+            let doc = resolveDocument(this)
+            if (doc && doc.readyState === 'complete') {
+                resolve(doc)
+            } else {
+                window.requestAnimationFrame(resolveTick)
+            }
+        }
+        resolveTick()
+    })
+
+}
+
+class IFrameRendering extends React.Component {
+
+    render () {
+        const bootstrapCDN =
+            <link
+                href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+                rel="stylesheet"
+                integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+                crossOrigin="anonymous">
+            </link>
+
+        return (
+            <IFrame head={bootstrapCDN}>
+                <div>I'm in iframe</div>
+            </IFrame>
+        )
+    }
+
+}
+
+export default IFrameRendering

--- a/examples/iframe-rendering/state.json
+++ b/examples/iframe-rendering/state.json
@@ -1,0 +1,277 @@
+{
+  "nodes": [
+    {
+      "kind": "block",
+      "type": "paragraph",
+      "nodes": [
+        {
+          "kind": "text",
+          "ranges": [
+            {
+              "text": "This example shows how you can render editor in frame component."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "block",
+      "type": "paragraph",
+      "nodes": [
+        {
+          "kind": "text",
+          "ranges": [
+            {
+              "text": "Check out this table, it has bootstrap styles, and top level document is not polluted by "
+            },
+            {
+              "text": "bootstrap.min.css",
+              "marks": [
+                {
+                  "type": "italic"
+                },
+                {
+                  "type": "bold"
+                }
+              ]
+            },
+            {
+              "text": "."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "block",
+      "type": "paragraph",
+      "nodes": [
+        {
+          "kind": "text",
+          "ranges": [
+            {
+              "text": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "block",
+      "type": "table",
+      "nodes": [
+        {
+          "kind": "block",
+          "type": "table-row",
+          "nodes": [
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "Human",
+                      "marks": [
+                        {
+                          "type": "bold"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "Dog",
+                      "marks": [
+                        {
+                          "type": "bold"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "Cat",
+                      "marks": [
+                        {
+                          "type": "bold"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "block",
+          "type": "table-row",
+          "nodes": [
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "# of Feet",
+                      "marks": [
+                        {
+                          "type": "bold"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "4"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "4"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "block",
+          "type": "table-row",
+          "nodes": [
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "# of Lives",
+                      "marks": [
+                        {
+                          "type": "bold"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "block",
+              "type": "table-cell",
+              "nodes": [
+                {
+                  "kind": "text",
+                  "ranges": [
+                    {
+                      "text": "9"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/index.js
+++ b/examples/index.js
@@ -136,7 +136,7 @@ const router = (
       <Route path="tables" component={Tables} />
       <Route path="dev-performance-plain" component={DevPerformancePlain} />
       <Route path="dev-performance-rich" component={DevPerformanceRich} />
-      <Route path="iframe" component={IFrameRendering}/>
+      <Route path="iframe" component={IFrameRendering} />
     </Route>
   </Router>
 )

--- a/examples/index.js
+++ b/examples/index.js
@@ -22,6 +22,7 @@ import RTL from './rtl'
 import Tables from './tables'
 import DevPerformancePlain from './development/performance-plain'
 import DevPerformanceRich from './development/performance-rich'
+import IFrameRendering from './iframe-rendering'
 
 /**
  * Perf.
@@ -76,6 +77,7 @@ class App extends React.Component {
         {this.renderTab('Read-only', 'read-only')}
         {this.renderTab('RTL', 'rtl')}
         {this.renderTab('Plugins', 'plugins')}
+        {this.renderTab('IFrame', 'iframe')}
       </div>
     )
   }
@@ -134,6 +136,7 @@ const router = (
       <Route path="tables" component={Tables} />
       <Route path="dev-performance-plain" component={DevPerformancePlain} />
       <Route path="dev-performance-rich" component={DevPerformanceRich} />
+      <Route path="iframe" component={IFrameRendering}/>
     </Route>
   </Router>
 )

--- a/lib/components/content.js
+++ b/lib/components/content.js
@@ -9,6 +9,7 @@ import TYPES from '../utils/types'
 import includes from 'lodash/includes'
 import keycode from 'keycode'
 import { IS_FIREFOX, IS_MAC } from '../utils/environment'
+import findElementWindow from '../utils/find-element-window'
 
 /**
  * Debug.
@@ -380,11 +381,13 @@ class Content extends React.Component {
     // Resolve the point where the drop occured.
     let range
 
+    const contextWindow = findElementWindow(e.nativeEvent.target)
+
     // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
-    if (window.document.caretRangeFromPoint) {
-      range = window.document.caretRangeFromPoint(x, y)
+    if (contextWindow.document.caretRangeFromPoint) {
+      range = contextWindow.document.caretRangeFromPoint(x, y)
     } else {
-      range = window.document.createRange()
+      range = contextWindow.document.createRange()
       range.setStart(e.nativeEvent.rangeParent, e.nativeEvent.rangeOffset)
     }
 
@@ -459,9 +462,11 @@ class Content extends React.Component {
     if (isNonEditable(e)) return
     debug('onInput')
 
+    const contextWindow = findElementWindow(e.nativeEvent.target)
+
     let { state, renderDecorations } = this.props
     const { selection } = state
-    const native = window.getSelection()
+    const native = contextWindow.getSelection()
     const { anchorNode, anchorOffset, focusOffset } = native
     const point = this.getPoint(anchorNode, anchorOffset)
     const { key, index, start, end } = point
@@ -624,9 +629,11 @@ class Content extends React.Component {
     if (this.tmp.isComposing) return
     if (isNonEditable(e)) return
 
+    const contextWindow = findElementWindow(e.nativeEvent.target)
+
     const { state, renderDecorations } = this.props
     let { document, selection } = state
-    const native = window.getSelection()
+    const native = contextWindow.getSelection()
     const data = {}
 
     // If there are no ranges, the editor was blurred natively.

--- a/lib/components/leaf.js
+++ b/lib/components/leaf.js
@@ -4,6 +4,7 @@ import OffsetKey from '../utils/offset-key'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import findElementWindow from '../utils/find-element-window'
+
 /**
  * Debugger.
  *
@@ -135,7 +136,7 @@ class Leaf extends React.Component {
       focusOffset = 0
     }
 
-    const contextWindow = findElementWindow(ReactDOM.findDOMNode(this));
+    const contextWindow = findElementWindow(ReactDOM.findDOMNode(this))
 
     // We have a selection to render, so prepare a few things...
     const native = contextWindow.getSelection()

--- a/lib/components/leaf.js
+++ b/lib/components/leaf.js
@@ -3,7 +3,7 @@ import Debug from 'debug'
 import OffsetKey from '../utils/offset-key'
 import React from 'react'
 import ReactDOM from 'react-dom'
-
+import findElementWindow from '../utils/find-element-window'
 /**
  * Debugger.
  *
@@ -135,14 +135,16 @@ class Leaf extends React.Component {
       focusOffset = 0
     }
 
+    const contextWindow = findElementWindow(ReactDOM.findDOMNode(this));
+
     // We have a selection to render, so prepare a few things...
-    const native = window.getSelection()
+    const native = contextWindow.getSelection()
     const el = findDeepestNode(ReactDOM.findDOMNode(this))
 
     // If both the start and end are here, set the selection all at once.
     if (hasAnchor && hasFocus) {
       native.removeAllRanges()
-      const range = window.document.createRange()
+      const range = contextWindow.document.createRange()
       range.setStart(el, anchorOffset - start)
       native.addRange(range)
       native.extend(el, focusOffset - start)
@@ -155,7 +157,7 @@ class Leaf extends React.Component {
     if (selection.isForward) {
       if (hasAnchor) {
         native.removeAllRanges()
-        const range = window.document.createRange()
+        const range = contextWindow.document.createRange()
         range.setStart(el, anchorOffset - start)
         native.addRange(range)
       } else if (hasFocus) {
@@ -170,14 +172,14 @@ class Leaf extends React.Component {
     else {
       if (hasFocus) {
         native.removeAllRanges()
-        const range = window.document.createRange()
+        const range = contextWindow.document.createRange()
         range.setStart(el, focusOffset - start)
         native.addRange(range)
       } else if (hasAnchor) {
         const endNode = native.focusNode
         const endOffset = native.focusOffset
         native.removeAllRanges()
-        const range = window.document.createRange()
+        const range = contextWindow.document.createRange()
         range.setStart(el, anchorOffset - start)
         native.addRange(range)
         native.extend(endNode, endOffset)

--- a/lib/plugins/core.js
+++ b/lib/plugins/core.js
@@ -5,6 +5,7 @@ import Debug from 'debug'
 import Placeholder from '../components/placeholder'
 import React from 'react'
 import String from '../utils/string'
+import findElementWindow from '../utils/find-element-window'
 
 /**
  * Debug.
@@ -28,7 +29,7 @@ function Plugin(options = {}) {
   const {
     placeholder,
     placeholderClassName,
-    placeholderStyle
+    placeholderStyle,
   } = options
 
   /**
@@ -204,7 +205,9 @@ function Plugin(options = {}) {
    */
 
   function onCutOrCopy(e, data, state) {
-    const native = window.getSelection()
+    const contextWindow = findElementWindow(e.nativeEvent.target)
+
+    const native = contextWindow.getSelection()
     if (!native.rangeCount) return
 
     const { fragment } = data
@@ -214,10 +217,10 @@ function Plugin(options = {}) {
     // fragment attached as an attribute, so it will show up in the copied HTML.
     const range = native.getRangeAt(0)
     const contents = range.cloneContents()
-    const wrapper = window.document.createElement('span')
+    const wrapper = contextWindow.document.createElement('span')
     const text = contents.childNodes[0]
     const char = text.textContent.slice(0, 1)
-    const first = window.document.createTextNode(char)
+    const first = contextWindow.document.createTextNode(char)
     const rest = text.textContent.slice(1)
     text.textContent = rest
     wrapper.appendChild(first)
@@ -225,8 +228,8 @@ function Plugin(options = {}) {
     contents.insertBefore(wrapper, text)
 
     // Add the phony content to the DOM, and select it, so it will be copied.
-    const body = window.document.querySelector('body')
-    const div = window.document.createElement('div')
+    const body = contextWindow.document.querySelector('body')
+    const div = contextWindow.document.createElement('div')
     div.setAttribute('contenteditable', true)
     div.style.position = 'absolute'
     div.style.left = '-9999px'
@@ -235,7 +238,7 @@ function Plugin(options = {}) {
 
     // COMPAT: In Firefox, trying to use the terser `native.selectAllChildren`
     // throws an error, so we use the older `range` equivalent. (2016/06/21)
-    const r = window.document.createRange()
+    const r = contextWindow.document.createRange()
     r.selectNodeContents(div)
     native.removeAllRanges()
     native.addRange(r)

--- a/lib/utils/find-element-window.js
+++ b/lib/utils/find-element-window.js
@@ -1,0 +1,12 @@
+/**
+ * Find the DOM context for the `node`, fallback to top level global window object.
+ *
+ * @param {Node} node
+ * @return {Element} el
+ */
+function findElementWindow (domNode) {
+    const doc = domNode.ownerDocument || domNode
+    return doc.defaultView || doc.parentWindow
+}
+
+export default findElementWindow

--- a/lib/utils/find-element-window.js
+++ b/lib/utils/find-element-window.js
@@ -1,10 +1,12 @@
+
 /**
- * Find the DOM context for the `node`, fallback to top level global window object.
+ * Find the window object for the domNode.
  *
- * @param {Node} node
- * @return {Element} el
+ * @param {Node} domNode
+ * @return {Window} window
  */
-function findElementWindow (domNode) {
+
+function findElementWindow(domNode) {
     const doc = domNode.ownerDocument || domNode
     return doc.defaultView || doc.parentWindow
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "react": "^15.2.0",
     "react-addons-perf": "^15.2.1",
     "react-dom": "^15.1.0",
+    "react-frame-aware-selection-plugin": "0.0.1",
+    "react-frame-component": "^0.6.2",
     "react-router": "^2.5.1",
     "read-metadata": "^1.0.0",
     "selection-position": "^1.0.0",


### PR DESCRIPTION
As discussed in #215 , added support for Slate IFrame rendering, but in quite different way. 

There is actually no need to pass `dom={...}` becasue valid window could be deducted by the `event.native.target` transparently. 

One more problem found in React `SelectionEventPlugin`: it also has hardcoded `window` references.
Basicly version of `SelectionEventPlugin` swallowing all onSelection events, and this leads to incosistent slection state in slate.

To handle this I created small project [react-frame-aware-selection-plugin](https://github.com/vleletko/react-frame-aware-selection-plugin)

It is used in provided example. 

 