### PR TITLE
Allow setting a defaultBlockType as object for HTML serializer

### DIFF
--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -70,6 +70,7 @@ class Html {
    * @param {Object} options
    *   @property {Array} rules
    *   @property {String} defaultBlockType
+   *   @property {String|Object} defaultBlockType
    */
 
   constructor(options = {}) {
@@ -108,10 +109,21 @@ class Html {
         return memo
       }
 
-      const block = {
-        kind: 'block',
-        type: this.defaultBlockType,
-        nodes: [node]
+      let block
+      if (this.defaultBlockType.constructor.name === 'String') {
+        block = {
+          kind: 'block',
+          type: this.defaultBlockType,
+          nodes: [node]
+        }
+      } else {
+        block = Object.assign(
+          this.defaultBlockType,
+          {
+            kind: 'block',
+            nodes: [node]
+          }
+        )
       }
 
       memo.push(block)

--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -109,22 +109,10 @@ class Html {
         return memo
       }
 
-      let block
-      if (this.defaultBlockType.constructor.name === 'String') {
-        block = {
-          kind: 'block',
-          type: this.defaultBlockType,
-          nodes: [node]
-        }
-      } else {
-        block = Object.assign(
-          this.defaultBlockType,
-          {
-            kind: 'block',
-            nodes: [node]
-          }
-        )
-      }
+      const commonProps = {kind: 'block', nodes: [node]}
+      const block = this.defaultBlockType.typeof === 'string'
+        ? {type: this.defaultBlockType, ...commonProps}
+        : {...commonProps, ...this.defaultBlockType}
 
       memo.push(block)
       return memo

--- a/test/serializers/fixtures/html/deserialize/default-block/index.js
+++ b/test/serializers/fixtures/html/deserialize/default-block/index.js
@@ -1,0 +1,24 @@
+
+export default {
+  rules: [
+    {
+      deserialize(el, next) {
+        switch (el.tagName) {
+          case 'p': {
+            return {
+              kind: 'block',
+              type: 'paragraph',
+              nodes: next(el.children)
+            }
+          }
+        }
+      }
+    }
+  ],
+  defaultBlockType: {
+    type: 'contentBlock',
+    data: {
+      style: 'default'
+    }
+  }
+}

--- a/test/serializers/fixtures/html/deserialize/default-block/input.html
+++ b/test/serializers/fixtures/html/deserialize/default-block/input.html
@@ -1,0 +1,2 @@
+<p>one</p>
+<div>two</div>

--- a/test/serializers/fixtures/html/deserialize/default-block/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/default-block/output.yaml
@@ -1,0 +1,25 @@
+data: {}
+nodes:
+  - type: paragraph
+    isVoid: false
+    data: {}
+    nodes:
+      - characters:
+          - text: o
+            marks: []
+          - text: n
+            marks: []
+          - text: e
+            marks: []
+  - type: contentBlock
+    isVoid: false
+    data: {style: default}
+    nodes:
+      - characters:
+          - text: t
+            marks: []
+          - text: w
+            marks: []
+          - text: o
+            marks: []
+


### PR DESCRIPTION
We need to be able to set the data on the defaultBlockType.