### PR TITLE
Add .babelrc into .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ examples
 src
 test
 tmp
+.babelrc


### PR DESCRIPTION
See Issue #1019 
This PR solves babel transform issue when user imports slate in webpack project with default `babel-loader` config.
