### PR TITLE
revert changes to up/down behavior near void nodes, fixes #1063

### DIFF
--- a/src/plugins/core.js
+++ b/src/plugins/core.js
@@ -653,9 +653,7 @@ function Plugin(options = {}) {
   }
 
   /**
-   * On `up` key down. If the previous block is void, make sure it is collapsed
-   * or extended (if shift) to start.
-   * For Macs, move the selection to start of the block if `alt` key is pressed.
+   * On `up` key down, for Macs, move the selection to start of the block.
    *
    * COMPAT: Certain browsers don't handle the selection updates properly. In
    * Chrome, option-shift-up doesn't properly extend the selection. And in
@@ -667,21 +665,13 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownUp(e, data, change) {
-    const { state } = change
-    const { selection, document, focusKey, focusBlock } = state
-    const previousBlock = document.getPreviousBlock(focusKey)
-
-    if (previousBlock && previousBlock.isVoid && !data.isAlt) {
-      const transform = data.isShift ? 'extendToStartOf' : 'collapseToStartOf'
-      e.preventDefault()
-      return change[transform](previousBlock)
-    }
-
     if (!IS_MAC || data.isCtrl || !data.isAlt) return
 
+    const { state } = change
+    const { selection, document, focusKey, focusBlock } = state
     const transform = data.isShift ? 'extendToStartOf' : 'collapseToStartOf'
     const block = selection.hasFocusAtStartOf(focusBlock)
-      ? previousBlock
+      ? document.getPreviousBlock(focusKey)
       : focusBlock
 
     if (!block) return
@@ -692,9 +682,7 @@ function Plugin(options = {}) {
   }
 
   /**
-   * On `down` key down. If the next block is void, make sure it is collapsed
-   * or extended (if shift) to start.
-   * For Macs, move the selection to end of the block if `alt` key is pressed.
+   * On `down` key down, for Macs, move the selection to end of the block.
    *
    * COMPAT: Certain browsers don't handle the selection updates properly. In
    * Chrome, option-shift-down doesn't properly extend the selection. And in
@@ -706,21 +694,13 @@ function Plugin(options = {}) {
    */
 
   function onKeyDownDown(e, data, change) {
-    const { state } = change
-    const { selection, document, focusKey, focusBlock } = state
-    const nextBlock = document.getNextBlock(focusKey)
-
-    if (nextBlock && nextBlock.isVoid && !data.isAlt) {
-      const transform = data.isShift ? 'extendToStartOf' : 'collapseToStartOf'
-      e.preventDefault()
-      return change[transform](nextBlock)
-    }
-
     if (!IS_MAC || data.isCtrl || !data.isAlt) return
 
+    const { state } = change
+    const { selection, document, focusKey, focusBlock } = state
     const transform = data.isShift ? 'extendToEndOf' : 'collapseToEndOf'
     const block = selection.hasFocusAtEndOf(focusBlock)
-      ? nextBlock
+      ? document.getNextBlock(focusKey)
       : focusBlock
 
     if (!block) return


### PR DESCRIPTION
Thank you @AlbertHilb for reporting this one. This is totally my fault, I didn't properly check the changes that were merged in to make sure there weren't any regressions.

@skogsmaskin can you explain what you were after with #1042? I had to revert it to fix this. I'm not sure exactly what you were trying to fix though because I couldn't reproduce your issue locally, so I wasn't sure how to revert and fix at the same time. Thanks!