### PR TITLE
Don't break macOS emoji insert nor composition when fixing #938

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -660,7 +660,6 @@ class Content extends React.Component {
     data.isModAlt = IS_MAC ? metaKey && altKey : ctrlKey && altKey
     data.isShift = shiftKey
     data.isWord = IS_MAC ? altKey : ctrlKey
-    data.isComposing = this.tmp.isComposing
 
     // These key commands have native behavior in contenteditable elements which
     // will cause our state to be out of sync, so prevent them.

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -660,6 +660,7 @@ class Content extends React.Component {
     data.isModAlt = IS_MAC ? metaKey && altKey : ctrlKey && altKey
     data.isShift = shiftKey
     data.isWord = IS_MAC ? altKey : ctrlKey
+    data.isComposing = this.tmp.isComposing
 
     // These key commands have native behavior in contenteditable elements which
     // will cause our state to be out of sync, so prevent them.

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -162,7 +162,7 @@ function Plugin(options = {}) {
       // the cursor isn't technique in the right spot. (2016/12/01)
       (!(pInline && !pInline.isVoid && startOffset == 0)) &&
       (!(nInline && !nInline.isVoid && startOffset == startText.length)) &&
-      // COMPAT: When inserting a Space character , Chrome will sometimes 
+      // COMPAT: When inserting a Space character, Chrome will sometimes
       // split the text node into two adjacent text nodes. See:
       // https://github.com/ianstormtaylor/slate/issues/938
       (!(e.data === ' ' && IS_CHROME)) &&

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -526,6 +526,7 @@ function Plugin(options = {}) {
   /**
    * On `Space` key down, prevent the default browser behavior
    * in Chrome, since in some situation it will result in loss of text.
+   * (unless we're composing or we're on a Mac and we want to insert emoji)
    * Reference: https://github.com/ianstormtaylor/slate/issues/938
    *
    * @param {Event} e
@@ -535,7 +536,7 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownSpace(e, data, state) {
-    if (IS_CHROME) {
+    if (IS_CHROME && !data.isComposing && !(IS_MAC && e.metaKey && e.ctrlKey)) {
       e.preventDefault()
       return state
         .transform()

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -162,6 +162,10 @@ function Plugin(options = {}) {
       // the cursor isn't technique in the right spot. (2016/12/01)
       (!(pInline && !pInline.isVoid && startOffset == 0)) &&
       (!(nInline && !nInline.isVoid && startOffset == startText.length)) &&
+      // COMPAT: When inserting a Space character , Chrome will sometimes 
+      // split the text node into two adjacent text nodes. See:
+      // https://github.com/ianstormtaylor/slate/issues/938
+      (!(e.data === ' ' && IS_CHROME)) &&
       // If the
       (chars.equals(nextChars))
     )
@@ -478,7 +482,6 @@ function Plugin(options = {}) {
 
     switch (data.key) {
       case 'enter': return onKeyDownEnter(e, data, state)
-      case 'space': return onKeyDownSpace(e, data, state)
       case 'backspace': return onKeyDownBackspace(e, data, state)
       case 'delete': return onKeyDownDelete(e, data, state)
       case 'left': return onKeyDownLeft(e, data, state)
@@ -521,28 +524,6 @@ function Plugin(options = {}) {
       .transform()
       .splitBlock()
       .apply()
-  }
-
-  /**
-   * On `Space` key down, prevent the default browser behavior
-   * in Chrome, since in some situation it will result in loss of text.
-   * (unless we're composing or we're on a Mac and we want to insert emoji)
-   * Reference: https://github.com/ianstormtaylor/slate/issues/938
-   *
-   * @param {Event} e
-   * @param {Object} data
-   * @param {State} state
-   * @return {State|Null}
-   */
-
-  function onKeyDownSpace(e, data, state) {
-    if (IS_CHROME && !data.isComposing && !(IS_MAC && e.metaKey && e.ctrlKey)) {
-      e.preventDefault()
-      return state
-        .transform()
-        .insertText(' ')
-        .apply()
-    }
   }
 
   /**


### PR DESCRIPTION
Re: https://github.com/ianstormtaylor/slate/issues/938 this makes synthetic Space insertion in Chrome less obtrusive, now allowing insertion of emoji chars and possibly fixing IME (although I don't have one around to test)