### PR TITLE
feat: Add ES6 polyfill to examples page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i&subset=latin-ext" >
     <link rel="stylesheet" href="index.css">
+    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es6"></script>
   </head>
   <body>
     <main></main>

--- a/examples/index.html
+++ b/examples/index.html
@@ -5,10 +5,10 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i&subset=latin-ext" >
     <link rel="stylesheet" href="index.css">
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es6"></script>
   </head>
   <body>
     <main></main>
+    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es6"></script>
     <script src="build.prod.js"></script>
   </body>
 </html>


### PR DESCRIPTION
* Fixes issue with IE11 simply not displaying anything on load due to missing `Symbol` shim