### PR TITLE
fix #342, Uncaught Error: Invalid `key` argument when `removeNodeByKey`

### DIFF
--- a/src/models/state.js
+++ b/src/models/state.js
@@ -5,7 +5,7 @@ import Mark from './mark'
 import Selection from './selection'
 import Transform from './transform'
 import uid from '../utils/uid'
-import { Record, Set, Stack } from 'immutable'
+import { Record, Set, Stack, List } from 'immutable'
 
 /**
  * History.
@@ -361,9 +361,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get marks() {
-    if (this.selection.anchorKey || this.selection.focusKey) {
-      return this.selection.marks || this.document.getMarksAtRange(this.selection)
-    }
+    return this.selection.isUnset
+      ? new List()
+      : this.selection.marks || this.document.getMarksAtRange(this.selection)
   }
 
   /**
@@ -373,9 +373,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get blocks() {
-    if (this.selection.anchorKey || this.selection.focusKey) {
-      return this.document.getBlocksAtRange(this.selection)
-    }
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getBlocksAtRange(this.selection)
   }
 
   /**
@@ -385,9 +385,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get fragment() {
-    if (this.selection.anchorKey || this.selection.focusKey) {
-      return this.document.getFragmentAtRange(this.selection)
-    }
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getFragmentAtRange(this.selection)
   }
 
   /**
@@ -397,9 +397,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get inlines() {
-    if (this.selection.anchorKey || this.selection.focusKey) {
-      return this.document.getInlinesAtRange(this.selection)
-    }
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getInlinesAtRange(this.selection)
   }
 
   /**
@@ -409,9 +409,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get texts() {
-    if (this.selection.anchorKey || this.selection.focusKey) {
-      return this.document.getTextsAtRange(this.selection)
-    }
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getTextsAtRange(this.selection)
   }
 
   /**

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -361,7 +361,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get marks() {
-    return this.selection.marks || this.document.getMarksAtRange(this.selection)
+    if (this.selection.anchorKey || this.selection.focusKey) {
+      return this.selection.marks || this.document.getMarksAtRange(this.selection)
+    }
   }
 
   /**
@@ -371,7 +373,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get blocks() {
-    return this.document.getBlocksAtRange(this.selection)
+    if (this.selection.anchorKey || this.selection.focusKey) {
+      return this.document.getBlocksAtRange(this.selection)
+    }
   }
 
   /**
@@ -381,7 +385,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get fragment() {
-    return this.document.getFragmentAtRange(this.selection)
+    if (this.selection.anchorKey || this.selection.focusKey) {
+      return this.document.getFragmentAtRange(this.selection)
+    }
   }
 
   /**
@@ -391,7 +397,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get inlines() {
-    return this.document.getInlinesAtRange(this.selection)
+    if (this.selection.anchorKey || this.selection.focusKey) {
+      return this.document.getInlinesAtRange(this.selection)
+    }
   }
 
   /**
@@ -401,7 +409,9 @@ class State extends new Record(DEFAULTS) {
    */
 
   get texts() {
-    return this.document.getTextsAtRange(this.selection)
+    if (this.selection.anchorKey || this.selection.focusKey) {
+      return this.document.getTextsAtRange(this.selection)
+    }
   }
 
   /**

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -362,7 +362,7 @@ class State extends new Record(DEFAULTS) {
 
   get marks() {
     return this.selection.isUnset
-      ? new List()
+      ? new Set()
       : this.selection.marks || this.document.getMarksAtRange(this.selection)
   }
 
@@ -386,7 +386,7 @@ class State extends new Record(DEFAULTS) {
 
   get fragment() {
     return this.selection.isUnset
-      ? new List()
+      ? Document.create()
       : this.document.getFragmentAtRange(this.selection)
   }
 


### PR DESCRIPTION
I found out causing error 

```
Uncaught Error: Invalid `key` argument! It must be either a block, an inline, a text, or a string. You passed: "null".
```
which mentioned in issue #342 is that when the node is removed `this.selection.anchorKey` and `this.selection.focusKey` are both `null` and are asked to get `getDescendant(key)`!