### PR TITLE
Apply stack.onBeforeChange in editor.onChange

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -130,8 +130,6 @@ class Editor extends React.Component {
         const stk = this.state.stack
         const change = this.state.state.change()
         stk[method](change, this, ...args)
-        stk.onBeforeChange(change, this)
-        stk.onChange(change, this)
         this.onChange(change)
       }
     }
@@ -240,9 +238,13 @@ class Editor extends React.Component {
     }
 
     const { onChange, onDocumentChange, onSelectionChange } = this.props
+    const { stack } = this.state
     const { document, selection } = this.tmp
     const { state } = change
     if (state == this.state.state) return
+
+    stack.onBeforeChange(change, this)
+    stack.onChange(change, this)
 
     onChange(change)
     if (onDocumentChange && state.document != document) onDocumentChange(state.document, change)


### PR DESCRIPTION
We just noticed from the Changelog that `onBeforeChange` is no longer called from the Editor `componentWillReceiveProps`.

This is causing issues for us, since after making changes outside of the editor (using `editor.onChange` actually) our rules are no longer applied. That’s exactly what @ianstormtaylor  explained in this issue https://github.com/ianstormtaylor/slate/issues/1111

We were thinking about a way to normalize the state ourselves, outside the editor. But this is not easy since we can’t easily get a hand on the same Schema instance than the editor’s. Not being able to do so breaks memoization.

So here is a temporary solution, that makes `stack.onBeforeChange` (and normalization) called even during the `editor.onChange`. If we end up moving the `schema` into the `state`, this will be not needed anymore :)