### PR TITLE
Check to not break if node does not have getRanges

### DIFF
--- a/src/utils/get-point.js
+++ b/src/utils/get-point.js
@@ -24,7 +24,7 @@ function getPoint(element, offset, state, editor) {
   // then afterwards for the correct `element`. (2017/03/03)
   const { key } = offsetKey
   const node = document.getDescendant(key)
-  if (!node) return null
+  if (!node || !node.getRanges) return null
 
   const decorators = document.getDescendantDecorators(key, schema)
   const ranges = node.getRanges(decorators)


### PR DESCRIPTION
I ran into a weird bug with slate-trailing-block where a `Block` was making it way here via `onSelect` on down arrow key. Anyway, that was leading to a Javascript error in the console as only `Text` has getRanges defined. This check gracefully returns if the node does not have a `getRanges` method.