### PR TITLE
Correctly pass `preserveSelection` option in tests

### DIFF
--- a/packages/slate/test/changes/index.js
+++ b/packages/slate/test/changes/index.js
@@ -29,7 +29,7 @@ describe('changes', async () => {
               const fn = module.default
               const change = input.change()
               fn(change)
-              const opts = { preseveSelection: true, preserveStateData: true }
+              const opts = { preserveSelection: true, preserveStateData: true }
               const actual = change.state.toJSON(opts)
               const expected = output.toJSON(opts)
               assert.deepEqual(actual, expected)

--- a/packages/slate/test/history/index.js
+++ b/packages/slate/test/history/index.js
@@ -22,7 +22,7 @@ describe('history', async () => {
           const { input, output } = module
           const fn = module.default
           const next = fn(input)
-          const opts = { preseveSelection: true, preserveStateData: true }
+          const opts = { preserveSelection: true, preserveStateData: true }
           const actual = next.toJSON(opts)
           const expected = output.toJSON(opts)
           assert.deepEqual(actual, expected)


### PR DESCRIPTION
There was a typo in `preserveSelection`.
A bunch of tests are suddenly failing. I haven't yet looked into them.