### PR TITLE
Fix hovering menu

### DIFF
--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -23,8 +23,7 @@ const schema = {
   }
 }
 
-const Menu = ({ menuRef, onChange, state }) => {
-
+function Menu({ menuRef, onChange, state }) {
   /**
    * Check if the current selection has a mark with `type` in it.
    *
@@ -61,7 +60,9 @@ const Menu = ({ menuRef, onChange, state }) => {
 
   function renderMarkButton(type, icon) {
     const isActive = hasMark(type)
-    const onMouseDown = e => onClickMark(e, type)
+    function onMouseDown(e) {
+      onClickMark(e, type)
+    }
 
     return (
       <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
@@ -124,6 +125,13 @@ class HoveringMenu extends React.Component {
   }
 
   /**
+   * Set menu ref
+   *
+   */
+
+  menuRef = el => this.menu = el
+
+  /**
    * Render.
    *
    * @return {Element}
@@ -133,7 +141,7 @@ class HoveringMenu extends React.Component {
     return (
       <div>
         <Menu
-          menuRef={el => this.menu = el}
+          menuRef={this.menuRef}
           state={this.state.state}
           onChange={this.onChange}
         />

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -25,7 +25,7 @@ const schema = {
 
 const Menu = ({ menuRef, onChange, state }) => {
 
-   /**
+  /**
    * Check if the current selection has a mark with `type` in it.
    *
    * @param {String} type
@@ -36,7 +36,7 @@ const Menu = ({ menuRef, onChange, state }) => {
     return state.activeMarks.some(mark => mark.type == type)
   }
 
-   /**
+  /**
    * When a mark button is clicked, toggle the current mark.
    *
    * @param {Event} e
@@ -50,6 +50,7 @@ const Menu = ({ menuRef, onChange, state }) => {
       .toggleMark(type)
     onChange(change)
   }
+
   /**
    * Render a mark-toggling toolbar button.
    *

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -2,9 +2,11 @@
 import { Editor } from 'slate-react'
 import { State } from 'slate'
 
-import Portal from 'react-portal'
 import React from 'react'
+import ReactDOM from 'react-dom'
 import initialState from './state.json'
+
+const root = document.querySelector('main')
 
 /**
  * Define a schema.
@@ -20,6 +22,65 @@ const schema = {
     underlined: props => <u>{props.children}</u>,
   }
 }
+
+const Menu = ({ menuRef, onChange, state }) => {
+
+   /**
+   * Check if the current selection has a mark with `type` in it.
+   *
+   * @param {String} type
+   * @return {Boolean}
+   */
+
+  function hasMark(type) {
+    return state.activeMarks.some(mark => mark.type == type)
+  }
+
+   /**
+   * When a mark button is clicked, toggle the current mark.
+   *
+   * @param {Event} e
+   * @param {String} type
+   */
+
+  function onClickMark(e, type) {
+    e.preventDefault()
+    const change = state
+      .change()
+      .toggleMark(type)
+    onChange(change)
+  }
+  /**
+   * Render a mark-toggling toolbar button.
+   *
+   * @param {String} type
+   * @param {String} icon
+   * @return {Element}
+   */
+
+  function renderMarkButton(type, icon) {
+    const isActive = hasMark(type)
+    const onMouseDown = e => onClickMark(e, type)
+
+    return (
+      <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
+        <span className="material-icons">{icon}</span>
+      </span>
+    )
+  }
+
+  return (
+    ReactDOM.createPortal(
+      <div className="menu hover-menu" ref={menuRef}>
+        {renderMarkButton('bold', 'format_bold')}
+        {renderMarkButton('italic', 'format_italic')}
+        {renderMarkButton('underlined', 'format_underlined')}
+        {renderMarkButton('code', 'code')}
+      </div>, root
+    )
+  )
+}
+
 
 /**
  * The hovering menu example.
@@ -52,18 +113,6 @@ class HoveringMenu extends React.Component {
   }
 
   /**
-   * Check if the current selection has a mark with `type` in it.
-   *
-   * @param {String} type
-   * @return {Boolean}
-   */
-
-  hasMark = (type) => {
-    const { state } = this.state
-    return state.activeMarks.some(mark => mark.type == type)
-  }
-
-  /**
    * On change.
    *
    * @param {Change} change
@@ -71,31 +120,6 @@ class HoveringMenu extends React.Component {
 
   onChange = ({ state }) => {
     this.setState({ state })
-  }
-
-  /**
-   * When a mark button is clicked, toggle the current mark.
-   *
-   * @param {Event} e
-   * @param {String} type
-   */
-
-  onClickMark = (e, type) => {
-    e.preventDefault()
-    const change = this.state.state
-      .change()
-      .toggleMark(type)
-    this.onChange(change)
-  }
-
-  /**
-   * When the portal opens, cache the menu element.
-   *
-   * @param {Element} portal
-   */
-
-  onOpen = (portal) => {
-    this.setState({ menu: portal.firstChild })
   }
 
   /**
@@ -107,64 +131,18 @@ class HoveringMenu extends React.Component {
   render() {
     return (
       <div>
-        {this.renderMenu()}
-        {this.renderEditor()}
-      </div>
-    )
-  }
-
-  /**
-   * Render the hovering menu.
-   *
-   * @return {Element}
-   */
-
-  renderMenu = () => {
-    return (
-      <Portal isOpened onOpen={this.onOpen}>
-        <div className="menu hover-menu">
-          {this.renderMarkButton('bold', 'format_bold')}
-          {this.renderMarkButton('italic', 'format_italic')}
-          {this.renderMarkButton('underlined', 'format_underlined')}
-          {this.renderMarkButton('code', 'code')}
-        </div>
-      </Portal>
-    )
-  }
-
-  /**
-   * Render a mark-toggling toolbar button.
-   *
-   * @param {String} type
-   * @param {String} icon
-   * @return {Element}
-   */
-
-  renderMarkButton = (type, icon) => {
-    const isActive = this.hasMark(type)
-    const onMouseDown = e => this.onClickMark(e, type)
-
-    return (
-      <span className="button" onMouseDown={onMouseDown} data-active={isActive}>
-        <span className="material-icons">{icon}</span>
-      </span>
-    )
-  }
-
-  /**
-   * Render the Slate editor.
-   *
-   * @return {Element}
-   */
-
-  renderEditor = () => {
-    return (
-      <div className="editor">
-        <Editor
-          schema={schema}
+        <Menu
+          menuRef={el => this.menu = el}
           state={this.state.state}
           onChange={this.onChange}
         />
+        <div className="editor">
+          <Editor
+            schema={schema}
+            state={this.state.state}
+            onChange={this.onChange}
+          />
+        </div>
       </div>
     )
   }
@@ -174,7 +152,8 @@ class HoveringMenu extends React.Component {
    */
 
   updateMenu = () => {
-    const { menu, state } = this.state
+    const { state } = this.state
+    const menu = this.menu
     if (!menu) return
 
     if (state.isBlurred || state.isEmpty) {


### PR DESCRIPTION
Try to fix hovering menu example on slatejs.org. It uses the new portal api, so it only works with React v16+. I am not sure whether it's a problem with examples.