### PR TITLE
Fix broken link to setKeyGenerator

### DIFF
--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -13,7 +13,7 @@ A short-lived, unique identifier for the node.
 
 By default, keys are **not** meant to be long-lived unique identifiers for nodes that you might store in a database, or elsewhere. They are meant purely to identify a node inside of a single Slate instance. For that reason, they are simply auto-incrementing strings. (eg. `'0'`, `'1'`, `'2'`, ...) 
 
-If you want to make your keys uniqueness long-lived, you'll need to supply your own key generating function via the [`setKeyGenerator`](../utils/utils.md#setkeygenerator) util.
+If you want to make your keys uniqueness long-lived, you'll need to supply your own key generating function via the [`setKeyGenerator`](./utils.md#setkeygenerator) util.
 
 ### `nodes`
 `Immutable.List`


### PR DESCRIPTION
Just noticed a 404 when clicking "setKeyGenerator" in the "key" property description here: https://docs.slatejs.org/slate-core/node

This PR fixes the path to the utils.md file.