### PR TITLE
Don't call `preventDefault` on `onDragOver` event.

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -449,8 +449,6 @@ class Content extends React.Component {
   onDragOver = (event) => {
     if (!this.isInEditor(event.target)) return
 
-    event.preventDefault()
-
     if (this.tmp.isDragging) return
     this.tmp.isDragging = true
     this.tmp.isInternalDrag = false


### PR DESCRIPTION
What is supposed to do the [`preventDefault` call](https://github.com/ianstormtaylor/slate/blob/master/src/components/content.js#L452) within the `onDragOver` `Content` handler?

In a non-editable context, default browser behavior is to not allow drop action, so in those circumstances calling `preventDefault` on `onDragOver` is necessary if you want give user a visual feedback.

On the contrary, when the target is `contentEditable`, like the Slate `Content` component, calling `preventDefault` on `onDragOver` stops the browser from showing with the text caret where the drop will take place: an extremely useful feedback!

If you drag around a string inside a Slate editor, you'll see the caret jumping onto the insert point only when drag enters a new element, for example when it enters a new paragraph. This happens because `preventDefault` is not called `onDragEnter` event.

This PR intends to fix this.