### PR TITLE
Fix copy paste

### DIFF
--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -261,11 +261,17 @@ function Plugin(options = {}) {
     const zws = [].slice.call(contents.querySelectorAll('[data-slate-zero-width]'))
     zws.forEach(zw => zw.parentNode.removeChild(zw))
 
-    // Insert an empty span that has the encoded fragment attached as an attribute.
-    const dataContainer = window.document.createElement('span')
+    // Wrap the first character of the selection in a span that has the encoded
+    // fragment attached as an attribute, so it will show up in the copied HTML.
+    const wrapper = window.document.createElement('span')
     const text = contents.childNodes[0]
-    dataContainer.setAttribute('data-slate-fragment', encoded)
-    contents.insertBefore(dataContainer, text)
+    const char = text.textContent.slice(0, 1)
+    const first = window.document.createTextNode(char)
+    const rest = text.textContent.slice(1)
+    text.textContent = rest
+    wrapper.appendChild(first)
+    wrapper.setAttribute('data-slate-fragment', encoded)
+    contents.insertBefore(wrapper, text)
 
     // Add the phony content to the DOM, and select it, so it will be copied.
     const body = window.document.querySelector('body')


### PR DESCRIPTION
Internal copy/paste broke with PR #716.
This reverts 3e573453a8c5d92963d3f290fb7266f66e2a6b78

Se issue https://github.com/ianstormtaylor/slate/issues/734 for more details.

EDIT: I thought I had a solution to support the intention of 3e57345 with this PR, but it was still containing a whitespace on the clipboard. Removed that commit from this PR. As it is just now a revert, feel free to close without merge. However, this should be taken care of ASAP as it breaks core functionality.