### PR TITLE
Add props “autoCorrect” to editor and content.

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -35,6 +35,7 @@ class Content extends React.Component {
    */
 
   static propTypes = {
+    autoCorrect: React.PropTypes.bool.isRequired,
     className: React.PropTypes.string,
     editor: React.PropTypes.object.isRequired,
     onBeforeInput: React.PropTypes.func.isRequired,
@@ -98,6 +99,7 @@ class Content extends React.Component {
     return (
       props.className != this.props.className ||
       props.schema != this.props.schema ||
+      props.autoCorrect != this.props.autoCorrect ||
       props.spellCheck != this.props.spellCheck ||
       props.state != this.props.state ||
       props.style != this.props.style
@@ -747,6 +749,7 @@ class Content extends React.Component {
         onKeyUp={this.onKeyUp}
         onPaste={this.onPaste}
         onSelect={this.onSelect}
+        autoCorrect={props.autoCorrect}
         spellCheck={spellCheck}
         style={style}
         role={readOnly ? null : (role || 'textbox')}

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -58,6 +58,7 @@ class Editor extends React.Component {
    */
 
   static propTypes = {
+    autoCorrect: React.PropTypes.bool,
     className: React.PropTypes.string,
     onBeforeChange: React.PropTypes.func,
     onChange: React.PropTypes.func,
@@ -83,6 +84,7 @@ class Editor extends React.Component {
    */
 
   static defaultProps = {
+    autoCorrect: true,
     onChange: noop,
     onDocumentChange: noop,
     onSelectionChange: noop,
@@ -250,6 +252,7 @@ class Editor extends React.Component {
         state={this.getState()}
         className={props.className}
         readOnly={props.readOnly}
+        autoCorrect={props.autoCorrect}
         spellCheck={props.spellCheck}
         style={props.style}
         tabIndex={props.tabIndex}

--- a/test/rendering/index.js
+++ b/test/rendering/index.js
@@ -56,6 +56,7 @@ function clean(html) {
     $(el).removeAttr('data-offset-key')
   })
 
+  $.root().children().removeAttr('autocorrect')
   $.root().children().removeAttr('spellcheck')
   $.root().children().removeAttr('style')
 


### PR DESCRIPTION
This allow user to turn off predictive text input on iOS thus mitigating #540…