### PR TITLE
When the `isInEditor` parameter is a text node use its parent only if the parent exists

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -251,6 +251,8 @@ class Content extends React.Component {
     const { element } = this
     // COMPAT: Text nodes don't have `isContentEditable` property. So, when
     // `target` is a text node use its parent element for check.
+    // COMPAT: `parentElement` is not defined on text nodes in certain browsers:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement#Browser_compatibility
     const el = (target.nodeType === 3 && target.parentElement) ? target.parentElement : target
     return (
       (el.isContentEditable) &&

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -251,7 +251,7 @@ class Content extends React.Component {
     const { element } = this
     // COMPAT: Text nodes don't have `isContentEditable` property. So, when
     // `target` is a text node use its parent element for check.
-    const el = target.nodeType === 3 ? target.parentElement : target
+    const el = (target.nodeType === 3 && target.parentElement) ? target.parentElement : target
     return (
       (el.isContentEditable) &&
       (el === element || findClosestNode(el, '[data-slate-editor]') === element)


### PR DESCRIPTION
Fix for a bug encountered in IE 10/11 where `isInEditor` can throw due to `el` not having an `isContentEditable` property (found while using the `Raw` serializer).

The issue appears to be that `target` can have a `nodeType` of 3 and no `parentElement`, which sets `el` to `undefined`. Likely related to https://github.com/ianstormtaylor/slate/pull/857.

To reproduce in IE 10/11: Click into the editor, make no edits or delete some text, then click out of the editor.