### PR TITLE
improve mark handling performance for large selections

### DIFF
--- a/src/models/node.js
+++ b/src/models/node.js
@@ -904,7 +904,8 @@ const Node = {
     return this
       .getCharactersAtRange(range)
       .reduce((memo, char) => {
-        return memo.concat(char.marks.toArray())
+        char.marks.toArray().forEach(c => memo.push(c))
+        return memo
       }, [])
   },
 


### PR DESCRIPTION
Related to #706.

When highlighting a 40k character document (not an uncommon blog post size for larger web publications) and applying marks, scripting time compounds with each additional mark, mostly due to the performance of `Node.getMarksAtRangeAsArray`. This was only tested in Chrome, but it seems that concatenating arrays at scale is less performant than looping and pushing.

**Using `concat`:**
* Add first mark: ~9s
* Add second mark: ~21s
* Add third mark: ~35s
* Total time: ~65s
<img width="1435" alt="screen shot 2017-07-12 at 12 39 11 pm" src="https://user-images.githubusercontent.com/2112202/28131800-08413690-6709-11e7-90be-dfde8c1d06ab.png">

**Using `forEach` + `push`:**
* Add first mark: ~6s
* Add second mark: ~6s
* Add third mark: ~7s
* Total time: ~19s
<img width="1435" alt="screen shot 2017-07-12 at 12 48 54 pm" src="https://user-images.githubusercontent.com/2112202/28131958-793598f0-6709-11e7-90af-a4d103541e6a.png">
