### PR TITLE
Keep selection while applying Transform.unwrapNodeByKey

### DIFF
--- a/src/transforms/by-key.js
+++ b/src/transforms/by-key.js
@@ -361,9 +361,8 @@ Transforms.unwrapNodeByKey = (transform, key, options = {}) => {
 
 
   if (parent.nodes.size === 1) {
-    // Remove the parent and replace it by the node itself.
-    transform.removeNodeByKey(parent.key, { normalize: false })
-    transform.insertNodeByKey(parentParent.key, parentIndex, node, options)
+    transform.moveNodeByKey(key, parentParent.key, parentIndex, { normalize: false })
+    transform.removeNodeByKey(parent.key, options)
   }
 
   else if (isFirst) {


### PR DESCRIPTION
Transforms should be applied in an order so that the selection is
preserved. This replaces "remove --> insert" with "move --> remove".

Close #670