### PR TITLE
Fix bug where first/last char of inline node couldn't be selected with keyboard

### DIFF
--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -491,11 +491,12 @@ function Plugin(options = {}) {
       const previousBlock = document.getClosestBlock(previous.key)
       const previousInline = document.getClosestInline(previous.key)
 
-      if (previousBlock == startBlock && previousInline && !previousInline.isVoid) {
+      if (previousBlock === startBlock && previousInline && !previousInline.isVoid) {
+        const extendOrMove = data.isShift ? 'extendBackward' : 'moveBackward'
         return state
           .transform()
           .collapseToEndOf(previous)
-          .moveBackward(1)
+          [extendOrMove](1)
           .apply()
       }
 
@@ -562,10 +563,11 @@ function Plugin(options = {}) {
       const nextInline = document.getClosestInline(next.key)
 
       if (nextBlock == startBlock && nextInline) {
+        const extendOrMove = data.isShift ? 'extendForward' : 'moveBackward'
         return state
           .transform()
           .collapseToStartOf(next)
-          .moveForward(1)
+          [extendOrMove](1)
           .apply()
       }
 


### PR DESCRIPTION
To show the bug:

* Load the link example. Delete the exclamation sign in the end of the first paragraph, leaving the inline link node at the end of the paragraph.

* Try to select the last character of the link with shift-left-arrow. It will not be selected.

This PR fixes that. I would love to write a test for it, but not sure how to do that.
