### PR TITLE
Add property "isEmpty"

### DIFF
--- a/docs/reference/models/state.md
+++ b/docs/reference/models/state.md
@@ -33,6 +33,7 @@ For convenience, in addition to transforms, many of the [`Selection`](./selectio
   - [`isExpanded`](#isExpanded)
   - [`isFocused`](#isfocused)
   - [`isForward`](#isForward)
+  - [`isEmpty`](#isEmpty)
 - [Static Methods](#static-methods)
   - [`State.create`](#statecreate)
 - [Methods](#methods)
@@ -153,6 +154,10 @@ Whether the current selection is focused.
 
 Whether the current selection is forward.
 
+### `isEmpty`
+`Boolean`
+
+Whether the current selection is empty.
 
 ## Static Methods
 

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -179,7 +179,7 @@ class HoveringMenu extends React.Component {
     const { menu, state } = this.state
     if (!menu) return
 
-    if (state.isBlurred || state.isCollapsed) {
+    if (state.isBlurred || state.isEmpty) {
       menu.removeAttribute('style')
       return
     }

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -432,10 +432,14 @@ class State extends new Record(DEFAULTS) {
    */
 
   get isEmpty() {
-    const { startKey, endKey, startOffset, endOffset } = this
+    const { startOffset, endOffset } = this
 
-    if (startKey == endKey) {
-      return (startOffset == endOffset)
+    if (this.isCollapsed) {
+      return
+    }
+
+    if (endOffset != 0 && startOffset != 0) {
+      return
     }
 
     return this.fragment.text.length == 0

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -435,11 +435,11 @@ class State extends new Record(DEFAULTS) {
     const { startOffset, endOffset } = this
 
     if (this.isCollapsed) {
-      return
+      return true
     }
 
     if (endOffset != 0 && startOffset != 0) {
-      return
+      return false
     }
 
     return this.fragment.text.length == 0

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -426,6 +426,22 @@ class State extends new Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the selection is empty.
+   *
+   * @return {Boolean}
+   */
+
+  get isEmpty() {
+    const { startKey, endKey, startOffset, endOffset } = this
+
+    if (startKey == endKey) {
+      return (startOffset == endOffset)
+    }
+
+    return this.fragment.text.length == 0
+  }
+
+  /**
    * Return a new `Transform` with the current state as a starting point.
    *
    * @param {Object} properties


### PR DESCRIPTION
Fix #862 by adding a property `isEmpty`. The computation tries to be performant by not computing `state.fragment` when the selection is "simple".

I've also updated the "Hovering menu", it works perfectly with it.

@ianstormtaylor I'm not sure where to put unit tests for this property.