### PR TITLE
improve perf delaying conversion to immutable objects

### DIFF
--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -31,9 +31,14 @@ baseline.forEach((suite, i) => {
     const faster = (b - c) < (0 - threshold)
     const percent = Math.round(Math.abs(b - c) / b * 100)
 
-    let output = `${b.toFixed(2)} --> ${c.toFixed(2)} iterations/sec`
+    let output = `${b.toFixed(2)} → ${c.toFixed(2)} iterations/sec`
     if (slower) output = chalk.red(`${output} (${percent}% slower)`)
-    if (faster) output = chalk.green(`${output} (${percent}% faster)`)
+    else if (faster) output = chalk.green(`${output} (${percent}% faster)`)
+    else output = chalk.gray(output)
+
+    if (percent > 1000) output += ' 😱'
+    else if (faster && percent > 100) output += ' 🙌'
+    else if (slower && percent > 100) output += ' 😟'
 
     console.log(`      ${base.title}`)
     console.log(`        ${output}`)

--- a/benchmark/fixtures/models/get-blocks-at-range/index.js
+++ b/benchmark/fixtures/models/get-blocks-at-range/index.js
@@ -1,0 +1,17 @@
+
+import { __clear } from '../../../../lib/utils/memoize'
+
+export default function ({ state, range }) {
+  state.document.getBlocksAtRange(range)
+}
+
+export function before(state) {
+  return {
+    state,
+    range: state.selection.moveToRangeOf(state.document),
+  }
+}
+
+export function after() {
+  __clear()
+}

--- a/benchmark/fixtures/models/get-blocks-at-range/input.yaml
+++ b/benchmark/fixtures/models/get-blocks-at-range/input.yaml
@@ -1,0 +1,683 @@
+nodes:
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        key: _cursor_
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'

--- a/benchmark/fixtures/models/get-characters-at-range/index.js
+++ b/benchmark/fixtures/models/get-characters-at-range/index.js
@@ -1,0 +1,18 @@
+
+import { __clear } from '../../../../lib/utils/memoize'
+
+export default function ({ state, range }) {
+  state.document.getCharactersAtRange(range)
+}
+
+export function before(state) {
+  return {
+    state,
+    range: state.selection.moveToRangeOf(state.document),
+  }
+}
+
+export function after() {
+  __clear()
+}
+

--- a/benchmark/fixtures/models/get-characters-at-range/input.yaml
+++ b/benchmark/fixtures/models/get-characters-at-range/input.yaml
@@ -1,0 +1,683 @@
+nodes:
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        key: _cursor_
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'

--- a/benchmark/fixtures/models/get-characters/index.js
+++ b/benchmark/fixtures/models/get-characters/index.js
@@ -1,0 +1,11 @@
+
+import { __clear } from '../../../../lib/utils/memoize'
+
+export default function (state) {
+  state.document.getCharacters()
+}
+
+export function after() {
+  __clear()
+}
+

--- a/benchmark/fixtures/models/get-characters/input.yaml
+++ b/benchmark/fixtures/models/get-characters/input.yaml
@@ -1,0 +1,683 @@
+nodes:
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        key: _cursor_
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'

--- a/benchmark/fixtures/models/get-inlines-at-range/index.js
+++ b/benchmark/fixtures/models/get-inlines-at-range/index.js
@@ -1,0 +1,17 @@
+
+import { __clear } from '../../../../lib/utils/memoize'
+
+export default function ({ state, range }) {
+  state.document.getInlinesAtRange(range)
+}
+
+export function before(state) {
+  return {
+    state,
+    range: state.selection.moveToRangeOf(state.document),
+  }
+}
+
+export function after() {
+  __clear()
+}

--- a/benchmark/fixtures/models/get-inlines-at-range/input.yaml
+++ b/benchmark/fixtures/models/get-inlines-at-range/input.yaml
@@ -1,0 +1,683 @@
+nodes:
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        key: _cursor_
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'

--- a/benchmark/fixtures/models/get-marks-at-range/index.js
+++ b/benchmark/fixtures/models/get-marks-at-range/index.js
@@ -1,0 +1,17 @@
+
+import { __clear } from '../../../../lib/utils/memoize'
+
+export default function ({ state, range }) {
+  state.document.getMarksAtRange(range)
+}
+
+export function before(state) {
+  return {
+    state,
+    range: state.selection.moveToRangeOf(state.document),
+  }
+}
+
+export function after() {
+  __clear()
+}

--- a/benchmark/fixtures/models/get-marks-at-range/input.yaml
+++ b/benchmark/fixtures/models/get-marks-at-range/input.yaml
@@ -1,0 +1,683 @@
+nodes:
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        key: _cursor_
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'

--- a/benchmark/fixtures/models/get-texts-at-range/index.js
+++ b/benchmark/fixtures/models/get-texts-at-range/index.js
@@ -1,0 +1,18 @@
+
+import { __clear } from '../../../../lib/utils/memoize'
+
+export default function ({ state, range }) {
+  state.document.getTextsAtRange(range)
+}
+
+export function before(state) {
+  return {
+    state,
+    range: state.selection.moveToRangeOf(state.document),
+  }
+}
+
+export function after() {
+  __clear()
+}
+

--- a/benchmark/fixtures/models/get-texts-at-range/input.yaml
+++ b/benchmark/fixtures/models/get-texts-at-range/input.yaml
@@ -1,0 +1,683 @@
+nodes:
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        key: _cursor_
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'This is editable '
+        - text: 'rich'
+          marks:
+          - type: bold
+        - text: ' text, '
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'much'
+          marks:
+          - type: italic
+        - text: ' better than a '
+        - text: '<textarea>'
+          marks:
+          - type: code
+        - text: '!'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        ranges:
+        - text: 'Since it''s rich text, you can do things like turn a selection of text '
+        - text: 'bold'
+          marks:
+          - type: bold
+        - text: ', or add a semantically rendered block quote in the middle of the page,
+            like this:'
+- kind: block
+  type: block-quote
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'A wise quote.'
+- kind: block
+  type: paragraph
+  nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+      - kind: text
+        text: 'Try it out for yourself!'

--- a/src/models/text.js
+++ b/src/models/text.js
@@ -181,9 +181,20 @@ class Text extends new Record(DEFAULTS) {
    */
 
   getMarks() {
-    return this.characters.reduce((marks, char) => {
-      return marks.union(char.marks)
-    }, new OrderedSet())
+    const array = this.getMarksAsArray()
+    return new OrderedSet(array)
+  }
+
+  /**
+   * Get all of the marks on the text as an array
+   *
+   * @return {Array}
+   */
+
+  getMarksAsArray() {
+    return this.characters.reduce((array, char) => {
+      return array.concat(char.marks.toArray())
+    }, [])
   }
 
   /**
@@ -398,6 +409,8 @@ class Text extends new Record(DEFAULTS) {
 memoize(Text.prototype, [
   'getDecorations',
   'getDecorators',
+  'getMarks',
+  'getMarksAsArray',
   'getMarksAtIndex',
   'getRanges',
   'validate'


### PR DESCRIPTION
A few performance tweaks to help ease some of the issues with #791...

Looking in the **Performance** tab of devtools, we can see that most of the tab is spent in re-rendering the toolbar buttons. Because when the selection changes, they need to recalculate whether they should be "active" or not.

![image](https://cloud.githubusercontent.com/assets/311752/25754985/0e9e3cb8-3176-11e7-9065-f2a9fe17cf6d.png)

Which (on my machine), when selecting the "large document" amount of text in the "rich text" example is taking 38 seconds. 😱  

Most of the time is spent re-rendering the mark buttons...

![image](https://cloud.githubusercontent.com/assets/311752/25754850/9866689a-3175-11e7-8c3e-e828fa4ec2c5.png)

But there is also a decent chunk spent recalculating the block buttons...

![image](https://cloud.githubusercontent.com/assets/311752/25755100/795eb41a-3176-11e7-91c8-c6b7179623f5.png)

![image](https://cloud.githubusercontent.com/assets/311752/25755154/a375a074-3176-11e7-8048-2673c572f38b.png)

All in all the largest amount of time is spent in...

```
78.2% RichText.renderToolbar()
    64.5% RichText.renderMarkButton()
        60.8% RichText.hasMark()
            60.8% getMarksAtRange()
                60.5% getCharactersAtRange()
                    60.5% reduce()
                        59.2% concat()
                            -> Immutable.js internals
    13.6% RichText.renderBlockButton()
        12.9% RichText.hasBlock()
            12.8% getBlocksAtRange()
                9.8% getClosestBlock()
                    9.6% getAncestors()
                        3.6% hasChild()
                            2.0% getChild()
                3.0% toOrderedSet()
                    -> Immutable.js internals
```

This PR changes the way lots of the `get*` and `get*AtRange` methods work to delay converting to Immutable.js objects until after iterating, since it's a lot faster to use `.map`, `.filter`, etc. with regular arrays when possible than with immutable objects.

After all of the changes, the benchmarks show a pretty decent increase for many things...

![image](https://cloud.githubusercontent.com/assets/311752/25758601/10dc85bc-3184-11e7-8c3f-d223d91a8973.png)

And now re-running the same performance analysis shows that the total time for the same re-rendering is now ~8 seconds instead of 38. And now the biggest time sink is actually in the block buttons, because the mark buttons have been significantly sped up...

![image](https://cloud.githubusercontent.com/assets/311752/25758314/ed382f5e-3182-11e7-95ce-500ba3f1b919.png)

Still more work to be done, but a pretty big win for very little work.