### PR TITLE
Fix selection issue in "Check List" example

### DIFF
--- a/examples/check-lists/index.js
+++ b/examples/check-lists/index.js
@@ -40,15 +40,21 @@ class CheckListItem extends React.Component {
     const { attributes, children, node } = this.props
     const checked = node.data.get('checked')
     return (
-      <div {...attributes} className="check-list-item">
-        <span contentEditable={false}>
+      <div
+        className="check-list-item"
+        contentEditable={false}
+        {...attributes}
+      >
+        <span>
           <input
             type="checkbox"
             checked={checked}
             onChange={this.onChange}
           />
         </span>
-        {children}
+        <span contentEditable>
+          {children}
+        </span>
       </div>
     )
   }

--- a/examples/index.css
+++ b/examples/index.css
@@ -208,7 +208,19 @@ input:focus {
   margin-top: 0;
 }
 
-.check-list-item [contenteditable="false"] {
-  display: inline-block;
+.check-list-item {
+  display: flex;
+  flex-direction: row;
+}
+
+.check-list-item > span:first-child {
   margin-right: 0.75em;
+}
+
+.check-list-item > span:last-child {
+  flex: 1;
+}
+
+.check-list-item > span:last-child:focus {
+  outline: none;
 }


### PR DESCRIPTION
Also with the new (shining :blush:) selection updating code, there are issue with selection in the "Check List" example.
For example, in Firefox, putting the caret on the left end of a check list item and pressing left arrow key moves the caret on the left of the checkbox.
This PR intends to fix this making contenteditable just the area we really want to be editable.
Basically, it replaces a structure of the type
```
<div contenteditable>
  <div>
    <span contenteditable="false">...<span>
    <span>...</span>
  </div>
</div>
```
in which the position on the left of the first `<span>` is a legitimate caret position because it lies inside a contenteditable area, with
```
<div contenteditable>
  <div contenteditable="false">
    <span>...<span>
    <span contenteditable>...</span>
  </div>
</div>
```
where the position on the left of the first `<span>` is no longer accessible.

This PR depends on PRs #692, #693 and #694 to work correctly.
 