### PR TITLE
Add `props.attributes` to the element used to render paragraphs.

### DIFF
--- a/examples/emojis/index.js
+++ b/examples/emojis/index.js
@@ -25,7 +25,7 @@ const EMOJIS = [
 
 const schema = {
   nodes: {
-    paragraph: props => <p>{props.children}</p>,
+    paragraph: props => <p {...props.attributes}>{props.children}</p>,
     emoji: (props) => {
       const { isSelected, node } = props
       const { data } = node


### PR DESCRIPTION
In the "Emojis" example, `props.attributes` are not added to the `p` elements used to render paragraphs.
This fixes that.