### PR TITLE
Fix: findDOMNode was called on an unmounted component

### DIFF
--- a/src/components/node.js
+++ b/src/components/node.js
@@ -162,6 +162,17 @@ class Node extends React.Component {
   }
 
   /**
+   * There is a corner case, that some nodes are unmounted right after they update
+   * Then, when the timer execute, it will throw the error
+   * `findDOMNode was called on an unmounted component`
+   * We should clear the timer from updateScroll here
+   */
+
+  componentWillUnmount = () => {
+    clearTimeout(this.scrollTimer)
+  }
+
+  /**
    * Update the scroll position after a change as occured if this is a leaf
    * block and it has the selection's ending edge. This ensures that scrolling
    * matches native `contenteditable` behavior even for cases where the edit is
@@ -182,7 +193,7 @@ class Node extends React.Component {
 
     // The native selection will be updated after componentDidMount or componentDidUpdate.
     // Use setTimeout to queue scrolling to the last when the native selection has been updated to the correct value.
-    setTimeout(() => {
+    this.scrollTimer = setTimeout(() => {
       const el = ReactDOM.findDOMNode(this)
       const window = getWindow(el)
       const native = window.getSelection()


### PR DESCRIPTION
This bug occurs after my previous fix at https://github.com/ianstormtaylor/slate/pull/847
It happens because some nodes are unmount right after they did update.

It's supposed to wrap only the get native scroll, not the whole findDOMNode included. That's my fault when I didn't think about this problem.