### PR TITLE
Add a way to customize shouldComponentUpdate logic

### DIFF
--- a/docs/reference/slate-react/custom-nodes.md
+++ b/docs/reference/slate-react/custom-nodes.md
@@ -12,6 +12,7 @@ Slate will render custom nodes for [`Block`](../slate/block.md) and [`Inline`](.
   - [`parent`](#parent)
   - [`readOnly`](#readonly)
   - [`state`](#state)
+- [`shouldNodeComponentUpdate`](#shouldnodecomponentupdate)
 
 ## Properties
 
@@ -97,3 +98,17 @@ Whether the editor is in "read-only" mode, where all of the rendering is the sam
 `State`
 
 A reference to the current [`State`](../slate/state.md) of the editor.
+
+## `shouldNodeComponentUpdate`
+
+By default, Slate implements a `shouldComponentUpdate` preventing useless re-renders for node components. While the default implementation covers most use cases, you can customize the logic to fit your needs. For example:
+
+```js
+class CustomNode extends React.Component {
+  static shouldNodeComponentUpdate(previousProps, nextProps) {
+    // return true here to trigger a re-render
+  }
+}
+```
+
+If `shouldNodeComponentUpdate` returns false, Slate will still figure out whether a re-render is needed or not.

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -4,6 +4,7 @@ import Debug from 'debug'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import SlateTypes from 'slate-prop-types'
+import logger from 'slate-dev-logger'
 import Types from 'prop-types'
 import getWindow from 'get-window'
 
@@ -102,7 +103,16 @@ class Node extends React.Component {
 
     // If the `Component` has enabled suppression of update checking, always
     // return true so that it can deal with update checking itself.
-    if (Component && Component.suppressShouldComponentUpdate) return true
+    if (Component && Component.suppressShouldComponentUpdate) {
+      logger.deprecate('2.2.0', 'The `suppressShouldComponentUpdate` property is deprecated because it led to an important performance loss, use `shouldNodeComponentUpdate` instead.')
+      return true
+    }
+
+    // If the `Component` has a custom logic to determine whether the component
+    // needs to be updated or not, return true if it returns true.
+    // If it returns false, we still want to benefit from the
+    // performance gain of the rest of the logic.
+    if (Component && Component.shouldNodeComponentUpdate && Component.shouldNodeComponentUpdate(p, n)) return true
 
     // If the `readOnly` status has changed, re-render in case there is any
     // user-land logic that depends on it, like nested editable contents.

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -112,7 +112,13 @@ class Node extends React.Component {
     // needs to be updated or not, return true if it returns true.
     // If it returns false, we still want to benefit from the
     // performance gain of the rest of the logic.
-    if (Component && Component.shouldNodeComponentUpdate && Component.shouldNodeComponentUpdate(p, n)) return true
+    if (
+      Component &&
+      Component.shouldNodeComponentUpdate &&
+      Component.shouldNodeComponentUpdate(p, n)
+    ) {
+      return true
+    }
 
     // If the `readOnly` status has changed, re-render in case there is any
     // user-land logic that depends on it, like nested editable contents.

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -112,10 +112,7 @@ class Node extends React.Component {
     // needs to be updated or not, return true if it returns true.
     // If it returns false, we still want to benefit from the
     // performance gain of the rest of the logic.
-    if (
-      Component &&
-      Component.shouldNodeComponentUpdate
-    ) {
+    if (Component && Component.shouldNodeComponentUpdate) {
       const shouldUpdate = Component.shouldNodeComponentUpdate(p, n)
 
       if (shouldUpdate) {

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -114,10 +114,17 @@ class Node extends React.Component {
     // performance gain of the rest of the logic.
     if (
       Component &&
-      Component.shouldNodeComponentUpdate &&
-      Component.shouldNodeComponentUpdate(p, n)
+      Component.shouldNodeComponentUpdate
     ) {
-      return true
+      const shouldUpdate = Component.shouldNodeComponentUpdate(p, n)
+
+      if (shouldUpdate) {
+        return true
+      }
+
+      if (shouldUpdate === false) {
+        logger.warn('Returning false in `shouldNodeComponentUpdate` does not disable Slate\'s internal `shouldComponentUpdate` logic. If you want to prevent updates, use React\'s `shouldComponentUpdate` instead.')
+      }
     }
 
     // If the `readOnly` status has changed, re-render in case there is any


### PR DESCRIPTION
We face issues with `shouldComponentUpdate` from times to times. For example, we're currently implementing a way for the user to sort top-level blocks in a document, with drag and drop. The node components need to be passed their index (within their parent, the `document`). While they're properly sorted, the `index` prop is not updated because the component rendering is blocked by `shouldComponentUpdate`.

For example, here's what would do the job for us:

```js
MyBlock.shouldNodeComponentUpdate = (props, nextProps) => {
    if (nextProps.parent !== nextProps.state.document) {
      return false;
    }

    const prevIndex = props.parent.findIndex(
        child => child.key === props.node.key
    );
    const newIndex = nextProps.parent.findIndex(
      child => child.key === nextProps.node.key
    );

    return prevIndex !== newIndex;
};
```

Basically, we'd just want to allow a re-render when the index changes and still benefit from Slate's `shouldComponentUpdate` performance gain. `suppressShouldComponentUpdate` is though as it requires us to duplicate Slate's logic.

This PR introduces a `shouldNodeComponentUpdate` that can be specified just like `suppressShouldComponentUpdate`. The function receives the previous and next properties and can return true to trigger a re-render. If it returns false, the rest of the logic remains.

Also, I added a deprecation warning to `suppressShouldComponentUpdate` although I'm not sure about the version to specify in the `logger.deprecate` call.

Probably fix #959 