### PR TITLE
resolve issue with line breaks before anchor nodes - closes #430

### DIFF
--- a/src/components/leaf.js
+++ b/src/components/leaf.js
@@ -267,12 +267,6 @@ class Leaf extends React.Component {
     // selection can be inserted next to it still.
     if (text == '') return <span className="slate-zero-width-space">{'\u200B'}</span>
 
-    // COMPAT: Browsers will collapse trailing new lines at the end of blocks,
-    // so we need to add an extra trailing new lines to prevent that.
-    const lastChar = text.charAt(text.length - 1)
-    const isLast = index == ranges.size - 1
-    if (isLast && lastChar == '\n') return `${text}\n`
-
     // Otherwise, just return the text.
     return text
   }


### PR DESCRIPTION
Because white-space: pre-wrap is set on the contenteditable root, the newline check is not needed any more.