### PR TITLE
Fix #318: Implement "splitBlockAtRange" as a node method

### DIFF
--- a/src/transforms/apply-operation.js
+++ b/src/transforms/apply-operation.js
@@ -312,44 +312,9 @@ function setSelection(state, operation) {
 function splitNode(state, operation) {
   const { path, offset } = operation
   let { document } = state
-  let node = document.assertPath(path)
-  let parent = document.getParent(node)
-  const isParent = document == parent
-  const index = parent.nodes.indexOf(node)
 
-  let child = node
-  let one
-  let two
+  document = document.splitNode(path, offset)
 
-  if (node.kind != 'text') {
-    child = node.getTextAtOffset(offset)
-  }
-
-  while (child && child != parent) {
-    if (child.kind == 'text') {
-      const i = node.kind == 'text' ? offset : offset - node.getOffset(child)
-      const { characters } = child
-      const oneChars = characters.take(i)
-      const twoChars = characters.skip(i)
-      one = child.merge({ characters: oneChars })
-      two = child.merge({ characters: twoChars, key: uid() })
-    }
-
-    else {
-      const { nodes } = child
-      const oneNodes = nodes.takeUntil(n => n.key == one.key).push(one)
-      const twoNodes = nodes.skipUntil(n => n.key == one.key).rest().unshift(two)
-      one = child.merge({ nodes: oneNodes })
-      two = child.merge({ nodes: twoNodes, key: uid() })
-    }
-
-    child = document.getParent(child)
-  }
-
-  parent = parent.removeNode(index)
-  parent = parent.insertNode(index, two)
-  parent = parent.insertNode(index, one)
-  document = isParent ? parent : document.updateDescendant(parent)
   state = state.merge({ document })
   return state
 }


### PR DESCRIPTION
This PR is intended to fix #318.

### Current Bug

Since upgrading to 0.14, `splitBlockAtRange` is no longer a method of `Node` (before it was a transform that was also set as a Node's method).

### Fix Implementation

I was not sure what kind of solution to apply to this problem, so feel free to reject this PR.

1. I've moved the code from the `splitNode` operation into a Node method
2. I've modified the `split_node` operation to call `node. splitNode`
3. I've implemented `node. splitBlockAtRange` (which require the transform of method `splitNode`)

### Problems remaining:

- The code for `splitBlockAtRange` is duplicated between the transform and the node method, I'm not sure how to fix this.
