### PR TITLE
remove Immutable.is check in node shouldComponentUpdate

### DIFF
--- a/src/components/node.js
+++ b/src/components/node.js
@@ -102,8 +102,9 @@ class Node extends React.Component {
     // If the node has changed, update. PERF: There are certain cases where the
     // node instance will have changed, but it's properties will be exactly the
     // same (copy-paste, delete backwards, etc.) in which case this will not
-    // catch a potentially avoidable re-render. But those cases should be much
-    // rarer than trying to deeply evaluate any changes in all nodes.
+    // catch a potentially avoidable re-render. But those cases are rare enough
+    // that they aren't really a drag on performance, so for simplicity we just
+    // let them through.
     if (nextProps.node != this.props.node) {
       return true
     }

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -99,13 +99,13 @@ class Node extends React.Component {
       return true
     }
 
-    // If the node has changed, update.
+    // If the node has changed, update. PERF: There are certain cases where the
+    // node instance will have changed, but it's properties will be exactly the
+    // same (copy-paste, delete backwards, etc.) in which case this will not
+    // catch a potentially avoidable re-render. But those cases should be much
+    // rarer than trying to deeply evaluate any changes in all nodes.
     if (nextProps.node != this.props.node) {
-      if (!IS_DEV || !Immutable.is(nextProps.node, this.props.node)) {
-        return true
-      } else {
-        warn('A new immutable Node instance was encountered with an identical structure to the previous instance. This is usually a mistake and can impact performance. Make sure to preserve immutable references when nothing has changed. The node in question was:', nextProps.node)
-      }
+      return true
     }
 
     const nextHasEdgeIn = nextProps.state.selection.hasEdgeIn(nextProps.node)


### PR DESCRIPTION
cc @SamyPesse @Soreine 

Wanted to run this by you two, just so you're aware of my thinking. In testing out `0.15` with this new warning added, I've realized that there are a few valid cases where a node will be exactly the same structure, but a different instance, when certain transforms happen to happen:

1. Select a range, copy, and paste it immediately without changing the selection. This will essentially cause nothing to happen, but it will have actually applied the paste transform. 

2. With the cursor in an empty paragraph, and a paragraph with text above it, delete backwards. This will essentially also cause nothing to happen, but it will have actually joined the empty text onto the previous paragraph's text.

3. There are probably other cases...

Now, those cases could have special-case code written to optimize for them, such that no transforms even occur. But I'm not sure it's worth it to get more complex (since I don't even know what all of the cases are), when we could instead not do it and use the regular logic, since they aren't common enough to actually degrade performance.

So basically…

- With this new realization that we're warning on valid cases…
- …and that in production we're already ignoring this…
- …and that we solved the bad case in `Node.normalize` that was causing this to actually crop up often and be a real performance issue…

…I think we should just eliminate this for simplicity for now. I think future performance issues will be found via other means, and it doesn't get us much, but it does throw unnecessary warnings.

I'm going to merge, but feel free to add thoughts and we can discuss!