### PR TITLE
Fix warning with latest react due to autocorrect being bool

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -859,7 +859,7 @@ class Content extends React.Component {
         onKeyUp={this.onKeyUp}
         onPaste={this.onPaste}
         onSelect={this.onSelect}
-        autoCorrect={props.autoCorrect}
+        autoCorrect={props.autoCorrect ? 'on' : 'off'}
         spellCheck={spellCheck}
         style={style}
         role={readOnly ? null : (role || 'textbox')}


### PR DESCRIPTION
`Received 'true' for non-boolean attribute 'autoCorrect'. If this is expected, cast the value to a string.`

Latest react won't autocast the bool to on/off