### PR TITLE
Upgrade debug package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "cheerio": "^0.22.0",
-    "debug": "^2.2.0",
+    "debug": "^2.3.2",
     "detect-browser": "^1.3.3",
     "direction": "^0.1.5",
     "esrever": "^0.2.0",


### PR DESCRIPTION
Fixes an issue where debug may clear localStorage.debug on start, making it impossible to use. See https://github.com/visionmedia/debug/issues/330