### PR TITLE
Editor: track latest state from props.

### DIFF
--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -122,9 +122,11 @@ class Editor extends React.Component {
       this.setState({ schema })
     }
 
-    this.setState({
-      state: this.onBeforeChange(props.state)
-    })
+    const state = this.onBeforeChange(props.state)
+    this.tmp.selection = state.selection
+    this.tmp.document = state.document
+
+    this.setState({ state })
   }
 
   /**


### PR DESCRIPTION
I was getting unexpected calls to `onDocumentChange` after passing in a
new state and then changing the /selection/ only. Since the new document
had not been set in `componentWillReceiveProps`, the selection change
triggered `onChange`, which found `state.document != this.tmp.document`,
which then triggered the spurious `onDocumentChange`.

After this change the same selection change does not trigger
`onDocumentChange`.
