### PR TITLE
Allow drop events on void nodes

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -525,9 +525,6 @@ class Content extends React.Component {
       isFocused: true
     })
 
-    // If the target is inside a void node, abort.
-    if (state.document.hasVoidParent(point.key)) return
-
     // Add drop-specific information to the data.
     data.target = target
     data.effect = dataTransfer.dropEffect

--- a/src/components/void.js
+++ b/src/components/void.js
@@ -42,7 +42,7 @@ class Void extends React.Component {
 
   /**
    * State
-   * 
+   *
    * @type {Object}
    */
 
@@ -92,40 +92,40 @@ class Void extends React.Component {
   /**
    * Increment counter, and temporarily switch node to editable to allow drop events
    * Counter required as onDragLeave fires when hovering over child elements
-   * 
+   *
    * @param {Event} event
    */
 
   onDragEnter = () => {
     this.setState((prevState) => {
-      const dragCounter = prevState.dragCounter + 1;
-      return { dragCounter, editable: undefined };
+      const dragCounter = prevState.dragCounter + 1
+      return { dragCounter, editable: undefined }
     })
   }
 
   /**
    * Decrement counter, and if counter 0, then no longer dragging over node
    * and thus switch back to non-editable
-   * 
+   *
    * @param {Event} event
    */
 
   onDragLeave = () => {
     this.setState((prevState) => {
-      const dragCounter = prevState.dragCounter + 1;
-      const editable = dragCounter === 0 ? false : undefined;
-      return { dragCounter, editable };
+      const dragCounter = prevState.dragCounter + 1
+      const editable = dragCounter === 0 ? false : undefined
+      return { dragCounter, editable }
     })
   }
 
   /**
    * If dropped item onto node, then reset state
-   * 
+   *
    * @param {Event} event
    */
 
   onDrop = () => {
-    this.setState({ dragCounter: 0, editable: false });
+    this.setState({ dragCounter: 0, editable: false })
   }
 
   /**

--- a/src/components/void.js
+++ b/src/components/void.js
@@ -41,6 +41,17 @@ class Void extends React.Component {
   }
 
   /**
+   * State
+   * 
+   * @type {Object}
+   */
+
+  state = {
+    dragCounter: 0,
+    editable: false
+  }
+
+  /**
    * Debug.
    *
    * @param {String} message
@@ -79,6 +90,45 @@ class Void extends React.Component {
   }
 
   /**
+   * Increment counter, and temporarily switch node to editable to allow drop events
+   * Counter required as onDragLeave fires when hovering over child elements
+   * 
+   * @param {Event} event
+   */
+
+  onDragEnter = () => {
+    this.setState((prevState) => {
+      const dragCounter = prevState.dragCounter + 1;
+      return { dragCounter, editable: undefined };
+    })
+  }
+
+  /**
+   * Decrement counter, and if counter 0, then no longer dragging over node
+   * and thus switch back to non-editable
+   * 
+   * @param {Event} event
+   */
+
+  onDragLeave = () => {
+    this.setState((prevState) => {
+      const dragCounter = prevState.dragCounter + 1;
+      const editable = dragCounter === 0 ? false : undefined;
+      return { dragCounter, editable };
+    })
+  }
+
+  /**
+   * If dropped item onto node, then reset state
+   * 
+   * @param {Event} event
+   */
+
+  onDrop = () => {
+    this.setState({ dragCounter: 0, editable: false });
+  }
+
+  /**
    * Render.
    *
    * @return {Element}
@@ -100,9 +150,16 @@ class Void extends React.Component {
     this.debug('render', { props })
 
     return (
-      <Tag data-slate-void style={style} onClick={this.onClick}>
+      <Tag
+        data-slate-void
+        style={style}
+        onClick={this.onClick}
+        onDragEnter={this.onDragEnter}
+        onDragLeave={this.onDragLeave}
+        onDrop={this.onDrop}
+      >
         {this.renderSpacer()}
-        <Tag contentEditable={false}>
+        <Tag contentEditable={this.state.editable}>
           {children}
         </Tag>
       </Tag>

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -399,18 +399,16 @@ function Plugin(options = {}) {
       .transform()
       .select(target)
 
-    let hasVoidParent = document.hasVoidParent(target.get('anchorKey'))
+    let hasVoidParent = document.hasVoidParent(target.anchorKey)
 
-    // For void targets, we want to find the nearest non-void text node
+    // Insert text into nearest text node
     if (hasVoidParent) {
-      let node = document.getNode(target.get('anchorKey'))
+      let node = document.getNode(target.anchorKey)
 
       while (hasVoidParent) {
-        node = document.getNextText(node.get('key'))
-
+        node = document.getNextText(node.key)
         if (!node) break
-
-        hasVoidParent = document.hasVoidParent(node.get('key'))
+        hasVoidParent = document.hasVoidParent(node.key)
       }
 
       if (node) transform.collapseToStartOf(node)

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -399,21 +399,21 @@ function Plugin(options = {}) {
       .transform()
       .select(target)
 
-    let hasVoidParent = document.hasVoidParent(target.get('anchorKey'));
+    let hasVoidParent = document.hasVoidParent(target.get('anchorKey'))
 
     // For void targets, we want to find the nearest non-void text node
     if (hasVoidParent) {
-      let node = document.getNode(target.get('anchorKey'));
-    
+      let node = document.getNode(target.get('anchorKey'))
+
       while (hasVoidParent) {
-        node = document.getNextText(node.get('key'));
+        node = document.getNextText(node.get('key'))
 
-        if (!node) break;
+        if (!node) break
 
-        hasVoidParent = document.hasVoidParent(node.get('key'));
+        hasVoidParent = document.hasVoidParent(node.get('key'))
       }
 
-      if (node) transform.collapseToStartOf(node);
+      if (node) transform.collapseToStartOf(node)
     }
 
     text

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -394,9 +394,27 @@ function Plugin(options = {}) {
     debug('onDropText', { data })
 
     const { text, target } = data
+    const { document } = state
     const transform = state
       .transform()
       .select(target)
+
+    let hasVoidParent = document.hasVoidParent(target.get('anchorKey'));
+
+    // For void targets, we want to find the nearest non-void text node
+    if (hasVoidParent) {
+      let node = document.getNode(target.get('anchorKey'));
+    
+      while (hasVoidParent) {
+        node = document.getNextText(node.get('key'));
+
+        if (!node) break;
+
+        hasVoidParent = document.hasVoidParent(node.get('key'));
+      }
+
+      if (node) transform.collapseToStartOf(node);
+    }
 
     text
       .split('\n')


### PR DESCRIPTION
As described here - https://github.com/ianstormtaylor/slate-drop-or-paste-images/issues/9, it isn't possible to fire drop events when dragging items onto void nodes.

This pull request adds drag handlers to the Void component, to temporarily switch off the `contenteditable=false` div, and adds new behaviour, so dropped text is inserted into the nearest non-void text node.