### PR TITLE
Fix getting index for inline node in unwrapInlineAtRange, fixes #620

### DIFF
--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -1032,7 +1032,7 @@ Transforms.unwrapInlineAtRange = (transform, range, properties, options = {}) =>
     .toList()
 
   inlines.forEach((inline) => {
-    const parent = document.getParent(inline.key)
+    const parent = transform.state.document.getParent(inline.key)
     const index = parent.nodes.indexOf(inline)
 
     inline.nodes.forEach((child, i) => {

--- a/test/transforms/fixtures/at-range/unwrap-inline-at-range/with-text-between/index.js
+++ b/test/transforms/fixtures/at-range/unwrap-inline-at-range/with-text-between/index.js
@@ -1,0 +1,18 @@
+
+export default function (state) {
+  const { document, selection } = state;
+  const texts = document.getTexts();
+  const first = texts.first();
+  const second = texts.last();
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 0,
+    focusKey: second.key,
+    focusOffset: 0
+  });
+
+  return state
+    .transform()
+    .unwrapInlineAtRange(range, 'link')
+    .apply()
+}

--- a/test/transforms/fixtures/at-range/unwrap-inline-at-range/with-text-between/input.yaml
+++ b/test/transforms/fixtures/at-range/unwrap-inline-at-range/with-text-between/input.yaml
@@ -1,0 +1,21 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        type: link
+        nodes:
+          - kind: text
+            text: Hello
+      - kind: text
+        text: " "
+      - kind: inline
+        type: link
+        nodes:
+          - kind: text
+            text: world!
+      - kind: text
+        text: ""

--- a/test/transforms/fixtures/at-range/unwrap-inline-at-range/with-text-between/output.yaml
+++ b/test/transforms/fixtures/at-range/unwrap-inline-at-range/with-text-between/output.yaml
@@ -1,0 +1,7 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "Hello world!"


### PR DESCRIPTION
Hi.
This pull request fix issue #620, when inline nodes with text between are unwrapped in incorrect way.