### PR TITLE
Fix an invalid require statement in base-64 serializer

### DIFF
--- a/src/serializers/base-64.js
+++ b/src/serializers/base-64.js
@@ -48,7 +48,7 @@ function deserialize(string, options) {
  */
 
 function deserializeNode(string, options) {
-  const Node = require('../models/node')
+  const Node = require('../models/node').default
   const raw = decode(string)
   const node = Node.fromJSON(raw, options)
   return node


### PR DESCRIPTION
It's puzzles me that it has to be required like this, but I see things break if I do a ``import Node from '../models/node'`` at top.

Anyway, it must get the ``.default`` export if required.

