### PR TITLE
Fix deleteCharBackwardAtRange

### DIFF
--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -131,8 +131,8 @@ export function deleteAtRange(transform, range, options = {}) {
 
 export function deleteCharBackwardAtRange(transform, range, options) {
   const { state } = transform
-  const { startOffset, startBlock } = state
-  const { text } = startBlock
+  const { startOffset, startText } = state
+  const { text } = startText
   const n = String.getCharOffsetBackward(text, startOffset)
   transform.deleteBackwardAtRange(range, n, options)
 }


### PR DESCRIPTION
When we have nested inlines in startBlock, startOffset points to the wrong character. So, i think that using startText will be correct here.