### PR TITLE
Use parent node to find text node parent

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -252,10 +252,8 @@ class Content extends React.Component {
   isInEditor = (target) => {
     const { element } = this
     // COMPAT: Text nodes don't have `isContentEditable` property. So, when
-    // `target` is a text node use its parent element for check.
-    // COMPAT: `parentElement` is not defined on text nodes in certain browsers:
-    // https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement#Browser_compatibility
-    const el = (target.nodeType === 3 && target.parentElement) ? target.parentElement : target
+    // `target` is a text node use its parent node for check.
+    const el = target.nodeType === 3 ? target.parentNode : target
     return (
       (el.isContentEditable) &&
       (el === element || findClosestNode(el, '[data-slate-editor]') === element)


### PR DESCRIPTION
Provides a more complete solution to https://github.com/ianstormtaylor/slate/pull/974 by using `parentNode` in place of `parentElement` to find the parent of a text node and perform the `isContentEditable` check.

`parentNode` has full browser compatibility as opposed to `parentElement`, which [is not defined for text nodes](https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement#Browser_compatibility) in IE and Opera.