### PR TITLE
fixes errors for basic app with installation

### DIFF
--- a/docs/walkthroughs/installing-slate.md
+++ b/docs/walkthroughs/installing-slate.md
@@ -82,7 +82,7 @@ class App extends React.Component {
   }
 
   // On change, update the app's React state with the new editor state.
-  onChange = (state) => {
+  onChange = ({ state }) => {
     this.setState({ state })
   }
 


### PR DESCRIPTION
The old onChange function caused a bunch of `Uncaught TypeError: _this.state.state.change is not a function` errors. Adding the object destructure to the arguments fixes this.