### PR TITLE
true sourcemaps for example dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "tests": "mocha --compilers js:babel-core/register ./test/index.js",
     "watch": "npm-run-all --parallel --print-label watch:lib watch:examples start",
     "watch:lib": "babel --watch --out-dir ./lib ./src --source-maps inline",
-    "watch:examples": "watchify --debug --transform babelify ./examples/index.js -o ./examples/build.dev.js -v"
+    "watch:examples": "watchify --debug --transform [babelify --sourceMaps=inline] ./examples/index.js -o ./examples/build.dev.js -v"
   },
   "browserify-global-shim": {
     "immutable": "Immutable",


### PR DESCRIPTION
The babelify transform in the `watch:examples` call isn't putting out sourcemaps, so source mapping only goes back to Babel output. This change provides inline sourcemaps in the Babel output so that dev tools can map back to the original source. Console error messages still reference the Babel output.