### PR TITLE
Use `isContentEditable` HTML element property to check if an element is editable

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -710,10 +710,8 @@ class Content extends React.Component {
  */
 
 function isNonEditable(event) {
-  const { target, currentTarget } = event
-  const nonEditable = target.closest('[contenteditable="false"]')
-  const isContained = currentTarget.contains(nonEditable)
-  return isContained
+  const { target } = event
+  return !target.isContentEditable
 }
 
 /**


### PR DESCRIPTION
Use `isContentEditable` HTML element property to check if an element is editable.
This does not change how Slate handles its content except for `contenteditable="true"` elements nested inside `contenteditable="false"`. Those elements, noneditable by Slate before, now are editable.
At the moment, as far as I could see, there should be no components with such a structure, so this PR shouldn't in fact alter Slate behavior.
Anyway, I manually tested few `isVoid: true` components: images, embeds and emojis, and they still work.

This PR fixes issue #410.