### PR TITLE
Remove unneeded check.

### DIFF
--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -33,7 +33,7 @@ const TEXT_RULE = {
       }
     }
 
-    if (el.tagName == 'span' || el.nodeName == '#text') {
+    if (el.nodeName == '#text') {
       if (el.value && el.value.match(/<!--.*?-->/)) return
 
       return {


### PR DESCRIPTION
Even if the `el.tagName` is a span, it will fall through to the child text node so the check introduced in #952 is unneeded.