### PR TITLE
Handle edge case in getFragmentAtRange

### DIFF
--- a/src/models/node.js
+++ b/src/models/node.js
@@ -585,18 +585,35 @@ const Node = {
     node.assertDescendant(startKey)
     node.assertDescendant(endKey)
 
+    const originalFurthestAncestor = node.getFurthestAncestor(startKey)
+
     // Split at the start and end.
     const start = range.collapseToStart()
     node = node.splitBlockAtRange(start, Infinity)
 
-    const next = node.getNextText(startKey)
+    const furthestAncestor = node.getFurthestAncestor(startKey)
+
+    let isSameAncestor = true
+    let next
+
+    if (originalFurthestAncestor.key !== furthestAncestor.key) {
+      isSameAncestor = false
+      next = node.getNode(startKey)
+    } else {
+      next = node.getNextText(startKey)
+    }
+
     const end = startKey == endKey
       ? range.collapseToStartOf(next).move(endOffset - startOffset)
       : range.collapseToEnd()
+
     node = node.splitBlockAtRange(end, Infinity)
 
     // Get the start and end nodes.
-    const startNode = node.getNextSibling(node.getFurthestAncestor(startKey).key)
+    const startNode = isSameAncestor
+      ? node.getNextSibling(node.getFurthestAncestor(startKey).key)
+      : node.getFurthestAncestor(startKey)
+
     const endNode = startKey == endKey
       ? node.getFurthestAncestor(next.key)
       : node.getFurthestAncestor(endKey)


### PR DESCRIPTION
fixes https://github.com/ianstormtaylor/slate/issues/910

At the moment `getFragmentAtRange` assumes, that the Text to split will be part of the first split (`start`). Thats why the `end` will be at the `nextText` Node.

In the case of an `inline` Node at the first position of a new line, it will split the fake empty text before it. The second split will then raise an error. (That's what I think is happening)