### PR TITLE
Slow renderer causes double-click selection to break

### DIFF
--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -1,4 +1,3 @@
-
 import { Editor, Mark, Raw } from '../..'
 import Portal from 'react-portal'
 import React from 'react'
@@ -69,7 +68,7 @@ class HoveringMenu extends React.Component {
    */
 
   onChange = (state) => {
-    this.setState({ state })
+      this.setState({ state })
   }
 
   /**
@@ -163,6 +162,16 @@ class HoveringMenu extends React.Component {
    */
 
   renderEditor = () => {
+
+    // this is a fake-delay simulating a slow renderer
+    function sleep(milliSeconds){
+      var startTime = new Date().getTime(); // get the current time
+      while (new Date().getTime() < startTime + milliSeconds); // hog cpu
+    }
+
+    // 300ms is really high, but it makes the error easier to reproduce
+    sleep(300)
+
     return (
       <div className="editor">
         <Editor

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -557,8 +557,10 @@ class Content extends React.Component {
    */
 
   onSelect = (e) => {
+
     if (this.props.readOnly) return
-    if (this.tmp.isRendering) return
+    // if this is enabled, the selection will not work properly:
+    // if (this.tmp.isRendering) return
     if (this.tmp.isCopying) return
     if (this.tmp.isComposing) return
     if (isNonEditable(e)) return


### PR DESCRIPTION
At the moment, [onSelect](https://github.com/arekkas/slate/blob/e367326618ec62f64ee914e802f0fdf2a1d58886/src/components/content.js#L559-L566) is aborting if `this.tmp.isRendering` is true. This results in buggy behaviour if the rendering method is slow. For demonstration purposes, I created this PR. To get the buggy behaviour, uncomment [this line](https://github.com/arekkas/slate/blob/e367326618ec62f64ee914e802f0fdf2a1d58886/src/components/content.js#L563), re-build everything (libs and examples) and double-click on some word in the editing area.

Additionally, I created two screencasts which show the problem.

With `this.tmp.isRendering` check in `onSelect`:

![http://g.recordit.co/cg9kTxLzKk.gif](http://g.recordit.co/cg9kTxLzKk.gif)

Without `this.tmp.isRendering` check in `onSelect`:

![http://g.recordit.co/Uh2vtslbcl.gif](http://g.recordit.co/Uh2vtslbcl.gif)

I don't know what the reasoning behind this check was. If it is ok to remove it, I will clean up this PR and propose a fix.
