### PR TITLE
Fix state.json in examples/links

### DIFF
--- a/examples/links/state.json
+++ b/examples/links/state.json
@@ -18,7 +18,7 @@
             {
               "kind": "text",
               "text": "hyperlinks"
-            },
+            }
           ]
         },
         {


### PR DESCRIPTION
Because of comma, this json file occured an syntax error. I removed it.
Below shows the error message.
```
Error: Parse error on line 18:
...hyperlinks"					}, ]				},				{					
----------------------^
Expecting 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[', got ']'
```