### PR TITLE
Make rules apply to everything if no match property is provided

### DIFF
--- a/docs/reference/models/schema.md
+++ b/docs/reference/models/schema.md
@@ -100,7 +100,7 @@ Internally, the `marks` and `nodes` properties of a schema are simply converted 
 }
 ```
 
-Slate schemas are built up of a set of rules. Each of the properties will add certain functionality to the schema, based on the properties it defines. 
+Slate schemas are built up of a set of rules. Each of the properties will add certain functionality to the schema, based on the properties it defines.
 
 ### `match`
 `Function match(object: Node || Mark)`
@@ -111,7 +111,7 @@ Slate schemas are built up of a set of rules. Each of the properties will add ce
 }
 ```
 
-The `match` property is the only required property of a rule. It determines which objects the rule applies to. 
+The `match` property determines which objects the rule applies to. It defaults to applying to all objects. (i.e. `() => true`)
 
 ### `decorate`
 `Function decorate(text: Node, object: Node) => List<Characters>`

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -78,7 +78,7 @@ class Schema extends new Record(DEFAULTS) {
    */
 
   __getComponent(object) {
-    const match = this.rules.find(rule => rule.render && rule.match(object))
+    const match = this.rules.find(rule => rule.render && (!rule.match || rule.match(object)))
     if (!match) return
     return match.render
   }
@@ -96,7 +96,7 @@ class Schema extends new Record(DEFAULTS) {
 
   __getDecorators(object) {
     return this.rules
-      .filter(rule => rule.decorate && rule.match(object))
+      .filter(rule => rule.decorate && (!rule.match || rule.match(object)))
       .map((rule) => {
         return (text) => {
           return rule.decorate(text, object)
@@ -121,7 +121,7 @@ class Schema extends new Record(DEFAULTS) {
 
     const match = this.rules.find((rule) => {
       if (!rule.validate) return
-      if (!rule.match(object)) return
+      if (!rule.match || !rule.match(object)) return
 
       value = rule.validate(object)
       return value

--- a/test/plugins/fixtures/match-by-default/index.js
+++ b/test/plugins/fixtures/match-by-default/index.js
@@ -1,0 +1,27 @@
+
+import { Mark } from '../../../..'
+
+const BOLD = {
+  fontWeight: 'bold'
+}
+
+function decorate(text, block) {
+  let { characters } = text
+  let second = characters.get(1)
+  const mark = Mark.create({ type: 'bold' })
+  const marks = second.marks.add(mark)
+  second = second.merge({ marks })
+  characters = characters.set(1, second)
+  return characters
+}
+
+export const plugins = [{
+  schema: {
+    marks: {
+      bold: BOLD
+    },
+    rules: [{
+      decorate,
+    }]
+  }
+}]

--- a/test/plugins/fixtures/match-by-default/input.yaml
+++ b/test/plugins/fixtures/match-by-default/input.yaml
@@ -1,0 +1,8 @@
+
+nodes:
+  - kind: block
+    type: default
+    nodes:
+      - kind: text
+        ranges:
+          - text: word

--- a/test/plugins/fixtures/match-by-default/output.html
+++ b/test/plugins/fixtures/match-by-default/output.html
@@ -1,0 +1,4 @@
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+    <div style="position:relative;"><span><span>w</span><span><span style="font-weight:bold;">o</span></span><span>rd</span></span>
+    </div>
+</div>


### PR DESCRIPTION
Wanted to kick off a discussion, I don't see any reasons to throw an error if a rule doesn't define `match`. (which is what currently happens)

This commit changes that behaviour by making rules match everything by default. Maybe there's a reason for the current behaviour, but I figured it'd be worth discussing!