### PR TITLE
Allow Data to be passed to Marks when using HTML Deserializer

### DIFF
--- a/src/serializers/html.js
+++ b/src/serializers/html.js
@@ -246,7 +246,7 @@ class Html {
    */
 
   deserializeMark = (mark) => {
-    const { type, value } = mark
+    const { type, data } = mark
 
     const applyMark = (node) => {
       if (node.kind == 'mark') {
@@ -257,7 +257,7 @@ class Html {
         if (!node.ranges) node.ranges = [{ text: node.text }]
         node.ranges = node.ranges.map((range) => {
           range.marks = range.marks || []
-          range.marks.push({ type, value })
+          range.marks.push({ type, data })
           return range
         })
       }

--- a/test/serializers/fixtures/html/deserialize/mark-with-data/index.js
+++ b/test/serializers/fixtures/html/deserialize/mark-with-data/index.js
@@ -1,0 +1,28 @@
+
+export default {
+  rules: [
+    {
+      deserialize(el, next) {
+        switch (el.tagName) {
+          case 'p': {
+            return {
+              kind: 'block',
+              type: 'paragraph',
+              nodes: next(el.childNodes)
+            }
+          }
+          case 'mark': {
+            return {
+              kind: 'mark',
+              type: 'highlight',
+              data: {
+                backgroundColor: 'green',
+              },
+              nodes: next(el.childNodes)
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/serializers/fixtures/html/deserialize/mark-with-data/input.html
+++ b/test/serializers/fixtures/html/deserialize/mark-with-data/input.html
@@ -1,0 +1,1 @@
+<p><mark>one</mark></p>

--- a/test/serializers/fixtures/html/deserialize/mark-with-data/output.yaml
+++ b/test/serializers/fixtures/html/deserialize/mark-with-data/output.yaml
@@ -1,0 +1,20 @@
+
+data: {}
+nodes:
+  - type: paragraph
+    isVoid: false
+    data: {}
+    nodes:
+      - characters:
+          - text: o
+            marks:
+              - type: highlight
+                data: { backgroundColor: "green" }
+          - text: n
+            marks:
+              - type: highlight
+                data: { backgroundColor: "green" }
+          - text: e
+            marks:
+              - type: highlight
+                data: { backgroundColor: "green" }


### PR DESCRIPTION
This pull requests reverts a previous change that I couldn't find any information on.  I'm not sure what `value` means to a mark, and I couldn't find anything relevant in `models/mark.js`.

I wrote a test to make sure in the future we don't break this functionality.  In master this test is failing but in my branch this test passes.