### PR TITLE
Issue with the Overriding Defaults example.

### DIFF
--- a/docs/reference/plugins/core.md
+++ b/docs/reference/plugins/core.md
@@ -67,7 +67,7 @@ However, sometimes you might want to disable the logic of the core plugin withou
 A noop `onBeforeInput` handler looks like:
 
 ```js
-function onBeforeInput(event, state, editor) {
+function onBeforeInput(event, data, state) {
   event.preventDefault()
   return state
 }


### PR DESCRIPTION
I tried using the exact code from the example to be met by errors.

The order of arguments in the function example is wrong, it should be use the API described in the [docs](https://docs.slatejs.org/reference/plugins/plugin.html#onbeforeinput).

```
Function onBeforeInput(event: Event, data: Object, state: State, editor: Editor) => State || Void
```