### PR TITLE
Break after applying first matching rule in HTML Serializer

### DIFF
--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -183,6 +183,7 @@ class Html {
       node = ret.kind == 'mark'
         ? this.deserializeMark(ret)
         : ret
+      break
     }
 
     return node || next(element.children)


### PR DESCRIPTION
Fixes #404
