### PR TITLE
Add data property to `document`.

### DIFF
--- a/docs/reference/models/document.md
+++ b/docs/reference/models/document.md
@@ -5,13 +5,14 @@
 import { Document } from 'slate'
 ```
 
-The top-level node in Slate's document model. 
+The top-level node in Slate's document model.
 
-Documents are made up of block nodes, inline nodes, and text nodes—just like in the DOM. 
+Documents are made up of block nodes, inline nodes, and text nodes—just like in the DOM.
 
 In some places, you'll see mention of "fragments", which are also `Document` objects, just that aren't attached to the main `State`. For example, when cutting-and-pasting a selection of content, that content will be referred to as a document "fragment".
 
 - [Properties](#properties)
+  - [`data`](#data)
   - [`nodes`](#nodes)
 - [Computed Properties](#computed-properties)
   - [`kind`](#kind)
@@ -29,6 +30,11 @@ Document({
   nodes: Immutable.List<Node>,
 })
 ```
+
+### `data`
+`Immutable.Map`
+
+Arbitrary data associated with the document. Defaults to an empty `Map`.
 
 ### `nodes`
 `Immutable.List`

--- a/src/models/document.js
+++ b/src/models/document.js
@@ -10,10 +10,11 @@ import './inline'
  * Dependencies.
  */
 
+import Data from './data'
 import Block from './block'
 import Node from './node'
 import generateKey from '../utils/generate-key'
-import { List, Record } from 'immutable'
+import { List, Map, Record } from 'immutable'
 
 /**
  * Default properties.
@@ -22,6 +23,7 @@ import { List, Record } from 'immutable'
  */
 
 const DEFAULTS = {
+  data: new Map(),
   key: null,
   nodes: new List(),
 }
