### PR TITLE
When the parameter passed to `isInEditor` is a text node use its parent instead

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -247,6 +247,8 @@ class Content extends React.Component {
 
   isInEditor = (target) => {
     const { element } = this
+    // If `target` is a text node use the parent in the check.
+    if (target.nodeType === 3) target = target.parentElement
     return (
       (target.isContentEditable) &&
       (target == element || findClosestNode(target, '[data-slate-editor]') == element)

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -247,11 +247,12 @@ class Content extends React.Component {
 
   isInEditor = (target) => {
     const { element } = this
-    // If `target` is a text node use the parent in the check.
-    if (target.nodeType === 3) target = target.parentElement
+    // COMPAT: Text nodes don't have `isContentEditable` property. So, when
+    // `target` is a text node use its parent element for check.
+    const el = target.nodeType === 3 ? target.parentElement : target
     return (
-      (target.isContentEditable) &&
-      (target == element || findClosestNode(target, '[data-slate-editor]') == element)
+      (el.isContentEditable) &&
+      (el === element || findClosestNode(el, '[data-slate-editor]') === element)
     )
   }
 


### PR DESCRIPTION
To test if `target` belongs to the editor, `isInEditor` `Content` method uses the code:

```
target.isContentEditable &&
(target == element || findClosestNode(target, '[data-slate-editor]') == element)
```

but `isContentEditable` is a property of `HTMLElement` only.
Therefore when `target` is a text node `isInEditor` returns false even when it should not.
To fix this, use `target` parent in the check when `target` is a text node.