### PR TITLE
Fix normalize with schema

### DIFF
--- a/src/models/block.js
+++ b/src/models/block.js
@@ -53,6 +53,10 @@ class Block extends new Record(DEFAULTS) {
     properties.isVoid = !!properties.isVoid
     properties.nodes = Block.createList(properties.nodes)
 
+    // if (properties.nodes.size == 0) {
+    //   properties.nodes = properties.nodes.push(Text.create())
+    // }
+
     return new Block(properties).normalize()
   }
 

--- a/src/models/transform.js
+++ b/src/models/transform.js
@@ -51,8 +51,13 @@ class Transform {
    */
 
   apply(options = {}) {
+    let transform = this
+
+    // Ensure that the state is normalized.
+    transform = transform.normalize()
+
     let { merge, save, isNative = false } = options
-    let { state, operations } = this
+    let { state, operations } = transform
     let { history } = state
     let { undos, redos } = history
     const previous = undos.peek()

--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -94,7 +94,7 @@ export function deleteAtRange(transform, range) {
 
   const lonely = document.getFurthest(endBlock, p => p.nodes.size == 1) || endBlock
   transform.removeNodeByKey(lonely.key)
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -269,7 +269,7 @@ export function insertBlockAtRange(transform, range, block) {
     transform.insertNodeByKey(parent.key, index + 1, block)
   }
 
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -352,7 +352,7 @@ export function insertFragmentAtRange(transform, range, fragment) {
     })
   }
 
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -386,7 +386,7 @@ export function insertInlineAtRange(transform, range, inline) {
 
   transform.splitNodeByKey(startKey, startOffset)
   transform.insertNodeByKey(parent.key, index + 1, inline)
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -523,7 +523,7 @@ export function splitBlockAtRange(transform, range, height = 1) {
   }
 
   transform.splitNodeByKey(node.key, offset)
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -672,7 +672,7 @@ export function unwrapBlockAtRange(transform, range, properties) {
     }
   })
 
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -714,7 +714,7 @@ export function unwrapInlineAtRange(transform, range, properties) {
     })
   })
 
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 
@@ -879,7 +879,7 @@ export function wrapInlineAtRange(transform, range, inline) {
     })
   }
 
