### PR TITLE
Refactor render arrow functions

### DIFF
--- a/docs/walkthroughs/adding-event-handlers.md
+++ b/docs/walkthroughs/adding-event-handlers.md
@@ -24,7 +24,7 @@ class App extends React.Component {
     this.setState({ state })
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -54,7 +54,7 @@ class App extends React.Component {
     console.log(event.which)
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -101,7 +101,7 @@ class App extends React.Component {
     return newState
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}

--- a/docs/walkthroughs/applying-custom-formatting.md
+++ b/docs/walkthroughs/applying-custom-formatting.md
@@ -38,7 +38,7 @@ class App extends React.Component {
       .apply()
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -96,7 +96,7 @@ class App extends React.Component {
     }
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         schema={this.state.schema}
@@ -174,7 +174,7 @@ class App extends React.Component {
     }
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         schema={this.state.schema}

--- a/docs/walkthroughs/defining-custom-block-nodes.md
+++ b/docs/walkthroughs/defining-custom-block-nodes.md
@@ -35,7 +35,7 @@ class App extends React.Component {
     return newState
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -103,7 +103,7 @@ class App extends React.Component {
     return newState
   }
 
-  render = () => {
+  render() {
     return (
       // Pass in the `schema` property...
       <Editor
@@ -154,7 +154,7 @@ class App extends React.Component {
       .apply()
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         schema={this.state.schema}
@@ -208,7 +208,7 @@ class App extends React.Component {
     
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         schema={this.state.schema}

--- a/docs/walkthroughs/installing-slate.md
+++ b/docs/walkthroughs/installing-slate.md
@@ -87,7 +87,7 @@ class App extends React.Component {
   }
 
   // Render the editor.
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}

--- a/docs/walkthroughs/saving-and-loading-html-content.md
+++ b/docs/walkthroughs/saving-and-loading-html-content.md
@@ -24,7 +24,7 @@ class App extends React.Component {
     this.setState({ state })
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -246,7 +246,7 @@ class App extends React.Component {
     localStorage.setItem('content', string)
   }
 
-  render = () => {
+  render() {
     // Add the `onDocumentChange` handler.
     return (
       <Editor

--- a/docs/walkthroughs/saving-to-a-database.md
+++ b/docs/walkthroughs/saving-to-a-database.md
@@ -26,7 +26,7 @@ class App extends React.Component {
     this.setState({ state })
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -63,7 +63,7 @@ class App extends React.Component {
     localStorage.setItem('content', content)
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -99,7 +99,7 @@ class App extends React.Component {
     localStorage.setItem('content', content)
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}
@@ -138,7 +138,7 @@ class App extends React.Component {
     localStorage.setItem('content', content)
   }
 
-  render = () => {
+  render() {
     // Add the `onDocumentChange` handler to the editor.
     return (
       <Editor
@@ -186,7 +186,7 @@ class App extends React.Component {
     localStorage.setItem('content', content)
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}

--- a/docs/walkthroughs/using-plugins.md
+++ b/docs/walkthroughs/using-plugins.md
@@ -38,7 +38,7 @@ class App extends React.Component {
       .apply()
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         schema={this.state.schema}
@@ -125,7 +125,7 @@ class App extends React.Component {
     this.setState({ state })
   }
 
-  render = () => {
+  render() {
     return (
       // Add the `plugins` property to the editor, and remove `onKeyDown`.
       <Editor
@@ -174,7 +174,7 @@ class App extends React.Component {
     this.setState({ state })
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         plugins={plugins}
@@ -259,7 +259,7 @@ class App extends React.Component {
     this.setState({ state })
   }
 
-  render = () => {
+  render() {
     return (
       <Editor
         plugins={plugins}

--- a/examples/check-lists/index.js
+++ b/examples/check-lists/index.js
@@ -36,7 +36,7 @@ class CheckListItem extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const { attributes, children, node } = this.props
     const checked = node.data.get('checked')
     return (
@@ -147,7 +147,7 @@ class CheckLists extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         <div className="editor">

--- a/examples/code-highlighting/index.js
+++ b/examples/code-highlighting/index.js
@@ -167,7 +167,7 @@ class CodeHighlighting extends React.Component {
    * @return {Component}
    */
 
-  render = () => {
+  render() {
     return (
       <div className="editor">
         <Editor

--- a/examples/dev/large-document/index.js
+++ b/examples/dev/large-document/index.js
@@ -131,7 +131,7 @@ class LargeDocument extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         placeholder={'Enter some plain text...'}

--- a/examples/dev/performance-plain/index.js
+++ b/examples/dev/performance-plain/index.js
@@ -37,7 +37,7 @@ class PlainText extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         placeholder={'Enter some plain text...'}

--- a/examples/dev/performance-rich/index.js
+++ b/examples/dev/performance-rich/index.js
@@ -198,7 +198,7 @@ class RichText extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         {this.renderToolbar()}

--- a/examples/embeds/index.js
+++ b/examples/embeds/index.js
@@ -50,7 +50,7 @@ class Embeds extends React.Component {
    * @return {Element} element
    */
 
-  render = () => {
+  render() {
     return (
       <div className="editor">
         <Editor

--- a/examples/embeds/video.js
+++ b/examples/embeds/video.js
@@ -60,7 +60,7 @@ class Video extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     return (
       <div {...this.props.attributes}>
         {this.renderVideo()}

--- a/examples/focus-blur/index.js
+++ b/examples/focus-blur/index.js
@@ -80,7 +80,7 @@ class FocusBlur extends React.Component {
    * @return {Element} element
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         {this.renderToolbar()}

--- a/examples/forced-layout/index.js
+++ b/examples/forced-layout/index.js
@@ -88,7 +88,7 @@ class ForcedLayout extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         state={this.state.state}

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -106,7 +106,7 @@ class HoveringMenu extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         {this.renderMenu()}

--- a/examples/iframes/index.js
+++ b/examples/iframes/index.js
@@ -168,7 +168,7 @@ class Iframes extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const bootstrap = (
       <link
         href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -95,7 +95,7 @@ class Images extends React.Component {
    * @return {Element} element
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         {this.renderToolbar()}

--- a/examples/links/index.js
+++ b/examples/links/index.js
@@ -145,7 +145,7 @@ class Links extends React.Component {
    * @return {Element} element
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         {this.renderToolbar()}

--- a/examples/markdown-preview/index.js
+++ b/examples/markdown-preview/index.js
@@ -125,7 +125,7 @@ class MarkdownPreview extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <div className="editor">
         <Editor

--- a/examples/markdown-shortcuts/index.js
+++ b/examples/markdown-shortcuts/index.js
@@ -71,7 +71,7 @@ class MarkdownShortcuts extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <div className="editor">
         <Editor

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -194,7 +194,7 @@ class PasteHtml extends React.Component {
    * @return {Component}
    */
 
-  render = () => {
+  render() {
     return (
       <div className="editor">
         <Editor

--- a/examples/plain-text/index.js
+++ b/examples/plain-text/index.js
@@ -36,7 +36,7 @@ class PlainText extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         placeholder={'Enter some plain text...'}

--- a/examples/plugins/index.js
+++ b/examples/plugins/index.js
@@ -85,7 +85,7 @@ The fourth is an example of using the plugin.render property to create a higher-
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         placeholder={'Enter some text...'}

--- a/examples/read-only/index.js
+++ b/examples/read-only/index.js
@@ -36,7 +36,7 @@ class ReadOnly extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         readOnly

--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -217,7 +217,7 @@ class RichText extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     return (
       <div>
         {this.renderToolbar()}

--- a/examples/rtl/index.js
+++ b/examples/rtl/index.js
@@ -66,7 +66,7 @@ class PlainText extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <Editor
         placeholder={'Enter some plain text...'}

--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -127,7 +127,7 @@ class Tables extends React.Component {
    * @return {Component} component
    */
 
-  render = () => {
+  render() {
     return (
       <div className="editor">
         <Editor

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -822,7 +822,7 @@ class Content extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const { props } = this
     const { className, readOnly, state, tabIndex, role } = props
     const { document } = state

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -240,7 +240,7 @@ class Editor extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const { props, state } = this
     const { stack } = state
     const children = stack

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -232,7 +232,7 @@ class Node extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const { props } = this
     const { node } = this.props
 

--- a/src/components/placeholder.js
+++ b/src/components/placeholder.js
@@ -83,7 +83,7 @@ class Placeholder extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const isVisible = this.isVisible()
     if (!isVisible) return null
 

--- a/src/components/void.js
+++ b/src/components/void.js
@@ -137,7 +137,7 @@ class Void extends React.Component {
    * @return {Element}
    */
 
-  render = () => {
+  render() {
     const { props } = this
     const { children, node } = props
     let Tag, style


### PR DESCRIPTION
Having debugged a problem while using server rendering for two days I figured that the render functions in slate does not work nicely with [react-prepare](https://github.com/elierotenberg/react-prepare/blob/master/src/utils/isReactCompositeComponent.js#L8)'s component check. The reason is that when using the `render() {}` method it transpiles to
```
  _createClass(Test, [{
    key: "render",
    value: function render() {}
  }]);
```
and is therefore possible to determine the `render` property on the prototype. While `render = () =>` transpiles to `this.render = function () {};` and results in undefined render on the prototype. This makes `_callClassCheck` raise `TypeError("Cannot call a class as a function");`, since `this` is undefined due to no [preparation](https://github.com/elierotenberg/react-prepare/blob/master/src/prepare.js#L51) of the component in react-prepare.

Babel transpile examples are provided [here](https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=true&presets=es2015%2Creact%2Cstage-2&targets=&browsers=&builtIns=false&debug=false&code_lz=MYGwhgzhAEAqCmEAu0DeAoa1PQE7wDsATeXAQV1wHsB3aAXmgAoBKBgPjQF8cd9jSAZSRhiYXEVbd0PdMCoEIVEPAB0IKgHMmAcgrUaALh0AaOIiSqADtSRUkATytr-JcpVos5CpSvVbdYVEicSJjMwRka1t7JxdCNyCxCRYgA)

I've done some research and haven't really found much usage of the render as arrow functions, is this done by intention? My understanding was that arrow functions usually are used for helper methods and event handlers in components for implicit .bind(), but not for the `render` method itself.

One could argue that this is something that should be accepted and improved in react-prepare, but I think that slate should use the most common practice.