### PR TITLE
Remove old `snapshot` parameter for Transform.apply

### DIFF
--- a/docs/reference/models/transform.md
+++ b/docs/reference/models/transform.md
@@ -89,7 +89,7 @@ Transform methods can either operate on the [`Document`](./document.md), the [`S
 
 Applies all of the current transform steps, returning the newly transformed [`State`](./state.md). An `options` object is optional, containing values of:
 
-- `snapshot: Boolean` — override the editor's built-in logic of whether to create a new snapshot in the history, that can be reverted to later.
+- `save: Boolean` — override the editor's built-in logic of whether to create a new snapshot in the history, that can be reverted to later.
 
 
 ## Current State Transforms

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -128,7 +128,7 @@ class Images extends React.Component {
         data: {}
       })
       .apply({
-        snapshot: false
+        save: false
       })
 
     this.onChange(normalized)

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -429,7 +429,7 @@ class State extends new Record(DEFAULTS) {
       rule.normalize(transform, document, value)
     }
 
-    return transform.apply({ snapshot: false })
+    return transform.apply({ save: false })
   }
 
   /**


### PR DESCRIPTION
I simply updated any reference to `snapshot` that I could find and replaced them with the new `save` parameter. The documentation still refers to the concept of snapshot though for clarity. Just the name of the parameter changed.

This also fixes a bug: that normalization was pushing a to the undo/redo history.