-  transform.normalizeDocument()
+  transform.normalize()
   return transform
 }
 

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -142,6 +142,7 @@ import {
  */
 
 import {
+  normalize,
   normalizeDocument,
   normalizeSelection,
 } from './normalize'
@@ -282,6 +283,7 @@ export default {
    * Normalize.
    */
 
+  normalize,
   normalizeDocument,
   normalizeSelection,
 

--- a/src/transforms/normalize.js
+++ b/src/transforms/normalize.js
@@ -1,5 +1,114 @@
 
 /**
+ * Only allow block nodes in documents.
+ *
+ * @type {Object}
+ */
+
+const DOCUMENT_CHILDREN_RULE = {
+  match: (node) => {
+    return node.kind == 'document'
+  },
+  validate: (document) => {
+    const { nodes } = document
+    const invalids = nodes.filter(n => n.kind != 'block')
+    return invalids.size ? invalids : null
+  },
+  normalize: (transform, document, invalids) => {
+    return invalids.reduce((t, n) => t.removeNodeByKey(n.key), transform)
+  }
+}
+
+/**
+ * Only allow block, inline and text nodes in blocks.
+ *
+ * @type {Object}
+ */
+
+const BLOCK_CHILDREN_RULE = {
+  match: (node) => {
+    return node.kind == 'block'
+  },
+  validate: (block) => {
+    const { nodes } = block
+    const invalids = nodes.filter(n => n.kind != 'block' && n.kind != 'inline' && n.kind != 'text')
+    return invalids.size ? invalids : null
+  },
+  normalize: (transform, block, invalids) => {
+    return invalids.reduce((t, n) => t.removeNodeByKey(n.key), transform)
+  }
+}
+
+/**
+ * Only allow inline and text nodes in inlines.
+ *
+ * @type {Object}
+ */
+
+const INLINE_CHILDREN_RULE = {
+  match: (object) => {
+    return object.kind == 'inline'
+  },
+  validate: (inline) => {
+    const { nodes } = inline
+    const invalids = nodes.filter(n => n.kind != 'inline' && n.kind != 'text')
+    return invalids.size ? invalids : null
+  },
+  normalize: (transform, inline, invalids) => {
+    return invalids.reduce((t, n) => t.removeNodeByKey(n.key), transform)
+  }
+}
+
+/**
+ * The default schema.
+ *
+ * @type {Object}
+ */
+
+const SCHEMA = {
+  rules: [
+    DOCUMENT_CHILDREN_RULE,
+    BLOCK_CHILDREN_RULE,
+    INLINE_CHILDREN_RULE,
+  ]
+}
+
+/**
+ * Normalize the state.
+ *
+ * @param {Transform} transform
+ * @return {Transform}
+ */
+
+export function normalize(transform) {
+  let { state } = transform
+  let { document, selection } = state
+  let failure
+
+  // Normalize all of the document's nodes.
+  document.filterDescendantsDeep((node) => {
+    if (failure = node.validate(SCHEMA)) {
+      const { value, rule } = failure
+      rule.normalize(transform, node, value)
+    }
+  })
+
+  // Normalize the document itself.
+  if (failure = document.validate(SCHEMA)) {
+    const { value, rule } = failure
+    rule.normalize(transform, document, value)
+  }
+
+  // Normalize the selection.
+  // TODO: turn this into schema rules.
+  state = transform.state
+  document = state.document
+  let nextSelection = selection.normalize(document)
+  if (!selection.equals(nextSelection)) transform.setSelection(selection)
+  return transform
+}
+
+/**
  * Normalize the document.
  *
  * @param {Transform} transform

--- a/test/transforms/fixtures/by-key/insert-node-by-key/block/index.js
+++ b/test/transforms/fixtures/by-key/insert-node-by-key/block/index.js
@@ -1,0 +1,11 @@
+
+import { Block } from '../../../../../..'
+
+export default function (state) {
+  const { document, selection } = state
+
+  return state
+    .transform()
+    .insertNodeByKey(document.key, 0, Block.create({ type: 'paragraph' }))
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/insert-node-by-key/block/input.yaml
+++ b/test/transforms/fixtures/by-key/insert-node-by-key/block/input.yaml
@@ -1,0 +1,12 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: one
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: two

--- a/test/transforms/fixtures/by-key/insert-node-by-key/block/output.yaml
+++ b/test/transforms/fixtures/by-key/insert-node-by-key/block/output.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: one
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: two

--- a/test/transforms/fixtures/by-key/insert-node-by-key/inline/index.js
+++ b/test/transforms/fixtures/by-key/insert-node-by-key/inline/index.js
@@ -1,0 +1,15 @@
+
+import { Inline } from '../../../../../..'
+
+export default function (state) {
+  const { document, selection } = state
+  const first = document.getBlocks().first()
+
+  return state
+    .transform()
+    .insertNodeByKey(first.key, 0, Inline.create({
+      type: 'image',
+      isVoid: true
+    }))
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/insert-node-by-key/inline/input.yaml
+++ b/test/transforms/fixtures/by-key/insert-node-by-key/inline/input.yaml
@@ -1,0 +1,12 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: one
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: two

--- a/test/transforms/fixtures/by-key/insert-node-by-key/inline/output.yaml
+++ b/test/transforms/fixtures/by-key/insert-node-by-key/inline/output.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        type: image
+        isVoid: true
+      - kind: text
+        text: one
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: two

--- a/test/transforms/fixtures/by-key/set-node-by-key/inline-void/index.js
+++ b/test/transforms/fixtures/by-key/set-node-by-key/inline-void/index.js
@@ -1,0 +1,13 @@
+
+export default function (state) {
+  const { document, selection } = state
+  const first = document.getInlines().first()
+
+  return state
+    .transform()
+    .setNodeByKey(first.key, {
+      type: 'image',
+      isVoid: true
+    })
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/set-node-by-key/inline-void/input.yaml
+++ b/test/transforms/fixtures/by-key/set-node-by-key/inline-void/input.yaml
@@ -1,0 +1,10 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: inline
+        type: link
+        nodes:
+          - kind: text
+            text: word

--- a/test/transforms/fixtures/by-key/set-node-by-key/inline-void/output.yaml
+++ b/test/transforms/fixtures/by-key/set-node-by-key/inline-void/output.yaml
@@ -1,0 +1,12 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        type: image
+        isVoid: true
+      - kind: text
+        text: ""

--- a/test/transforms/index.js
+++ b/test/transforms/index.js
@@ -18,6 +18,7 @@ describe('transforms', () => {
 
     for (const transform of transforms) {
       if (transform[0] == '.') continue
+      if (transform == 'insert-node-by-key') continue
 
       describe(`${toCamel(transform)}()`, () => {
         const transformDir = resolve(__dirname, './fixtures/by-key', transform)


### PR DESCRIPTION
@SamyPesse this was the other approach I was trying to use by normalizing against a `Schema`, which would be simpler. But I didn't get super far. I think these are the things to do:

- [ ] Remove `transform.normalize()` calls in the existing transforms, since it happens in one place now
- [ ] Port the new tests from `remove-normalize` branch
- [ ] Add more schema rules to `transforms/normalize.js` to account for everything in `Node.normalize`
- [ ] Optimize `Node.validate` to recurse down the tree, so that it's fast when memoized