### PR TITLE
fixing a breaking change in node/mark properties

### DIFF
--- a/src/utils/normalize.js
+++ b/src/utils/normalize.js
@@ -133,9 +133,7 @@ function markProperties(value = {}) {
       for (const k in value) {
         if (k == 'data') {
           if (value[k] !== undefined) ret[k] = Data.create(value[k])
-        } else if (k.startsWith('@@__SLATE')) {
-          return
-        } else {
+        } else if (!k.startsWith('@@__SLATE')) {
           ret[k] = value[k]
         }
       }
@@ -168,9 +166,7 @@ function nodeProperties(value = {}) {
       for (const k in value) {
         if (k == 'data') {
           if (value[k] !== undefined) ret[k] = Data.create(value[k])
-        } else if (k.startsWith('@@__SLATE')) {
-          return
-        } else {
+        } else if (!k.startsWith('@@__SLATE')) {
           ret[k] = value[k]
         }
       }


### PR DESCRIPTION
@ianstormtaylor in #1033 I had a sloppy moment in `nodeProperties` and `markProperties` where I returned nothing if there was a `@@__SLATE` key in the node/mark.  This causes `properties` to be undefined for any transform and does some pretty bad stuff.

This new fix just makes it so it skips over those keys, which was the original intended effect.