@@ -45,6 +47,7 @@ class Document extends new Record(DEFAULTS) {
     if (properties instanceof Document) return properties
 
     properties.key = properties.key || generateKey()
+    properties.data = Data.create(properties.data)
     properties.nodes = Block.createList(properties.nodes)
 
     return new Document(properties)

--- a/src/serializers/raw.js
+++ b/src/serializers/raw.js
@@ -62,6 +62,7 @@ const Raw = {
   deserializeDocument(object, options) {
     return Document.create({
       key: object.key,
+      data: object.data,
       nodes: Block.createList(object.nodes.map((node) => {
         return Raw.deserializeNode(node, options)
       }))
@@ -254,6 +255,7 @@ const Raw = {
 
   serializeDocument(document, options = {}) {
     const object = {
+      data: document.data.toJSON(),
       key: document.key,
       kind: document.kind,
       nodes: document.nodes
@@ -467,6 +469,7 @@ const Raw = {
     const ret = {}
     ret.nodes = object.nodes
     if (object.key) ret.key = object.key
+    if (!isEmpty(object.data)) ret.data = object.data
     return ret
   },
 
@@ -679,6 +682,7 @@ const Raw = {
     return {
       kind: 'state',
       document: {
+        data: object.data,
         key: object.key,
         kind: 'document',
         nodes: object.nodes

--- a/src/transforms/apply-operation.js
+++ b/src/transforms/apply-operation.js
@@ -32,7 +32,8 @@ const OPERATIONS = {
   set_node: setNode,
   split_node: splitNode,
   // Selection operations.
-  set_selection: setSelection
+  set_selection: setSelection,
+  set_document_data: setDocumentData
 }
 
 /**
@@ -301,6 +302,23 @@ function removeText(state, operation) {
   node = node.removeText(offset, length)
   document = document.updateDescendant(node)
   state = state.merge({ document, selection })
+  return state
+}
+
+/**
+ * Set `data` property on document.
+ *
+ * @param {State} state
+ * @param {Object} operation
+ * @return {State}
+ */
+
+function setDocumentData(state, operation) {
+  let { document } = state
+  const { data } = operation
+
+  document = document.merge({ data })
+  state = state.merge({ document })
   return state
 }
 

--- a/src/transforms/apply-operation.js
+++ b/src/transforms/apply-operation.js
@@ -32,8 +32,7 @@ const OPERATIONS = {
   set_node: setNode,
   split_node: splitNode,
   // Selection operations.
-  set_selection: setSelection,
-  set_document_data: setDocumentData
+  set_selection: setSelection
 }
 
 /**
@@ -306,23 +305,6 @@ function removeText(state, operation) {
 }
 
 /**
- * Set `data` property on document.
- *
- * @param {State} state
- * @param {Object} operation
- * @return {State}
- */
-
-function setDocumentData(state, operation) {
-  let { document } = state
-  const { data } = operation
-
-  document = document.merge({ data })
-  state = state.merge({ document })
-  return state
-}
-
-/**
  * Set `properties` on mark on text at `offset` and `length` in node by `path`.
  *
  * @param {State} state
@@ -366,7 +348,7 @@ function setNode(state, operation) {
   }
 
   node = node.merge(properties)
-  document = document.updateDescendant(node)
+  document = node.kind === 'document' ? node : document.updateDescendant(node)
   state = state.merge({ document })
   return state
 }

--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -255,8 +255,8 @@ export function setNodeByKey(transform, key, properties, options = {}) {
   transform.setNodeOperation(path, properties)
 
   if (normalize) {
-    const parent = document.getParent(key)
-    transform.normalizeNodeByKey(parent.key, SCHEMA)
+    const node = key === document.key ? document : document.getParent(key)
+    transform.normalizeNodeByKey(node.key, SCHEMA)
   }
 }
 

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -29,6 +29,7 @@ import {
   setMarkOperation,
   setNodeOperation,
   setSelectionOperation,
+  setDocumentDataOperation,
   splitNodeAtOffsetOperation,
   splitNodeOperation,
 } from './operations'
@@ -214,6 +215,7 @@ export default {
   setMarkOperation,
   setNodeOperation,
   setSelectionOperation,
+  setDocumentDataOperation,
   splitNodeAtOffsetOperation,
   splitNodeOperation,
 

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -29,7 +29,6 @@ import {
   setMarkOperation,
   setNodeOperation,
   setSelectionOperation,
-  setDocumentDataOperation,
   splitNodeAtOffsetOperation,
   splitNodeOperation,
 } from './operations'
@@ -215,7 +214,6 @@ export default {
   setMarkOperation,
   setNodeOperation,
   setSelectionOperation,
-  setDocumentDataOperation,
   splitNodeAtOffsetOperation,
   splitNodeOperation,
 

--- a/src/transforms/operations.js
+++ b/src/transforms/operations.js
@@ -278,6 +278,32 @@ export function removeTextOperation(transform, path, offset, length) {
 }
 
 /**
+ * Set `data` property on document.
+ *
+ * @param {Transform} transform
+ * @param {Object} data
+ */
+
+export function setDocumentDataOperation(transform, data) {
+  const { state } = transform
+  const { document } = state
+  const inverseData = document.data
+
+  const inverse = [{
+    type: 'set_document_data',
+    data: inverseData,
+  }]
+
+  const operation = {
+    type: 'set_document_data',
+    data,
+    inverse,
+  }
+
+  transform.applyOperation(operation)
+}
+
+/**
  * Set `properties` on mark on text at `offset` and `length` in node by `path`.
  *
  * @param {Transform} transform

--- a/src/transforms/operations.js
+++ b/src/transforms/operations.js
@@ -290,13 +290,15 @@ export function setDocumentDataOperation(transform, data) {
   const inverseData = document.data
 
   const inverse = [{
-    type: 'set_document_data',
-    data: inverseData,
+    type: 'set_node',
+    path: [],
+    properties: {data: inverseData}
   }]
 
   const operation = {
-    type: 'set_document_data',
-    data,
+    type: 'set_node',
+    path: [],
+    properties: {data},
     inverse,
   }
 

--- a/src/transforms/operations.js
+++ b/src/transforms/operations.js
@@ -278,34 +278,6 @@ export function removeTextOperation(transform, path, offset, length) {
 }
 
 /**
- * Set `data` property on document.
- *
- * @param {Transform} transform
- * @param {Object} data
- */
-
-export function setDocumentDataOperation(transform, data) {
-  const { state } = transform
-  const { document } = state
-  const inverseData = document.data
-
-  const inverse = [{
-    type: 'set_node',
-    path: [],
-    properties: {data: inverseData}
-  }]
-
-  const operation = {
-    type: 'set_node',
-    path: [],
-    properties: {data},
-    inverse,
-  }
-
-  transform.applyOperation(operation)
-}
-
-/**
  * Set `properties` on mark on text at `offset` and `length` in node by `path`.
  *
  * @param {Transform} transform

--- a/test/serializers/fixtures/html/deserialize/block-nested/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/block-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: quote
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/block-no-children/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/block-no-children/output.yaml
@@ -1,4 +1,4 @@
-
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/block-with-data/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/block-with-data/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/block-with-is-void/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/block-with-is-void/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: true

--- a/test/serializers/fixtures/html/deserialize/block/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/block/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/inline-nested/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/inline-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/inline-no-children/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/inline-no-children/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/inline-with-data/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/inline-with-data/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/inline-with-is-void/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/inline-with-is-void/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/inline/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/inline/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/mark-interleaved/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/mark-interleaved/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/mark-nested/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/mark-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/mark/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/mark/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/multiple-matching-rules/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/multiple-matching-rules/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: one
     isVoid: false

--- a/test/serializers/fixtures/html/deserialize/no-next/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/no-next/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/plain/deserialize/line-multiple/output.yaml
+++ b/test/serializers/fixtures/plain/deserialize/line-multiple/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: line
     isVoid: false

--- a/test/serializers/fixtures/plain/deserialize/line/output.yaml
+++ b/test/serializers/fixtures/plain/deserialize/line/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: line
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/block-nested/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/block-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: quote
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/block-with-data/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/block-with-data/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/block-with-empty-nodes/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/block-with-empty-nodes/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/block-with-is-void/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/block-with-is-void/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: true

--- a/test/serializers/fixtures/raw/deserialize-terse/block-with-no-nodes/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/block-with-no-nodes/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/block/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/block/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/inline-nested/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/inline-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/inline-with-data/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/inline-with-data/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/inline-with-is-void/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/inline-with-is-void/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/inline/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/inline/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/range-with-mark/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/range-with-mark/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/text-with-mark-without-range/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/text-with-mark-without-range/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize-terse/text-without-range/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize-terse/text-without-range/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/block-nested/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/block-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: quote
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/block-with-data/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/block-with-data/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/block-with-is-void/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/block-with-is-void/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: true

--- a/test/serializers/fixtures/raw/deserialize/block/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/block/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/inline-nested/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/inline-nested/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/inline-with-data/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/inline-with-data/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/inline-with-is-void/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/inline-with-is-void/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/inline/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/inline/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/deserialize/range-with-mark/output.yaml
+++ b/test/serializers/fixtures/raw/deserialize/range-with-mark/output.yaml
@@ -1,4 +1,5 @@
 
+data: {}
 nodes:
   - type: paragraph
     isVoid: false

--- a/test/serializers/fixtures/raw/serialize/block-nested/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/block-nested/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/block-with-data/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/block-with-data/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/block-with-is-void/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/block-with-is-void/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/block/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/block/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/character-with-mark/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/character-with-mark/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/inline-nested/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/inline-nested/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/inline-with-data/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/inline-with-data/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/inline-with-is-void/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/inline-with-is-void/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block

--- a/test/serializers/fixtures/raw/serialize/inline/output.yaml
+++ b/test/serializers/fixtures/raw/serialize/inline/output.yaml
@@ -1,6 +1,7 @@
 
 kind: state
 document:
+  data: {}
   kind: document
   nodes:
     - kind: block


### PR DESCRIPTION
Add data property to `document`. It is useful, for example, to store document level metadata: creation date, author, keywords, etc.

Of course, I'm open to any change you think needed. 