### PR TITLE
Document `replaceNodeByKey`

### DIFF
--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -274,7 +274,7 @@ Remove a `mark` from `length` characters starting at an `offset` in a [`Node`](.
 Remove a [`Node`](./node.md) from the document by its `key`.
 
 ### `replaceNodeByKey`
-`removeNodeByKey(key: String, node: Node) => Change`
+`replaceNodeByKey(key: String, node: Node) => Change`
 
 Replace a [`Node`](./node.md) in the document with a new [`Node`](./node.md) by its `key`.
 

--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -273,6 +273,11 @@ Remove a `mark` from `length` characters starting at an `offset` in a [`Node`](.
 
 Remove a [`Node`](./node.md) from the document by its `key`.
 
+### `replaceNodeByKey`
+`removeNodeByKey(key: String, node: Node) => Change`
+
+Replace a [`Node`](./node.md) in the document with a new [`Node`](./node.md) by its `key`.
+
 ### `removeTextByKey`
 `removeTextByKey(key: String, offset: Number, length: Number) => Change`
 


### PR DESCRIPTION
I noticed this method recommended in the changelog for 0.25.0 so this just adds it to the docs. It does take an [optional Options argument](https://github.com/ianstormtaylor/slate/blob/f9894ed443706174085e3317fc5ca3d4e6b69ec8/packages/slate/src/changes/by-key.js#L379) to manage normalization, but I presume thats an internal implementation detail is its been omitted from other methods that feature it too?