### PR TITLE
Add props "tabIndex" and "role"

### DIFF
--- a/docs/reference/components/editor.md
+++ b/docs/reference/components/editor.md
@@ -95,6 +95,10 @@ An optional dictionary of styles to apply to the content editable element.
 
 Indicates if it should participate to [sequential keyboard navigation](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex).
 
+### `role`
+
+ARIA property to define the role of the editor, it defaults to `textbox` when erditable.
+
 ## Placeholder Properties
 
 ```js

--- a/docs/reference/components/editor.md
+++ b/docs/reference/components/editor.md
@@ -51,7 +51,7 @@ The top-level React component that renders the Slate editor itself.
 />
 ```
 
-### `className` 
+### `className`
 `String`
 
 An optional class name to apply to the content editable element.
@@ -91,6 +91,9 @@ A [`State`](../models/state.md) object representing the current state of the edi
 
 An optional dictionary of styles to apply to the content editable element.
 
+### `tabIndex`
+
+Indicates if it should participate to [sequential keyboard navigation](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex).
 
 ## Placeholder Properties
 
@@ -122,7 +125,7 @@ An optional dictionary of styles to apply to the default block type's placeholde
 
 In addition to its own properties, the editor allows passing any of the properties that a [plugin](../plugins/plugin.md) defines as well.
 
-These properties are actually just a convenience—an implicit plugin definition. Internally, they are grouped together and turned into a plugin that is given first priority in the plugin stack. 
+These properties are actually just a convenience—an implicit plugin definition. Internally, they are grouped together and turned into a plugin that is given first priority in the plugin stack.
 
 For example, these two snippets of code are equivalent:
 
