### PR TITLE
Rewrite drag&drop code related to void nodes.

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -42,17 +42,6 @@ class Void extends React.Component {
   }
 
   /**
-   * State
-   *
-   * @type {Object}
-   */
-
-  state = {
-    dragCounter: 0,
-    editable: false,
-  }
-
-  /**
    * Debug.
    *
    * @param {String} message
@@ -90,44 +79,9 @@ class Void extends React.Component {
     })
   }
 
-  /**
-   * Increment counter, and temporarily switch node to editable to allow drop events
-   * Counter required as onDragLeave fires when hovering over child elements
-   *
-   * @param {Event} event
-   */
+  onDragOver = event => event.preventDefault()
 
-  onDragEnter = () => {
-    this.setState((prevState) => {
-      const dragCounter = prevState.dragCounter + 1
-      return { dragCounter, editable: undefined }
-    })
-  }
-
-  /**
-   * Decrement counter, and if counter 0, then no longer dragging over node
-   * and thus switch back to non-editable
-   *
-   * @param {Event} event
-   */
-
-  onDragLeave = () => {
-    this.setState((prevState) => {
-      const dragCounter = prevState.dragCounter - 1
-      const editable = dragCounter === 0 ? false : undefined
-      return { dragCounter, editable }
-    })
-  }
-
-  /**
-   * If dropped item onto node, then reset state
-   *
-   * @param {Event} event
-   */
-
-  onDrop = () => {
-    this.setState({ dragCounter: 0, editable: false })
-  }
+  onDragEnter = event => event.preventDefault()
 
   /**
    * Render.
@@ -156,13 +110,13 @@ class Void extends React.Component {
     return (
       <Tag
         data-slate-void
+        data-key={node.key}
         onClick={this.onClick}
+        onDragOver={this.onDragOver}
         onDragEnter={this.onDragEnter}
-        onDragLeave={this.onDragLeave}
-        onDrop={this.onDrop}
       >
         {this.renderSpacer()}
-        <Tag contentEditable={this.state.editable} style={style}>
+        <Tag contentEditable={false} style={style}>
           {children}
         </Tag>
       </Tag>

--- a/packages/slate-react/src/utils/get-drop-point.js
+++ b/packages/slate-react/src/utils/get-drop-point.js
@@ -1,0 +1,88 @@
+
+import getWindow from 'get-window'
+
+import findClosestNode from './find-closest-node'
+import getPoint from './get-point'
+
+/**
+ * Get the target point for a drop event.
+ *
+ * @param {Event} event
+ * @param {State} state
+ * @param {Editor} editor
+ * @return {Object}
+ */
+
+function getDropPoint(event, state, editor) {
+  const { document } = state
+  const { nativeEvent, target } = event
+  const { x, y } = nativeEvent
+  const nodeEl = findClosestNode(target, '[data-key]')
+  const nodeKey = nodeEl.getAttribute('data-key')
+  const node = document.key === nodeKey ? document : document.getDescendant(nodeKey)
+
+  // If the drop DOM target is inside an inline void node use last position of
+  // the previous sibling text node or first position of the next sibling text
+  // node as Slate target.
+  if (node.isVoid && node.kind === 'inline') {
+    const rect = nodeEl.getBoundingClientRect()
+    const previous = x - rect.left < rect.left + rect.width - x
+    const text = previous ?
+      document.getPreviousSibling(nodeKey) :
+      document.getNextSibling(nodeKey)
+    const key = text.key
+    const offset = previous ? text.characters.size : 0
+
+    return { key, offset }
+  }
+
+  // If the drop DOM target is inside a block void node use last position of
+  // the previous sibling block node or first position of the next sibling block
+  // node as Slate target.
+  if (node.isVoid) {
+    const rect = nodeEl.getBoundingClientRect()
+    const previous = y - rect.top < rect.top + rect.height - y
+
+    if (previous) {
+      const block = document.getPreviousBlock(nodeKey)
+      const text = block.getLastText()
+      const { key } = text
+      const offset = text.characters.size
+      return { key, offset }
+    }
+
+    const block = document.getNextBlock(nodeKey)
+    const text = block.getLastText()
+    const { key } = text
+    const offset = 0
+
+    return { key, offset }
+  }
+
+  // Otherwise, resolve the caret position where the drop occured.
+  const window = getWindow(event.target)
+  let offsetNode, offset
+
+  // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
+  if (window.document.caretRangeFromPoint) {
+    const range = window.document.caretRangeFromPoint(x, y)
+    offsetNode = range.startContainer
+    offset = range.startOffset
+  } else {
+    const position = window.document.caretPositionFromPoint(x, y)
+    offsetNode = position.offsetNode
+    offset = position.offset
+  }
+
+  const point = getPoint(offsetNode, offset, state, editor)
+
+  return point
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default getDropPoint

--- a/packages/slate-react/src/utils/get-drop-point.js
+++ b/packages/slate-react/src/utils/get-drop-point.js
@@ -17,7 +17,23 @@ function getDropPoint(event, state, editor) {
   const { document } = state
   const { nativeEvent, target } = event
   const { x, y } = nativeEvent
-  const nodeEl = findClosestNode(target, '[data-key]')
+
+  // Resolve the caret position where the drop occured.
+  const window = getWindow(target)
+  let n, o
+
+  // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
+  if (window.document.caretRangeFromPoint) {
+    const range = window.document.caretRangeFromPoint(x, y)
+    n = range.startContainer
+    o = range.startOffset
+  } else {
+    const position = window.document.caretPositionFromPoint(x, y)
+    n = position.offsetNode
+    o = position.offset
+  }
+
+  const nodeEl = findClosestNode(n, '[data-key]')
   const nodeKey = nodeEl.getAttribute('data-key')
   const node = document.key === nodeKey ? document : document.getDescendant(nodeKey)
 
@@ -59,22 +75,7 @@ function getDropPoint(event, state, editor) {
     return { key, offset }
   }
 
-  // Otherwise, resolve the caret position where the drop occured.
-  const window = getWindow(event.target)
-  let offsetNode, offset
-
-  // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
-  if (window.document.caretRangeFromPoint) {
-    const range = window.document.caretRangeFromPoint(x, y)
-    offsetNode = range.startContainer
-    offset = range.startOffset
-  } else {
-    const position = window.document.caretPositionFromPoint(x, y)
-    offsetNode = position.offsetNode
-    offset = position.offset
-  }
-
-  const point = getPoint(offsetNode, offset, state, editor)
+  const point = getPoint(n, o, state, editor)
 
   return point
 }


### PR DESCRIPTION
The state of drag&drop in Slate is far from perfect especially when void nodes are involved (see #1170 and #1192 for examples).

This PR aims to solve some of those problems.

First of all, `onDragEnter`, `onDragLeave` and `onDrop` `Void` handlers are removed . That code is a bit tricky (among other things it temporally changes the editable state of the node content) and we can live without it.

In place of the removed code, a new function, `getDropPoint`, is added to `utils`.
It returns the document point (key and offset) for a drop event.
The point is chosen following the rules below:

1. if the drop event DOM target is inside an inline void node, the point is the first position of the next sibling text node if the event happens closer to the right side of the void node, the last position of the previous sibling text node otherwise.

1. If the drop event DOM target is inside a block void node, the point is the first position of the next sibling block node if the event happens closer to the lower side of the void node, the last position of the previous sibling block node otherwise.

1. If the drop event DOM target isn't inside a void node, the point is the caret position where the drop occurred as in the current code.

`getDropPoint` is used by `onDrop` `Content` handler to get the Slate drop action target.

Since void nodes are now valid DOM drop targets, `isInEditor` checks within `Content` drag&drop handlers are removed.
However, `isInEditor` was used also to avoid managing drag&drop events coming from other editor instances embedded inside the first. To keep that behavior, the new code prevents those events from bubbling up calling `stopPropagation`.

A problem this PR leaves open is the drag feedback effect not in sync with drop action: dragging over a void node, you miss a caret showing where the insert point is, for example.
To fix this, I guess, the only solution is to not let the browser draw the feedback, doing it by ourselves.
On drag over events we could call `getDropPoint` to determine where is the insertion point and then draw a fake caret there.
If you want I can try to add this in a future PR.

Let me know your opinion, I'm open to all changes you believe are needed. :blush:
