### PR TITLE
Various fixes for selections

### DIFF
--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -221,7 +221,7 @@ function Plugin(options = {}) {
   function onCutOrCopy(e, data, state) {
     const window = getWindow(e.target)
     const native = window.getSelection()
-    if (!native.rangeCount) return
+    if (native.isCollapsed) return
 
     const { fragment } = data
     const encoded = Base64.serializeNode(fragment)

--- a/src/transforms/on-selection.js
+++ b/src/transforms/on-selection.js
@@ -35,7 +35,7 @@ export function collapseToEndOfNextBlock(transform) {
   const { document, selection } = state
   const blocks = document.getBlocksAtRange(selection)
   const last = blocks.last()
-  const next = document.getNextBlock(last)
+  const next = document.getNextBlock(last.key)
   if (!next) return
 
   const sel = selection.collapseToEndOf(next)
@@ -53,7 +53,7 @@ export function collapseToEndOfNextText(transform) {
   const { document, selection } = state
   const texts = document.getTextsAtRange(selection)
   const last = texts.last()
-  const next = document.getNextText(last)
+  const next = document.getNextText(last.key)
   if (!next) return
 
   const sel = selection.collapseToEndOf(next)
@@ -71,7 +71,7 @@ export function collapseToEndOfPreviousBlock(transform) {
   const { document, selection } = state
   const blocks = document.getBlocksAtRange(selection)
   const first = blocks.first()
-  const previous = document.getPreviousBlock(first)
+  const previous = document.getPreviousBlock(first.key)
   if (!previous) return
 
   const sel = selection.collapseToEndOf(previous)
@@ -89,7 +89,7 @@ export function collapseToEndOfPreviousText(transform) {
   const { document, selection } = state
   const texts = document.getTextsAtRange(selection)
   const first = texts.first()
-  const previous = document.getPreviousText(first)
+  const previous = document.getPreviousText(first.key)
   if (!previous) return
 
   const sel = selection.collapseToEndOf(previous)
@@ -107,7 +107,7 @@ export function collapseToStartOfNextBlock(transform) {
   const { document, selection } = state
   const blocks = document.getBlocksAtRange(selection)
   const last = blocks.last()
-  const next = document.getNextBlock(last)
+  const next = document.getNextBlock(last.key)
   if (!next) return
 
   const sel = selection.collapseToStartOf(next)
@@ -125,7 +125,7 @@ export function collapseToStartOfNextText(transform) {
   const { document, selection } = state
   const texts = document.getTextsAtRange(selection)
   const last = texts.last()
-  const next = document.getNextText(last)
+  const next = document.getNextText(last.key)
   if (!next) return
 
   const sel = selection.collapseToStartOf(next)
@@ -143,7 +143,7 @@ export function collapseToStartOfPreviousBlock(transform) {
   const { document, selection } = state
   const blocks = document.getBlocksAtRange(selection)
   const first = blocks.first()
-  const previous = document.getPreviousBlock(first)
+  const previous = document.getPreviousBlock(first.key)
   if (!previous) return
 
   const sel = selection.collapseToStartOf(previous)
@@ -161,7 +161,7 @@ export function collapseToStartOfPreviousText(transform) {
   const { document, selection } = state
   const texts = document.getTextsAtRange(selection)
   const first = texts.first()
-  const previous = document.getPreviousText(first)
+  const previous = document.getPreviousText(first.key)
   if (!previous) return
 
   const sel = selection.collapseToStartOf(previous)


### PR DESCRIPTION
Use key, not node, with ``document.getNextBlock``  and ``document.getPreviousBlock``to avoid deprecation warnings.

Also, in the core plugin onCutCopy, one must check for a selection with ``isCollapsed``, because ``rangeCount`` can return 1 even though nothing is selected.
