### PR TITLE
Always call `preventDefault()` on `onDrop` events

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -491,10 +491,10 @@ class Content extends React.Component {
    */
 
   onDrop = (event) => {
+    event.preventDefault()
+
     if (this.props.readOnly) return
     if (!this.isInEditor(event.target)) return
-
-    event.preventDefault()
 
     const window = getWindow(event.target)
     const { state, editor } = this.props


### PR DESCRIPTION
As stated in #9, when a drop happens inside Slate, on a position not allowed by the editor, then the default browser action takes place: for example, if an URL is dropped on a void node, the browser loads that resource in the current tab.

PR #921 should have solved this issue, but it didn't, at least in Firefox.
Drop a string on an emojii in the Slate example using Firefox to see that.

This PR fixes definitively the issue calling always `preventDefault` on  drop events.
  