### PR TITLE
Clarify usage of plugin.render

### DIFF
--- a/docs/reference/plugins/plugin.md
+++ b/docs/reference/plugins/plugin.md
@@ -220,7 +220,7 @@ Like `onChange`, `onBeforeChange` is cummulative.
 ### `render`
 `Function render(props: Object, state: State, editor: Editor) => Object || Void`
 
-The `render` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `props.children`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. This can be useful for rendering toolbars, styling the editor, rendering validation, etc.
+The `render` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `props.children`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. This can be useful for rendering toolbars, styling the editor, rendering validation, etc. Remember that the `render` function has to render `props.children` for editor's children to render.
 
 ### `schema`
 `Object`


### PR DESCRIPTION
Hey @ianstormtaylor, I am adding some clarification to the docs so that others don't run into the issue that I did. However, I am not sure if that is the clearest way to explain the point - so please double-check!

Also, since React doesn't allow you to return an array of nodes, this necessarily means that all the plugins will render nested components, i.e., if you have two toolbars, one would be the parent of another as well as the parent of the editor itself.

Let me know if that should be added, and what do you think is the best way do phrase that note. 

Finally, do you think there should be a way to allow plugins to render as siblings rather than parents of each other?