### PR TITLE
Fix exception thrown when normalizing selection on empty documents

### DIFF
--- a/lib/models/selection.js
+++ b/lib/models/selection.js
@@ -288,6 +288,11 @@ class Selection extends new Record(DEFAULTS) {
     const { isCollapsed } = selection
     let { anchorKey, anchorOffset, focusKey, focusOffset, isBackward } = selection
 
+
+    if (node.getTexts().size === 0) {
+      return this
+    }
+
     // If the selection isn't formed yet or is malformed, set it to the
     // beginning of the node.
     if (

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
+    "assert": "^1.4.1",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.1.0",

--- a/test/unit/selection.js
+++ b/test/unit/selection.js
@@ -1,0 +1,12 @@
+import assert from 'assert'
+import { Selection, Document } from '../../lib'
+
+describe('selection', () => {
+  describe('normalize', () => {
+    it("works for an empty document", () => {
+      const document = Document.create({nodes: []})
+
+      assert.doesNotThrow(() => Selection.create(undefined).normalize(document))
+    })
+  })
+})


### PR DESCRIPTION
I wasn't entirely sure on where to put the test so I added a new folder. Unless I'm blind there are no unit tests anyhow. Maybe I'm wrong but I also couldn't find a library to do regular asserts :-)
