### PR TITLE
Fix critical bug with onChange/onBeforeChange

### DIFF
--- a/src/models/stack.js
+++ b/src/models/stack.js
@@ -148,10 +148,6 @@ for (const method of EVENT_HANDLER_METHODS) {
   Stack.prototype[method] = function (state, editor, ...args) {
     debug(method)
 
-    if (method == 'onChange') {
-      state = this.onBeforeChange(state, editor)
-    }
-
     for (const plugin of this.plugins) {
       if (!plugin[method]) continue
       const next = plugin[method](...args, state, editor)
@@ -176,6 +172,10 @@ for (const method of EVENT_HANDLER_METHODS) {
 for (const method of STATE_ACCUMULATOR_METHODS) {
   Stack.prototype[method] = function (state, editor, ...args) {
     debug(method)
+
+    if (method == 'onChange') {
+      state = this.onBeforeChange(state, editor)
+    }
 
     for (const plugin of this.plugins) {
       if (!plugin[method]) continue


### PR DESCRIPTION
The `onBeforeChange` (and so normalization) was never called after a keyboard event.

The issue come from the call of `onBeforeChange` which was not at the right spot.

So currently, the normalization is only called when the `<Editor />` receive a new state (in `constructor` and `componentWillReceiveProps`).

I found this bug while trying to implement a normalization to prevent an empty document. When pressing <kbd>Backspace</kbd> in an unique void node, it was crashing the app, because the document was left empty.