### PR TITLE
The rich-text example: the ol&ul menu should be active when user navigate to correspond DOM

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -276,7 +276,19 @@ class RichText extends React.Component {
    */
 
   renderBlockButton = (type, icon) => {
-    const isActive = this.hasBlock(type)
+    let isActive = false
+    if (type != 'bulleted-list' && type != 'numbered-list') {
+      isActive = this.hasBlock(type)
+    } else {
+      const { blocks, document } = this.state.state
+      const isList = this.hasBlock('list-item')
+      const isType = blocks.some((block) => {
+        return !!document.getClosest(block.key, parent => parent.type == type)
+      });
+      if (isList && isType) {
+        isActive = true
+      }
+    }
     const onMouseDown = e => this.onClickBlock(e, type)
 
     return (


### PR DESCRIPTION
the ul&ol menu in the examples/rich-text should be active when user navigate to ul&ol dom in the editor.