### PR TITLE
Check platform before adjusting selection

### DIFF
--- a/src/constants/environment.js
+++ b/src/constants/environment.js
@@ -75,5 +75,6 @@ export const IS_CHROME = BROWSER === 'chrome'
 export const IS_FIREFOX = BROWSER === 'firefox'
 export const IS_SAFARI = BROWSER === 'safari'
 
+export const IS_IOS = OS === 'ios'
 export const IS_MAC = OS === 'macos'
 export const IS_WINDOWS = OS === 'windows'

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -8,7 +8,7 @@ import Placeholder from '../components/placeholder'
 import React from 'react'
 import getWindow from 'get-window'
 import findDOMNode from '../utils/find-dom-node'
-import { IS_CHROME, IS_MAC, IS_SAFARI } from '../constants/environment'
+import { IS_CHROME, IS_IOS, IS_MAC, IS_SAFARI } from '../constants/environment'
 
 /**
  * Debug.
@@ -106,26 +106,28 @@ function Plugin(options = {}) {
     // is replaced. But the `select` event for this change doesn't fire until after
     // the `beforeInput` event, even though the native selection is updated. So we
     // need to manually adjust the selection to be in sync. (03/18/2017)
-    const window = getWindow(e.target)
-    const native = window.getSelection()
-    const { anchorNode, anchorOffset, focusNode, focusOffset } = native
-    const anchorPoint = getPoint(anchorNode, anchorOffset, state, editor)
-    const focusPoint = getPoint(focusNode, focusOffset, state, editor)
-    if (anchorPoint && focusPoint) {
-      const { selection } = state
-      if (
-        selection.anchorKey !== anchorPoint.key ||
-        selection.anchorOffset !== anchorPoint.offset ||
-        selection.focusKey !== focusPoint.key ||
-        selection.focusOffset !== focusPoint.offset
-      ) {
-        transform = transform
-          .select({
-            anchorKey: anchorPoint.key,
-            anchorOffset: anchorPoint.offset,
-            focusKey: focusPoint.key,
-            focusOffset: focusPoint.offset
-          })
+    if (IS_IOS) {
+      const window = getWindow(e.target)
+      const native = window.getSelection()
+      const { anchorNode, anchorOffset, focusNode, focusOffset } = native
+      const anchorPoint = getPoint(anchorNode, anchorOffset, state, editor)
+      const focusPoint = getPoint(focusNode, focusOffset, state, editor)
+      if (anchorPoint && focusPoint) {
+        const { selection } = state
+        if (
+          selection.anchorKey !== anchorPoint.key ||
+          selection.anchorOffset !== anchorPoint.offset ||
+          selection.focusKey !== focusPoint.key ||
+          selection.focusOffset !== focusPoint.offset
+        ) {
+          transform = transform
+            .select({
+              anchorKey: anchorPoint.key,
+              anchorOffset: anchorPoint.offset,
+              focusKey: focusPoint.key,
+              focusOffset: focusPoint.offset
+            })
+        }
       }
     }
 


### PR DESCRIPTION
This PR closes #810.

There is a selection adjustment in `onBeforeInput()` in core.js, to fix a problem with iOS text suggestion (#655).
But it's always applied regardless of the current platform.
This causes #810.

I've confirmed this does not break iOS text suggestion.