### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "immutable": "^3.8.1",
     "is-empty": "^1.0.0",
     "keycode": "^2.1.2",
-    "lodash": "^4.13.1",
     "type-of": "^2.0.1",
     "ua-parser-js": "^0.7.10"
   },

--- a/perf/index.js
+++ b/perf/index.js
@@ -17,7 +17,6 @@ const jsdomGlobal = require('jsdom-global')
 jsdomGlobal()
 
 const fs = require('fs')
-const _ = require('lodash')
 const readMetadata = require('read-metadata')
 const { Raw } = require('..')
 const memoize = require('../lib/utils/memoize')
@@ -97,7 +96,7 @@ function runBenchmarks() {
       setup() {
         const scope = global.getScope()
         // Each benchmark is given the chance to do its own setup
-        const state = scope.benchmark.setup(
+        const state = scope.benchmark.setup( // eslint-disable-line no-unused-vars
           scope.Raw.deserialize(scope.input, { terse: true })
         )
       },
@@ -119,20 +118,20 @@ function runBenchmarks() {
 
   suite
   // On benchmark completion
-  .on('cycle', (event) => {
-    const result = serializeResult(event)
-    results[result.name] = result
-    compareResult(result, reference)
-  })
+    .on('cycle', (event) => {
+      const result = serializeResult(event)
+      results[result.name] = result
+      compareResult(result, reference)
+    })
   // On suite completion
-  .on('complete', (event) => {
-    if (outputPath) {
-      save(results, outputPath)
-      print(`\nSaved results as JSON to ${outputPath}`)
-    }
-  })
+    .on('complete', (event) => {
+      if (outputPath) {
+        save(results, outputPath)
+        print(`\nSaved results as JSON to ${outputPath}`)
+      }
+    })
   // Run async to properly flush logs
-  .run({ 'async': true })
+    .run({ 'async': true })
 }
 
 /**
@@ -141,10 +140,10 @@ function runBenchmarks() {
  */
 
 function parseCommandLineOptions(process) {
-  let outputPath,
-      reference,
-      only,
-      help = false
+  let outputPath
+  let reference
+  let only
+  let help = false
 
   const options = process.argv.slice(2)
 
@@ -224,12 +223,12 @@ function serializeResult(event) {
 
   else {
     const { hz } = target
-    const { mean, rme } = target.stats
-    const stats = _.pick(target.stats, [
-      'rme',
-      'mean',
-      'sample'
-    ])
+    const { mean, rme, sample } = target.stats
+    const stats = {
+      rme,
+      mean,
+      sample
+    }
 
     Object.assign(result, {
       hz,

--- a/src/constants/environment.js
+++ b/src/constants/environment.js
@@ -1,7 +1,6 @@
 
 import Parser from 'ua-parser-js'
 import browser from 'detect-browser'
-import includes from 'lodash/includes'
 
 /**
  * Export.
@@ -18,7 +17,7 @@ export const IS_IOS = process.browser && browser.name == 'ios'
 export const IS_MAC = process.browser && new Parser().getOS().name == 'Mac OS'
 export const IS_SAFARI = process.browser && browser.name == 'safari'
 export const IS_UBUNTU = process.browser && new Parser().getOS().name == 'Ubuntu'
-export const IS_WINDOWS = process.browser && includes(new Parser().getOS().name, 'Windows')
+export const IS_WINDOWS = process.browser && /Windows/.test(new Parser().getOS().name)
 
 export default {
   IS_ANDROID,


### PR DESCRIPTION
This removes `lodash` from the dependencies. I think it's for the best. If we need some utilities, we can always include them individually instead.