### PR TITLE
Fix dragging text in the editor

### DIFF
--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -178,27 +178,7 @@ class Images extends React.Component {
   onDrop = (e, data, state, editor) => {
     switch (data.type) {
       case 'files': return this.onDropOrPasteFiles(e, data, state, editor)
-      case 'node': return this.onDropNode(e, data, state)
     }
-  }
-
-  /**
-   * On drop node, insert the node wherever it is dropped.
-   *
-   * @param {Event} e
-   * @param {Object} data
-   * @param {State} state
-   * @return {State}
-   */
-
-  onDropNode = (e, data, state) => {
-    return state
-      .transform()
-      .deselect()
-      .removeNodeByKey(data.node.key)
-      .select(data.target)
-      .insertBlock(data.node)
-      .apply()
   }
 
   /**

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -211,6 +211,12 @@ class Node extends React.Component {
 
   onDragStart = (e) => {
     const { node } = this.props
+
+    // Only void node are draggable
+    if (!node.isVoid) {
+      return
+    }
+
     const encoded = Base64.serializeNode(node, { preserveKeys: true })
     const data = e.nativeEvent.dataTransfer
     data.setData(TYPES.NODE, encoded)

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -341,7 +341,47 @@ function Plugin(options = {}) {
         return onDropText(e, data, state)
       case 'fragment':
         return onDropFragment(e, data, state)
+      case 'node':
+        return onDropNode(e, data, state)
     }
+  }
+
+  /**
+   * On drop node, insert the node wherever it is dropped.
+   *
+   * @param {Event} e
+   * @param {Object} data
+   * @param {State} state
+   * @return {State}
+   */
+
+  function onDropNode(e, data, state) {
+    debug('onDropNode', { data })
+
+    const { selection } = state
+    let { node, target, isInternal } = data
+
+    // If the drag is internal and the target is after the selection, it
+    // needs to account for the selection's content being deleted.
+    if (
+      isInternal &&
+      selection.endKey == target.endKey &&
+      selection.endOffset < target.endOffset
+    ) {
+      target = target.move(selection.startKey == selection.endKey
+        ? 0 - selection.endOffset - selection.startOffset
+        : 0 - selection.endOffset)
+    }
+
+    const transform = state.transform()
+
+    if (isInternal) transform.delete()
+
+    return transform
+      .select(target)
+      .insertBlock(node)
+      .removeNodeByKey(node.key)
+      .apply()
   }
 
   /**

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -336,6 +336,7 @@ function Plugin(options = {}) {
     debug('onDrop', { data })
 
     switch (data.type) {
+      case 'node':
       case 'text':
       case 'html':
         return onDropText(e, data, state)

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -336,7 +336,6 @@ function Plugin(options = {}) {
     debug('onDrop', { data })
 
     switch (data.type) {
-      case 'node':
       case 'text':
       case 'html':
         return onDropText(e, data, state)


### PR DESCRIPTION
Currently drag and drop of text in the same editor doesn't work (You can test it at http://slatejs.org/#/rich-text).

The `data.type` is set to `node` only when dragging a void node. I've also moved to the core plugin, the `onDrop` handling when `data.type == 'node'`.

I don't understand why the type `node` has been introduced instead of just using the type `fragment` when dragging a void node; but anyway with this fix, dragging text works fine, and dragging void nodes works fine as well.
