### PR TITLE
Documentation: use correct localStorage method for setting content

### DIFF
--- a/docs/walkthroughs/saving-and-loading-html-content.md
+++ b/docs/walkthroughs/saving-and-loading-html-content.md
@@ -243,7 +243,7 @@ class App extends React.Component {
   // When the document changes, save the serialized HTML to Local Storage.
   onDocumentChange = (document, state) => {
     const string = html.serialize(state)
-    localStorage.set('content', string)
+    localStorage.setItem('content', string)
   }
 
   render = () => {


### PR DESCRIPTION
the section on saving and loading content was using `set` instead of `setItem`