### PR TITLE
deprecate data, add getEventRange and getEventTransfer helpers

### DIFF
--- a/examples/links/index.js
+++ b/examples/links/index.js
@@ -1,5 +1,5 @@
 
-import { Editor } from 'slate-react'
+import { Editor, getEventTransfer } from 'slate-react'
 import { State } from 'slate'
 
 import React from 'react'
@@ -132,14 +132,17 @@ class Links extends React.Component {
 
   onPaste = (e, data, change) => {
     if (change.state.isCollapsed) return
-    if (data.type != 'text' && data.type != 'html') return
-    if (!isUrl(data.text)) return
+
+    const transfer = getEventTransfer(e)
+    const { type, text } = transfer
+    if (type != 'text' && type != 'html') return
+    if (!isUrl(text)) return
 
     if (this.hasLinks()) {
       change.call(unwrapLink)
     }
 
-    change.call(wrapLink, data.text)
+    change.call(wrapLink, text)
     return true
   }
 

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -1,6 +1,6 @@
 
 import Html from 'slate-html-serializer'
-import { Editor } from 'slate-react'
+import { Editor, getEventTransfer } from 'slate-react'
 import { State } from 'slate'
 
 import React from 'react'
@@ -180,9 +180,9 @@ class PasteHtml extends React.Component {
    */
 
   onPaste = (e, data, change) => {
-    if (data.type != 'html') return
-    if (data.isShift) return
-    const { document } = serializer.deserialize(data.html)
+    const transfer = getEventTransfer(e)
+    if (transfer.type != 'html') return
+    const { document } = serializer.deserialize(transfer.html)
     change.insertFragment(document)
     return true
   }

--- a/packages/slate-dev-logger/src/index.js
+++ b/packages/slate-dev-logger/src/index.js
@@ -78,7 +78,7 @@ function warn(message, ...args) {
  */
 
 function deprecate(version, message, ...args) {
-  log('warn', `Deprecation (v${version}): ${message}`, ...args)
+  log('warn', `Deprecation (${version}): ${message}`, ...args)
 }
 
 /**

--- a/packages/slate-react/src/index.js
+++ b/packages/slate-react/src/index.js
@@ -1,6 +1,8 @@
 
 import Editor from './components/editor'
 import Placeholder from './components/placeholder'
+import getEventRange from './utils/get-event-range'
+import getEventTransfer from './utils/get-event-transfer'
 import findDOMNode from './utils/find-dom-node'
 import findDOMRange from './utils/find-dom-range'
 import findNode from './utils/find-node'
@@ -15,6 +17,8 @@ import findRange from './utils/find-range'
 export {
   Editor,
   Placeholder,
+  getEventRange,
+  getEventTransfer,
   findDOMNode,
   findDOMRange,
   findNode,
@@ -24,6 +28,8 @@ export {
 export default {
   Editor,
   Placeholder,
+  getEventRange,
+  getEventTransfer,
   findDOMNode,
   findDOMRange,
   findNode,

--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -1,0 +1,69 @@
+
+import getWindow from 'get-window'
+
+import findDOMNode from './find-dom-node'
+import findRange from './find-range'
+
+/**
+ * Get the target range from a DOM `event`.
+ *
+ * @param {Event} event
+ * @param {State} state
+ * @return {Range}
+ */
+
+function getEventRange(event, state) {
+  if (event.nativeEvent) {
+    event = event.nativeEvent
+  }
+
+  const { x, y } = event
+  if (x == null || y == null) return null
+
+  // Resolve a range from the caret position where the drop occured.
+  const window = getWindow(event.target)
+  let r
+
+  // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
+  if (window.document.caretRangeFromPoint) {
+    r = window.document.caretRangeFromPoint(x, y)
+  } else {
+    const position = window.document.caretPositionFromPoint(x, y)
+    r = window.document.createRange()
+    r.setStart(position.offsetNode, position.offset)
+    r.setEnd(position.offsetNode, position.offset)
+  }
+
+  // Resolve a Slate range from the DOM range.
+  let range = findRange(r, state)
+  if (!range) return null
+
+  const { document } = state
+  const node = document.getNode(range.anchorKey)
+  const parent = document.getParent(node.key)
+  const el = findDOMNode(parent)
+
+  // If the drop target is inside a void node, move it into either the next or
+  // previous node, depending on which side the `x` and `y` coordinates are
+  // closest to.
+  if (parent.isVoid) {
+    const rect = el.getBoundingClientRect()
+    const isPrevious = parent.kind == 'inline'
+      ? x - rect.left < rect.left + rect.width - x
+      : y - rect.top < rect.top + rect.height - y
+
+    range = isPrevious
+      ? range.moveToEndOf(document.getPreviousText(node.key))
+      : range.moveToStartOf(document.getNextText(node.key))
+  }
+
+  return range
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default getEventRange

--- a/packages/slate-react/src/utils/get-event-transfer.js
+++ b/packages/slate-react/src/utils/get-event-transfer.js
@@ -12,13 +12,18 @@ import TRANSFER_TYPES from '../constants/transfer-types'
 const FRAGMENT_MATCHER = / data-slate-fragment="([^\s"]+)"/
 
 /**
- * Get the data and type from a native data `transfer`.
+ * Get the transfer data from an `event`.
  *
- * @param {DataTransfer} transfer
+ * @param {Event} event
  * @return {Object}
  */
 
-function getTransferData(transfer) {
+function getEventTransfer(event) {
+  if (event.nativeEvent) {
+    event = event.nativeEvent
+  }
+
+  const transfer = event.dataTransfer || event.clipboardData
   let fragment = getType(transfer, TRANSFER_TYPES.FRAGMENT)
   let node = getType(transfer, TRANSFER_TYPES.NODE)
   const html = getType(transfer, 'text/html')
@@ -148,4 +153,4 @@ function getType(transfer, type) {
  * @type {Function}
  */
 
-export default getTransferData
+export default getEventTransfer


### PR DESCRIPTION
This deprecates the remaining `data.*` properties. I'm going to push this as a patch release because it was so close to the `slate-react@0.5.0` which deprecated other `data.*` properties, to make it easier for people to update all in one go. (I generally try to avoid deprecating in patches, but since it's all deprecations, and it's just logging in dev, I sometimes make exceptions.)

Right now this deprecation is achieved by duplicating a lot of logic. Soon we'll remove all of the existing deprecations, and then we'll be able to remove lots of code.

Fixes #1240 