### PR TITLE
Make sure nodes always know if they're selected

### DIFF
--- a/examples/embeds/video.js
+++ b/examples/embeds/video.js
@@ -17,7 +17,7 @@ class Video extends React.Component {
 
   isSelected = () => {
     const { node, state } = this.props
-    const isSelected = state.selection.hasEdgeIn(node)
+    const isSelected = state.isFocused && state.blocks.includes(node)
     return isSelected
   }
 

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -28,7 +28,7 @@ const schema = {
   nodes: {
     image: (props) => {
       const { node, state } = props
-      const active = state.isFocused && state.selection.hasEdgeIn(node)
+      const active = state.isFocused && state.blocks.includes(node)
       const src = node.data.get('src')
       const className = active ? 'active' : null
       return (

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -111,14 +111,18 @@ class Node extends React.Component {
     if (nextProps.node != props.node) return true
 
     // If the node is a block or inline, which can have custom renderers, we
-    // include an extra check to re-render if the node's focus changes, to make
-    // it simple for users to show a node's "selected" state.
+    // include an extra check to re-render if the node either becomes part of,
+    // or leaves, a selection. This is to make it simple for users to show a
+    // node's "selected" state.
     if (nextProps.node.kind != 'text') {
-      const hasEdgeIn = props.state.selection.hasEdgeIn(props.node)
-      const nextHasEdgeIn = nextProps.state.selection.hasEdgeIn(nextProps.node)
-      const hasFocus = props.state.isFocused || nextProps.state.isFocused
-      const hasEdge = hasEdgeIn || nextHasEdgeIn
-      if (hasFocus && hasEdge) return true
+      const nodes = `${props.node.kind}s`
+      const isInSelection = props.state[nodes].includes(props.node)
+      const nextIsInSelection = nextProps.state[nodes].includes(nextProps.node)
+      const hasFocus = props.state.isFocused
+      const nextHasFocus = nextProps.state.isFocused
+      const selectionChanged = isInSelection != nextIsInSelection
+      const focusChanged = hasFocus != nextHasFocus
+      if (selectionChanged || focusChanged) return true
     }
 
     // If the node is a text node, re-render if the current decorations have


### PR DESCRIPTION
As described in #536, it's currently impossible (or at least very hard) for `block` and `inline` nodes to know whether or not they're part of a selection. The reason being that they only re-render if their focus changes, which I don't think is enough.

What's worked for us is to instead re-render if:

1. A node became part of a selection

**or**

2. A node was part of a selection, but isn't any longer.