### PR TITLE
Add `locked` state to editor.

### DIFF
--- a/src/models/stack.js
+++ b/src/models/stack.js
@@ -39,6 +39,8 @@ const EVENT_METHODS = [
 const ACCUMULATOR_METHODS = [
   'onBeforeChange',
   'onChange',
+  'onEditorLockChange',
+  'onReadOnlyChange'
 ]
 
 /**


### PR DESCRIPTION
This PR intends to fix issue #520.

Alongside the read-only state triggered by the `readOnly` editor property, it introduces a new read-only state called `locked` state.

The `locked` state can be switched on and off by the new editor methods `lock` and `unlock`. It should be used by editor components that want to edit their associated nodes, handling user inputs by themselves.

Two plugin cumulative handlers are added: `onReadOnlyChange` and `onEditorLockChange`.
They can be used by node components implementing nested editable content to listen to read-only editor state changes and adapt to them.

Of course, I'm open to whatever change you think it's needed.
