### PR TITLE
Focus and blur should not clear marks on selection

### DIFF
--- a/src/transforms/operations.js
+++ b/src/transforms/operations.js
@@ -371,9 +371,18 @@ export function setSelectionOperation(transform, properties) {
     prevProps[k] = selection[k]
   }
 
-  // If the current selection has marks, and the new selection doesn't change
-  // them in some way, they are old and should be removed.
-  if (selection.marks && properties.marks == selection.marks) {
+  // If the selection moves, clear any marks, unless the new selection
+  // does change the marks in some way
+  const moved = [
+      'anchorKey',
+      'anchorOffset',
+      'focusKey',
+      'focusOffset',
+  ].some(p => props.hasOwnProperty(p))
+
+  if (selection.marks
+      && properties.marks == selection.marks
+      && moved) {
     props.marks = null
   }
 

--- a/test/transforms/fixtures/on-selection/blur/marks/index.js
+++ b/test/transforms/fixtures/on-selection/blur/marks/index.js
@@ -1,0 +1,26 @@
+
+import assert from 'assert'
+import { Mark } from '../../../../../..'
+
+export default function (state) {
+  const { startText, selection } = state
+  const sel = selection.merge({
+    marks: Mark.createSet([
+        Mark.create({
+            type: 'bold'
+        })
+    ])
+  })
+
+  const next = state
+    .transform()
+    .addMark('bold')
+    .focus()
+    .blur()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    sel.toJS()
+  )
+}

--- a/test/transforms/fixtures/on-selection/blur/marks/input.yaml
+++ b/test/transforms/fixtures/on-selection/blur/marks/input.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: one
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: two
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: three

--- a/test/transforms/fixtures/on-selection/focus/marks/index.js
+++ b/test/transforms/fixtures/on-selection/focus/marks/index.js
@@ -1,0 +1,26 @@
+
+import assert from 'assert'
+import { Mark } from '../../../../../..'
+
+export default function (state) {
+  const { startText, selection } = state
+  const sel = selection.merge({
+    isFocused: true,
+    marks: Mark.createSet([
+        Mark.create({
+            type: 'bold'
+        })
+    ])
+  })
+
+  const next = state
+    .transform()
+    .addMark('bold')
+    .focus()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    sel.toJS()
+  )
+}

--- a/test/transforms/fixtures/on-selection/focus/marks/input.yaml
+++ b/test/transforms/fixtures/on-selection/focus/marks/input.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: one
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: two
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: three


### PR DESCRIPTION
In our editor, we have buttons to toggle style, and to ensure that clicking on it does not remove focus, we `.focus()` after toggling marks. But the [current implementation](https://github.com/ianstormtaylor/slate/blob/master/src/transforms/operations.js#L374-L378) of the `setSelectionOperation` clear the marks on focus/blur. So our style buttons do not work on a collapsed selection.

I see two options:

1. Implement a different `focus` transform (or modify it) to not clear the marks.
2. Adapt the condition in `setSelectionOperation`

This PR opts for 2.
