### PR TITLE
Fix bug with updating a deselected selection and void block selection issues

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -164,14 +164,12 @@ class Content extends React.Component {
       return
     }
 
-    const { anchorKey, focusKey } = selection
-
     // If the selection isn't set, do nothing.
     if (selection.isUnset) return
 
     // Otherwise, figure out which DOM nodes should be selected...
     const { anchorText, focusText } = state
-    const { anchorOffset, focusOffset } = selection
+    const { anchorKey, anchorOffset, focusKey, focusOffset } = selection
     const schema = editor.getSchema()
     const anchorDecorators = document.getDescendantDecorators(anchorKey, schema)
     const focusDecorators = document.getDescendantDecorators(focusKey, schema)

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -164,9 +164,14 @@ class Content extends React.Component {
       return
     }
 
+    const { anchorKey, focusKey } = selection
+
+    // If the selection has no anchorKey and focusKey (deselected) do nothing
+    if (!selection.anchorKey && !selection.focusKey) return
+
     // Otherwise, figure out which DOM nodes should be selected...
     const { anchorText, focusText } = state
-    const { anchorKey, anchorOffset, focusKey, focusOffset } = selection
+    const { anchorOffset, focusOffset } = selection
     const schema = editor.getSchema()
     const anchorDecorators = document.getDescendantDecorators(anchorKey, schema)
     const focusDecorators = document.getDescendantDecorators(focusKey, schema)

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -166,8 +166,8 @@ class Content extends React.Component {
 
     const { anchorKey, focusKey } = selection
 
-    // If the selection has no anchorKey and focusKey (deselected) do nothing
-    if (!selection.anchorKey && !selection.focusKey) return
+    // If the selection isn't set, do nothing.
+    if (selection.isUnset) return
 
     // Otherwise, figure out which DOM nodes should be selected...
     const { anchorText, focusText } = state

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -790,13 +790,29 @@ class Content extends React.Component {
         isBackward: null
       }
 
-      // If the selection is at the end of a non-void inline node, and there is
-      // a node after it, put it in the node after instead.
       const anchorText = document.getNode(anchor.key)
       const focusText = document.getNode(focus.key)
       const anchorInline = document.getClosestInline(anchor.key)
       const focusInline = document.getClosestInline(focus.key)
+      const focusBlock = document.getClosestBlock(focus.key)
+      const anchorBlock = document.getClosestBlock(anchor.key)
 
+      // When going from a non-void block to the start of a void-block
+      // the focus is most of the time collpased to the end of the void block.
+      // This is getting the void-block selected as well when it shouldn't.
+      // Make sure it is collapsed to the start in those cases.
+      if (anchorBlock && !anchorBlock.isVoid && focusBlock && focusBlock.isVoid && focus.offset == 1) {
+        properties.focusOffset = 0
+      }
+
+      // If anchor and focus block is the same void block make sure it is anchored to start
+      // so we are able to select and delete it
+      if (anchorBlock && anchorBlock.isVoid && focusBlock && focusBlock.key == anchorBlock.key) {
+        properties.anchorOffset = 0
+      }
+
+      // If the selection is at the end of a non-void inline node, and there is
+      // a node after it, put it in the node after instead.
       if (anchorInline && !anchorInline.isVoid && anchor.offset == anchorText.text.length) {
         const block = document.getClosestBlock(anchor.key)
         const next = block.getNextText(anchor.key)


### PR DESCRIPTION
There are two things fixed here. The first one is a fix for ``content.updateSelection`` when the selection is deselected and ``anchorKey`` and ``focusKey`` is unset.  It should then return as the rest of the code acts on ``anchorKey`` and ``focusKey``.

The second fix is regarding selecting void nodes. When selecting text from a non-void block to the end, neighbouring a void-block, the ``focusOffset`` is (most of the time) set at the end of the void block when it shouldn't. This will delete the void block as well when you press backspace. Therefore make sure that the ``focusOffset`` is always set to 0 in the void block in those conditions.

Also if you move the cursor to a void-block, the same problem occur. It is most of the time set to anchor and focusOffset 1, making it impossible to delete it. In this case, set the ``anchorOffset`` to 0.

This was what I originally tried to fix in https://github.com/ianstormtaylor/slate/pull/1042
which was reverted via  https://github.com/ianstormtaylor/slate/issues/1063 because of issues. It was probably the wrong place trying to fix it, but I hope this PR will make it proper and there are no side effects. Unfortunately it is a bit difficult to test because it relies on browser behaviour.

