### PR TITLE
Fix Edge Drag & Drop Issues

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -527,7 +527,8 @@ class Content extends React.Component {
     // Add drop-specific information to the data.
     data.target = target
 
-    // Edge throws "Permission denied" errors when accessing `dropEffect` or `effectAllowed`
+    // COMPAT: Edge throws "Permission denied" errors when
+    // accessing `dropEffect` or `effectAllowed` (2017/7/12)
     try {
       data.effect = dataTransfer.dropEffect
     } catch (err) {

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -14,6 +14,7 @@ import findClosestNode from '../utils/find-closest-node'
 import findDeepestNode from '../utils/find-deepest-node'
 import getPoint from '../utils/get-point'
 import getTransferData from '../utils/get-transfer-data'
+import setTransferData from '../utils/set-transfer-data'
 import { IS_FIREFOX, IS_MAC } from '../constants/environment'
 
 /**
@@ -473,7 +474,8 @@ class Content extends React.Component {
     const { state } = this.props
     const { fragment } = state
     const encoded = Base64.serializeNode(fragment)
-    dataTransfer.setData(TYPES.FRAGMENT, encoded)
+
+    setTransferData(dataTransfer, TYPES.FRAGMENT, encoded)
 
     debug('onDragStart', { event })
   }

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -444,13 +444,7 @@ class Content extends React.Component {
   onDragOver = (event) => {
     if (!this.isInEditor(event.target)) return
 
-    const { dataTransfer } = event.nativeEvent
-    const data = getTransferData(dataTransfer)
-
-    // Prevent default when nodes are dragged to allow dropping.
-    if (data.type == 'node') {
-      event.preventDefault()
-    }
+    event.preventDefault();
 
     if (this.tmp.isDragging) return
     this.tmp.isDragging = true

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -445,7 +445,7 @@ class Content extends React.Component {
   onDragOver = (event) => {
     if (!this.isInEditor(event.target)) return
 
-    event.preventDefault();
+    event.preventDefault()
 
     if (this.tmp.isDragging) return
     this.tmp.isDragging = true
@@ -530,7 +530,7 @@ class Content extends React.Component {
     // Edge throws "Permission denied" errors when accessing `dropEffect` or `effectAllowed`
     try {
       data.effect = dataTransfer.dropEffect
-    } catch(err) {
+    } catch (err) {
       data.effect = null
     }
 

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -524,7 +524,13 @@ class Content extends React.Component {
 
     // Add drop-specific information to the data.
     data.target = target
-    data.effect = dataTransfer.dropEffect
+
+    // Edge throws "Permission denied" errors when accessing `dropEffect` or `effectAllowed`
+    try {
+      data.effect = dataTransfer.dropEffect
+    } catch(err) {
+      data.effect = null
+    }
 
     if (data.type == 'fragment' || data.type == 'node') {
       data.isInternal = this.tmp.isInternalDrag

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -10,6 +10,7 @@ import Leaf from './leaf'
 import Void from './void'
 import getWindow from 'get-window'
 import scrollToSelection from '../utils/scroll-to-selection'
+import setTransferData from '../utils/set-transfer-data'
 
 /**
  * Debug.
@@ -212,8 +213,9 @@ class Node extends React.Component {
   onDragStart = (e) => {
     const { node } = this.props
     const encoded = Base64.serializeNode(node, { preserveKeys: true })
-    const data = e.nativeEvent.dataTransfer
-    data.setData(TYPES.NODE, encoded)
+    const { dataTransfer } = e.nativeEvent
+
+    setTransferData(dataTransfer, TYPES.NODE, encoded)
 
     this.debug('onDragStart', e)
   }

--- a/src/utils/get-transfer-data.js
+++ b/src/utils/get-transfer-data.js
@@ -37,7 +37,8 @@ function getTransferData(transfer) {
     if (encoded) fragment = encoded
   }
 
-  // Handle embedded types in text (Edge doesn't handle custom data types)
+  // COMPAT: Edge doesn't handle custom data types
+  // These will be embedded in text/plain in this case (2017/7/12)
   if (text) {
     const embeddedTypes = getEmbeddedTypes(text)
 
@@ -50,7 +51,8 @@ function getTransferData(transfer) {
   if (fragment) fragment = Base64.deserializeNode(fragment)
   if (node) node = Base64.deserializeNode(node)
 
-  // Edge sometimes throws 'NotSupportedError' whena accessing `transfer.items`
+  // COMPAT: Edge sometimes throws 'NotSupportedError'
+  // when accessing `transfer.items` (2017/7/12)
   try {
     // Get and normalize files if they exist.
     if (transfer.items && transfer.items.length) {
@@ -91,7 +93,7 @@ function getEmbeddedTypes(text) {
   // Otherwise, already had data embedded
   try {
     return JSON.parse(text.substring(prefix.length))
-  } catch (err2) {
+  } catch (err) {
     throw new Error('Unable to parse custom embedded drag data')
   }
 }

--- a/src/utils/get-transfer-data.js
+++ b/src/utils/get-transfer-data.js
@@ -39,8 +39,8 @@ function getTransferData(transfer) {
 
   // Handle embedded types in text (Edge doesn't handle custom data types)
   if (text) {
-    let embeddedTypes = getEmbeddedTypes(text)
-    
+    const embeddedTypes = getEmbeddedTypes(text)
+
     if (embeddedTypes[TYPES.FRAGMENT]) fragment = embeddedTypes[TYPES.FRAGMENT]
     if (embeddedTypes[TYPES.NODE]) node = embeddedTypes[TYPES.NODE]
     if (embeddedTypes['text/plain']) text = embeddedTypes['text/plain']
@@ -49,7 +49,7 @@ function getTransferData(transfer) {
   // Decode a fragment or node if they exist.
   if (fragment) fragment = Base64.deserializeNode(fragment)
   if (node) node = Base64.deserializeNode(node)
-  
+
   // Edge sometimes throws 'NotSupportedError' whena accessing `transfer.items`
   try {
     // Get and normalize files if they exist.
@@ -75,7 +75,7 @@ function getTransferData(transfer) {
 /**
  * Takes text input, checks whether contains embedded data
  * and returns object with original text +/- additional data
- * 
+ *
  * @param {String} text
  * @return {Object}
  */

--- a/src/utils/get-transfer-data.js
+++ b/src/utils/get-transfer-data.js
@@ -49,14 +49,21 @@ function getTransferData(transfer) {
   // Decode a fragment or node if they exist.
   if (fragment) fragment = Base64.deserializeNode(fragment)
   if (node) node = Base64.deserializeNode(node)
-
-  // Get and normalize files if they exist.
-  if (transfer.items && transfer.items.length) {
-    files = Array.from(transfer.items)
-      .map(item => item.kind == 'file' ? item.getAsFile() : null)
-      .filter(exists => exists)
-  } else if (transfer.files && transfer.files.length) {
-    files = Array.from(transfer.files)
+  
+  // Edge sometimes throws 'NotSupportedError' whena accessing `transfer.items`
+  try {
+    // Get and normalize files if they exist.
+    if (transfer.items && transfer.items.length) {
+      files = Array.from(transfer.items)
+        .map(item => item.kind == 'file' ? item.getAsFile() : null)
+        .filter(exists => exists)
+    } else if (transfer.files && transfer.files.length) {
+      files = Array.from(transfer.files)
+    }
+  } catch (err) {
+    if (transfer.files && transfer.files.length) {
+      files = Array.from(transfer.files)
+    }
   }
 
   // Determine the type of the data.

--- a/src/utils/set-transfer-data.js
+++ b/src/utils/set-transfer-data.js
@@ -1,7 +1,7 @@
 /**
  * Set data on dataTransfer
- * In Edge, custom types throw errors, so embed all non-standard types
- * in text/plain compound object.
+ * COMPAT: In Edge, custom types throw errors, so embed all non-standard
+ * types in text/plain compound object. (2017/7/12)
  *
  * @param {DataTransfer} dataTransfer
  * @param {String} type

--- a/src/utils/set-transfer-data.js
+++ b/src/utils/set-transfer-data.js
@@ -2,7 +2,7 @@
  * Set data on dataTransfer
  * In Edge, custom types throw errors, so embed all non-standard types
  * in text/plain compound object.
- * 
+ *
  * @param {DataTransfer} dataTransfer
  * @param {String} type
  * @param {String} content
@@ -14,7 +14,7 @@ function setTransferData(dataTransfer, type, content) {
   } catch (err) {
     const prefix = 'SLATE-DATA-EMBED::'
     let obj = {}
-    let text = dataTransfer.getData('text/plain')
+    const text = dataTransfer.getData('text/plain')
 
     // If prefixed, assume embedded drag data
     if (text.substring(0, prefix.length) === prefix) {

--- a/src/utils/set-transfer-data.js
+++ b/src/utils/set-transfer-data.js
@@ -1,0 +1,42 @@
+/**
+ * Set data on dataTransfer
+ * In Edge, custom types throw errors, so embed all non-standard types
+ * in text/plain compound object.
+ * 
+ * @param {DataTransfer} dataTransfer
+ * @param {String} type
+ * @param {String} content
+ */
+
+function setTransferData(dataTransfer, type, content) {
+  try {
+    dataTransfer.setData(type, content)
+  } catch (err) {
+    const prefix = 'SLATE-DATA-EMBED::'
+    let obj = {}
+    let text = dataTransfer.getData('text/plain')
+
+    // If prefixed, assume embedded drag data
+    if (text.substring(0, prefix.length) === prefix) {
+      try {
+        obj = JSON.parse(text.substring(prefix.length))
+      } catch (err2) {
+        throw new Error('Unable to parse custom embedded drag data')
+      }
+    } else {
+      obj['text/plain'] = text
+    }
+
+    obj[type] = content
+
+    dataTransfer.setData('text/plain', `${prefix}${JSON.stringify(obj)}`)
+  }
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default setTransferData


### PR DESCRIPTION
As described here: https://github.com/ianstormtaylor/slate/issues/922

A few weird things to work around; the main problem was the custom node and fragment types causing errors to be thrown with `dataTransfer.setData()`. Now when this happens, all custom data is stored in JSON object under `text/plain`.