### PR TITLE
Add a GitHub link as icon in the docs

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,6 +1,12 @@
 {
+  "gitbook": "3.2.2",
   "root": "./docs",
-  "plugins": ["-highlight", "prism"],
+  "plugins": ["-highlight", "prism", "github"],
+  "pluginsConfig": {
+    "github": {
+      "url": "https://github.com/ianstormtaylor/slate"
+    }
+  },
   "structure": {
     "readme": "Readme.md",
     "summary": "Summary.md"


### PR DESCRIPTION
This adds a button that links to the GitHub repo

<img width="163" alt="screen shot 2016-12-06 at 13 08 55" src="https://cloud.githubusercontent.com/assets/5644953/20925124/3412498a-bbb5-11e6-9d07-624f74e36809.png">
