### PR TITLE
Fixing getSelectionIndexes

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1448,7 +1448,7 @@ class Node {
       }
 
       // PERF: exit early if both start and end have been found.
-      return start != null && end != null
+      return start == null || end == null
     })
 
     if (isSelected && start == null) start = 0


### PR DESCRIPTION
Fixes #1204, and perhaps more?

The current behavior of the changed line is opposite of the comment above said line.  Return `false` from a Immutable.List forEach loop causes the forEach to exit early.  I'm pretty sure we only want to return early if both start and end aren't `null`.

Let me know if you see any problems @ianstormtaylor 