### PR TITLE
Add replaceNodeByKey change

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -601,8 +601,7 @@ Changes.insertBlockAtRange = (change, range, block, options = {}) => {
   }
 
   else if (startBlock.isEmpty) {
-    change.removeNodeByKey(startBlock.key)
-    change.insertNodeByKey(parent.key, index, block, { normalize })
+    change.insertNodeByKey(parent.key, index + 1, block, { normalize })
   }
 
   else if (range.isAtStartOf(startBlock)) {

--- a/packages/slate/src/changes/by-key.js
+++ b/packages/slate/src/changes/by-key.js
@@ -367,6 +367,31 @@ Changes.removeTextByKey = (change, key, offset, length, options = {}) => {
 }
 
 /**
+`* Replace a `node` with another `node`
+ *
+ * @param {Change} change
+ * @param {String} key
+ * @param {Object|Node} node
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Changes.replaceNodeByKey = (change, key, newNode, options = {}) => {
+  newNode = Node.create(newNode)
+  const { normalize = true } = options
+  const { state } = change
+  const { document } = state
+  const node = document.getNode(key)
+  const parent = document.getParent(key)
+  const index = parent.nodes.indexOf(node)
+  change.removeNodeByKey(key, { normalize: false })
+  change.insertNodeByKey(parent.key, index, newNode, options)
+  if (normalize) {
+    change.normalizeNodeByKey(parent.key, SCHEMA)
+  }
+}
+
+/**
  * Set `properties` on mark on text at `offset` and `length` in node by `key`.
  *
  * @param {Change} change

--- a/packages/slate/test/changes/by-key/replace-node-by-key/block.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/block.js
@@ -3,17 +3,16 @@
 import h from '../../../helpers/h'
 
 export default function (change) {
-  change.insertBlock('quote')
+  const key = '123'
+  const quote = { kind: 'block', type: 'quote' }
+  change.replaceNodeByKey(key, quote)
 }
 
 export const input = (
   <state>
     <document>
-      <paragraph>
-        <cursor />
-      </paragraph>
-      <paragraph>
-        not empty
+      <paragraph key="123">
+        word
       </paragraph>
     </document>
   </state>
@@ -22,13 +21,7 @@ export const input = (
 export const output = (
   <state>
     <document>
-      <paragraph />
-      <quote>
-        <cursor />
-      </quote>
-      <paragraph>
-        not empty
-      </paragraph>
+      <quote />
     </document>
   </state>
 )

--- a/packages/slate/test/changes/by-key/replace-node-by-key/inline.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/inline.js
@@ -3,17 +3,15 @@
 import h from '../../../helpers/h'
 
 export default function (change) {
-  change.insertBlock('quote')
+  const quote = { kind: 'block', type: 'quote' }
+  change.replaceNodeByKey('a', quote)
 }
 
 export const input = (
   <state>
     <document>
       <paragraph>
-        <cursor />
-      </paragraph>
-      <paragraph>
-        not empty
+        one <link key="a">two</link>
       </paragraph>
     </document>
   </state>
@@ -22,12 +20,8 @@ export const input = (
 export const output = (
   <state>
     <document>
-      <paragraph />
-      <quote>
-        <cursor />
-      </quote>
       <paragraph>
-        not empty
+        one <quote />
       </paragraph>
     </document>
   </state>

--- a/packages/slate/test/changes/by-key/replace-node-by-key/text.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/text.js
@@ -3,18 +3,20 @@
 import h from '../../../helpers/h'
 
 export default function (change) {
-  change.insertBlock('quote')
+  const key = change.state.document.getTexts().first().key
+  const text = { kind: 'text', text: 'three' }
+  change.replaceNodeByKey(key, text)
 }
 
 export const input = (
   <state>
     <document>
       <paragraph>
-        <cursor />
+        one
       </paragraph>
       <paragraph>
-        not empty
-      </paragraph>
+        two
+    </paragraph>
     </document>
   </state>
 )
@@ -22,12 +24,11 @@ export const input = (
 export const output = (
   <state>
     <document>
-      <paragraph />
-      <quote>
-        <cursor />
-      </quote>
       <paragraph>
-        not empty
+        three
+      </paragraph>
+      <paragraph>
+        two
       </paragraph>
     </document>
   </state>


### PR DESCRIPTION
This follows up https://github.com/ianstormtaylor/slate/pull/665.

Add ``change.replaceBlock(oldBlock, newBlock)`` method to replace a block with another block.

Remove code that replaced an empty block in ``.insertBlock``
