### PR TITLE
sCU - Let only nodeless Nodes determine if they need to update or not.

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -3,6 +3,7 @@ import Base64 from 'slate-base64-serializer'
 import Debug from 'debug'
 import React from 'react'
 import ReactDOM from 'react-dom'
+import Slate from 'slate'
 import SlateTypes from 'slate-prop-types'
 import Types from 'prop-types'
 import getWindow from 'get-window'
@@ -120,7 +121,7 @@ class Node extends React.Component {
 
     // If the node's selection state has changed, re-render in case there is any
     // user-land logic depends on it to render.
-    if (n.isSelected != p.isSelected) return true
+    if (n.node.kind != 'text' && n.node.nodes.size != 0 && !Slate.Text.isTextList(n.node.nodes)) return true
 
     // If the node is a text node, re-render if the current decorations have
     // changed, even if the content of the text node itself hasn't.

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -104,6 +104,10 @@ class Node extends React.Component {
     // return true so that it can deal with update checking itself.
     if (Component && Component.suppressShouldComponentUpdate) return true
 
+    // If the `Component` has more child nodes, let them determine if they should
+    // or shouldn't re-render;
+    if (n.node.nodes.size !== 0) return true
+
     // If the `readOnly` status has changed, re-render in case there is any
     // user-land logic that depends on it, like nested editable contents.
     if (n.readOnly != p.readOnly) return true


### PR DESCRIPTION
This change adds a line that doesn't allow a node to return false in `shouldComponentUpdate` unless it has no children nodes.  Here is the problem this is trying to solve.  Say you have something that looks like this.

```
- Paragraph
  - Text
  - Link
  - Text
- Paragraph
  - Text
```

If at any point `Paragraph` decides that it shouldn't update, every node underneath it won't.  This would be a safe assumption but since `Node` is a recursive component that is basically walking a tree.  It's difficult to make calculations at the top of the tree that determine if the rest of the tree is useless or not. 