### PR TITLE
(PIM-11845) Fixed text parent node use.

### DIFF
--- a/src/components/content.js
+++ b/src/components/content.js
@@ -251,7 +251,7 @@ class Content extends React.Component {
     const { element } = this
     // COMPAT: Text nodes don't have `isContentEditable` property. So, when
     // `target` is a text node use its parent element for check.
-    const el = target.nodeType === 3 ? target.parentElement : target
+    const el = target.nodeType === 3 ? target.parentNode : target
     return (
       (el.isContentEditable) &&
       (el === element || findClosestNode(el, '[data-slate-editor]') === element)


### PR DESCRIPTION
It seems that _target.parentElement_ needs to be replaced by _target.parentNode_ ( src/components/content.js:254), because in some cases _parentElement_ could be equal to null.

See https://github.com/OpusCapita/react-markdown/issues/47 for details.