### PR TITLE
Drop deprecated `escape` and `unescape`

### DIFF
--- a/lib/serializers/base-64.js
+++ b/lib/serializers/base-64.js
@@ -10,7 +10,7 @@ import Raw from './raw'
 
 function encode(object) {
   const string = JSON.stringify(object)
-  const encoded = window.btoa(window.unescape(window.encodeURIComponent(string)))
+  const encoded = window.btoa(window.encodeURIComponent(string))
   return encoded
 }
 
@@ -22,7 +22,7 @@ function encode(object) {
  */
 
 function decode(string) {
-  const decoded = window.decodeURIComponent(window.escape(window.atob(string)))
+  const decoded = window.decodeURIComponent(window.atob(string))
   const object = JSON.parse(decoded)
   return object
 }


### PR DESCRIPTION
As the title suggests, it'd be best to drop [`escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape) and [`unescape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape) since they are both deprecated methods that serve no real purpose when in combination with `decodeURIComponent` and `encodeURIComponent`.

In addition, a quick [benchmark](https://jsfiddle.net/w00fz/3mgLe6bf/) shows a ~50% boost in speed.