### PR TITLE
getFragmentAtRange returns range when selection is collapsed (including in void nodes)

### DIFF
--- a/src/models/node.js
+++ b/src/models/node.js
@@ -500,9 +500,6 @@ const Node = {
     let node = this
     let nodes = new List()
 
-    // If the range is collapsed, there's nothing to do.
-    if (range.isCollapsed) return Document.create({ nodes })
-
     // Make sure the children exist.
     const { startKey, startOffset, endKey, endOffset } = range
     node.assertDescendant(startKey)


### PR DESCRIPTION
As per @ianstormtaylor's [comment here](https://github.com/ianstormtaylor/slate/issues/660#issuecomment-287970164), this PR removes the code which was returning early when selection was collapsed.

When the selection is collapsed and not in void node, it return fragment with no text inside. If the selection is collapsed and in void nodes, it returns the void node block.