### PR TITLE
Fix issue with scrollTo

### DIFF
--- a/src/utils/scroll-to.js
+++ b/src/utils/scroll-to.js
@@ -6,19 +6,19 @@
 import getWindow from 'get-window'
 
 function scrollWindow(window, cursorTop, cursorLeft, cursorHeight) {
-  let deltaX = 0
-  let deltaY = 0
+  let scrollX = window.scrollX
+  let scrollY = window.scrollY
   let cursorBottom = cursorTop + cursorHeight
 
   if (cursorTop < 0 || cursorBottom > window.innerHeight) {
-    deltaY = cursorTop - window.scrollY + window.innerHeight / 2 - cursorHeight / 2
+    scrollY += cursorTop - window.innerHeight / 2 + cursorHeight / 2
   }
 
   if (cursorLeft < 0 || cursorLeft > window.innerWidth) {
-    deltaX = cursorLeft - window.scrollX + window.innerWidth / 2
+    scrollX += cursorLeft - window.innerWidth / 2
   }
 
-  window.scrollBy(deltaX, deltaY)
+  window.scrollTo(scrollX, scrollY)
 }
 
 function scrollTo(element) {
@@ -36,7 +36,7 @@ function scrollTo(element) {
       let wrapperRect = wrapper.getBoundingClientRect()
       let currentY = cursorTop
       let cursorBottom = cursorTop + cursorHeight
-      if (cursorTop < wrapperRect.top || cursorBottom > wrapperRect.bottom) {
+      if (cursorTop < wrapperRect.top || cursorBottom > wrapperRect.top + wrapper.offsetHeight) {
         cursorTop = wrapperRect.top + wrapperRect.height / 2 - cursorHeight / 2
         wrapper.scrollTop += currentY - cursorTop
       }


### PR DESCRIPTION
I realized I made a mistake in the scrollWindow function I was calculating the scrollBy position incorrectly. I decided to just switch to scrollTo instead of scrollBy

Also I was getting an issue where the `getBoundingClientRect().bottom` of one of my wrapper elements was incorrect when the height changed via newline or deletion. I'm not entirely sure why but I noticed that if I used wrapperRect.top + wrapper.offsetHeight it gave the correct bottom so I swapped to use that instead. Let me know if there's any issue with these changes.

Also I'm wondering is there anyway to add tests for these changes? I'm not too familiar with testing for scroll. 