### PR TITLE
Fix drop cursor

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -445,7 +445,9 @@ class Content extends React.Component {
   onDragOver = (event) => {
     if (!this.isInEditor(event.target)) return
 
-    event.preventDefault()
+    if (!this.tmp.isInternalDrag) {
+      event.preventDefault()
+    }
 
     if (this.tmp.isDragging) return
     this.tmp.isDragging = true


### PR DESCRIPTION
This change brings back the drop cursor, which became invisible after the commits for Edge support.

This pull request will break Edge support for DnD, but we can get that back with the strategies discussed here: https://github.com/ianstormtaylor/slate/issues/927