### PR TITLE
Pasting external HTML does not work with Slate example. (#1129)

### DIFF
--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -128,7 +128,7 @@ const RULES = [
         type: 'link',
         nodes: next(el.childNodes),
         data: {
-          href: el.attrs.find(({ name }) => name == 'href').value
+          href: el.href
         }
       }
     }

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -128,7 +128,7 @@ const RULES = [
         type: 'link',
         nodes: next(el.childNodes),
         data: {
-          href: el.href
+          href: el.getAttribute('href')
         }
       }
     }


### PR DESCRIPTION
*Due to the upgrade of slate, adjust the way of el.attrs.find to el.href.
Since the upgrade of slate, el is now become an NamedNodeMap and not support .find anymore,
so I adjust it with el.href to explicit get the href value.