### PR TITLE
Fix "Auto-Markdown" Doc Link

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -73,7 +73,7 @@ To get a sense for how you might use Slate, check out a few of the examples:
 
 - [**Plain text**](https://github.com/ianstormtaylor/slate/tree/master/examples/plain-text) — showing the most basic case: a glorified `<textarea>`.
 - [**Rich text**](https://github.com/ianstormtaylor/slate/tree/master/examples/rich-text) — showing the features you'd expect from a basic editor.
-- [**Auto-markdown**](https://github.com/ianstormtaylor/slate/tree/master/examples/auto-markdown) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Auto-markdown**](https://github.com/ianstormtaylor/slate/tree/master/examples/markdown-preview) — showing how to add key handlers for Markdown-like shortcuts.
 - [**Links**](https://github.com/ianstormtaylor/slate/tree/master/examples/links) — showing how wrap text in inline nodes with associated data.
 - [**Images**](https://github.com/ianstormtaylor/slate/tree/master/examples/images) — showing how to use void (text-less) nodes to add images.
 - [**Hovering menu**](https://github.com/ianstormtaylor/slate/tree/master/examples/hovering-menu) — showing how a contextual hovering menu can be implemented.


### PR DESCRIPTION
Fixes the auto markdown preview link in the list of examples