### PR TITLE
Remove isNative

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -100,10 +100,6 @@ class Content extends React.Component {
     // the cursor will be added or removed again.
     if (props.readOnly != this.props.readOnly) return true
 
-    // If the state has been transformed natively, never re-render, or else we
-    // will end up duplicating content.
-    if (props.state.isNative) return false
-
     return (
       props.className != this.props.className ||
       props.schema != this.props.schema ||
@@ -734,7 +730,6 @@ class Content extends React.Component {
     // If there are no ranges, the editor was blurred natively.
     if (!native.rangeCount) {
       data.selection = selection.set('isFocused', false)
-      data.isNative = true
     }
 
     // Otherwise, determine the Slate selection from the native one.

--- a/src/models/state.js
+++ b/src/models/state.js
@@ -27,8 +27,7 @@ const DEFAULTS = {
   document: new Document(),
   selection: new Selection(),
   history: new History(),
-  data: new Map(),
-  isNative: false
+  data: new Map()
 }
 
 /**

--- a/src/models/transform.js
+++ b/src/models/transform.js
@@ -45,7 +45,6 @@ class Transform {
    * Apply the transform and return the new state.
    *
    * @param {Object} options
-   *   @property {Boolean} isNative
    *   @property {Boolean} merge
    *   @property {Boolean} save
    * @return {State}
@@ -53,7 +52,7 @@ class Transform {
 
   apply(options = {}) {
     const transform = this
-    let { merge, save, isNative = false } = options
+    let { merge, save } = options
 
     // Ensure that the selection is normalized.
     transform.normalizeSelection()
@@ -84,8 +83,8 @@ class Transform {
     // Save the new operations.
     if (save) this.save({ merge })
 
-    // Return the new state with the `isNative` flag set.
-    return this.state.set('isNative', !!isNative)
+    // Return the new state.
+    return this.state
   }
 
 }

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -44,9 +44,6 @@ function Plugin(options = {}) {
    */
 
   function onBeforeChange(state, editor) {
-    // Don't normalize with plugins schema when typing text in native mode
-    if (state.isNative) return state
-
     const schema = editor.getSchema()
     const prevState = editor.getState()
 
@@ -137,44 +134,9 @@ function Plugin(options = {}) {
     const nextText = next.startText
     const nextChars = nextText.getDecorations(decorators)
 
-    // We do not have to re-render if the current selection is collapsed, the
-    // current node is not empty, there are no marks on the cursor, the cursor
-    // is not at the edge of an inline node, the cursor isn't at the starting
-    // edge of a text node after an inline node, and the natively inserted
-    // characters would be the same as the non-native.
-    const isNative = (
-      // If the selection is expanded, we don't know what the edit will look
-      // like so we can't let it happen natively.
-      (state.isCollapsed) &&
-      // If the selection has marks, then we need to render it non-natively
-      // because we need to create the new marks as well.
-      (state.selection.marks == null) &&
-      // If the text node in question has no content, browsers might do weird
-      // things so we need to insert it normally instead.
-      (state.startText.text != '') &&
-      // COMPAT: Browsers do weird things when typing at the edges of inline
-      // nodes, so we can't let them render natively. (?)
-      (!startInline || !state.selection.isAtStartOf(startInline)) &&
-      (!startInline || !state.selection.isAtEndOf(startInline)) &&
-      // COMPAT: In Chrome & Safari, it isn't possible to have a selection at
-      // the starting edge of a text node after another inline node. It will
-      // have been automatically changed. So we can't render natively because
-      // the cursor isn't technique in the right spot. (2016/12/01)
-      (!(pInline && !pInline.isVoid && startOffset == 0)) &&
-      (!(nInline && !nInline.isVoid && startOffset == startText.length)) &&
-      // If the
-      (chars.equals(nextChars))
-    )
+    e.preventDefault()
 
-    // Add the `isNative` flag directly, so we don't have to re-transform.
-    if (isNative) {
-      next = next.set('isNative', isNative)
-    }
-
-    // If not native, prevent default so that the DOM remains untouched.
-    if (!isNative) e.preventDefault()
-
-    debug('onBeforeInput', { data, isNative })
+    debug('onBeforeInput', { data })
     return next
   }
 


### PR DESCRIPTION
@ianstormtaylor I've [removed isNative](https://github.com/ianstormtaylor/slate/issues/963)

I guess the library benchmarks don't give us much info on the performance changes here, any tips on checking the performance of this in the browser?

```
benchmarks
    models
      get-blocks
        295.26 → 283.60 iterations/sec
      get-blocks-at-range
        2.73 → 2.80 iterations/sec
      get-characters
        86.72 → 100.63 iterations/sec
      get-characters-at-range
        7.47 → 8.48 iterations/sec
      get-inlines
        294.12 → 294.65 iterations/sec
      get-inlines-at-range
        2.64 → 2.68 iterations/sec
      get-marks
        17.04 → 17.32 iterations/sec
      get-marks-at-range
        5.04 → 4.42 iterations/sec
      get-path
        37.46 → 38.18 iterations/sec
      get-ranges
        1098.85 → 1056.25 iterations/sec
      get-texts
        259.95 → 244.42 iterations/sec
      get-texts-at-range
        95.68 → 97.23 iterations/sec
      update-descendant
        72.57 → 77.09 iterations/sec
    rendering
      normal
        1.23 → 1.25 iterations/sec
    serializers
      raw-deserialize
        5.64 → 5.63 iterations/sec
      raw-serialize
        62.00 → 59.60 iterations/sec
    transforms
      delete-backward
        246.63 → 285.42 iterations/sec
      insert-text
        285.92 → 289.88 iterations/sec
      normalize
        87.54 → 105.78 iterations/sec (21% faster)
      split-block
        69.83 → 83.92 iterations/sec (20% faster)
```

Also this appears to change the nature of at least one bug https://github.com/ianstormtaylor/slate/issues/938, instead of deleting the previous line, it does not allow you to add spaces on a wrapped line. I was working on a solution to this separately but still had some things to iron out.