### PR TITLE
fixed a typo where the method for focus was blur()

### DIFF
--- a/docs/reference/components/editor.md
+++ b/docs/reference/components/editor.md
@@ -175,7 +175,7 @@ To see how these properties behave, check out the [Plugins reference](../plugins
 Programmatically blur the editor.
 
 ### `focus`
-`blur() => Void`
+`focus() => Void`
 
 Programmatically focus the editor.
 


### PR DESCRIPTION
In the Editor reference documentation, there was a typo.  Blur() is listed twice; once under "blur" and again under "focus."

