### PR TITLE
Set the `Void` `Inline` wrapper css `display` property to `inline-block`

### DIFF
--- a/src/components/void.js
+++ b/src/components/void.js
@@ -86,11 +86,20 @@ class Void extends React.Component {
   render = () => {
     const { props } = this
     const { children, node } = props
-    const Tag = node.kind == 'block' ? 'div' : 'span'
+    let Tag, style
 
     // Make the outer wrapper relative, so the spacer can overlay it.
-    const style = {
-      position: 'relative'
+    if (node.kind === 'block') {
+      Tag = 'div'
+      style = {
+        position: 'relative'
+      }
+    } else {
+      Tag = 'span'
+      style = {
+        display: 'inline-block',
+        position: 'relative'
+      }
     }
 
     this.debug('render', { props })

--- a/test/rendering/fixtures/custom-inline-void/output.html
+++ b/test/rendering/fixtures/custom-inline-void/output.html
@@ -6,7 +6,7 @@
         <span data-slate-zero-width="true">&#x200B;</span>
       </span>
     </span>
-    <span data-slate-void="true" style="position:relative;">
+    <span data-slate-void="true" style="display:inline-block;position:relative;">
       <span style="position:relative;top:0px;left:-9999px;text-indent:-9999px;">
         <span>
           <span data-slate-zero-width="true">&#x200B;</span>


### PR DESCRIPTION
In Chrome, when it is positioned right before a `Void ` `Inline` node, the caret is not visible.
That can be verified, for example, by using the [Emojiis example](http://slatejs.org/#/emojis).
This PR fixes that issue setting to `inline-block` the css `display` property of the `Void` `Inline` wrappers.

As always I'm open to any change you think needed. :blush: 