### PR TITLE
Fix state.isEmpty

### DIFF
--- a/src/models/state.js
+++ b/src/models/state.js
@@ -502,7 +502,7 @@ class State extends Record(DEFAULTS) {
       return true
     }
 
-    if (endOffset != 0 && startOffset != 0) {
+    if (startOffset < endOffset) {
       return false
     }
 


### PR DESCRIPTION
#### What's the current behavior?

`state.isEmpty()` returns true even though the selection state is not empty.

#### What's the expected behavior?

`state.isEmpty()` should return false when there is text in the selection state.

#### Example

Check out http://slatejs.org/#/hovering-menu and select an entire block.

![hover-menu-bug](https://user-images.githubusercontent.com/1265681/30240311-71ca0392-956e-11e7-997a-0bcc73380d87.gif)

#### Solution 

~~Use `state.fragment.text.size` instead of `state.fragment.text.length`~~

```js
if (startOffset < endOffset) {
    return false
}
```
