### PR TITLE
Fix inserting fragment at the end of current text node

### DIFF
--- a/src/transforms/at-current-range.js
+++ b/src/transforms/at-current-range.js
@@ -262,6 +262,7 @@ export function insertFragment(transform, fragment) {
   const lastText = fragment.getTexts().last()
   const lastInline = fragment.getClosestInline(lastText)
   const beforeTexts = document.getTexts()
+  const appending = selection.hasEdgeAtEndOf(document.getDescendant(selection.endKey))
 
   transform.unsetSelection()
   transform.insertFragmentAtRange(selection, fragment)
@@ -270,15 +271,11 @@ export function insertFragment(transform, fragment) {
 
   const keys = beforeTexts.map(text => text.key)
   const news = document.getTexts().filter(n => !keys.includes(n.key))
-  const text = news.size ? news.takeLast(2).first() : null
+  const text = appending ? news.last() : news.takeLast(2).first()
   let after
 
   if (text && lastInline) {
     after = selection.collapseToEndOf(text)
-  }
-
-  else if (text && lastInline) {
-    after = selection.collapseToStart()
   }
 
   else if (text) {

--- a/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/fragment.yaml
+++ b/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/fragment.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: list-item
+    nodes:
+      - kind: text
+        text: fragment
+  - kind: block
+    type: list-item
+    nodes:
+      - kind: text
+        text: second fragment
+  - kind: block
+    type: list-item
+    nodes:
+      - kind: text
+        text: third fragment

--- a/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/index.js
+++ b/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/index.js
@@ -1,0 +1,41 @@
+
+import assert from 'assert'
+import path from 'path'
+import readMetadata from 'read-metadata'
+import { Raw } from '../../../../../..'
+
+export default function (state) {
+  const file = path.resolve(__dirname, 'fragment.yaml')
+  const raw = readMetadata.sync(file)
+  const fragment = Raw.deserialize(raw, { terse: true }).document
+
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: first.length,
+    focusKey: first.key,
+    focusOffset: first.length
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .insertFragment(fragment)
+    .apply()
+
+  const last = next.document.getTexts().last()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.merge({
+      anchorKey: last.key,
+      anchorOffset: last.length,
+      focusKey: last.key,
+      focusOffset: last.length
+    }).toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/input.yaml
+++ b/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/input.yaml
@@ -1,0 +1,7 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: word

--- a/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/output.yaml
+++ b/test/transforms/fixtures/at-current-range/insert-fragment/end-block-multiple-blocks/output.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: wordfragment
+  - kind: block
+    type: list-item
+    nodes:
+      - kind: text
+        text: second fragment
+  - kind: block
+    type: list-item
+    nodes:
+      - kind: text
+        text: third fragment


### PR DESCRIPTION
Previously inserting fragment at the end of current text node may lead to inconsistent selection, where offset was greater than text length.