### PR TITLE
Remove depecration for Text.fromJSON({ test })

### DIFF
--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -91,7 +91,6 @@ class Text extends Record(DEFAULTS) {
     } = object
 
     if (object.text) {
-      logger.deprecate('0.23.0', 'Passing `object.text` to `Text.fromJSON` has been deprecated, please use `object.ranges` instead.')
       ranges = [{ text: object.text }]
     }
 


### PR DESCRIPTION
We would like to revert the deprecation of:

```js
Text.fromJSON({
  text: '...'
})
```

We have a **lot** of tests, and older documents in our database, that are written using this shortcut:

```yaml
document:
  nodes:
    - kind: block
      type: paragraph
      nodes:
        - kind: text
          text: "..."
```

It was a real pain to update the tests. And now it is complicated for us to avoid that warning when we load old documents from our database.

As a result, I am questioning the will to deprecate this, in the first place.

Thoughts?