### PR TITLE
Upgrade react-frame-component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-addons-perf": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-frame-aware-selection-plugin": "^1.0.0",
-    "react-frame-component": "^1.0.3",
+    "react-frame-component": "^1.1.1",
     "react-router": "^2.5.1",
     "react-router-dom": "^4.1.1",
     "read-metadata": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4855,9 +4855,9 @@ react-frame-aware-selection-plugin@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-frame-aware-selection-plugin/-/react-frame-aware-selection-plugin-1.0.0.tgz#6a0d40efd56721179160159709f10ec70469c2ec"
 
-react-frame-component@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-1.0.3.tgz#00a5deea81671927ea973954a0d8eb19ecc339de"
+react-frame-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-1.1.1.tgz#05b7f5689a2d373f25baf0c9adb0e59d78103388"
 
 react-portal@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Gets rid of warning in dev about directly accessing `React.PropTypes`

<img width="1920" alt="screenshot 2017-07-31 22 57 24" src="https://user-images.githubusercontent.com/1896112/28807458-a66b6144-7643-11e7-9d88-2eaa6cdc7e3f.png">
