### PR TITLE
Do not process onInput events when selection is lost

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -418,6 +418,7 @@ class Content extends React.Component {
   onInput = (e) => {
     if (this.tmp.isRendering) return
     if (this.tmp.isComposing) return
+    if (this.props.state.isBlurred) return
     if (isNonEditable(e)) return
     debug('onInput')
 


### PR DESCRIPTION
Resolves an issue where `this.getPoint(anchorNode, anchorOffset)` throws an error if a key event is triggered although not in focus.