### PR TITLE
Resolve focus issue with firefox

### DIFF
--- a/src/components/leaf.js
+++ b/src/components/leaf.js
@@ -133,6 +133,7 @@ class Leaf extends React.Component {
    */
 
   updateSelection() {
+
     const { state, ranges, isVoid } = this.props
     const { selection } = state
 
@@ -156,7 +157,8 @@ class Leaf extends React.Component {
     }
 
     // We have a selection to render, so prepare a few things...
-    const el = findDeepestNode(ReactDOM.findDOMNode(this))
+    const ref = ReactDOM.findDOMNode(this)
+    const el = findDeepestNode(ref)
     const window = getWindow(el)
     const native = window.getSelection()
 
@@ -164,6 +166,8 @@ class Leaf extends React.Component {
     if (hasAnchor && hasFocus) {
       native.removeAllRanges()
       const range = window.document.createRange()
+      // Workaround for firefox focus issue
+      setTimeout(() => ref.focus(ref.closest('[contenteditable]').focus()), 0)
       range.setStart(el, anchorOffset - start)
       native.addRange(range)
       native.extend(el, focusOffset - start)


### PR DESCRIPTION
This PR resolves issues with the focus transform in firefox. A similar solution was suggested on [stackoverflow](http://stackoverflow.com/questions/2388164/set-focus-on-div-contenteditable-element).

I don't know how to write a test for this.