### PR TITLE
Fix triple select bug

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -175,16 +175,6 @@ class Content extends React.Component {
     let anchorOff
     let focusOff
 
-    console.log('=============')
-    if (focusKey !== anchorKey && anchorOffset === 0 && focusOffset === 0) {
-      console.log('next block selected', selection)
-    } else {
-      console.log('selection', selection)
-    }
-
-    console.log('anchorRanges', anchorRanges)
-    console.log('focusRanges', focusRanges)
-
     anchorRanges.forEach((range, i, ranges) => {
       const { length } = range.text
       a += length
@@ -226,8 +216,16 @@ class Content extends React.Component {
     native.addRange(range)
     extendSelection(native, focusEl, focusOff)
 
-    if (focusKey !== anchorKey && anchorOffset === 0 && focusOffset === 0) {
-      // Update selection here
+    // Make sure double/triple-click doesn't select the next block
+    if (anchorKey !== focusKey && anchorOffset === 0 && focusOffset === 0) {
+      // Create an updated state with the text replaced.
+      const next = state
+        .transform()
+        .moveToRangeOf(state.startBlock)
+        .apply()
+
+      // Change the current state.
+      this.onChange(next)
     }
 
     // Then unset the `isSelecting` flag after a delay.

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -175,6 +175,16 @@ class Content extends React.Component {
     let anchorOff
     let focusOff
 
+    console.log('=============')
+    if (focusKey !== anchorKey && anchorOffset === 0 && focusOffset === 0) {
+      console.log('next block selected', selection)
+    } else {
+      console.log('selection', selection)
+    }
+
+    console.log('anchorRanges', anchorRanges)
+    console.log('focusRanges', focusRanges)
+
     anchorRanges.forEach((range, i, ranges) => {
       const { length } = range.text
       a += length
@@ -215,6 +225,10 @@ class Content extends React.Component {
     range.setStart(anchorEl, anchorOff)
     native.addRange(range)
     extendSelection(native, focusEl, focusOff)
+
+    if (focusKey !== anchorKey && anchorOffset === 0 && focusOffset === 0) {
+      // Update selection here
+    }
 
     // Then unset the `isSelecting` flag after a delay.
     setTimeout(() => {

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -216,9 +216,9 @@ class Content extends React.Component {
     native.addRange(range)
     extendSelection(native, focusEl, focusOff)
 
-    // Make sure double/triple-click doesn't select the next block
+    // Make sure double/triple-click doesn't select the next block.
     if (anchorKey !== focusKey && anchorOffset === 0 && focusOffset === 0) {
-      // Create an updated state with the text replaced.
+      // Create an updated state with the selection adjusted.
       const next = state
         .transform()
         .moveToRangeOf(state.startBlock)


### PR DESCRIPTION
This relates to issue #752 and is still a work in progress. Just wanted to go ahead and open a PR as I debug this issue to keep discussion in one place.

The idea is to update the selection conditionally if it has been _triple selected_ (similar to how Draft.js [does it](https://github.com/facebook/draft-js/blob/213cd764f61cc64552bddd672ae1748529d55333/src/model/modifier/RichTextEditorUtil.js#L262-L265)) in order to avoid the next block from being selected.

Here is the info I've found so far:

![image](https://user-images.githubusercontent.com/7340187/28472225-be816ece-6e0d-11e7-8cb9-2613d887014f.png)

It seems when the next block is selected, it becomes the focus. I wonder what the best way to update the focus/selection is...