### PR TITLE
Fix #763: Add prop "props" to pass custom props to nodes

### DIFF
--- a/docs/reference/components/editor.md
+++ b/docs/reference/components/editor.md
@@ -16,6 +16,9 @@ The top-level React component that renders the Slate editor itself.
   - [`readOnly`](#readonly)
   - [`state`](#state)
   - [`style`](#style)
+  - [`tabIndex`](#tabindex)
+  - [`role`](#role)
+  - [`props`](#props)
 - [Placeholder Properties](#placeholder-properties)
   - [`placeholder`](#placeholder)
   - [`placeholderClassName`](#placeholderclassname)
@@ -99,6 +102,10 @@ Indicates if it should participate to [sequential keyboard navigation](https://d
 ### `role`
 
 ARIA property to define the role of the editor, it defaults to `textbox` when editable.
+
+### `props`
+
+Custom properties to pass to all node components. An update of these props re-renders all the nodes.
 
 ## Placeholder Properties
 

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -52,6 +52,7 @@ class Content extends React.Component {
     onKeyDown: React.PropTypes.func.isRequired,
     onPaste: React.PropTypes.func.isRequired,
     onSelect: React.PropTypes.func.isRequired,
+    props: React.PropTypes.object,
     readOnly: React.PropTypes.bool.isRequired,
     role: React.PropTypes.string,
     schema: React.PropTypes.object,
@@ -879,7 +880,7 @@ class Content extends React.Component {
    */
 
   renderNode = (node) => {
-    const { editor, readOnly, schema, state } = this.props
+    const { editor, readOnly, schema, state, props } = this.props
 
     return (
       <Node
@@ -891,6 +892,7 @@ class Content extends React.Component {
         state={state}
         editor={editor}
         readOnly={readOnly}
+        props={props}
       />
     )
   }

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -73,13 +73,14 @@ class Editor extends React.Component {
     placeholderClassName: React.PropTypes.string,
     placeholderStyle: React.PropTypes.object,
     plugins: React.PropTypes.array,
+    props: React.PropTypes.object,
     readOnly: React.PropTypes.bool,
     role: React.PropTypes.string,
     schema: React.PropTypes.object,
     spellCheck: React.PropTypes.bool,
     state: React.PropTypes.instanceOf(State).isRequired,
     style: React.PropTypes.object,
-    tabIndex: React.PropTypes.number,
+    tabIndex: React.PropTypes.number
   }
 
   /**

--- a/src/components/leaf.js
+++ b/src/components/leaf.js
@@ -3,6 +3,7 @@ import Debug from 'debug'
 import OffsetKey from '../utils/offset-key'
 import React from 'react'
 import ReactDOM from 'react-dom'
+import shallowEqual from 'fbjs/lib/shallowEqual'
 import findDeepestNode from '../utils/find-deepest-node'
 import { IS_FIREFOX } from '../constants/environment'
 
@@ -36,6 +37,7 @@ class Leaf extends React.Component {
     node: React.PropTypes.object.isRequired,
     offset: React.PropTypes.number.isRequired,
     parent: React.PropTypes.object.isRequired,
+    props: React.PropTypes.object,
     ranges: React.PropTypes.object.isRequired,
     schema: React.PropTypes.object.isRequired,
     state: React.PropTypes.object.isRequired,
@@ -80,6 +82,11 @@ class Leaf extends React.Component {
       props.schema != this.props.schema ||
       props.text != this.props.text
     ) {
+      return true
+    }
+
+    // If custom props have changed, re-render
+    if (!shallowEqual(props.props, this.props.props)) {
       return true
     }
 
@@ -182,6 +189,7 @@ class Leaf extends React.Component {
           schema={schema}
           state={state}
           text={text}
+          props={props.props}
         >
           {memo}
         </Component>

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -139,7 +139,7 @@ class Node extends React.Component {
     }
 
     // If the custom props of the editor changed
-    if (nextProps.props !== props.props || !shallowEqual(nextProps.props, props.props)) {
+    if (!shallowEqual(nextProps.props, props.props)) {
       return true
     }
 
@@ -331,7 +331,7 @@ class Node extends React.Component {
    */
 
   renderLeaf = (ranges, range, index, offset) => {
-    const { block, node, parent, schema, state, editor } = this.props
+    const { block, node, parent, schema, state, editor, props } = this.props
     const { text, marks } = range
 
     return (
@@ -348,6 +348,7 @@ class Node extends React.Component {
         schema={schema}
         state={state}
         text={text}
+        props={props}
       />
     )
   }

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -233,7 +233,7 @@ class Node extends React.Component {
    */
 
   renderNode = (child) => {
-    const { block, editor, node, readOnly, schema, state } = this.props
+    const { block, editor, node, readOnly, schema, state, props } = this.props
     return (
       <Node
         key={child.key}
@@ -244,6 +244,7 @@ class Node extends React.Component {
         readOnly={readOnly}
         schema={schema}
         state={state}
+        props={props}
       />
     )
   }
@@ -255,7 +256,7 @@ class Node extends React.Component {
    */
 
   renderElement = () => {
-    const { editor, node, parent, readOnly, state } = this.props
+    const { editor, node, parent, readOnly, state, props } = this.props
     const { Component } = this.state
     const children = node.nodes.map(this.renderNode).toArray()
 
@@ -282,6 +283,7 @@ class Node extends React.Component {
         node={node}
         readOnly={readOnly}
         state={state}
+        props={props}
       >
         {children}
       </Component>

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -3,6 +3,7 @@ import Base64 from '../serializers/base-64'
 import Debug from 'debug'
 import React from 'react'
 import ReactDOM from 'react-dom'
+import shallowEqual from 'fbjs/lib/shallowEqual'
 import TYPES from '../constants/types'
 import Leaf from './leaf'
 import Void from './void'
@@ -36,6 +37,7 @@ class Node extends React.Component {
     editor: React.PropTypes.object.isRequired,
     node: React.PropTypes.object.isRequired,
     parent: React.PropTypes.object.isRequired,
+    props: React.PropTypes.object,
     readOnly: React.PropTypes.bool.isRequired,
     schema: React.PropTypes.object.isRequired,
     state: React.PropTypes.object.isRequired
@@ -134,6 +136,11 @@ class Node extends React.Component {
       const last = props.parent.nodes.last()
       const nextLast = nextProps.parent.nodes.last()
       if (props.node == last && nextProps.node != nextLast) return true
+    }
+
+    // If the custom props of the editor changed
+    if (nextProps.props !== props.props || !shallowEqual(nextProps.props, props.props)) {
+      return true
     }
 
     // Otherwise, don't update.

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -876,6 +876,7 @@ function Plugin(options = {}) {
         state={state}
         style={props.style}
         tabIndex={props.tabIndex}
+        props={props.props}
       />
     )
   }

--- a/test/rendering/fixtures/custom-props-block/index.js
+++ b/test/rendering/fixtures/custom-props-block/index.js
@@ -1,0 +1,15 @@
+
+import React from 'react'
+
+function Code(props) {
+  return <pre {...props.attributes} className={props.props.className}><code>{props.children}</code></pre>
+}
+
+export const schema = {
+  nodes: {
+    code: Code
+  }
+}
+export const props = {
+  className: 'custom-classname'
+}

--- a/test/rendering/fixtures/custom-props-block/input.yaml
+++ b/test/rendering/fixtures/custom-props-block/input.yaml
@@ -1,0 +1,14 @@
+
+nodes:
+  - kind: block
+    type: default
+    nodes:
+      - kind: text
+        ranges:
+          - text: word
+  - kind: block
+    type: code
+    nodes:
+      - kind: text
+        ranges:
+          - text: another

--- a/test/rendering/fixtures/custom-props-block/output.html
+++ b/test/rendering/fixtures/custom-props-block/output.html
@@ -1,0 +1,15 @@
+
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+  <div style="position:relative;">
+    <span>
+      <span>word</span>
+    </span>
+  </div>
+  <pre class="custom-classname">
+    <code>
+      <span>
+        <span>another</span>
+      </span>
+    </code>
+  </pre>
+</div>

--- a/test/rendering/fixtures/custom-props-inline/index.js
+++ b/test/rendering/fixtures/custom-props-inline/index.js
@@ -1,0 +1,16 @@
+
+import React from 'react'
+
+function Link(props) {
+  const href = props.node.data.get('href')
+  return <a {...props.attributes} className={props.props.className} href={href}>{props.children}</a>
+}
+
+export const schema = {
+  nodes: {
+    link: Link
+  }
+}
+export const props = {
+  className: 'custom-classname'
+}

--- a/test/rendering/fixtures/custom-props-inline/input.yaml
+++ b/test/rendering/fixtures/custom-props-inline/input.yaml
@@ -1,0 +1,17 @@
+
+nodes:
+  - kind: block
+    type: default
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        type: link
+        data:
+          href: https://google.com
+        nodes:
+          - kind: text
+            ranges:
+              - text: word
+      - kind: text
+        text: ""

--- a/test/rendering/fixtures/custom-props-inline/output.html
+++ b/test/rendering/fixtures/custom-props-inline/output.html
@@ -1,0 +1,20 @@
+
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+  <div style="position:relative;">
+    <span>
+      <span>
+        <span data-slate-zero-width="true">&#x200A;</span>
+      </span>
+    </span>
+    <a class="custom-classname" href="https://google.com">
+      <span>
+        <span>word</span>
+      </span>
+    </a>
+    <span>
+      <span>
+        <span data-slate-zero-width="true">&#x200A;</span>
+      </span>
+    </span>
+  </div>
+</div>

--- a/test/rendering/fixtures/custom-props-mark/index.js
+++ b/test/rendering/fixtures/custom-props-mark/index.js
@@ -1,0 +1,15 @@
+
+import React from 'react'
+
+function Bold(props) {
+  return <strong className={props.props.className}>{props.children}</strong>
+}
+
+export const schema = {
+  marks: {
+    bold: Bold
+  }
+}
+export const props = {
+  className: 'custom-classname'
+}

--- a/test/rendering/fixtures/custom-props-mark/input.yaml
+++ b/test/rendering/fixtures/custom-props-mark/input.yaml
@@ -1,0 +1,12 @@
+
+nodes:
+  - kind: block
+    type: default
+    nodes:
+      - kind: text
+        ranges:
+          - text: one
+          - text: two
+            marks:
+              - type: bold
+          - text: three

--- a/test/rendering/fixtures/custom-props-mark/output.html
+++ b/test/rendering/fixtures/custom-props-mark/output.html
@@ -1,0 +1,10 @@
+
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+  <div style="position:relative;">
+    <span>
+      <span>one</span>
+      <span><strong class="custom-classname">two</strong></span>
+      <span>three</span>
+    </span>
+  </div>
+</div>

--- a/test/rendering/index.js
+++ b/test/rendering/index.js
@@ -59,6 +59,7 @@ function clean(html) {
   $.root().children().removeAttr('autocorrect')
   $.root().children().removeAttr('spellcheck')
   $.root().children().removeAttr('style')
+  $.root().children().removeAttr('data-gramm')
 
   return $.html()
 }


### PR DESCRIPTION
This PR fixes #763 by adding a prop `props` that can be used to pass a set of props to all nodes (inline, marks and blocks).

The nodes are re-rendered if `props` changes. It uses `fbjs/lib/shallowEqual` to compare the props.

- [x] Add prop `props`
- [x] Re-render if the prop changed
- [x] Documentation
- [x] Unit tests