### PR TITLE
sCU Changes for #1058

### DIFF
--- a/src/components/node.js
+++ b/src/components/node.js
@@ -111,6 +111,10 @@ class Node extends React.Component {
     // for simplicity we just let them through.
     if (nextProps.node != props.node) return true
 
+    // If the Node has more Nodes inside of it that aren't Texts, allow
+    // them to decide if they should render or not.
+    if (nextProps.node.nodes.size === nextProps.node.getTexts().size) return true
+
     // If the node is a block or inline, which can have custom renderers, we
     // include an extra check to re-render if the node either becomes part of,
     // or leaves, a selection. This is to make it simple for users to show a

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -111,12 +111,9 @@ class Node extends React.Component {
     // for simplicity we just let them through.
     if (nextProps.node != props.node) return true
 
-    // If the Node has more Nodes inside of it that aren't Texts, allow
-    // them to decide if they should render or not.
-    if (
-      nextProps.node.nodes &&
-      nextProps.node.nodes.size === nextProps.node.getTexts().size
-    ) return true
+    // If the Node has children that aren't just Text's then allow them to decide
+    // If they should update it or not.
+    if (nextProps.node.kind != 'text' && Text.isTextList(nextProps.node.nodes) == false) return true
 
     // If the node is a block or inline, which can have custom renderers, we
     // include an extra check to re-render if the node either becomes part of,

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -113,7 +113,10 @@ class Node extends React.Component {
 
     // If the Node has more Nodes inside of it that aren't Texts, allow
     // them to decide if they should render or not.
-    if (nextProps.node.nodes.size === nextProps.node.getTexts().size) return true
+    if (
+      nextProps.node.nodes &&
+      nextProps.node.nodes.size === nextProps.node.getTexts().size
+    ) return true
 
     // If the node is a block or inline, which can have custom renderers, we
     // include an extra check to re-render if the node either becomes part of,


### PR DESCRIPTION
In #1058 we figured out that the selection logic checks in sCU aren't aggressive enough to cover every case.  I believe this change would cover all of our bases.  Basically, if you have nodes that aren't text nodes, then you must let your child nodes determine wether or not they can re-render.  We can change this to be more performant if we find that selection is the only case where this is true, but I kept it open ended.

I was having trouble figuring out how to run the performance tests, is there any documentation on that?

Thoughts?