### PR TITLE
Allow HTMLSerializer to deserialize an empty doc

### DIFF
--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -96,6 +96,11 @@ class Html {
     const children = $.children().toArray()
     let nodes = this.deserializeElements(children)
 
+    const { defaultBlockType } = this
+    const defaults = typeof defaultBlockType == 'string'
+      ? { type: defaultBlockType }
+      : defaultBlockType
+
     // HACK: ensure for now that all top-level inline are wrapped into a block.
     nodes = nodes.reduce((memo, node, i, original) => {
       if (node.kind == 'block') {
@@ -108,11 +113,6 @@ class Html {
         block.nodes.push(node)
         return memo
       }
-
-      const { defaultBlockType } = this
-      const defaults = typeof defaultBlockType == 'string'
-        ? { type: defaultBlockType }
-        : defaultBlockType
 
       const block = {
         kind: 'block',
@@ -127,8 +127,8 @@ class Html {
     if (nodes.length === 0) {
       nodes = [{
         kind: 'block',
-        type: 'paragraph',
         nodes: [],
+        ...defaults
       }]
     }
 

--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -124,6 +124,14 @@ class Html {
       return memo
     }, [])
 
+    if (nodes.length === 0) {
+      nodes = [{
+        kind: 'block',
+        type: 'paragraph',
+        nodes: [],
+      }]
+    }
+
     const raw = {
       kind: 'state',
       document: {

--- a/test/serializers/fixtures/html/deserialize/empty-string/index.js
+++ b/test/serializers/fixtures/html/deserialize/empty-string/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/serializers/fixtures/html/deserialize/empty-string/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/empty-string/output.yaml
@@ -1,0 +1,7 @@
+data: {}
+nodes:
+  - type: paragraph
+    isVoid: false
+    data: {}
+    nodes:
+      - characters: []

--- a/test/serializers/index.js
+++ b/test/serializers/index.js
@@ -31,6 +31,25 @@ describe('serializers', () => {
         })
       }
 
+      it('can deserialize an empty string', () => {
+        const html = new Html()
+        const input = ''
+        const serialized = html.deserialize(input, { toRaw: true })
+        assert.deepEqual(serialized, {
+          kind: 'state',
+          document: {
+            kind: 'document',
+            nodes: [
+              {
+                kind: 'block',
+                type: 'paragraph',
+                nodes: []
+              }
+            ]
+          }
+        })
+      })
+
       it('optionally returns a raw representation', () => {
         const html = new Html(require('./fixtures/html/deserialize/block').default)
         const input = fs.readFileSync(resolve(__dirname, './fixtures/html/deserialize/block/input.html'), 'utf8')

--- a/test/serializers/index.js
+++ b/test/serializers/index.js
@@ -31,25 +31,6 @@ describe('serializers', () => {
         })
       }
 
-      it('can deserialize an empty string', () => {
-        const html = new Html()
-        const input = ''
-        const serialized = html.deserialize(input, { toRaw: true })
-        assert.deepEqual(serialized, {
-          kind: 'state',
-          document: {
-            kind: 'document',
-            nodes: [
-              {
-                kind: 'block',
-                type: 'paragraph',
-                nodes: []
-              }
-            ]
-          }
-        })
-      })
-
       it('optionally returns a raw representation', () => {
         const html = new Html(require('./fixtures/html/deserialize/block').default)
         const input = fs.readFileSync(resolve(__dirname, './fixtures/html/deserialize/block/input.html'), 'utf8')


### PR DESCRIPTION
Thanks to @vpontis for doing the actual work, I noticed that all we need to close this PR https://github.com/ianstormtaylor/slate/pull/742  and this issue https://github.com/ianstormtaylor/slate/issues/539 was a test case to cover deserialising an empty string. Let me know if this looks ok?