### PR TITLE
use pageXOffset instead of scrollX for IE11 support

### DIFF
--- a/src/utils/scroll-to-selection.js
+++ b/src/utils/scroll-to-selection.js
@@ -13,17 +13,17 @@ function scrollToSelection(selection) {
   const backward = isBackward(selection)
   const range = selection.getRangeAt(0)
   const rect = range.getBoundingClientRect()
-  const { innerWidth, innerHeight, scrollY, scrollX } = window
-  const top = (backward ? rect.top : rect.bottom) + scrollY
-  const left = (backward ? rect.left : rect.right) + scrollX
+  const { innerWidth, innerHeight, pageYOffset, pageXOffset } = window
+  const top = (backward ? rect.top : rect.bottom) + pageYOffset
+  const left = (backward ? rect.left : rect.right) + pageXOffset
 
-  const x = left < scrollX || innerWidth + scrollX < left
+  const x = left < pageXOffset || innerWidth + pageXOffset < left
     ? left - innerWidth / 2
-    : scrollX
+    : pageXOffset
 
-  const y = top < scrollY || innerHeight + scrollY < top
+  const y = top < pageYOffset || innerHeight + pageYOffset < top
     ? top - innerHeight / 2
-    : scrollY
+    : pageYOffset
 
   window.scrollTo(x, y)
 }


### PR DESCRIPTION
Since I already had the code loaded up for this one I figured a pull-request was easy. This will add support for scrolling in IE (even though other things are broken) which prior was scrolling to the top frequently. See #663 for my other IE11 support items.

For more info on IE compatibility with window scrolling, see the [MDN article on scrollX](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX).