### PR TITLE
fixing empty leaft nodes in text getting desynced

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -67,7 +67,8 @@ class Leaf extends React.Component {
       props.index != this.props.index ||
       props.marks != this.props.marks ||
       props.schema != this.props.schema ||
-      props.text != this.props.text
+      props.text != this.props.text ||
+      props.parent != this.props.parent
     ) {
       return true
     }


### PR DESCRIPTION
fixes #1159 

Now if the parent node is changed, leaves will make sure that they are rendered correctly, instead of not updating at all.