### PR TITLE
Fix forgotten props 'block' for Leaf

### DIFF
--- a/src/components/void.js
+++ b/src/components/void.js
@@ -152,7 +152,7 @@ class Void extends React.Component {
    */
 
   renderLeaf = () => {
-    const { node, schema, state, editor } = this.props
+    const { block, node, schema, state, editor } = this.props
     const child = node.getFirstText()
     const ranges = child.getRanges()
     const text = ''
@@ -167,6 +167,7 @@ class Void extends React.Component {
     return (
       <Leaf
         key={offsetKey}
+        block={block}
         editor={editor}
         index={index}
         marks={marks}


### PR DESCRIPTION
Hi.

I found, that [here](https://github.com/ianstormtaylor/slate/commit/059ee96db8d9ea73db94375eb1365625a56b6ec8#diff-93192bd0f30cb73c4088f025f5cf47d4R32) `block` property was added  for `Leaf` node. But, the `Void` component doesn't set this props for the `Leaf`.
This pull should fix the issue. Because, `React` throws warning when a `Leaf` component is rendered by `Void` component.