### PR TITLE
Fix SCU `isSelected` logic.

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -114,9 +114,12 @@ class Node extends React.Component {
     // for simplicity we just let them through.
     if (n.node != p.node) return true
 
-    // If the node's selection state has changed, re-render in case there is any
-    // user-land logic depends on it to render.
-    if (n.isSelected != p.isSelected) return true
+    // If the selection state of the node or of some of its children has changed,
+    // re-render in case there is any user-land logic depends on it to render.
+    // if the node is selected update it, even if it was already selected: the
+    // selection state of some of its children could have been changed and they
+    // need to be rendered again.
+    if (n.isSelected || p.isSelected) return true
 
     // If the node is a text node, re-render if the current decorations have
     // changed, even if the content of the text node itself hasn't.


### PR DESCRIPTION
This fixes #1102.

The sCU `isSelected` logic could be made more effective if `isSelected`was a three-state variable:

* `-1` if the node does not intersect selection
* `0` if the node contains one of the selection edges
* `1` if the node is all inside the selection

In this case we can avoid to update a node that is, and was already, entirely selected.

But I don't know if the gain is worth the code we should add. 




 