### PR TITLE
Don't blur selection when focus moves to nested editable elements

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -272,6 +272,7 @@ class Content extends React.Component {
     if (this.props.readOnly) return
     if (this.tmp.isCopying) return
     if (!this.isInContentEditable(event)) return
+    if (this.element.contains(event.relatedTarget)) return
 
     const data = {}
 


### PR DESCRIPTION
If Slate editor contains nested editable components and the native selection enters one of those, focus moves from the `Content` DOM element to the new active one but editor doesn't really lose focus and selection must not be blurred.