### PR TITLE
Reckon with inconsistencies between parse5 and native DOMParser

### DIFF
--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -80,7 +80,7 @@ const MARK_TAGS = {
 const RULES = [
   {
     deserialize(el, next) {
-      const block = BLOCK_TAGS[el.tagName]
+      const block = BLOCK_TAGS[el.tagName.toLowerCase()]
       if (!block) return
       return {
         kind: 'block',
@@ -91,7 +91,7 @@ const RULES = [
   },
   {
     deserialize(el, next) {
-      const mark = MARK_TAGS[el.tagName]
+      const mark = MARK_TAGS[el.tagName.toLowerCase()]
       if (!mark) return
       return {
         kind: 'mark',
@@ -103,9 +103,9 @@ const RULES = [
   {
     // Special case for code blocks, which need to grab the nested childNodes.
     deserialize(el, next) {
-      if (el.tagName != 'pre') return
+      if (el.tagName.toLowerCase() != 'pre') return
       const code = el.childNodes[0]
-      const childNodes = code && code.tagName == 'code'
+      const childNodes = code && code.tagName.toLowerCase() == 'code'
         ? code.childNodes
         : el.childNodes
 
@@ -119,7 +119,7 @@ const RULES = [
   {
     // Special case for links, to grab their href.
     deserialize(el, next) {
-      if (el.tagName != 'a') return
+      if (el.tagName.toLowerCase() != 'a') return
       return {
         kind: 'inline',
         type: 'link',


### PR DESCRIPTION
There's a few inconsistencies between parse5's output and the native DOMParser that were causing problems:

* The native DOMParser outputs tag names in CAPS. It's not clear to me if this is a consistent behavior across browsers, so I just updated the HTML example to force to lower case.

* The native DOMParser uses a `NodeList` for `childNodes`. Updated to coerce into an array if that's the case so `filter` exists.

* The native DOMParser will parse error with `application/xml` and something that is not valid HTML. I changed to `text/html` which will always work but does wrap the output in `html` and `body` tags, and then added a line to dig back to the actual output

* The native DOMParser will render a parsing of a plain text string as a `span` instead of a `#text` node

Also changed from `if (options.parseHtml !== null)` to `if (typeof options.parseHtml === 'function')` to account for `parseHtml` being undefined (or some other invalid value)

Fixes #948 