### PR TITLE
[IME] Disable iOS COMPAT behaviour on desktop

### DIFF
--- a/packages/slate-react/src/constants/environment.js
+++ b/packages/slate-react/src/constants/environment.js
@@ -76,5 +76,6 @@ export const IS_FIREFOX = BROWSER === 'firefox'
 export const IS_SAFARI = BROWSER === 'safari'
 export const IS_IE = BROWSER === 'ie'
 
+export const IS_IOS = OS === 'ios'
 export const IS_MAC = OS === 'macos'
 export const IS_WINDOWS = OS === 'windows'

--- a/packages/slate-react/src/plugins/core.js
+++ b/packages/slate-react/src/plugins/core.js
@@ -10,7 +10,7 @@ import Content from '../components/content'
 import Placeholder from '../components/placeholder'
 import findDOMNode from '../utils/find-dom-node'
 import findRange from '../utils/find-range'
-import { IS_CHROME, IS_MAC, IS_SAFARI } from '../constants/environment'
+import { IS_CHROME, IS_IOS, IS_MAC, IS_SAFARI } from '../constants/environment'
 
 /**
  * Debug.
@@ -77,14 +77,16 @@ function Plugin(options = {}) {
     // selection will be changed to span the existing word, so that the word is
     // replaced. But the `select` fires after the `beforeInput` event, even
     // though the native selection is updated. So we need to manually check if
-    // the selection has gotten out of sync, and adjust it if so. (03/18/2017)
-    const window = getWindow(e.target)
-    const native = window.getSelection()
-    const range = findRange(native, state)
-    const hasMismatch = range && !range.equals(selection)
+    // the selection has gotten out of sync, and adjust it if so. (10/16/2017)
+    if (IS_IOS) {
+      const window = getWindow(e.target)
+      const native = window.getSelection()
+      const range = findRange(native, state)
+      const hasMismatch = range && !range.equals(selection)
 
-    if (hasMismatch) {
-      change.select(range)
+      if (hasMismatch) {
+        change.select(range)
+      }
     }
 
     change.insertText(e.data)


### PR DESCRIPTION
This PR closes a series of desktop IME issues: #1229 #1209 #854 #810 .
It also closes PR #885 #880 .

All issues mentions above is caused by a workaround introduced in #655 , which adds a piece of iOS COMPAT code fixing autocorrect behaviour. In this workaround, `onBeforeInput ` will adjust slate's selection **if selection is expanded**, resolve the mismatch.

However, during desktop IME composition, the selection is also expanded. This leads to deletion of unrelated text, in other word, 'eating' characters afterwards:

### Current Behaviour
![before](https://user-images.githubusercontent.com/7312949/31594089-90d71bca-b1f8-11e7-88f0-ca6dec307413.gif)

Previous solution adds composition-state-related `data` for `onBeforeInput`, this works but may introduce more potential issues. In fact, by simply limiting the iOS COMPAT code according to environment, this issue can be solved in a much simpler way. Moreover, it also benefits performance by reducing unnecessary DOM ops like `window.getSelection()` on other platforms.

This patch not only solves Chinese Pinyin IME issues, for other languages it also works:

### After: Native Pinyin IME
![after-native-pinyin](https://user-images.githubusercontent.com/7312949/31594145-e3d04b76-b1f8-11e7-9b3e-5a438beab8c4.gif)

### After: Thiry Party Pinyin IME
![after-third-party-pinyin](https://user-images.githubusercontent.com/7312949/31594310-c6b3fc58-b1f9-11e7-86d1-278ca234c961.gif)

### After: Native Japanese IME
![after-native-japanese](https://user-images.githubusercontent.com/7312949/31594334-e78e84c0-b1f9-11e7-85e4-56ed9fd427df.gif)

### After: Native Korean IME
![after-native-korean](https://user-images.githubusercontent.com/7312949/31594325-d7a815da-b1f9-11e7-9618-7a08e0a211ee.gif)

BTW, another IME related bug can be solved based on this PR with React 16's error boundary, I may submit another PR if this one can get merged 💪