### PR TITLE
[Doc] Fix minor typos

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -24,7 +24,7 @@
 - [Block](./reference/slate/block.md)
 - [Change](./reference/slate/change.md)
 - [Character](./reference/slate/character.md)
-- [Data](./reference//slate/data.md)
+- [Data](./reference/slate/data.md)
 - [Document](./reference/slate/document.md)
 - [Inline](./reference/slate/inline.md)
 - [Mark](./reference//slate/mark.md)

--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -115,7 +115,7 @@ If no other plugin handles this event, it will be handled by the [Core plugin](.
 
 This handler is called when any key is pressed in the `contenteditable` element, before any action is taken.
 
-The `data` object contains the `key` which is a string name of the key that was pressed, as well as it's `code`. It also contains a series of helpful utility properties for determining hotkey logic. For example, `isCtrl` which is true if the `control` key was pressed, or
+The `data` object contains the `key` which is a string name of the key that was pressed, as well as it's `code`. It also contains a series of helpful utility properties for determining hotkey logic. For example, `isCtrl` is true if the `control` key was pressed before.
 
 ```js
 {

--- a/docs/reference/slate/block.md
+++ b/docs/reference/slate/block.md
@@ -81,9 +81,9 @@ Create a list of block nodes from a plain Javascript `array`.
 Create a block from a JSON `object`.
 
 ### `Block.isBlock`
-`Block.isBlock(value: Any) => Boolean`
+`Block.isBlock(maybeBlock: Any) => Boolean`
 
-Returns a boolean if the passed in `value` is a `Block`.
+Returns a boolean if the passed in argument is a `Block`.
 
 
 ## Node Methods

--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -171,12 +171,12 @@ Collapse the current selection to the `{Edge}` of `node`. Where `{Edge}` is eith
 ### `collapseTo{Edge}Of{Direction}Block`
 `collapseTo{Edge}Of{Direction}Block() => Change`
 
-Collapse the current selection to the `{Edge}` of the next [`Block`](./block.md) node in `{Direction}`. Where `{Edge}` is either `{Start}` or `{End}` and `{Direction}` is either `Next` or `Previous`.
+Collapse the current selection to the `{Edge}` of the next [`Block`](./block.md) node in `{Direction}`. Where `{Edge}` is either `Start` or `End` and `{Direction}` is either `Next` or `Previous`.
 
 ### `collapseTo{Edge}Of{Direction}Text`
 `collapseTo{Edge}Of{Direction}Text() => Change`
 
-Collapse the current selection to the `{Edge}` of the next [`Text`](./text.md) node in `{Direction}`. Where `{Edge}` is either `{Start}` or `{End}` and `{Direction}` is either `Next` or `Previous`.
+Collapse the current selection to the `{Edge}` of the next [`Text`](./text.md) node in `{Direction}`. Where `{Edge}` is either `Start` or `End` and `{Direction}` is either `Next` or `Previous`.
 
 ### `extend`
 `extend(n: Number) => Change`
@@ -206,7 +206,7 @@ Move the current selection's offsets by  `n`.
 ### `move{Edge}`
 `move{Edge}(n: Number) => Change`
 
-Move the current selection's `edge` offset by  `n`. `edge` can be one of `Start`, `End`.
+Move the current selection's `{Edge}` offset by  `n`. `{Edge}` can be one of `Start`, `End`.
 
 ### `moveOffsetsTo`
 `moveOffsetsTo(anchorOffset: Number, focusOffset: Number) => Change`
@@ -254,7 +254,7 @@ Insert a [`Fragment`](./fragment.md) at `index` inside a parent [`Node`](./node.
 ### `insertTextByKey`
 `insertTextByKey(key: String, offset: Number, text: String, [marks: Set]) => Change`
 
-Insert `text` at an `offset` in a [`Text Node`](./text.md) with optional `marks`.
+Insert `text` at an `offset` in a [`Text Node`](./text.md) by its `key` with optional `marks`.
 
 ### `moveNodeByKey`
 `moveNodeByKey(key: String, newKey: String, newIndex: Number) => Change`
@@ -301,13 +301,13 @@ Split a node by its `key` at an `offset`.
 `unwrapInlineByKey(key: String, properties: Object) => Change` <br/>
 `unwrapInlineByKey(key: String, type: String) => Change`
 
-Unwrap all inner content of an [`Inline`](./inline.md) node that match `properties`. For convenience, you can pass a `type` string or `properties` object.
+Unwrap all inner content of an [`Inline`](./inline.md) node by its `key` that match `properties`. For convenience, you can pass a `type` string or `properties` object.
 
 ### `unwrapBlockByKey`
 `unwrapBlockByKey(key: String, properties: Object) => Change` <br/>
 `unwrapBlockByKey(key: String, type: String) => Change`
 
-Unwrap all inner content of a [`Block`](./block.md) node that match `properties`. For convenience, you can pass a `type` string or `properties` object.
+Unwrap all inner content of a [`Block`](./block.md) node by its `key` that match `properties`. For convenience, you can pass a `type` string or `properties` object.
 
 ### `unwrapNodeByKey`
 `unwrapNodeByKey(key: String) => Change`

--- a/docs/reference/slate/document.md
+++ b/docs/reference/slate/document.md
@@ -49,7 +49,7 @@ A concatenated string of all of the descendant [`Text`](./text.md) nodes of this
 ### `Document.create`
 `Document.create(properties: Object) => Document`
 
-Create a block from a plain Javascript object of `properties`.
+Create a document from a plain Javascript object of `properties`.
 
 ### `Document.fromJSON`
 `Document.fromJSON(object: Object) => Document`

--- a/docs/reference/slate/inline.md
+++ b/docs/reference/slate/inline.md
@@ -66,9 +66,9 @@ A concatenated string of all of the descendant [`Text`](./text.md) nodes of this
 ## Static Methods
 
 ### `Inline.create`
-`Inline.create(properties: Object) => Block`
+`Inline.create(properties: Object) => Inline`
 
-Create a block from a plain Javascript object of `properties`.
+Create an inline from a plain Javascript object of `properties`.
 
 ### `Inline.createList`
 `Inline.createList(array: Array) => List`

--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -26,7 +26,7 @@ A list of child nodes. Defaults to a list with a single text node child.
 ### `kind`
 `String`
 
-An immutable string value of `'block'` for easily separating this node from [`Inline`](./inline.md) or [`Text`](./text.md) nodes.
+An immutable string value of `'document'`, `'block'`, `'inline'` or `'text'` for easily separating this node from [`Inline`](./inline.md) or [`Text`](./text.md) nodes.
 
 ### `text`
 `String`

--- a/docs/walkthroughs/defining-custom-block-nodes.md
+++ b/docs/walkthroughs/defining-custom-block-nodes.md
@@ -46,7 +46,7 @@ class App extends React.Component {
 
 Now let's add "code blocks" to our editor.
 
-The problem is, code blocks won't just be rendered as a plain paragraph, they'll need to be rendered differently. To make that happen, we need to define a "renderer" for `code` nodes
+The problem is, code blocks won't just be rendered as a plain paragraph, they'll need to be rendered differently. To make that happen, we need to define a "renderer" for `code` nodes.
 
 Node renderers are just simple React components, like so:
 


### PR DESCRIPTION
During translating [Slate's Chinese doc](https://doodlewind.github.io/slate-doc-cn/) I've found several typos. This PR simply fixes them together.

BTW, Chinese translation for `v0.24.1` is done and released now. If this PR get merged, I'll be able to sync latest change from upstream then 😀 For any suggestion about this [side project](https://github.com/doodlewind/slate-doc-cn) please let me know.