### PR TITLE
Fixing Drag and Drop, and getFragmentAtRange

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -762,7 +762,7 @@ class Node {
     }
 
     // Get the start and end nodes.
-    const next = node.getNextText(startKey)
+    const next = node.getNextText(node.getNextText(startKey).key)
     const startNode = node.getNextSibling(node.getFurthestAncestor(startKey).key)
     const endNode = startKey == endKey
       ? node.getFurthestAncestor(next.key)


### PR DESCRIPTION
fixes #1123 

This one is weird, and I think there may be another underlying problem?

Basically, if they start and end keys are the same, we `getNextText`, but that always returns an empty text node next to our startNode.  This causes splice to fire on the same index, and returns no  nodes.

Is there a better way to do this?  I don't think `getNextText` should be modified.  Is it okay to assume that we just need to do it twice?