### PR TITLE
added breaking tests for inline elements with leading/trailing newline

### DIFF
--- a/test/transforms/fixtures/at-current-range/delete-backward/before-inline-with-trailing-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-backward/before-inline-with-trailing-newline/index.js
@@ -1,0 +1,27 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 4,
+    focusKey: first.key,
+    focusOffset: 4
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteBackward()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.moveBackward().toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-backward/before-inline-with-trailing-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/before-inline-with-trailing-newline/input.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc
+
+'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-backward/before-inline-with-trailing-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/before-inline-with-trailing-newline/output.yaml
@@ -1,0 +1,14 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-leading-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-leading-newline/index.js
@@ -1,0 +1,27 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const second = texts.get(1)
+  const range = selection.merge({
+    anchorKey: second.key,
+    anchorOffset: 1,
+    focusKey: second.key,
+    focusOffset: 1
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteBackward()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.moveBackward().toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-leading-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-leading-newline/input.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: '
+
+def'

--- a/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-leading-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-leading-newline/output.yaml
@@ -1,0 +1,14 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-trailing-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-trailing-newline/index.js
@@ -1,0 +1,28 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.get(1)
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 0,
+    focusKey: first.key,
+    focusOffset: 0
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteBackward()
+    .apply()
+
+  // Not sure what this should look like
+  // assert.deepEqual(
+  //   next.selection.toJS(),
+  //   range.toJS()
+  // )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-trailing-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-trailing-newline/input.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc
+
+'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-trailing-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/inside-inline-with-trailing-newline/output.yaml
@@ -1,0 +1,14 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-leading-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-leading-newline/index.js
@@ -1,0 +1,28 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  console.log(first)
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 3,
+    focusKey: first.key,
+    focusOffset: 3
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteForward()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.collapseToStart().toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-leading-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-leading-newline/input.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: '
+
+def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-leading-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-leading-newline/output.yaml
@@ -1,0 +1,14 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-trailing-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-trailing-newline/index.js
@@ -1,0 +1,28 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  console.log(first)
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 3,
+    focusKey: first.key,
+    focusOffset: 3
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteForward()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.collapseToStart().toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-trailing-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-trailing-newline/input.yaml
@@ -1,0 +1,15 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc
+'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-trailing-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/before-inline-with-trailing-newline/output.yaml
@@ -1,0 +1,14 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-leading-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-leading-newline/index.js
@@ -1,0 +1,28 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  console.log(first)
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 3,
+    focusKey: first.key,
+    focusOffset: 3
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteForward()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.collapseToStart().toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-leading-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-leading-newline/input.yaml
@@ -1,0 +1,21 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: '
+
+def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-leading-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-leading-newline/output.yaml
@@ -1,0 +1,19 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-trailing-newline/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-trailing-newline/index.js
@@ -1,0 +1,28 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  console.log(first)
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 3,
+    focusKey: first.key,
+    focusOffset: 3
+  })
+
+  const next = state
+    .transform()
+    .moveTo(range)
+    .deleteForward()
+    .apply()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.collapseToStart().toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-trailing-newline/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-trailing-newline/input.yaml
@@ -1,0 +1,21 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'abc
+
+'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'

--- a/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-trailing-newline/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/between-inlines-with-trailing-newline/output.yaml
@@ -1,0 +1,19 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'abc'
+      - kind: inline
+        type: link
+        data:
+          href: url
+        nodes:
+          - kind: text
+            text: 'def'


### PR DESCRIPTION
I observed some issues with newlines and inline nodes, so I wrote tests for it. Some of them are failing, and they reflect what I see in my editor.