### PR TITLE
Fix issue #302

### DIFF
--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -178,6 +178,7 @@ class Images extends React.Component {
   onDropNode = (e, data, state) => {
     return state
       .transform()
+      .unsetSelection()
       .removeNodeByKey(data.node.key)
       .moveTo(data.target)
       .insertBlock(data.node)


### PR DESCRIPTION
Fix this https://github.com/ianstormtaylor/slate/issues/302

@ianstormtaylor Not really sure, but I think to prevent this kind of problem should `removeNodeByKey` unset selection before doing it's job?