### PR TITLE
Avoid duplicate content with `onChange` handlers

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -551,7 +551,11 @@ class Content extends React.Component {
     debug('onInput', { event })
 
     const window = getWindow(event.target)
-    const { state, editor } = this.props
+    const { editor } = this.props
+    const { pendingOnBeforeInputState } = editor.tmp
+    const state = pendingOnBeforeInputState ?
+      pendingOnBeforeInputState :
+      this.props.state
 
     // Get the selection point.
     const native = window.getSelection()
@@ -585,7 +589,10 @@ class Content extends React.Component {
     // If the text is no different, abort.
     const range = ranges.get(index)
     const { text, marks } = range
-    if (textContent == text) return
+    if (textContent == text) {
+      this.onChange(state)
+      return
+    }
 
     // Determine what the selection should be after changing the text.
     const delta = textContent.length - text.length

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -126,9 +126,13 @@ class Editor extends React.Component {
 
     // Create a bound event handler for each event.
     for (const method of EVENT_HANDLERS) {
-      this[method] = (...args) => {
-        const next = this.state.stack[method](this.state.state, this, ...args)
-        this.onChange(next)
+      this[method] = (event, ...others) => {
+        const next = this.state.stack[method](this.state.state, this, event, ...others)
+        if (method === 'onBeforeInput' && !event.defaultPrevented) {
+          this.tmp.pendingOnBeforeInputState = next
+        } else {
+          this.onChange(next)
+        }
       }
     }
   }
@@ -232,6 +236,7 @@ class Editor extends React.Component {
     onChange(state)
     if (state.document != document) onDocumentChange(state.document, state)
     if (state.selection != selection) onSelectionChange(state.selection, state)
+    if (this.tmp.pendingOnBeforeInputState) this.tmp.pendingOnBeforeInputState = null
   }
 
   /**


### PR DESCRIPTION
This PR intends to fix issue #750.

It changes a bit the way Slate elaborates a user input.

At the end of the `onBeforeInput` handlers stage, if the `onBeforeInput` event has not been canceled, the editor does not call any more `onBeforeChange` and `onChange` handlers, but stores temporarily the state.

After the changes are applied to the DOM an `input` event is fired, then the editor takes the stored state, calls `onBeforeChange` and `onChange` handlers and finally sets the outcoming editor state.

In this way, if a `isNative = true` state returned by the `onBeforeInput` stage is mutated by `onBeforeChange` or `onChange` handlers, it is rendered after DOM has already been mutated and the changes don't cumulate.

As always any change you think needed is welcome. :blush:
