### PR TITLE
add support for nested content-editables

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -149,19 +149,22 @@ class Content extends React.Component {
    * @param {Element} n
    */
 
-  ref = (n) => this.element = n
+  ref = (element) => {
+    this.element = element
+  }
 
   /**
-   * Check if an `event` is being fired from inside a non-contentediable child
-   * element, in which case we'll want to ignore it.
+   * Check if an `event` is being fired from within the contenteditable element.
+   * This will return false for edits happening in non-contenteditable children,
+   * such as void nodes and other nested Slate editors.
    *
    * @param {Event} event
    * @return {Boolean}
    */
 
-  isNonEditable = (event) => {
+  isInContentEditable = (event) => {
     const { target } = event
-    return !target.isContentEditable || target !== this.element
+    return target.isContentEditable && target === this.element
   }
 
   /**
@@ -172,7 +175,7 @@ class Content extends React.Component {
 
   onBeforeInput = (e) => {
     if (this.props.readOnly) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     const data = {}
 
@@ -189,7 +192,7 @@ class Content extends React.Component {
   onBlur = (e) => {
     if (this.props.readOnly) return
     if (this.tmp.isCopying) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     const data = {}
 
@@ -215,7 +218,7 @@ class Content extends React.Component {
    */
 
   onCompositionStart = (e) => {
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     this.tmp.isComposing = true
     this.tmp.compositions++
@@ -232,7 +235,7 @@ class Content extends React.Component {
    */
 
   onCompositionEnd = (e) => {
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     this.forces++
     const count = this.tmp.compositions
@@ -255,7 +258,7 @@ class Content extends React.Component {
    */
 
   onCopy = (e) => {
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
     const window = getWindow(e.target)
 
     this.tmp.isCopying = true
@@ -280,7 +283,7 @@ class Content extends React.Component {
 
   onCut = (e) => {
     if (this.props.readOnly) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
     const window = getWindow(e.target)
 
     this.tmp.isCopying = true
@@ -304,7 +307,7 @@ class Content extends React.Component {
    */
 
   onDragEnd = (e) => {
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     this.tmp.isDragging = false
     this.tmp.isInternalDrag = null
@@ -319,7 +322,7 @@ class Content extends React.Component {
    */
 
   onDragOver = (e) => {
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     const { dataTransfer } = e.nativeEvent
     const transfer = new Transfer(dataTransfer)
@@ -343,7 +346,7 @@ class Content extends React.Component {
    */
 
   onDragStart = (e) => {
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     this.tmp.isDragging = true
     this.tmp.isInternalDrag = true
@@ -369,7 +372,7 @@ class Content extends React.Component {
 
   onDrop = (e) => {
     if (this.props.readOnly) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     e.preventDefault()
 
@@ -426,7 +429,7 @@ class Content extends React.Component {
   onInput = (e) => {
     if (this.tmp.isComposing) return
     if (this.props.state.isBlurred) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
     debug('onInput')
 
     const window = getWindow(e.target)
@@ -496,7 +499,7 @@ class Content extends React.Component {
 
   onKeyDown = (e) => {
     if (this.props.readOnly) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     const key = keycode(e.which)
     const data = {}
@@ -551,7 +554,7 @@ class Content extends React.Component {
 
   onPaste = (e) => {
     if (this.props.readOnly) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     e.preventDefault()
     const transfer = new Transfer(e.clipboardData)
@@ -571,7 +574,7 @@ class Content extends React.Component {
     if (this.props.readOnly) return
     if (this.tmp.isCopying) return
     if (this.tmp.isComposing) return
-    if (this.isNonEditable(e)) return
+    if (!this.isInContentEditable(e)) return
 
     const window = getWindow(e.target)
     const { state } = this.props

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -144,6 +144,27 @@ class Content extends React.Component {
   }
 
   /**
+   * The React ref method to set the root content element locally.
+   *
+   * @param {Element} n
+   */
+
+  ref = (n) => this.element = n
+
+  /**
+   * Check if an `event` is being fired from inside a non-contentediable child
+   * element, in which case we'll want to ignore it.
+   *
+   * @param {Event} event
+   * @return {Boolean}
+   */
+
+  isNonEditable = (event) => {
+    const { target } = event
+    return !target.isContentEditable || target !== this.element
+  }
+
+  /**
    * On before input, bubble up.
    *
    * @param {Event} e
@@ -151,7 +172,7 @@ class Content extends React.Component {
 
   onBeforeInput = (e) => {
     if (this.props.readOnly) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     const data = {}
 
@@ -168,7 +189,7 @@ class Content extends React.Component {
   onBlur = (e) => {
     if (this.props.readOnly) return
     if (this.tmp.isCopying) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     const data = {}
 
@@ -194,7 +215,7 @@ class Content extends React.Component {
    */
 
   onCompositionStart = (e) => {
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     this.tmp.isComposing = true
     this.tmp.compositions++
@@ -211,7 +232,7 @@ class Content extends React.Component {
    */
 
   onCompositionEnd = (e) => {
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     this.forces++
     const count = this.tmp.compositions
@@ -234,7 +255,7 @@ class Content extends React.Component {
    */
 
   onCopy = (e) => {
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
     const window = getWindow(e.target)
 
     this.tmp.isCopying = true
@@ -259,7 +280,7 @@ class Content extends React.Component {
 
   onCut = (e) => {
     if (this.props.readOnly) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
     const window = getWindow(e.target)
 
     this.tmp.isCopying = true
@@ -283,7 +304,7 @@ class Content extends React.Component {
    */
 
   onDragEnd = (e) => {
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     this.tmp.isDragging = false
     this.tmp.isInternalDrag = null
@@ -298,7 +319,7 @@ class Content extends React.Component {
    */
 
   onDragOver = (e) => {
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     const { dataTransfer } = e.nativeEvent
     const transfer = new Transfer(dataTransfer)
@@ -322,7 +343,7 @@ class Content extends React.Component {
    */
 
   onDragStart = (e) => {
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     this.tmp.isDragging = true
     this.tmp.isInternalDrag = true
@@ -348,7 +369,7 @@ class Content extends React.Component {
 
   onDrop = (e) => {
     if (this.props.readOnly) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     e.preventDefault()
 
@@ -405,7 +426,7 @@ class Content extends React.Component {
   onInput = (e) => {
     if (this.tmp.isComposing) return
     if (this.props.state.isBlurred) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
     debug('onInput')
 
     const window = getWindow(e.target)
@@ -475,7 +496,7 @@ class Content extends React.Component {
 
   onKeyDown = (e) => {
     if (this.props.readOnly) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     const key = keycode(e.which)
     const data = {}
@@ -530,7 +551,7 @@ class Content extends React.Component {
 
   onPaste = (e) => {
     if (this.props.readOnly) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     e.preventDefault()
     const transfer = new Transfer(e.clipboardData)
@@ -550,7 +571,7 @@ class Content extends React.Component {
     if (this.props.readOnly) return
     if (this.tmp.isCopying) return
     if (this.tmp.isComposing) return
-    if (isNonEditable(e)) return
+    if (this.isNonEditable(e)) return
 
     const window = getWindow(e.target)
     const { state } = this.props
@@ -640,6 +661,7 @@ class Content extends React.Component {
     return (
       <div
         key={this.forces}
+        ref={this.ref}
         contentEditable={!readOnly}
         suppressContentEditableWarning
         className={className}
@@ -688,19 +710,6 @@ class Content extends React.Component {
     )
   }
 
-}
-
-/**
- * Check if an `event` is being fired from inside a non-contentediable child
- * element, in which case we'll want to ignore it.
- *
- * @param {Event} event
- * @return {Boolean}
- */
-
-function isNonEditable(event) {
-  const { target } = event
-  return !target.isContentEditable
 }
 
 /**


### PR DESCRIPTION
I am attempting to embed a Slate editor inside a void node inside another Slate editor. In v0.14 this actually worked alright, but in v0.15 the events started bubbling up improperly. This is probably a more extreme use case for Slate, however adding support was very straight forward and on the surface this appears to work consistently.

The original code was just checking that bubbled events happen inside of a content-editable node, not specifically the one created by the content node. My changes add a React ref for the root content-editable and then all events make sure the event bubbled from the correct element.

I wanted to add tests for this, however Slate appears to be missing integration tests currently. I am happy to add tests for this if/when those are in place.