### PR TITLE
Avoid unnecessary renders and normalization

### DIFF
--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -55,7 +55,7 @@ const PLUGINS_PROPS = [
  * @type {Component}
  */
 
-class Editor extends React.Component {
+class Editor extends React.PureComponent {
 
   /**
    * Property types.


### PR DESCRIPTION
I noticed in my app that, even if every props I passed to `Slate.Editor` had not changed, there was a schema normalization call.

I thought we had fixed these problems long ago. I could not find again when, in Slate, the normalization is called. I could only find the `Content.shouldComponentUpdate`, which looked all right. So I simply wrapped the Editor in a `React.PureComponent` and now it updates as needed.