### PR TITLE
Add an attribute to uniquely identify divs used to render `content` component

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -167,7 +167,7 @@ class Content extends React.Component {
     const { target } = event
     return (
       (target.isContentEditable) &&
-      (target === element || target.closest('[contenteditable]') == element)
+      (target === element || target.closest('[data-slate-content]') === element)
     )
   }
 
@@ -670,6 +670,7 @@ class Content extends React.Component {
 
     return (
       <div
+        data-slate-content={true}
         key={this.forces}
         ref={this.ref}
         contentEditable={!readOnly}

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -670,7 +670,7 @@ class Content extends React.Component {
 
     return (
       <div
-        data-slate-content={true}
+        data-slate-content
         key={this.forces}
         ref={this.ref}
         contentEditable={!readOnly}

--- a/test/rendering/fixtures/custom-block-void/output.html
+++ b/test/rendering/fixtures/custom-block-void/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span style="position:absolute;top:0px;left:-9999px;text-indent:-9999px;">
       <span>

--- a/test/rendering/fixtures/custom-block/output.html
+++ b/test/rendering/fixtures/custom-block/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>word</span>

--- a/test/rendering/fixtures/custom-decorator/output.html
+++ b/test/rendering/fixtures/custom-decorator/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>o</span>

--- a/test/rendering/fixtures/custom-inline-void/output.html
+++ b/test/rendering/fixtures/custom-inline-void/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>

--- a/test/rendering/fixtures/custom-inline/output.html
+++ b/test/rendering/fixtures/custom-inline/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <a href="https://google.com">
       <span>

--- a/test/rendering/fixtures/custom-mark-with-component/output.html
+++ b/test/rendering/fixtures/custom-mark-with-component/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/custom-mark-with-function/output.html
+++ b/test/rendering/fixtures/custom-mark-with-function/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/custom-mark-with-mixed/output.html
+++ b/test/rendering/fixtures/custom-mark-with-mixed/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span><span style="font-weight:bold;">one</span></span>

--- a/test/rendering/fixtures/custom-mark-with-object/output.html
+++ b/test/rendering/fixtures/custom-mark-with-object/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/custom-mark-with-string/output.html
+++ b/test/rendering/fixtures/custom-mark-with-string/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/default-block-and-inline/output.html
+++ b/test/rendering/fixtures/default-block-and-inline/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span style="position:relative;">
       <span>

--- a/test/rendering/fixtures/default-block/output.html
+++ b/test/rendering/fixtures/default-block/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>word</span>

--- a/test/rendering/fixtures/empty-text/output.html
+++ b/test/rendering/fixtures/empty-text/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span><br></span>

--- a/test/rendering/fixtures/multiple-custom-block/output.html
+++ b/test/rendering/fixtures/multiple-custom-block/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>word</span>

--- a/test/rendering/fixtures/multiple-custom-inline/output.html
+++ b/test/rendering/fixtures/multiple-custom-inline/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <a href="https://google.com">
       <span>

--- a/test/rendering/fixtures/nested-text-direction/output.html
+++ b/test/rendering/fixtures/nested-text-direction/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
   <div dir="rtl" style="position:relative;">
     <span>

--- a/test/rendering/fixtures/text-direction/output.html
+++ b/test/rendering/fixtures/text-direction/output.html
@@ -1,5 +1,5 @@
 
-<div contenteditable="true">
+<div data-slate-content="true" contenteditable="true">
   <div style="position:relative;">
     <span>
       <span>Hello World</span>


### PR DESCRIPTION
Add `data-slate-content` attribute to the divs used to render `content` components.
Use that attribute to uniquely identify them.
Update test expected results to reflect the presence of the new attribute.

This fixes issue #468.

