### PR TITLE
fix html parsing

### DIFF
--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -120,12 +120,14 @@ const RULES = [
     // Special case for links, to grab their href.
     deserialize(el, next) {
       if (el.tagName != 'a') return
+      // Convert NamedNodeMap to Array
+      const attrs = Array.prototype.slice.call(el.attributes)
       return {
         kind: 'inline',
         type: 'link',
         nodes: next(el.childNodes),
         data: {
-          href: el.attrs.find(({ name }) => name == 'href').value
+          href: attrs.find(({ name }) => name == 'href').value
         }
       }
     }

--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -38,7 +38,7 @@ const TEXT_RULE = {
 
       return {
         kind: 'text',
-        text: el.value
+        text: el.textContent
       }
     }
   },
@@ -83,7 +83,7 @@ class Html {
     this.defaultBlockType = options.defaultBlockType || 'paragraph'
 
     // Set DOM parser function or fallback to native DOMParser if present.
-    if (options.parseHtml !== null) {
+    if (options.parseHtml) {
       this.parseHtml = options.parseHtml
     } else if (typeof DOMParser !== 'undefined') {
       this.parseHtml = (html) => {
@@ -169,19 +169,19 @@ class Html {
    */
 
   deserializeElements = (elements = []) => {
-    let nodes = []
+    const nodes = []
 
-    elements.filter(this.cruftNewline).forEach((element) => {
-      const node = this.deserializeElement(element)
-      switch (typeOf(node)) {
-        case 'array':
-          nodes = nodes.concat(node)
-          break
-        case 'object':
+    for (const element of elements) {
+      if (this.cruftNewline(element)) {
+        const node = this.deserializeElement(element)
+
+        if (Array.isArray(node)) {
+          nodes.push(...node)
+        } else {
           nodes.push(node)
-          break
+        }
       }
-    })
+    }
 
     return nodes
   }
@@ -197,10 +197,11 @@ class Html {
     let node
 
     const next = (elements) => {
+      if (NodeList.prototype.isPrototypeOf(elements)) {
+        return this.deserializeElements(elements)
+      }
       switch (typeOf(elements)) {
-        case 'array':
-          return this.deserializeElements(elements)
-        case 'object':
+        case 'element':
           return this.deserializeElement(elements)
         case 'null':
         case 'undefined':


### PR DESCRIPTION
Fixes #948.

Update methods in the HTML serializer and the paste-html example to work with raw DOM elements and NodeLists.