### PR TITLE
F/upstream inline selection

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -659,7 +659,7 @@ class Content extends React.Component {
       const anchorInline = document.getClosestInline(anchor.key)
       const focusInline = document.getClosestInline(focus.key)
 
-      if (anchorInline && !anchorInline.isVoid && anchor.offset == anchorText.length) {
+      if (anchorInline && anchorInline.isVoid && anchor.offset == anchorText.length) {
         const block = document.getClosestBlock(anchor.key)
         const next = block.getNextText(anchor.key)
         if (next) {
@@ -668,7 +668,7 @@ class Content extends React.Component {
         }
       }
 
-      if (focusInline && !focusInline.isVoid && focus.offset == focusText.length) {
+      if (focusInline && focusInline.isVoid && focus.offset == focusText.length) {
         const block = document.getClosestBlock(focus.key)
         const next = block.getNextText(focus.key)
         if (next) {


### PR DESCRIPTION
I am trying to fix here a problem which occurs when i click into a `inline` node having `isVoid: true`.

My plugin gets a selection in `onSelect` which is located somewhere before my inline node instead of afterwards.

In my manual testing this didnt broke anything. Ideas ?  