### PR TITLE
Add unwrapNodeByKey

### DIFF
--- a/docs/reference/models/transform.md
+++ b/docs/reference/models/transform.md
@@ -59,6 +59,7 @@ Transform methods can either operate on the [`Document`](./document.md), the [`S
   - [`splitNodeByKey`](#splitnodebykey)
   - [`unwrapInlineByKey`](#unwrapinlinebykey)
   - [`unwrapBlockByKey`](#unwrapblockbykey)
+  - [`unwrapNodeByKey`](#unwrapnodebykey)
   - [`wrapBlockByKey`](#wrapblockbykey)
   - [`wrapInlineByKey`](#wrapinlinebykey)
 - [Document Transforms](#document-transforms)
@@ -332,6 +333,11 @@ Unwrap all inner content of an [`Inline`](./inline.md) node that match `properti
 `unwrapBlockByKey(key: String, type: String) => Transform`
 
 Unwrap all inner content of a [`Block`](./block.md) node that match `properties`. For convenience, you can pass a `type` string or `properties` object.
+
+### `unwrapNodeByKey`
+`unwrapNodeByKey(key: String) => Transform`
+
+Unwrap a single node from its parent. If the node is surrounded with siblings, its parent will be split. If the node is the only child, the parent is removed, and simply replaced by the node itself. Cannot unwrap a root node.
 
 ### `wrapBlockByKey`
 `wrapBlockByKey(key: String, properties: Object) => Transform` <br/>

--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -276,7 +276,7 @@ export function splitNodeByKey(transform, key, offset, options = {}) {
   let { document } = state
   const path = document.getPath(key)
 
-  transform.splitNodeOperation(path, offset)
+  transform.splitNodeAtOffsetOperation(path, offset)
 
   if (normalize) {
     const parent = document.getParent(key)

--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -325,11 +325,11 @@ export function unwrapBlockByKey(transform, key, properties, options) {
 }
 
 /**
- * Unwrap a node from its parent. If the node has siblings, its parent
- * will be split. Otherwise, the parent is removed, and simply
- * replaced by the node itself.
+ * Unwrap a single node from its parent.
  *
- * Cannot unwrap a root node.
+ * If the node is surrounded with siblings, its parent will be
+ * split. If the node is the only child, the parent is removed, and
+ * simply replaced by the node itself.  Cannot unwrap a root node.
  *
  * @param {Transform} transform
  * @param {String} key

--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -324,6 +324,44 @@ export function unwrapBlockByKey(transform, key, properties, options) {
   transform.unwrapBlockAtRange(range, properties, options)
 }
 
+/**
+ * Unwrap a node from its parent. If the node has siblings, its parent
+ * will be split. Otherwise, the parent is removed, and simply
+ * replaced by the node itself.
+ *
+ * Cannot unwrap a root node.
+ *
+ * @param {Transform} transform
+ * @param {String} key
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+export function unwrapNodeByKey(transform, key, options) {
+  const { state } = transform
+  const { document } = state
+  const parent = document.getParent(key)
+  const node = parent.getChild(key)
+
+  const parentParent = document.getParent(parent.key)
+  const parentIndex = parentParent.nodes.indexOf(parent)
+
+  if (parent.nodes.size === 1) {
+
+    // Remove the parent
+    transform.removeNodeByKey(parent.key, { normalize: false })
+    // and replace it by the node itself
+    transform.insertNodeByKey(parentParent.key, parentIndex, node)
+  } else {
+    const parentPath = document.getPath(parent.key)
+    const index = parent.nodes.indexOf(node)
+
+    // Split the parent
+    transform.splitNodeOperation(parentPath, index)
+    // Extract the node in between the splitted node
+    transform.moveNodeByKey(key, parentParent.key, parentIndex + 1)
+  }
+}
 
 /**
  * Wrap a node in an inline with `properties`.

--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -344,22 +344,36 @@ export function unwrapNodeByKey(transform, key, options = {}) {
   const parent = document.getParent(key)
   const node = parent.getChild(key)
 
+  const index = parent.nodes.indexOf(node)
+  const isFirst = index === 0
+  const isLast = index === parent.nodes.size - 1
+
   const parentParent = document.getParent(parent.key)
   const parentIndex = parentParent.nodes.indexOf(parent)
 
-  if (parent.nodes.size === 1) {
 
+  if (parent.nodes.size === 1) {
     // Remove the parent
     transform.removeNodeByKey(parent.key, { normalize: false })
     // and replace it by the node itself
     transform.insertNodeByKey(parentParent.key, parentIndex, node, options)
-  } else {
-    const parentPath = document.getPath(parent.key)
-    const index = parent.nodes.indexOf(node)
+  }
 
+  else if (isFirst) {
+    // Just move the node before its parent
+    transform.moveNodeByKey(key, parentParent.key, parentIndex, options)
+  }
+
+  else if (isLast) {
+    // Just move the node after its parent
+    transform.moveNodeByKey(key, parentParent.key, parentIndex + 1, options)
+  }
+
+  else {
+    const parentPath = document.getPath(parent.key)
     // Split the parent
     transform.splitNodeOperation(parentPath, index)
-    // Extract the node in between the splitted node
+    // Extract the node in between the splitted parent
     transform.moveNodeByKey(key, parentParent.key, parentIndex + 1, { normalize: false })
 
     if (normalize) {

--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -337,7 +337,8 @@ export function unwrapBlockByKey(transform, key, properties, options) {
  *   @property {Boolean} normalize
  */
 
-export function unwrapNodeByKey(transform, key, options) {
+export function unwrapNodeByKey(transform, key, options = {}) {
+  const { normalize = true } = options
   const { state } = transform
   const { document } = state
   const parent = document.getParent(key)
@@ -351,7 +352,7 @@ export function unwrapNodeByKey(transform, key, options) {
     // Remove the parent
     transform.removeNodeByKey(parent.key, { normalize: false })
     // and replace it by the node itself
-    transform.insertNodeByKey(parentParent.key, parentIndex, node)
+    transform.insertNodeByKey(parentParent.key, parentIndex, node, options)
   } else {
     const parentPath = document.getPath(parent.key)
     const index = parent.nodes.indexOf(node)
@@ -359,7 +360,11 @@ export function unwrapNodeByKey(transform, key, options) {
     // Split the parent
     transform.splitNodeOperation(parentPath, index)
     // Extract the node in between the splitted node
-    transform.moveNodeByKey(key, parentParent.key, parentIndex + 1)
+    transform.moveNodeByKey(key, parentParent.key, parentIndex + 1, { normalize: false })
+
+    if (normalize) {
+      transform.normalizeNodeByKey(parentParent.key, SCHEMA)
+    }
   }
 }
 

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -115,6 +115,7 @@ import {
   splitNodeByKey,
   unwrapInlineByKey,
   unwrapBlockByKey,
+  unwrapNodeByKey,
   wrapBlockByKey,
   wrapInlineByKey,
 } from './by-key'
@@ -292,6 +293,7 @@ export default {
   splitNodeByKey,
   unwrapInlineByKey,
   unwrapBlockByKey,
+  unwrapNodeByKey,
   wrapBlockByKey,
   wrapInlineByKey,
 

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -29,6 +29,7 @@ import {
   setMarkOperation,
   setNodeOperation,
   setSelectionOperation,
+  splitNodeAtOffsetOperation,
   splitNodeOperation,
 } from './operations'
 
@@ -211,6 +212,7 @@ export default {
   setMarkOperation,
   setNodeOperation,
   setSelectionOperation,
+  splitNodeAtOffsetOperation,
   splitNodeOperation,
 
   /**

--- a/src/transforms/operations.js
+++ b/src/transforms/operations.js
@@ -432,7 +432,7 @@ export function setSelectionOperation(transform, properties, options = {}) {
  * @param {Number} offset
  */
 
-export function splitNodeOperation(transform, path, offset) {
+export function splitNodeAtOffsetOperation(transform, path, offset) {
   const inversePath = path.slice()
   inversePath[path.length - 1] += 1
 
@@ -440,13 +440,45 @@ export function splitNodeOperation(transform, path, offset) {
     type: 'join_node',
     path: inversePath,
     withPath: path,
-    deep: true // we need to join nodes recursively
+    // we will split down to the text nodes, so we must join nodes recursively
+    deep: true
   }]
 
   const operation = {
     type: 'split_node',
     path,
     offset,
+    count: null,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
+ * Split a node by `path` after its 'count' child.
+ *
+ * @param {Transform} transform
+ * @param {Array} path
+ * @param {Number} count
+ */
+
+export function splitNodeOperation(transform, path, count) {
+  const inversePath = path.slice()
+  inversePath[path.length - 1] += 1
+
+  const inverse = [{
+    type: 'join_node',
+    path: inversePath,
+    withPath: path,
+    deep: false
+  }]
+
+  const operation = {
+    type: 'split_node',
+    path,
+    offset: null,
+    count,
     inverse,
   }
 

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/first-sibling/index.js
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/first-sibling/index.js
@@ -1,0 +1,7 @@
+
+export default function (state) {
+  return state
+    .transform()
+    .unwrapNodeByKey('to-unwrap')
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/first-sibling/input.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/first-sibling/input.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        key: 'to-unwrap'
+        nodes:
+          - kind: text
+            text: word1
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word2

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/first-sibling/output.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/first-sibling/output.yaml
@@ -1,0 +1,15 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: word1
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word2

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/last-sibling/index.js
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/last-sibling/index.js
@@ -1,0 +1,7 @@
+
+export default function (state) {
+  return state
+    .transform()
+    .unwrapNodeByKey('to-unwrap')
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/last-sibling/input.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/last-sibling/input.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word1
+      - kind: block
+        type: paragraph
+        key: 'to-unwrap'
+        nodes:
+          - kind: text
+            text: word2

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/last-sibling/output.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/last-sibling/output.yaml
@@ -1,0 +1,15 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word1
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: word2

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/single-block/index.js
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/single-block/index.js
@@ -1,0 +1,7 @@
+
+export default function (state) {
+  return state
+    .transform()
+    .unwrapNodeByKey('to-unwrap')
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/single-block/input.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/single-block/input.yaml
@@ -1,0 +1,19 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        key: 'to-unwrap'
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/single-block/output.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/single-block/output.yaml
@@ -1,0 +1,15 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: word
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/with-siblings/index.js
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/with-siblings/index.js
@@ -1,0 +1,7 @@
+
+export default function (state) {
+  return state
+    .transform()
+    .unwrapNodeByKey('to-unwrap')
+    .apply()
+}

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/with-siblings/input.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/with-siblings/input.yaml
@@ -1,0 +1,21 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word1
+      - kind: block
+        type: paragraph
+        key: 'to-unwrap'
+        nodes:
+          - kind: text
+            text: word2
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word3

--- a/test/transforms/fixtures/by-key/unwrap-node-by-key/with-siblings/output.yaml
+++ b/test/transforms/fixtures/by-key/unwrap-node-by-key/with-siblings/output.yaml
@@ -1,0 +1,23 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word1
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: word2
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word3

--- a/test/transforms/fixtures/on-history/undo/unwrap-node-by-key/index.js
+++ b/test/transforms/fixtures/on-history/undo/unwrap-node-by-key/index.js
@@ -1,0 +1,11 @@
+
+export default function (state) {
+  return state
+    .transform()
+    .unwrapNodeByKey('to-unwrap')
+    .apply()
+
+    .transform()
+    .undo()
+    .apply()
+}

--- a/test/transforms/fixtures/on-history/undo/unwrap-node-by-key/input.yaml
+++ b/test/transforms/fixtures/on-history/undo/unwrap-node-by-key/input.yaml
@@ -1,0 +1,21 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word1
+      - kind: block
+        type: paragraph
+        key: 'to-unwrap'
+        nodes:
+          - kind: text
+            text: word2
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word3

--- a/test/transforms/fixtures/on-history/undo/unwrap-node-by-key/output.yaml
+++ b/test/transforms/fixtures/on-history/undo/unwrap-node-by-key/output.yaml
@@ -1,0 +1,20 @@
+
+nodes:
+  - kind: block
+    type: quote
+    nodes:
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word1
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word2
+      - kind: block
+        type: paragraph
+        nodes:
+          - kind: text
+            text: word3


### PR DESCRIPTION
This PR adds a transform named `unwrapNodeByKey`, to unwrap a particular node from its parent.
Calling `unwrapNodeByKey` on a block is not equivalent to calling `unwrapBlockByKey` on that same block though, because the latter will unwrap the block's children, whereas the former will unwrap the block itself from its parent. I'm open to renaming that transform for that reason, but I could not find another name.

I needed that one to fix an issue with unwrapping lists https://github.com/GitbookIO/slate-edit-list/issues/13

I have added tests for all the cases covered by this transform, as well as documentation.
