### PR TITLE
Fix for OPTION-SHIFT-UP and OPTION-SHIFT-DOWN

### DIFF
--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -530,17 +530,17 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownUp(e, data, state) {
-    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return;
-    e.preventDefault();
+    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return
+    e.preventDefault()
     const {selection, document, focusBlock} = state
     const isStart = selection.hasFocusAtStartOf(focusBlock)
-    const selectBlock = isStart ? document.getPreviousBlock(focusBlock.get('key')) : focusBlock;
-    if (!selectBlock) return;
-    var selectText = selectBlock.getTextAtOffset(0);
+    const selectBlock = isStart ? document.getPreviousBlock(focusBlock.get('key')) : focusBlock
+    if (!selectBlock) return
+    const selectText = selectBlock.getTextAtOffset(0)
     return state
       .transform()
       .extendToStartOf(selectText)
-      .apply();
+      .apply()
   }
 
   /**
@@ -561,17 +561,17 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownDown(e, data, state) {
-    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return;
-    e.preventDefault();
+    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return
+    e.preventDefault()
     const {selection, document, focusBlock} = state
     const isEnd = selection.hasFocusAtEndOf(focusBlock)
-    const selectBlock = isEnd ? document.getNextBlock(focusBlock.get('key')) : focusBlock;
-    if (!selectBlock) return;
-    var selectText = selectBlock.getTextAtOffset(selectBlock.length);
+    const selectBlock = isEnd ? document.getNextBlock(focusBlock.get('key')) : focusBlock
+    if (!selectBlock) return
+    const selectText = selectBlock.getTextAtOffset(selectBlock.length)
     return state
       .transform()
       .extendToEndOf(selectText)
-      .apply();
+      .apply()
   }
 
   /**

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -353,6 +353,8 @@ function Plugin(options = {}) {
       case 'delete': return onKeyDownDelete(e, data, state)
       case 'left': return onKeyDownLeft(e, data, state)
       case 'right': return onKeyDownRight(e, data, state)
+      case 'up': return onKeyDownUp(e, data, state)
+      case 'down': return onKeyDownDown(e, data, state)
       case 'd': return onKeyDownD(e, data, state)
       case 'h': return onKeyDownH(e, data, state)
       case 'k': return onKeyDownK(e, data, state)
@@ -508,6 +510,68 @@ function Plugin(options = {}) {
         [method](nextText)
         .apply()
     }
+  }
+
+  /**
+   * On `up` key down, for Macs, fix select to start of block.
+   *
+   * OPTION-SHIFT-UP is supposed to expand to the start of the current block
+   * then the start of the previous block and so on.
+   *
+   * On Chrome and possibly other browsers, OPTION-SHIFT-UP expands the
+   * selection to the start of the current block then extends the selection to
+   * somewhere in the previous block but not to the start of the next
+   * block. This problem does not appear for OPTION-UP.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownUp(e, data, state) {
+    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return;
+    e.preventDefault();
+    const {selection, document, focusBlock} = state
+    const isStart = selection.hasFocusAtStartOf(focusBlock)
+    const selectBlock = isStart ? document.getPreviousBlock(focusBlock.get('key')) : focusBlock;
+    if (!selectBlock) return;
+    var selectText = selectBlock.getTextAtOffset(0);
+    return state
+      .transform()
+      .extendToStartOf(selectText)
+      .apply();
+  }
+
+  /**
+   * On `down` key down, for Macs, fix select to end of block.
+   *
+   * OPTION-SHIFT-DOWN is supposed to expand to the end of the current block
+   * then the end of the next block and so on.
+   *
+   * On Chrome and possibly other browsers, OPTION-SHIFT-DOWN expands the
+   * selection to the end of the current block then extends the selection to
+   * somewhere in the next block but not to the end of the next
+   * block. This problem does not appear for OPTION-DOWN.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onKeyDownDown(e, data, state) {
+    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return;
+    e.preventDefault();
+    const {selection, document, focusBlock} = state
+    const isEnd = selection.hasFocusAtEndOf(focusBlock)
+    const selectBlock = isEnd ? document.getNextBlock(focusBlock.get('key')) : focusBlock;
+    if (!selectBlock) return;
+    var selectText = selectBlock.getTextAtOffset(selectBlock.length);
+    return state
+      .transform()
+      .extendToEndOf(selectText)
+      .apply();
   }
 
   /**

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -530,7 +530,7 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownUp(e, data, state) {
-    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return
+    if (!IS_MAC || data.isCtrl || !data.isAlt) return
     e.preventDefault()
     const {selection, document, focusBlock} = state
     const isStart = selection.hasFocusAtStartOf(focusBlock)
@@ -539,7 +539,7 @@ function Plugin(options = {}) {
     const selectText = selectBlock.getTextAtOffset(0)
     return state
       .transform()
-      .extendToStartOf(selectText)
+      [data.isShift ? 'extendToStartOf' : 'collapseToStartOf'](selectText)
       .apply()
   }
 
@@ -561,7 +561,7 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownDown(e, data, state) {
-    if (!IS_MAC || data.isCtrl || !data.isAlt || !data.isShift) return
+    if (!IS_MAC || data.isCtrl || !data.isAlt) return
     e.preventDefault()
     const {selection, document, focusBlock} = state
     const isEnd = selection.hasFocusAtEndOf(focusBlock)
@@ -570,7 +570,7 @@ function Plugin(options = {}) {
     const selectText = selectBlock.getTextAtOffset(selectBlock.length)
     return state
       .transform()
-      .extendToEndOf(selectText)
+      [data.isShift ? 'extendToEndOf' : 'collapseToEndOf'](selectText)
       .apply()
   }
 


### PR DESCRIPTION
This is a fix for the following issue:

https://github.com/ianstormtaylor/slate/issues/464

Reposted the details here:

According to the "Mac Keyboard Shortcuts" listing here:

https://support.apple.com/en-ca/HT201236

And also confirmed in the Pages app on Mac OS X, these are expected behaviours:

**Option–Shift–Up Arrow** Extend text selection to the beginning of the current paragraph, then to the beginning of the following paragraph if pressed again.

**Option–Shift–Down Arrow** Extend text selection to the end of the current paragraph, then to the end of the following paragraph if pressed again.

In Slate, using Chrome, it does not go the beginning or end of each additional paragraph selected. Instead, it goes to a position that is based on the offset (within a block) of the anchor position. This damages the utility of using the shortcut for selecting complete blocks.