### PR TITLE
Sanitize tagName check

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -27,7 +27,7 @@ const String = new Record({
 const TEXT_RULE = {
 
   deserialize(el) {
-    if (el.tagName == 'br') {
+    if (el.tagName.toLowerCase() == 'br') {
       return {
         kind: 'text',
         ranges: [{ text: '\n' }],


### PR DESCRIPTION
`In XML (and XML-based languages such as XHTML), tagName preserves case. On HTML elements in DOM trees flagged as HTML documents, tagName returns the element name in the uppercase form.`