### PR TITLE
Fix Text.updateMark

### DIFF
--- a/lib/models/text.js
+++ b/lib/models/text.js
@@ -3,7 +3,7 @@ import Character from './character'
 import Mark from './mark'
 import memoize from '../utils/memoize'
 import uid from '../utils/uid'
-import { List, Record, Set } from 'immutable'
+import { List, Record, Set, is } from 'immutable'
 
 /**
  * Range.
@@ -291,10 +291,11 @@ class Text extends new Record(DEFAULTS) {
       if (i < index) return char
       if (i >= index + length) return char
       let { marks } = char
-      const j = marks.indexOf(mark)
-      let m = marks.get(j)
-      m = m.merge(properties)
-      marks = marks.set(j, m)
+      marks = marks.map(m => {
+        return is(m, mark)
+          ? m.merge(properties)
+          : m
+      })
       char = char.merge({ marks })
       return char
     })


### PR DESCRIPTION
I was testing the `setMarkByKey` transform, and I think there is a bug here, because I got `marks.indexOf is not a function` :
https://github.com/ianstormtaylor/slate/blob/8fc3631328481b3c56c48a56e1a9bad2eb24bd5a/lib/models/text.js#L294

`char.marks` is an `Immutable.Set` which does not have `.indexOf` method.