### PR TITLE
Fix behaviour where deleteBackward/Forward on empty non-void block deleted the void block above/below

### DIFF
--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -204,9 +204,14 @@ export function deleteBackwardAtRange(transform, range, n = 1, options = {}) {
     return
   }
 
-  // If the closest block is void, delete it.
   const block = document.getClosestBlock(startKey)
+  // If the closest block is void, delete it.
   if (block && block.isVoid) {
+    transform.removeNodeByKey(block.key, { normalize })
+    return
+  }
+  // If the closest is not void, but empty, remove it
+  if (block && !block.isVoid && block.isEmpty) {
     transform.removeNodeByKey(block.key, { normalize })
     return
   }
@@ -383,9 +388,14 @@ export function deleteForwardAtRange(transform, range, n = 1, options = {}) {
     return
   }
 
-  // If the closest block is void, delete it.
   const block = document.getClosestBlock(startKey)
+  // If the closest block is void, delete it.
   if (block && block.isVoid) {
+    transform.removeNodeByKey(block.key, { normalize })
+    return
+  }
+  // If the closest is not void, but empty, remove it
+  if (block && !block.isVoid && block.isEmpty) {
     transform.removeNodeByKey(block.key, { normalize })
     return
   }

--- a/test/transforms/fixtures/at-current-range/delete-backward/empty-after-void-block/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-backward/empty-after-void-block/index.js
@@ -1,0 +1,10 @@
+
+export default function (state) {
+  const { document } = state
+  const nodeToBeFocused = document.nodes.last()
+  return state
+    .transform()
+    .collapseToStartOf(nodeToBeFocused)
+    .deleteBackward()
+    .apply()
+}

--- a/test/transforms/fixtures/at-current-range/delete-backward/empty-after-void-block/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/empty-after-void-block/input.yaml
@@ -1,0 +1,10 @@
+
+nodes:
+  - kind: block
+    type: image
+    isVoid: true
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""

--- a/test/transforms/fixtures/at-current-range/delete-backward/empty-after-void-block/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-backward/empty-after-void-block/output.yaml
@@ -1,0 +1,5 @@
+
+nodes:
+  - kind: block
+    type: image
+    isVoid: true

--- a/test/transforms/fixtures/at-current-range/delete-forward/empty-before-void-block/index.js
+++ b/test/transforms/fixtures/at-current-range/delete-forward/empty-before-void-block/index.js
@@ -1,0 +1,10 @@
+
+export default function (state) {
+  const { document } = state
+  const nodeToBeFocused = document.nodes.first()
+  return state
+    .transform()
+    .collapseToStartOf(nodeToBeFocused)
+    .deleteForward()
+    .apply()
+}

--- a/test/transforms/fixtures/at-current-range/delete-forward/empty-before-void-block/input.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/empty-before-void-block/input.yaml
@@ -1,0 +1,10 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: image
+    isVoid: true

--- a/test/transforms/fixtures/at-current-range/delete-forward/empty-before-void-block/output.yaml
+++ b/test/transforms/fixtures/at-current-range/delete-forward/empty-before-void-block/output.yaml
@@ -1,0 +1,5 @@
+
+nodes:
+  - kind: block
+    type: image
+    isVoid: true


### PR DESCRIPTION
The expected behaviour should be to delete the current empty non-void block instead.