### PR TITLE
Fix error when pasted HTML includes a doctype

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -59,7 +59,8 @@ const TEXT_RULE = {
 }
 
 /**
- * A default `parseHtml` option using the native `DOMParser`.
+ * A default `parseHtml` function that returns the `<body>` using the 
+ * native `DOMParser`.
  *
  * @param {String} html
  * @return {Object}
@@ -71,8 +72,8 @@ function defaultParseHtml(html) {
   }
 
   const parsed = new DOMParser().parseFromString(html, 'text/html')
-  // Unwrap from <html> and <body>.
-  return parsed.body
+  const { body } = parsed
+  return body
 }
 
 /**

--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -72,8 +72,7 @@ function defaultParseHtml(html) {
 
   const parsed = new DOMParser().parseFromString(html, 'text/html')
   // Unwrap from <html> and <body>.
-  const fragment = parsed.childNodes[0].childNodes[1]
-  return fragment
+  return parsed.body
 }
 
 /**


### PR DESCRIPTION
When pasted HTML includes a doctype definition, `parsed.childNodes[0]` is the doctype node, not the `<html>` node, so it's not safe to assume that `parsed.childNodes[0].childNodes[1]` is the `<body>` node.

Using `parsed.body` ensures that we always get the `<body>` node no matter where it is in the document.

I wanted to add a test for this, but it looks like the HTML serializer tests are currently only able to run in Node using parse5, so can't exercise `DOMParser`. If there is a way to test this and I've missed it, please let me know.

The easiest way I've found to reproduce this issue manually is (weirdly enough) to type some text into a macOS Messages input field, then select all, copy, and paste into Slate. The [Paste HTML example](http://localhost:8080/dev.html#/paste-html) exhibits the issue.