### PR TITLE
Improve `examples` so that code changes propagate to browser

### DIFF
--- a/examples/dev.html
+++ b/examples/dev.html
@@ -8,6 +8,17 @@
   </head>
   <body>
     <main></main>
-    <script src="build.dev.js"></script>
+    <script>
+      // Dynamically creates the script tag and adds the current time in ms
+      // as a query on the URL. This ensures the script is always reloaded.
+      //
+      // Useful during debugging because we want to see changes to the
+      // JavaScript code immediately.
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = 'build.dev.js?' + new Date().getTime();
+      head.appendChild(script);
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "tests": "mocha --compilers js:babel-core/register ./test/index.js",
     "watch": "npm-run-all --parallel --print-label watch:lib watch:examples start",
     "watch:lib": "babel --watch --out-dir ./lib ./src",
-    "watch:examples": "watchify --debug --transform babelify ./examples/index.js -o ./examples/build.dev.js"
+    "watch:examples": "watchify --debug --transform babelify ./examples/index.js -o ./examples/build.dev.js -v"
   },
   "browserify-global-shim": {
     "immutable": "Immutable",


### PR DESCRIPTION
I was trying to start working on some issues and I wanted to use the examples to find out how Slate works inside; however, I could not get any changes I made to the code to show up in the browser. I was using `npm run watch` to do so.

I dived into various things and when I looked at watchify, I noticed I couldn't tell if bundling was even happening. It helped when I set the `watch:examples` script to `watchify -v` to get some feedback. This is also helpful when working on code because you need to wait for the bundling to happen before you can reload the examples page and the verbose mode lets you see when the bundling has finished.

Eventually I realized that Chrome was reloading the HTML page but was not updating the loaded script. This is because it doesn't know that the code inside the loaded `<script>` has changed and is using the cached version.

Because of this, I updated `examples/dev.html` so that it dynamically appended the `<script src="build.dev.js">` tag. It appends a query string which is simple the time in ms so that we can ensure it will always be unique.

With these two changes, experimenting with the code becomes a lot easier.