@@ -140,7 +143,7 @@ const plugins = [
 
 ```js
 const editorPlugin = {
-  onKeyDown: myKeyHandler 
+  onKeyDown: myKeyHandler
 }
 
 const plugins = [
@@ -179,17 +182,17 @@ Programmatically blur the editor.
 
 Programmatically focus the editor.
 
-### `getSchema` 
+### `getSchema`
 `getSchema() => Schema`
 
 Return the editor's current schema.
 
-### `getState` 
+### `getState`
 `getState() => State`
 
 Return the editor's current state.
 
-### `onChange` 
+### `onChange`
 `onChange(state: State) => Void`
 
 Effectively the same as `setState`. Invoking this method will update the state of the editor, running it through all of it's plugins, and passing it the parent component, before it cycles back down as the new `state` property of the editor.

--- a/docs/reference/components/editor.md
+++ b/docs/reference/components/editor.md
@@ -97,7 +97,7 @@ Indicates if it should participate to [sequential keyboard navigation](https://d
 
 ### `role`
 
-ARIA property to define the role of the editor, it defaults to `textbox` when erditable.
+ARIA property to define the role of the editor, it defaults to `textbox` when editable.
 
 ## Placeholder Properties
 

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -50,7 +50,8 @@ class Content extends React.Component {
     schema: React.PropTypes.object,
     spellCheck: React.PropTypes.bool.isRequired,
     state: React.PropTypes.object.isRequired,
-    style: React.PropTypes.object
+    style: React.PropTypes.object,
+    tabIndex: React.PropTypes.number
   };
 
   /**
@@ -694,7 +695,7 @@ class Content extends React.Component {
 
   render = () => {
     const { props } = this
-    const { className, readOnly, state } = props
+    const { className, readOnly, state, tabIndex } = props
     const { document } = state
     const children = document.nodes
       .map(node => this.renderNode(node))
@@ -747,6 +748,7 @@ class Content extends React.Component {
         onSelect={this.onSelect}
         spellCheck={spellCheck}
         style={style}
+        tabIndex={tabIndex}
       >
         {children}
       </div>

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -47,6 +47,7 @@ class Content extends React.Component {
     onPaste: React.PropTypes.func.isRequired,
     onSelect: React.PropTypes.func.isRequired,
     readOnly: React.PropTypes.bool.isRequired,
+    role: React.PropTypes.string,
     schema: React.PropTypes.object,
     spellCheck: React.PropTypes.bool.isRequired,
     state: React.PropTypes.object.isRequired,
@@ -695,7 +696,7 @@ class Content extends React.Component {
 
   render = () => {
     const { props } = this
-    const { className, readOnly, state, tabIndex } = props
+    const { className, readOnly, state, tabIndex, role } = props
     const { document } = state
     const children = document.nodes
       .map(node => this.renderNode(node))
@@ -748,6 +749,7 @@ class Content extends React.Component {
         onSelect={this.onSelect}
         spellCheck={spellCheck}
         style={style}
+        role={readOnly ? null : (role || 'textbox')}
         tabIndex={tabIndex}
       >
         {children}

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -71,7 +71,8 @@ class Editor extends React.Component {
     schema: React.PropTypes.object,
     spellCheck: React.PropTypes.bool,
     state: React.PropTypes.instanceOf(State).isRequired,
-    style: React.PropTypes.object
+    style: React.PropTypes.object,
+    tabIndex: React.PropTypes.number
   };
 
   /**
@@ -250,6 +251,7 @@ class Editor extends React.Component {
         readOnly={props.readOnly}
         spellCheck={props.spellCheck}
         style={props.style}
+        tabIndex={props.tabIndex}
       />
     )
   }

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -68,6 +68,7 @@ class Editor extends React.Component {
     placeholderStyle: React.PropTypes.object,
     plugins: React.PropTypes.array,
     readOnly: React.PropTypes.bool,
+    role: React.PropTypes.string,
     schema: React.PropTypes.object,
     spellCheck: React.PropTypes.bool,
     state: React.PropTypes.instanceOf(State).isRequired,
@@ -252,6 +253,7 @@ class Editor extends React.Component {
         spellCheck={props.spellCheck}
         style={props.style}
         tabIndex={props.tabIndex}
+        role={props.role}
       />
     )
   }

--- a/test/rendering/fixtures/custom-block-void/output.html
+++ b/test/rendering/fixtures/custom-block-void/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div data-slate-void="true" style="position:relative;">
     <span style="position:absolute;top:0px;left:-9999px;text-indent:-9999px;">
       <span>

--- a/test/rendering/fixtures/custom-block/output.html
+++ b/test/rendering/fixtures/custom-block/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>word</span>

--- a/test/rendering/fixtures/custom-decorator/output.html
+++ b/test/rendering/fixtures/custom-decorator/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>o</span>

--- a/test/rendering/fixtures/custom-inline-void/output.html
+++ b/test/rendering/fixtures/custom-inline-void/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>

--- a/test/rendering/fixtures/custom-inline/output.html
+++ b/test/rendering/fixtures/custom-inline/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>

--- a/test/rendering/fixtures/custom-mark-with-component/output.html
+++ b/test/rendering/fixtures/custom-mark-with-component/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/custom-mark-with-function/output.html
+++ b/test/rendering/fixtures/custom-mark-with-function/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/custom-mark-with-mixed/output.html
+++ b/test/rendering/fixtures/custom-mark-with-mixed/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span><span style="font-weight:bold;">one</span></span>

--- a/test/rendering/fixtures/custom-mark-with-object/output.html
+++ b/test/rendering/fixtures/custom-mark-with-object/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/custom-mark-with-string/output.html
+++ b/test/rendering/fixtures/custom-mark-with-string/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>one</span>

--- a/test/rendering/fixtures/default-block-and-inline/output.html
+++ b/test/rendering/fixtures/default-block-and-inline/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>

--- a/test/rendering/fixtures/default-block/output.html
+++ b/test/rendering/fixtures/default-block/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>word</span>

--- a/test/rendering/fixtures/empty-text/output.html
+++ b/test/rendering/fixtures/empty-text/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span><br></span>

--- a/test/rendering/fixtures/multiple-custom-block/output.html
+++ b/test/rendering/fixtures/multiple-custom-block/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>word</span>

--- a/test/rendering/fixtures/multiple-custom-inline/output.html
+++ b/test/rendering/fixtures/multiple-custom-inline/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>

--- a/test/rendering/fixtures/nested-text-direction/output.html
+++ b/test/rendering/fixtures/nested-text-direction/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
   <div dir="rtl" style="position:relative;">
     <span>

--- a/test/rendering/fixtures/text-direction/output.html
+++ b/test/rendering/fixtures/text-direction/output.html
@@ -1,5 +1,5 @@
 
-<div data-slate-editor="true" contenteditable="true">
+<div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative;">
     <span>
       <span>Hello World</span>


### PR DESCRIPTION
This PR adds two accessibility properties to the `<Editor />`:

- [`tabIndex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
- `role`