### PR TITLE
Eliminate duplicates in getBlocksAtRange

### DIFF
--- a/src/models/node.js
+++ b/src/models/node.js
@@ -260,6 +260,7 @@ const Node = {
     return this
       .getTexts()
       .map(text => this.getClosestBlock(text.key))
+      // Eliminate duplicates
       .toOrderedSet()
       .toList()
   },
@@ -275,6 +276,9 @@ const Node = {
     return this
       .getTextsAtRange(range)
       .map(text => this.getClosestBlock(text.key))
+      // Eliminate duplicates
+      .toOrderedSet()
+      .toList()
   },
 
   /**


### PR DESCRIPTION
Looking at `getBlocks` implementation confirma my thoughts that `getBlocksAtRange` is broken and can return the same block multiple times.