### PR TITLE
fix onDrop

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -163,8 +163,17 @@ class Content extends React.Component {
    */
 
   isInContentEditable = (event) => {
-    const { target } = event
-    return target.isContentEditable && target === this.element
+    let { target } = event
+
+    while (target) {
+      if (target.hasAttribute("contenteditable")) {
+        return target.isContentEditable && target === this.element
+      }
+
+      target = target.parentNode
+    }
+
+    return false
   }
 
   /**


### PR DESCRIPTION
So my changes broke the onDrop event (woops!) which was actually predictable given how event bubbling works. Surprising that it was not caught earlier though, seeing as the previous `isNonEditable()` should have been susceptible as well.

Anyways, my fix is to traverse up the target's parents for elements with the `contenteditable` attribute. This feels a little dirty, but I must check for the existence of the attribute and can't just use `isContentEditable` so that void nodes are also caught. Let me know what you think. 