### PR TITLE
fix copying text with leading/trailing white space, fixes #1153

### DIFF
--- a/packages/slate-react/src/plugins/core.js
+++ b/packages/slate-react/src/plugins/core.js
@@ -203,7 +203,6 @@ function Plugin(options = {}) {
     // in the HTML, and can be used for intra-Slate pasting. If it's a text
     // node, wrap it in a `<span>` so we have something to set an attribute on.
     if (attach.nodeType == 3) {
-      contents.removeChild(attach)
       const span = window.document.createElement('span')
 
       // COMPAT: In Chrome and Safari, if we don't add the `white-space` style

--- a/packages/slate-react/src/plugins/core.js
+++ b/packages/slate-react/src/plugins/core.js
@@ -203,7 +203,13 @@ function Plugin(options = {}) {
     // in the HTML, and can be used for intra-Slate pasting. If it's a text
     // node, wrap it in a `<span>` so we have something to set an attribute on.
     if (attach.nodeType == 3) {
+      contents.removeChild(attach)
       const span = window.document.createElement('span')
+
+      // COMPAT: In Chrome and Safari, if we don't add the `white-space` style
+      // then leading and trailing spaces will be ignored. (2017/09/21)
+      span.style.whiteSpace = 'pre'
+
       span.appendChild(attach)
       contents.appendChild(span)
       attach = span


### PR DESCRIPTION
@skogsmaskin this is just a different way to fix #1153 that is a bit cleaner hopefully, and in a weird way kind of makes sense, but not really.