### PR TITLE
Ignore Void nodes onClick in read-only

### DIFF
--- a/src/components/void.js
+++ b/src/components/void.js
@@ -34,9 +34,9 @@ class Void extends React.Component {
     block: Types.object,
     children: Types.any.isRequired,
     editor: Types.object.isRequired,
-    readOnly: Types.bool.isRequired,
     node: Types.object.isRequired,
     parent: Types.object.isRequired,
+    readOnly: Types.bool.isRequired,
     schema: Types.object.isRequired,
     state: Types.object.isRequired,
   }

--- a/src/components/void.js
+++ b/src/components/void.js
@@ -34,6 +34,7 @@ class Void extends React.Component {
     block: Types.object,
     children: Types.any.isRequired,
     editor: Types.object.isRequired,
+    readOnly: Types.bool.isRequired,
     node: Types.object.isRequired,
     parent: Types.object.isRequired,
     schema: Types.object.isRequired,
@@ -61,6 +62,8 @@ class Void extends React.Component {
    */
 
   onClick = (event) => {
+    if (this.props.readOnly) return
+
     this.debug('onClick', { event })
 
     const { node, editor } = this.props


### PR DESCRIPTION
As pointed here, in read-only mode, Void nodes onClick still triggers.

https://github.com/ianstormtaylor/slate/issues/508#issuecomment-265607814