### PR TITLE
terse text can contain marks

### DIFF
--- a/lib/serializers/raw.js
+++ b/lib/serializers/raw.js
@@ -569,7 +569,8 @@ const Raw = {
     return {
       kind: object.kind,
       ranges: [{
-        text: object.text
+        text: object.text,
+        marks: object.marks || []
       }]
     }
   }

--- a/test/serializers/fixtures/raw/deserialize-terse/text-with-mark-without-range/input.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/text-with-mark-without-range/input.yaml
@@ -1,0 +1,11 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: one
+      - kind: text
+        text: two
+        marks:
+          - type: bold

--- a/test/serializers/fixtures/raw/deserialize-terse/text-with-mark-without-range/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/text-with-mark-without-range/output.yaml
@@ -1,0 +1,25 @@
+
+nodes:
+  - type: paragraph
+    isVoid: false
+    data: {}
+    nodes:
+      - characters:
+          - text: o
+            marks: []
+          - text: n
+            marks: []
+          - text: e
+            marks: []
+          - text: t
+            marks:
+              - type: bold
+                data: {}
+          - text: w
+            marks:
+              - type: bold
+                data: {}
+          - text: o
+            marks:
+              - type: bold
+                data: {}


### PR DESCRIPTION
Text nodes in terse form can contain marks - but currently they are being ignored when "untersifying Text".

Referenced in https://github.com/GitbookIO/markup-it/pull/23
