### PR TITLE
Fixed autocorrect causing dupe text

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -2,7 +2,7 @@
 import Base64 from '../serializers/base-64'
 import Debug from 'debug'
 import Node from './node'
-import OffsetKey from '../utils/offset-key'
+import getPoint from '../utils/get-point'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import Selection from '../models/selection'
@@ -148,24 +148,7 @@ class Content extends React.Component {
 
   getPoint(element, offset) {
     const { state, editor } = this.props
-    const { document } = state
-    const schema = editor.getSchema()
-
-    // If we can't find an offset key, we can't get a point.
-    const offsetKey = OffsetKey.findKey(element, offset)
-    if (!offsetKey) return null
-
-    // COMPAT: If someone is clicking from one Slate editor into another, the
-    // select event fires two, once for the old editor's `element` first, and
-    // then afterwards for the correct `element`. (2017/03/03)
-    const { key } = offsetKey
-    const node = document.getDescendant(key)
-    if (!node) return null
-
-    const decorators = document.getDescendantDecorators(key, schema)
-    const ranges = node.getRanges(decorators)
-    const point = OffsetKey.findPoint(offsetKey, ranges)
-    return point
+    return getPoint(element, offset, state, editor)
   }
 
   /**

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -139,19 +139,6 @@ class Content extends React.Component {
   }
 
   /**
-   * Get a point from a native selection's DOM `element` and `offset`.
-   *
-   * @param {Element} element
-   * @param {Number} offset
-   * @return {Object}
-   */
-
-  getPoint(element, offset) {
-    const { state, editor } = this.props
-    return getPoint(element, offset, state, editor)
-  }
-
-  /**
    * The React ref method to set the root content element locally.
    *
    * @param {Element} n
@@ -389,7 +376,7 @@ class Content extends React.Component {
     event.preventDefault()
 
     const window = getWindow(event.target)
-    const { state } = this.props
+    const { state, editor } = this.props
     const { nativeEvent } = event
     const { dataTransfer, x, y } = nativeEvent
     const data = getTransferData(dataTransfer)
@@ -406,7 +393,7 @@ class Content extends React.Component {
     }
 
     const { startContainer, startOffset } = range
-    const point = this.getPoint(startContainer, startOffset)
+    const point = getPoint(startContainer, startOffset, state, editor)
     if (!point) return
 
     const target = Selection.create({
@@ -446,16 +433,16 @@ class Content extends React.Component {
     debug('onInput', { event })
 
     const window = getWindow(event.target)
+    const { state, editor } = this.props
 
     // Get the selection point.
     const native = window.getSelection()
     const { anchorNode, anchorOffset } = native
-    const point = this.getPoint(anchorNode, anchorOffset)
+    const point = getPoint(anchorNode, anchorOffset, state, editor)
     if (!point) return
 
     // Get the range in question.
     const { key, index, start, end } = point
-    const { state, editor } = this.props
     const { document, selection } = state
     const schema = editor.getSchema()
     const decorators = document.getDescendantDecorators(key, schema)
@@ -617,7 +604,7 @@ class Content extends React.Component {
     if (!this.isInContentEditable(event)) return
 
     const window = getWindow(event.target)
-    const { state } = this.props
+    const { state, editor } = this.props
     const { document, selection } = state
     const native = window.getSelection()
     const data = {}
@@ -631,8 +618,8 @@ class Content extends React.Component {
     // Otherwise, determine the Slate selection from the native one.
     else {
       const { anchorNode, anchorOffset, focusNode, focusOffset } = native
-      const anchor = this.getPoint(anchorNode, anchorOffset)
-      const focus = this.getPoint(focusNode, focusOffset)
+      const anchor = getPoint(anchorNode, anchorOffset, state, editor)
+      const focus = getPoint(focusNode, focusOffset, state, editor)
       if (!anchor || !focus) return
 
       // There are valid situations where a select event will fire when we're

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -100,8 +100,11 @@ function Plugin(options = {}) {
 
     let transform = state.transform()
 
-    // Determine if selection is out of sync, which can happen during autocorrect,
-    // and update accordingly.
+    // COMPAT: In iOS, when choosing from the predictive text suggestions, the
+    // native selection will be changed to span the existing word, so that the word
+    // is replaced. But the `select` event for this change doesn't fire until after
+    // the `beforeInput` event, even though the native selection is updated. So we
+    // need to manually adjust the selection to be in sync. (03/18/2017)
     const window = getWindow(event.target)
     const native = window.getSelection()
     const { anchorNode, anchorOffset, focusNode, focusOffset } = native

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -3,6 +3,7 @@ import Base64 from '../serializers/base-64'
 import Content from '../components/content'
 import Character from '../models/character'
 import Debug from 'debug'
+import getPoint from '../utils/get-point'
 import Placeholder from '../components/placeholder'
 import React from 'react'
 import getWindow from 'get-window'
@@ -97,9 +98,35 @@ function Plugin(options = {}) {
 
     const chars = initialChars.insert(startOffset, char)
 
+    let nextTransform = state.transform()
+
+    // Determine if selection is out of sync, which can happen during autocorrect,
+    // and update accordingly.
+    const window = getWindow(event.target)
+    const native = window.getSelection()
+    const { anchorNode, anchorOffset, focusNode, focusOffset } = native
+    const anchorPoint = getPoint(anchorNode, anchorOffset, state, editor)
+    const focusPoint = getPoint(focusNode, focusOffset, state, editor)
+    if (anchorPoint && focusPoint) {
+      const { selection } = state
+      if (
+        selection.anchorKey !== anchorPoint.key ||
+        selection.anchorOffset !== anchorPoint.offset ||
+        selection.focusKey !== focusPoint.key ||
+        selection.focusOffset !== focusPoint.offset
+      ) {
+        nextTransform = nextTransform
+          .select({
+            anchorKey: anchorPoint.key,
+            anchorOffset: anchorPoint.offset,
+            focusKey: focusPoint.key,
+            focusOffset: focusPoint.offset
+          })
+      }
+    }
+
     // Determine what the characters should be, if not natively inserted.
-    let next = state
-      .transform()
+    let next = nextTransform
       .insertText(e.data)
       .apply()
 

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -98,7 +98,7 @@ function Plugin(options = {}) {
 
     const chars = initialChars.insert(startOffset, char)
 
-    let nextTransform = state.transform()
+    let transform = state.transform()
 
     // Determine if selection is out of sync, which can happen during autocorrect,
     // and update accordingly.
@@ -115,7 +115,7 @@ function Plugin(options = {}) {
         selection.focusKey !== focusPoint.key ||
         selection.focusOffset !== focusPoint.offset
       ) {
-        nextTransform = nextTransform
+        transform = transform
           .select({
             anchorKey: anchorPoint.key,
             anchorOffset: anchorPoint.offset,
@@ -126,7 +126,7 @@ function Plugin(options = {}) {
     }
 
     // Determine what the characters should be, if not natively inserted.
-    let next = nextTransform
+    let next = transform
       .insertText(e.data)
       .apply()
 

--- a/src/utils/get-point.js
+++ b/src/utils/get-point.js
@@ -1,0 +1,40 @@
+import OffsetKey from './offset-key'
+
+/**
+ * Get a point from a native selection's DOM `element` and `offset`.
+ *
+ * @param {Element} element
+ * @param {Number} offset
+ * @param {State} state
+ * @param {Editor} editor
+ * @return {Object}
+ */
+
+function getPoint(element, offset, state, editor) {
+  const { document } = state
+  const schema = editor.getSchema()
+
+  // If we can't find an offset key, we can't get a point.
+  const offsetKey = OffsetKey.findKey(element, offset)
+  if (!offsetKey) return null
+
+  // COMPAT: If someone is clicking from one Slate editor into another, the
+  // select event fires two, once for the old editor's `element` first, and
+  // then afterwards for the correct `element`. (2017/03/03)
+  const { key } = offsetKey
+  const node = document.getDescendant(key)
+  if (!node) return null
+
+  const decorators = document.getDescendantDecorators(key, schema)
+  const ranges = node.getRanges(decorators)
+  const point = OffsetKey.findPoint(offsetKey, ranges)
+  return point
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default getPoint


### PR DESCRIPTION
For #540

Here's an explanation of what the following codes try to achieve.

> During autocorrection (in iOS’s Safari), `onSelect` event is triggered after `onBeforeInput` event.
> The plugins/core updates the state during `onBeforeInput` event, thus causing selection triggered by autocorrect to be lost/overridden.
> This behaviour caused dupe text bug during autocorrection.
>
> To overcome this issue, we try to query the selection and conditionally fix out of sync cases with an additional transform before inserting the text.

The con of this fix is that it adds an additional query to native selection per text input.

I choose this solution because it is less destructive to existing execution flow.

Feel free to reject or rewrite if this isn't the right way to fix this.
