### PR TITLE
[WIP] Scoll to selection tweaks, possible fix for #1032

### DIFF
--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -3,6 +3,28 @@ import getWindow from 'get-window'
 import isBackward from 'selection-is-backward'
 
 /**
+ * Find the nearest container which has scrolling
+ * Fallback to window
+ * @param {elm} HTML Element
+ */
+
+function findScrollContainer(elm) {
+  let scrollContainerElement
+  let scrollContainer = elm.parentNode
+  while (!scrollContainerElement) {
+    if (!scrollContainer.parentNode) {
+      break
+    }
+    if (['overlay', 'auto', 'scroll'].includes(window.getComputedStyle(scrollContainer).overflowY)) {
+      scrollContainerElement = scrollContainer
+      break
+    }
+    scrollContainer = scrollContainer.parentNode
+  }
+  return scrollContainerElement || getWindow(elm)
+}
+
+/**
  * Scroll the current selection's focus point into view if needed.
  *
  * @param {Selection} selection
@@ -11,23 +33,45 @@ import isBackward from 'selection-is-backward'
 function scrollToSelection(selection) {
   if (!selection.anchorNode) return
 
-  const window = getWindow(selection.anchorNode)
+  const scrollContainer = findScrollContainer(selection.anchorNode)
+  const scrollContainerIsWindow = scrollContainer == scrollContainer.window
   const backward = isBackward(selection)
   const range = selection.getRangeAt(0)
   const rect = range.getBoundingClientRect()
-  const { innerWidth, innerHeight, pageYOffset, pageXOffset } = window
-  const top = (backward ? rect.top : rect.bottom) + pageYOffset
-  const left = (backward ? rect.left : rect.right) + pageXOffset
+  let width
+  let height
+  let yOffset
+  let xOffset
+  if (scrollContainerIsWindow) {
+    const { innerWidth, innerHeight, pageYOffset, pageXOffset } = scrollContainer
+    width = innerWidth
+    height = innerHeight
+    yOffset = pageYOffset
+    xOffset = pageXOffset
+  } else {
+    const { offsetWidth, offsetHeight, scrollTop, scrollLeft } = scrollContainer
+    width = offsetWidth
+    height = offsetHeight
+    yOffset = scrollTop
+    xOffset = scrollLeft
+  }
+  const top = (backward ? rect.top : rect.bottom) + yOffset
+  const left = (backward ? rect.left : rect.right) + xOffset
 
-  const x = left < pageXOffset || innerWidth + pageXOffset < left
-    ? left - innerWidth / 2
-    : pageXOffset
+  const x = left < yOffset || innerWidth + xOffset < left
+    ? left - width / 2
+    : xOffset
 
-  const y = top < pageYOffset || innerHeight + pageYOffset < top
-    ? top - innerHeight / 2
-    : pageYOffset
+  const y = top < yOffset || height + yOffset < top
+    ? top - height / 2
+    : yOffset
 
-  window.scrollTo(x, y)
+  if (scrollContainerIsWindow) {
+    window.scrollTo(x, y)
+  } else {
+    scrollContainer.scrollTop = scrollContainer.scrollTop + y
+    scrollContainer.scrollLeft = scrollContainer.scrollLeft + x
+  }
 }
 
 /**

--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -50,8 +50,9 @@ function findScrollContainer(el) {
 function scrollToSelection(selection) {
   if (!selection.anchorNode) return
 
+  const window = getWindow(selection.anchorNode)
   const scroller = findScrollContainer(selection.anchorNode)
-  const isWindow = scroller == scroller.window
+  const isWindow = scroller == window
   const backward = isBackward(selection)
   const range = selection.getRangeAt(0)
   const rect = range.getBoundingClientRect()


### PR DESCRIPTION
As the editor may be inside a scrollcontainer with it's own scrolling, the ``scrollToSelection`` should look for this first and scroll there,  otherwise deal with ``window``.

This is a proposal for how this can be checked and dealt with accordingly.

Se more about this issue in https://github.com/ianstormtaylor/slate/issues/1032

Before:

![Before](http://g.recordit.co/kOZpoiduFN.gif)

After:

![After](http://g.recordit.co/bTfWKa2lW0.gif)
