### PR TITLE
Fix IME input not work

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -83,7 +83,6 @@ class Content extends React.Component {
     super(props)
     this.tmp = {}
     this.tmp.compositions = 0
-    this.tmp.forces = 0
   }
 
   /**
@@ -339,35 +338,19 @@ class Content extends React.Component {
 
   onCompositionStart = (event) => {
     if (!this.isInEditor(event.target)) return
-
     this.tmp.isComposing = true
-    this.tmp.compositions++
-
     debug('onCompositionStart', { event })
   }
 
   /**
-   * On composition end, remove the `isComposing` flag on the next tick. Also
-   * increment the `forces` key, which will force the contenteditable element
-   * to completely re-render, since IME puts React in an unreconcilable state.
+   * On composition end, remove the `isComposing` flag on the next tick.
    *
    * @param {Event} event
    */
 
   onCompositionEnd = (event) => {
     if (!this.isInEditor(event.target)) return
-
-    this.tmp.forces++
-    const count = this.tmp.compositions
-
-    // The `count` check here ensures that if another composition starts
-    // before the timeout has closed out this one, we will abort unsetting the
-    // `isComposing` flag, since a composition in still in affect.
-    setTimeout(() => {
-      if (this.tmp.compositions > count) return
-      this.tmp.isComposing = false
-    })
-
+    this.tmp.isComposing = false
     debug('onCompositionEnd', { event })
   }
 
@@ -842,7 +825,6 @@ class Content extends React.Component {
     return (
       <div
         data-slate-editor
-        key={this.tmp.forces}
         ref={this.ref}
         data-key={document.key}
         contentEditable={!readOnly}

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -140,7 +140,7 @@ class Content extends React.Component {
    */
 
   updateSelection = () => {
-    if (this.tmp.isComposing) return;
+    if (this.tmp.isComposing) return
     const { editor, state } = this.props
     const { document, selection } = state
     const window = getWindow(this.element)
@@ -344,7 +344,9 @@ class Content extends React.Component {
   }
 
   /**
-   * On composition end, remove the `isComposing` flag on the next tick.
+   * On composition end, remove the `isComposing` flag on the next tick. Also
+   * increment the `forces` key, which will force the contenteditable element
+   * to completely re-render, since IME puts React in an unreconcilable state.
    *
    * @param {Event} event
    */

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -82,7 +82,7 @@ class Content extends React.Component {
   constructor(props) {
     super(props)
     this.tmp = {}
-    this.tmp.compositions = 0
+    this.tmp.forces = 0
   }
 
   /**
@@ -140,6 +140,7 @@ class Content extends React.Component {
    */
 
   updateSelection = () => {
+    if (this.tmp.isComposing) return;
     const { editor, state } = this.props
     const { document, selection } = state
     const window = getWindow(this.element)
@@ -351,6 +352,9 @@ class Content extends React.Component {
   onCompositionEnd = (event) => {
     if (!this.isInEditor(event.target)) return
     this.tmp.isComposing = false
+    this.tmp.forces++
+    this.forceUpdate()
+
     debug('onCompositionEnd', { event })
   }
 
@@ -825,6 +829,7 @@ class Content extends React.Component {
     return (
       <div
         data-slate-editor
+        key={this.tmp.forces}
         ref={this.ref}
         data-key={document.key}
         contentEditable={!readOnly}


### PR DESCRIPTION
At first I just wanted to closes #879 , but I found is the wrong way. 

I found when use IME input, while the state is updated but react did not render the current DOM. And it really need to re-render when onCompositionEnd to update the forceKey. But not enough, I have to use forceUpdate() to update the DOM.

It can fixed #871 #875 #844 


