### PR TITLE
Fix #385: Re-render when selection state changed for a node

### DIFF
--- a/src/components/node.js
+++ b/src/components/node.js
@@ -125,8 +125,8 @@ class Node extends React.Component {
     // the node, to allow for intuitive selection-based rendering.
     if (
       this.props.node.kind != 'text' &&
-      this.props.state.isFocused &&
-      this.props.state.selection.hasEdgeIn(this.props.node)
+      props.state.isFocused != this.props.state.isFocused &&
+      this.props.state.selection.hasEdgeIn(props.node) != props.state.selection.hasEdgeIn(props.node)
     ) {
       return true
     }

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -125,8 +125,10 @@ class Node extends React.Component {
     // the node, to allow for intuitive selection-based rendering.
     if (
       this.props.node.kind != 'text' &&
-      props.state.isFocused != this.props.state.isFocused &&
-      this.props.state.selection.hasEdgeIn(props.node) != props.state.selection.hasEdgeIn(props.node)
+      (
+          props.state.isFocused != this.props.state.isFocused ||
+          this.props.state.selection.hasEdgeIn(this.props.node) != props.state.selection.hasEdgeIn(props.node)
+      )
     ) {
       return true
     }


### PR DESCRIPTION
This PR fixes #385, basically it extends the condition in the `shouldComponentUpdate` of `Node` to re-render when selection has changed for an `inline` or `block` node:

- selection is in the node != selection was in the node
- was focused != is focused

We'd be great to have unit tests for this, but I'm not sure how to write unit tests for `shouldComponentUpdate`.
