### PR TITLE
Recover from fatal error with React 16's error boundary

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -193,6 +193,16 @@ class Editor extends React.Component {
   }
 
   /**
+   * When vDOM and DOM are out of sync, recover from current state.
+   */
+
+  componentDidCatch = () => {
+    requestAnimationFrame(() => {
+      this.componentWillReceiveProps(this.props)
+    })
+  }
+
+  /**
    * Cache a `state` object to be able to compare against it later.
    *
    * @param {State} state


### PR DESCRIPTION
This PR closes #1114 #967 and maybe #1224 .

Currently there are certain cases which causes editor to break. It happens when environment break React's vDOM against DOM. Draft.js also [suffers from this](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls.html#browser-plugins-extensions):

> As with any React application, browser plugins and extensions that modify the DOM can cause Draft editors to break.
> 
> Grammar checkers, for instance, may modify the DOM within contentEditable elements, adding styles like underlines and backgrounds. Since React cannot reconcile the DOM if the browser does not match its expectations, the editor state may fail to remain in sync with the DOM.
> 
> Certain old ad blockers are also known to break the native DOM Selection API -- a bad idea no matter what! -- and since Draft depends on this API to maintain controlled selection state, this can cause trouble for editor interaction.

This is somewhat inevitable with Slate's architecture, but the good news is that we have React 16's error boundary as a fallback now. For example, when native selection selects across multi blocks, texting with IME will remove selected DOM, which can't be cancelled. In this case a fatal error is raised, user can't even continue editing:

### Current Behaviour
![error-handle-before](https://user-images.githubusercontent.com/7312949/31604503-27afab4a-b229-11e7-9a4b-75be1a78a2ca.gif)

As a solution, this PR utilizes the `componentDidCatch` hook to recover from current state. Although error is still raised, editing can now seamlessly continued:

### Patched with Error Boundary
![error-handle-after](https://user-images.githubusercontent.com/7312949/31604621-85fb0de8-b229-11e7-9cb6-a4481083617d.gif)

Besides, this hook does not affect React 15's behaviour, so it won't break backward compatibility.