### PR TITLE
Reset drag counter properly in void nodes

### DIFF
--- a/src/components/void.js
+++ b/src/components/void.js
@@ -115,7 +115,7 @@ class Void extends React.Component {
 
   onDragLeave = () => {
     this.setState((prevState) => {
-      const dragCounter = prevState.dragCounter + 1
+      const dragCounter = prevState.dragCounter - 1
       const editable = dragCounter === 0 ? false : undefined
       return { dragCounter, editable }
     })


### PR DESCRIPTION
I stumbled upon this while debugging some weird behavior regarding DnD. Currently, once a void node has had something dragged over it, it will always stay editable (since the drag counter is never decremented).