### PR TITLE
Remove `display: inline-block` from void blocks

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -143,7 +143,6 @@ class Void extends React.Component {
     if (node.kind === 'block') {
       Tag = 'div'
       style = {
-        display: 'inline-block',
         verticalAlign: 'top',
         width: '100%'
       }

--- a/packages/slate-react/test/rendering/fixtures/custom-block-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-void.js
@@ -29,7 +29,7 @@ export const output = `
         <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
-    <div contenteditable="false" style="display:inline-block;vertical-align:top;width:100%;">
+    <div contenteditable="false" style="vertical-align:top;width:100%;">
       <img src="https://example.com/image.png">
     </div>
   </div>


### PR DESCRIPTION
As implied by the name itself, "blocks" shouldn't be expected to be displayed as inline elements.

Aside from that, styled `<div/>` wrappers can change the behaviour of nested elements without giving any API controls to the developer. For example, if the editor contains a `<figure/>` element that is expected to float left of the text, `display:inline-block` property will overwrite that behaviour, which can not be fixed with CSS:
***
You can see from the code below that the `<figure/>` element is prescribed to float left, but that doesn't work:
<img width="600" alt="Broken behaviour, text shifted down" src="https://user-images.githubusercontent.com/8587882/31314903-2643332e-ac36-11e7-8652-388c7e07ea69.png">
***
Expected behaviour is to have the image float left and the text wrap around it on the right, which can only work if the wrapping `<div/>` isn't displayed as `inline-block`:
<img width="600" alt="Expected behaviour, text wraps around image" src="https://user-images.githubusercontent.com/8587882/31314933-95d0bdba-ac36-11e7-9ba4-79164659f377.png">
***

**This tiny PR simply removes the CSS rule and restores expected behaviour.**