### PR TITLE
Added `state` as a property to Transform in the documentation

### DIFF
--- a/docs/reference/models/transform.md
+++ b/docs/reference/models/transform.md
@@ -11,6 +11,8 @@ All changes are performed through `Transform` objects, so that a history of chan
 
 Transform methods can either operate on the [`Document`](./document.md), the [`Selection`](./selection.md), or both at once.
 
+- [Properties](#properties)
+  - [`state`](#state)
 - [Methods](#methods)
   - [`apply`](#apply)
 - [Current State Transforms](#current-state-transforms)
@@ -85,6 +87,13 @@ Transform methods can either operate on the [`Document`](./document.md), the [`S
 - [History Transforms](#history-transforms)
   - [`redo`](#redo)
   - [`undo`](#undo)
+
+
+## Properties
+
+### `state`
+
+An instance of [`State`](./state.md) where the transform was created from.
 
 
 ## Methods

--- a/docs/reference/models/transform.md
+++ b/docs/reference/models/transform.md
@@ -93,7 +93,7 @@ Transform methods can either operate on the [`Document`](./document.md), the [`S
 
 ### `state`
 
-An instance of [`State`](./state.md) where the transform was created from.
+A [`State`](./state.md) with the transform's current operations applied. Each time you run a new transform function this property will be updated.
 
 
 ## Methods


### PR DESCRIPTION
I noticed that in the code, it's pretty common to pull the `state` out of the `transform`.

The only way I was able to learn about this was by looking through the code and then I wasn't sure if it was a supported property. Considering that it seems to be fairly commonly used and looks like it will be officially supported, I made a pull request to add it to the documentation.