### PR TITLE
To hide caret inside `Void` `Inline` nodes, set spacer CSS `color` property to `transparent`

### DIFF
--- a/src/components/leaf.js
+++ b/src/components/leaf.js
@@ -264,7 +264,12 @@ class Leaf extends React.Component {
     // COMPAT: If the text is empty otherwise, it's because it's on the edge of
     // an inline void node, so we render a zero-width space so that the
     // selection can be inserted next to it still.
-    if (text == '') return <span data-slate-zero-width>{'\u200B'}</span>
+    if (text == '') {
+      // COMPAT: In Chrome, zero-width space produces graphics glitches, so use
+      // hair space in place of it. (2017/02/12)
+      const space = IS_FIREFOX ? '\u200B' : '\u200A'
+      return <span data-slate-zero-width>{space}</span>
+    }
 
     // COMPAT: Browsers will collapse trailing new lines at the end of blocks,
     // so we need to add an extra trailing new lines to prevent that.

--- a/src/components/void.js
+++ b/src/components/void.js
@@ -96,12 +96,6 @@ class Void extends React.Component {
       }
     } else {
       Tag = 'span'
-      // COMPAT: In Chrome, without setting `display: inline-block` the cursor
-      // will disappear when placed before an inline void node. (2017/02/07)
-      style = {
-        display: 'inline-block',
-        position: 'relative'
-      }
     }
 
     this.debug('render', { props })
@@ -145,12 +139,8 @@ class Void extends React.Component {
           textIndent: '-9999px'
         }
     } else {
-      style = {
-        position: 'absolute',
-        top: '0px',
-        left: '-9999px',
-        textIndent: '-9999px',
-      }
+      // Set `color` to `transparent` to hide caret inside the spacer.
+      style = {color: 'transparent'}
     }
 
     return (

--- a/test/rendering/fixtures/custom-block-void/output.html
+++ b/test/rendering/fixtures/custom-block-void/output.html
@@ -3,7 +3,7 @@
   <div data-slate-void="true" style="position:relative;">
     <span style="position:absolute;top:0px;left:-9999px;text-indent:-9999px;">
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
     <div contenteditable="false">

--- a/test/rendering/fixtures/custom-inline-void/output.html
+++ b/test/rendering/fixtures/custom-inline-void/output.html
@@ -3,13 +3,13 @@
   <div style="position:relative;">
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
-    <span data-slate-void="true" style="display:inline-block;position:relative;">
-      <span style="position:absolute;top:0px;left:-9999px;text-indent:-9999px;">
+    <span data-slate-void="true">
+      <span style="color:transparent;">
         <span>
-          <span data-slate-zero-width="true">&#x200B;</span>
+          <span data-slate-zero-width="true">&#x200A;</span>
         </span>
       </span>
       <span contenteditable="false">
@@ -18,7 +18,7 @@
     </span>
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
   </div>

--- a/test/rendering/fixtures/custom-inline/output.html
+++ b/test/rendering/fixtures/custom-inline/output.html
@@ -3,7 +3,7 @@
   <div style="position:relative;">
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
     <a href="https://google.com">
@@ -13,7 +13,7 @@
     </a>
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
   </div>

--- a/test/rendering/fixtures/default-block-and-inline/output.html
+++ b/test/rendering/fixtures/default-block-and-inline/output.html
@@ -3,7 +3,7 @@
   <div style="position:relative;">
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
     <span style="position:relative;">
@@ -13,7 +13,7 @@
     </span>
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
   </div>

--- a/test/rendering/fixtures/multiple-custom-inline/output.html
+++ b/test/rendering/fixtures/multiple-custom-inline/output.html
@@ -3,7 +3,7 @@
   <div style="position:relative;">
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
     <a href="https://google.com">
@@ -13,7 +13,7 @@
     </a>
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
     <a href="https://google.com">
@@ -23,7 +23,7 @@
     </a>
     <span>
       <span>
-        <span data-slate-zero-width="true">&#x200B;</span>
+        <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
   </div>


### PR DESCRIPTION
Trying to hide text cursor inside `Void` `Inline` nodes, commit a836a347861d7f0d3cb452bfe0f5b6e82cf04e31 has introduced some weird bugs in caret movement in Chrome. To understand what I mean go to [emoji example](http://slatejs.org/#/emojis), place the cursor on the first line of text (even far from emoji) then press down arrow key. The cursor should jump on the second line, but it doesn't.
After some investigations, I found the best way to hide the caret avoiding that sort of problems is to make it invisible setting to `transparent` the spacer CSS `color` property, instead of moving the spacer out of screen.
This PR implements that idea.
Among other things, to avoid graphics glitches, in Chrome, it replaces the zero-width space inside spacer with an hair space.

As always l'm open to any change you think needed. :blush: 