### PR TITLE
Add failing test showing splitBlock with isVoid bug

### DIFF
--- a/lib/models/transforms.js
+++ b/lib/models/transforms.js
@@ -612,7 +612,8 @@ const Transforms = {
       secondChild = Block.create({
         nodes: secondChildren,
         type: parent.type,
-        data: parent.data
+        data: parent.data,
+        isVoid: parent.isVoid
       })
 
       // Add the new children.

--- a/test/transforms/fixtures/split-block/with-void/index.js
+++ b/test/transforms/fixtures/split-block/with-void/index.js
@@ -1,0 +1,24 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 0,
+    focusKey: first.key,
+    focusOffset: 0
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .splitBlock()
+    .apply()
+
+  console.dir(next.document.getBlocks().toJS());
+
+  return next
+}

--- a/test/transforms/fixtures/split-block/with-void/input.yaml
+++ b/test/transforms/fixtures/split-block/with-void/input.yaml
@@ -1,0 +1,5 @@
+
+nodes:
+  - kind: block
+    type: video
+    isVoid: true

--- a/test/transforms/fixtures/split-block/with-void/output.yaml
+++ b/test/transforms/fixtures/split-block/with-void/output.yaml
@@ -1,0 +1,8 @@
+
+nodes:
+  - kind: block
+    type: video
+    isVoid: true
+  - kind: block
+    type: video
+    isVoid: true


### PR DESCRIPTION
Not sure what I actually expected calling `splitBlock()` on void block, but I would expect `splitBlock()` to respect a given block type's isVoid property.
This failing test demonstrates that `splitBlock()` always creates a the new block with `isVoid: false`.

Edit: Sorry, here's the test runner output... the second block has `isVoid: false` and some extra child nodes:

![image](https://cloud.githubusercontent.com/assets/159373/18111313/f1194a42-6f61-11e6-8b91-4d694d07758f.png)
