### PR TITLE
Fix selection after transform.wrapInline

### DIFF
--- a/test/transforms/fixtures/at-current-range/wrap-inline/whole-block/index.js
+++ b/test/transforms/fixtures/at-current-range/wrap-inline/whole-block/index.js
@@ -1,0 +1,34 @@
+
+import assert from 'assert'
+
+export default function (state) {
+  const { document, selection } = state
+  const texts = document.getTexts()
+  const first = texts.first()
+  const range = selection.merge({
+    anchorKey: first.key,
+    anchorOffset: 0,
+    focusKey: first.key,
+    focusOffset: 4
+  })
+
+  const next = state
+    .transform()
+    .select(range)
+    .wrapInline('hashtag')
+    .apply()
+
+  const updated = next.document.getTexts().get(1)
+
+  assert.deepEqual(
+    next.selection.toJS(),
+    range.merge({
+      anchorKey: updated.key,
+      anchorOffset: 0,
+      focusKey: updated.key,
+      focusOffset: updated.length
+    }).toJS()
+  )
+
+  return next
+}

--- a/test/transforms/fixtures/at-current-range/wrap-inline/whole-block/input.yaml
+++ b/test/transforms/fixtures/at-current-range/wrap-inline/whole-block/input.yaml
@@ -1,0 +1,7 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: word

--- a/test/transforms/fixtures/at-current-range/wrap-inline/whole-block/output.yaml
+++ b/test/transforms/fixtures/at-current-range/wrap-inline/whole-block/output.yaml
@@ -1,0 +1,10 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: inline
+        type: hashtag
+        nodes:
+          - kind: text
+            text: word


### PR DESCRIPTION
When using `transform.wrapInline` with a selection containing the entire content of a block, the selection is reset to the beginning of the block. Instead it should preserve around the whole block.

It impacts user for example if wrapping all the text in a paragraph in a link.

I'm adding a failing test, but I'm not sure how to fix correctly (I'll investigate).

- [x] Add failing test
- [ ] Fix it