### PR TITLE
Add "data-key" to root div for the whole document

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -836,6 +836,7 @@ class Content extends React.Component {
         data-slate-editor
         key={this.tmp.forces}
         ref={this.ref}
+        data-key={document.key}
         contentEditable={!readOnly}
         suppressContentEditableWarning
         className={className}

--- a/test/rendering/index.js
+++ b/test/rendering/index.js
@@ -59,6 +59,7 @@ function clean(html) {
   $.root().children().removeAttr('autocorrect')
   $.root().children().removeAttr('spellcheck')
   $.root().children().removeAttr('style')
+  $.root().children().removeAttr('data-gramm')
 
   return $.html()
 }


### PR DESCRIPTION
The goal is to be able to use `findDOMNode` with the `document` itself.

The tests were failing since https://github.com/ianstormtaylor/slate/commit/a98b687aa538138be427f419ac5489cdbf72d51c. Since PR also fixes them.