### PR TITLE
Make onDrop in more cases available for other plugins to use

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -492,7 +492,6 @@ class Content extends React.Component {
 
   onDrop = (event) => {
     if (this.props.readOnly) return
-    if (!this.isInEditor(event.target)) return
 
     event.preventDefault()
 
@@ -525,8 +524,10 @@ class Content extends React.Component {
       isFocused: true
     })
 
-    // If the target is inside a void node, abort.
-    if (state.document.hasVoidParent(point.key)) return
+    // If the target is inside a void node.
+    if (state.document.hasVoidParent(point.key)) {
+      data.isInsideVoid = true
+    }
 
     // Add drop-specific information to the data.
     data.target = target


### PR DESCRIPTION
At our company we have multiple plugins which are using the `onDrop` handler. We have the issue, that there a some cases where the onDrop event is returned early and not exposed to the plugins.

To get our drop-indicator plugin to work, I need these changes to happen. The Plugin will get open sourced after we decoupled it from our internal code basis.

Could somebody please explain me the reasons behind these if statements?
@ianstormtaylor 

What do you think about this? With this PR and [the other one](https://github.com/ianstormtaylor/slate/pull/903), the drop-indicator plugin is able to do something like this mentioned here: https://github.com/ianstormtaylor/slate/issues/772