### PR TITLE
Node shouldComponentUpdate use Immutable.is

### DIFF
--- a/src/components/node.js
+++ b/src/components/node.js
@@ -1,5 +1,6 @@
 
 import Base64 from '../serializers/base-64'
+import Immutable from 'immutable'
 import Debug from 'debug'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -97,7 +98,7 @@ class Node extends React.Component {
     }
 
     // If the node has changed, update.
-    if (props.node != this.props.node) {
+    if (!Immutable.is(props.node, this.props.node)) {
       return true
     }
 


### PR DESCRIPTION
This tiny PR fixes the false positives for `Node.shouldComponentUpdate` when the new `node` prop was a different object, but its value did not actually change.

Instead of a reference comparison `newNode != oldNode`, we use `Immutable.is` that is optimized to compare properties values if needed. It cannot be worst in term of performance. 

However it highlights the fact that we sometimes return new Immutable objects without actually changing their values. We have noticed it in the given situation: Put cursor in the middle of a paragraph of the Rich Text example, hit Return. Then, all blocks in the document are re-rendered, and fail the equality check because `node.nodes` is a different, cloned `Immutable.List`.
