### PR TITLE
Add State.characters to docs

### DIFF
--- a/docs/reference/models/state.md
+++ b/docs/reference/models/state.md
@@ -101,6 +101,11 @@ Get a list of the lowest-depth [`Inline`](./inline.md) nodes in the current sele
 
 Get a list of the [`Text`](./text.md) nodes in the current selection.
 
+### `characters`
+`List`
+
+Get a list of the [`Character`](./character.md) objects in the current selection.
+
 ### `hasUndos`
 `Boolean`
 


### PR DESCRIPTION
Realized while discussing https://github.com/ianstormtaylor/slate/pull/990 that the docs were missing this.