### PR TITLE
fix IME input will replace characters after cursor

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -266,7 +266,7 @@ class Content extends React.Component {
     if (this.props.readOnly) return
     if (!this.isInEditor(event.target)) return
 
-    const data = {}
+    const data = { isComposing: this.tmp.isComposing }
 
     debug('onBeforeInput', { event, data })
     this.props.onBeforeInput(event, data)

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -111,7 +111,11 @@ function Plugin(options = {}) {
     const { anchorNode, anchorOffset, focusNode, focusOffset } = native
     const anchorPoint = getPoint(anchorNode, anchorOffset, state, editor)
     const focusPoint = getPoint(focusNode, focusOffset, state, editor)
-    if (anchorPoint && focusPoint) {
+
+    // The IME will delete preview characters in the editor when user commits input words,
+    // so need not to update selection during composing, or the words after will be replaced.
+    const isComposing = data.isComposing
+    if (anchorPoint && focusPoint && !isComposing) {
       const { selection } = state
       if (
         selection.anchorKey !== anchorPoint.key ||


### PR DESCRIPTION
When using Chinese input method, the characters after cursor will be replaced by the committed words.

Reason:
The IME will delete preview characters in the editor when user commits input words, so need not to update selection during composing, or the words after will be replaced.