### PR TITLE
Allow inserting successive empty non-void blocks

### DIFF
--- a/src/transforms/at-current-range.js
+++ b/src/transforms/at-current-range.js
@@ -163,11 +163,11 @@ Transforms.deleteWordForward = (transform) => {
  * @param {String|Object|Block} block
  */
 
-Transforms.insertBlock = (transform, block) => {
+Transforms.insertBlock = (transform, block, options) => {
   block = Normalize.block(block)
   const { state } = transform
   const { selection } = state
-  transform.insertBlockAtRange(selection, block)
+  transform.insertBlockAtRange(selection, block, options)
 
   // If the node was successfully inserted, update the selection.
   const node = transform.state.document.getNode(block.key)

--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -508,7 +508,7 @@ Transforms.deleteForwardAtRange = (transform, range, n = 1, options = {}) => {
 
 Transforms.insertBlockAtRange = (transform, range, block, options = {}) => {
   block = Normalize.block(block)
-  const { normalize = true } = options
+  const { normalize = true, replaceEmpty = true } = options
 
   if (range.isExpanded) {
     transform.deleteAtRange(range)
@@ -527,7 +527,7 @@ Transforms.insertBlockAtRange = (transform, range, block, options = {}) => {
     transform.insertNodeByKey(parent.key, index + 1, block, { normalize })
   }
 
-  else if (startBlock.isEmpty) {
+  else if (startBlock.isEmpty && replaceEmpty) {
     transform.removeNodeByKey(startBlock.key)
     transform.insertNodeByKey(parent.key, index, block, { normalize })
   }

--- a/test/transforms/fixtures/at-current-range/insert-block/replace-empty-false-option/index.js
+++ b/test/transforms/fixtures/at-current-range/insert-block/replace-empty-false-option/index.js
@@ -1,0 +1,30 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 0,
+    focusKey: first.key,
+    focusOffset: 0
+  })
+
+  const next = state
+    .transform()
+    .select(range)
+    .insertBlock('paragraph', { replaceEmpty: false })
+    .insertBlock('paragraph', { replaceEmpty: false })
+    .apply()
+
+  const updated = next.document.getTexts().first()
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.collapseToStartOf(updated).toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/insert-block/replace-empty-false-option/input.yaml
+++ b/test/transforms/fixtures/at-current-range/insert-block/replace-empty-false-option/input.yaml
@@ -1,0 +1,12 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: not empty

--- a/test/transforms/fixtures/at-current-range/insert-block/replace-empty-false-option/output.yaml
+++ b/test/transforms/fixtures/at-current-range/insert-block/replace-empty-false-option/output.yaml
@@ -1,0 +1,22 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: not empty


### PR DESCRIPTION
Slate will not allow inserting successive empty non-void blocks through ``transform.insertBlock``. Not sure about the rationale behind this logic, but I suppose there is a reason for this (please enlighten me).

This PR is an experiment with allowing ``insertBlock`` to allow take an option to allow inserting successive empty non-void blocks (``replaceEmpty: false``).

What do you think?
