### PR TITLE
Ignore comments in Html deserializer

### DIFF
--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -35,6 +35,8 @@ const TEXT_RULE = {
     }
 
     if (el.type == 'text') {
+      if (el.data && el.data.match(/<!--.*?-->/)) return
+
       return {
         kind: 'text',
         text: el.data

--- a/test/serializers/fixtures/html/deserialize/html-comment/index.js
+++ b/test/serializers/fixtures/html/deserialize/html-comment/index.js
@@ -1,0 +1,18 @@
+
+export default {
+  rules: [
+    {
+      deserialize(el, next) {
+        switch (el.tagName) {
+          case 'p': {
+            return {
+              kind: 'block',
+              type: 'paragraph',
+              nodes: next(el.children)
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/serializers/fixtures/html/deserialize/html-comment/input.html
+++ b/test/serializers/fixtures/html/deserialize/html-comment/input.html
@@ -1,0 +1,2 @@
+<!-- This comment should be ignored -->
+<p>text</p>

--- a/test/serializers/fixtures/html/deserialize/html-comment/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/html-comment/output.yaml
@@ -1,0 +1,16 @@
+
+data: {}
+nodes:
+  - type: paragraph
+    isVoid: false
+    data: {}
+    nodes:
+      - characters:
+          - text: t
+            marks: []
+          - text: e
+            marks: []
+          - text: x
+            marks: []
+          - text: t
+            marks: []


### PR DESCRIPTION
If you paste in HTML with comments, the comments get pasted in as text. I noticed this when using Google Sheets with cell borders.