### PR TITLE
Keep node style when deleting empty line above node

### DIFF
--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -117,7 +117,7 @@ Transforms.deleteAtRange = (transform, range, options = {}) => {
     let blockToKeep = startBlock
 
     // We keep the style of the blockToKeep. endBlock should keep style if deleting empty line.
-    if (startBlock.isEmpty && !endBlock.isEmpty) {
+    if (startBlock.isEmpty) {
       blockToRemove = startBlock
       blockToKeep = endBlock
     }

--- a/src/transforms/at-range.js
+++ b/src/transforms/at-range.js
@@ -113,14 +113,23 @@ Transforms.deleteAtRange = (transform, range, options = {}) => {
   const endBlock = document.getClosestBlock(document.getNextText(endKey).key)
 
   if (startBlock.key !== endBlock.key) {
-    endBlock.nodes.forEach((child, i) => {
-      const newKey = startBlock.key
-      const newIndex = startBlock.nodes.size + i
+    let blockToRemove = endBlock
+    let blockToKeep = startBlock
+
+    // We keep the style of the blockToKeep. endBlock should keep style if deleting empty line.
+    if (startBlock.isEmpty && !endBlock.isEmpty) {
+      blockToRemove = startBlock
+      blockToKeep = endBlock
+    }
+
+    blockToRemove.nodes.forEach((child, i) => {
+      const newKey = blockToKeep.key
+      const newIndex = blockToKeep.nodes.size + i
       transform.moveNodeByKey(child.key, newKey, newIndex, OPTS)
     })
 
-    // Remove parents of endBlock as long as they have a single child
-    const lonely = document.getFurthestOnlyChildAncestor(endBlock.key) || endBlock
+    // Remove parents of blockToRemove as long as they have a single child
+    const lonely = document.getFurthestOnlyChildAncestor(blockToRemove.key) || blockToRemove
     transform.removeNodeByKey(lonely.key, OPTS)
   }
 


### PR DESCRIPTION
Right now when you merge a block with the previous block, the previous
block's style always wins, even if the previous block's content is
empty. This does not make sense since deleting empty lines should not
affect style.

This updates the `deleteAtRange` transform to keep the style of the
bottom block in the case that the previous block is empty.

Closes #548