### PR TITLE
Use `block.getClosest` instead of `document.getClosest`

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -188,7 +188,7 @@ class RichText extends React.Component {
     else {
       const isList = this.hasBlock('list-item')
       const isType = state.blocks.some((block) => {
-        return !!document.getClosest(block.key, parent => parent.type == type)
+        return !!block.getClosest(block.key, parent => parent.type == type)
       })
 
       if (isList && isType) {


### PR DESCRIPTION
`getClosest` is [a method of Slate's `Node` model](https://docs.slatejs.org/reference/models/node.html#getclosest)