### PR TITLE
[WIP] Sort out cut/copy/paste issues

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -392,8 +392,6 @@ class Content extends React.Component {
 
     const { state } = this.props
     const data = {}
-    data.type = 'fragment'
-    data.fragment = state.fragment
 
     debug('onCopy', { event, data })
     this.props.onCopy(event, data)
@@ -417,8 +415,6 @@ class Content extends React.Component {
 
     const { state } = this.props
     const data = {}
-    data.type = 'fragment'
-    data.fragment = state.fragment
 
     debug('onCut', { event, data })
     this.props.onCut(event, data)

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -390,7 +390,6 @@ class Content extends React.Component {
       this.tmp.isCopying = false
     })
 
-    const { state } = this.props
     const data = {}
 
     debug('onCopy', { event, data })
@@ -413,7 +412,6 @@ class Content extends React.Component {
       this.tmp.isCopying = false
     })
 
-    const { state } = this.props
     const data = {}
 
     debug('onCut', { event, data })

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -264,7 +264,7 @@ function Plugin(options = {}) {
     // If the selection is collapsed, and it isn't inside a void node, abort.
     if (native.isCollapsed && !isVoid) return
 
-    const { fragment } = data
+    const { fragment } = state
     const encoded = Base64.serializeNode(fragment)
     const range = native.getRangeAt(0)
     let contents = range.cloneContents()

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -305,12 +305,33 @@ function Plugin(options = {}) {
 
     attach.setAttribute('data-slate-fragment', encoded)
 
-    if (!_XmlSerializer) {
-      _XmlSerializer = new XMLSerializer()
-    }
+    let htmlData
 
-    e.nativeEvent.clipboardData.setData('text/html', _XmlSerializer.serializeToString(contents))
-    e.nativeEvent.clipboardData.setData('text/plain', contents.textContent)
+    // Use the HtmlSerializer passed in the event data
+    if (data.htmlSerializer && typeof data.htmlSerializer === 'function') {
+      htmlData = data.htmlSerializer.serialize(contents)
+    } else {
+      // Fall back to the native XMLSerializer
+      // Note: the terser .outerHTML does not work on DocumentFragment
+      if (!_XmlSerializer) {
+        _XmlSerializer = new XMLSerializer()
+      }
+      htmlData = _XmlSerializer.serializeToString(contents)
+    }
+    e.nativeEvent.clipboardData.setData('text/html', htmlData)
+
+    let textData
+    // Use the PlainSerializer passed in the event data
+    if (data.plainSerializer && typeof data.plainSerializer === 'function') {
+      textData = data.plainSerializer.serialize(contents)
+    } else {
+      // Fall back to the native .textContent
+      textData = contents.textContent
+    }
+    e.nativeEvent.clipboardData.setData('text/plain', textData)
+
+    // Prevent the default copy action, to make sure our custom data
+    // lands into the clipboard instead.
     e.preventDefault()
   }
 

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -18,7 +18,7 @@ import { IS_CHROME, IS_MAC, IS_SAFARI } from '../constants/environment'
 
 const debug = Debug('slate:core')
 
-const xml_serializer = new XMLSerializer();
+let _XmlSerializer
 
 /**
  * The default plugin.
@@ -305,9 +305,13 @@ function Plugin(options = {}) {
 
     attach.setAttribute('data-slate-fragment', encoded)
 
-    e.nativeEvent.clipboardData.setData('text/html', xml_serializer.serializeToString(contents))
+    if (!_XmlSerializer) {
+      _XmlSerializer = new XMLSerializer()
+    }
+
+    e.nativeEvent.clipboardData.setData('text/html', _XmlSerializer.serializeToString(contents))
     e.nativeEvent.clipboardData.setData('text/plain', contents.textContent)
-    e.preventDefault();
+    e.preventDefault()
   }
 
   /**

--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -18,6 +18,8 @@ import { IS_CHROME, IS_MAC, IS_SAFARI } from '../constants/environment'
 
 const debug = Debug('slate:core')
 
+const xml_serializer = new XMLSerializer();
+
 /**
  * The default plugin.
  *
@@ -303,28 +305,9 @@ function Plugin(options = {}) {
 
     attach.setAttribute('data-slate-fragment', encoded)
 
-    // Add the phony content to the DOM, and select it, so it will be copied.
-    const body = window.document.querySelector('body')
-    const div = window.document.createElement('div')
-    div.setAttribute('contenteditable', true)
-    div.style.position = 'absolute'
-    div.style.left = '-9999px'
-    div.appendChild(contents)
-    body.appendChild(div)
-
-    // COMPAT: In Firefox, trying to use the terser `native.selectAllChildren`
-    // throws an error, so we use the older `range` equivalent. (2016/06/21)
-    const r = window.document.createRange()
-    r.selectNodeContents(div)
-    native.removeAllRanges()
-    native.addRange(r)
-
-    // Revert to the previous selection right after copying.
-    window.requestAnimationFrame(() => {
-      body.removeChild(div)
-      native.removeAllRanges()
-      native.addRange(range)
-    })
+    e.nativeEvent.clipboardData.setData('text/html', xml_serializer.serializeToString(contents))
+    e.nativeEvent.clipboardData.setData('text/plain', contents.textContent)
+    e.preventDefault();
   }
 
   /**


### PR DESCRIPTION
Re: #734 (Work in progress)

References: 
* https://bugs.chromium.org/p/chromium/issues/detail?id=758485
* https://github.com/w3c/editing/issues/168

Basically I'm swapping the "move into contenteditable div, select it, and let the browser copy the contents" technique with manually setting the clipboard data for `text/plain` and `text/html`.

There's an opportunity here to plugin in a Slate HTMLSerializer and PlainSerializer if the author wants to make the clipboard data conform to a certain schema. (There's a discussion about this, I think?) — DONE ✓

What still needs to be done (any help appreciated):

1. See if anything obvious regresses
2. Assess the browser support for `setData()` and whether we can be sure the data has been set. (Otherwise, browsers silently ignoring `setData()` will not be able to copy anything to the clipboard) — and fall back to the div technique if necessary