### PR TITLE
Remove space after first char when copying from Slate

### DIFF
--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -261,17 +261,11 @@ function Plugin(options = {}) {
     const zws = [].slice.call(contents.querySelectorAll('[data-slate-zero-width]'))
     zws.forEach(zw => zw.parentNode.removeChild(zw))
 
-    // Wrap the first character of the selection in a span that has the encoded
-    // fragment attached as an attribute, so it will show up in the copied HTML.
-    const wrapper = window.document.createElement('span')
+    // Insert an empty span that has the encoded fragment attached as an attribute.
+    const dataContainer = window.document.createElement('span')
     const text = contents.childNodes[0]
-    const char = text.textContent.slice(0, 1)
-    const first = window.document.createTextNode(char)
-    const rest = text.textContent.slice(1)
-    text.textContent = rest
-    wrapper.appendChild(first)
-    wrapper.setAttribute('data-slate-fragment', encoded)
-    contents.insertBefore(wrapper, text)
+    dataContainer.setAttribute('data-slate-fragment', encoded)
+    contents.insertBefore(dataContainer, text)
 
     // Add the phony content to the DOM, and select it, so it will be copied.
     const body = window.document.querySelector('body')


### PR DESCRIPTION
Right now if you copy "This thing" from Slate and paste
into a plain text app you will get "T his thing" because
Slate is making the first character a data holding span.

This diff makes the data containing span empty to eliminate
this extra space.

Closes #562