### PR TITLE
Fix bug where cursor is not shown when dragging selected fragment

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -448,9 +448,6 @@ class Content extends React.Component {
 
   onDragOver = (event) => {
     if (!this.isInEditor(event.target)) return
-
-    event.preventDefault()
-
     if (this.tmp.isDragging) return
     this.tmp.isDragging = true
     this.tmp.isInternalDrag = false


### PR DESCRIPTION
Slate no longer shows the cursor when dragging a fragment, so there is no way to tell where the target actually is. This worked fine before https://github.com/ianstormtaylor/slate/pull/923.

The reason is that the ``event.preventDefault()`` is called in the content component's ``onDragOver``method.

Not sure why this event is required to be prevented (can't find a good reason), I see it is discussed here: https://github.com/ianstormtaylor/slate/pull/923#pullrequestreview-49357444

@mjadobson: any comments on this?
