### PR TITLE
Fix IE11 error

### DIFF
--- a/packages/slate-react/src/utils/find-dom-point.js
+++ b/packages/slate-react/src/utils/find-dom-point.js
@@ -15,14 +15,17 @@ import findDOMNode from './find-dom-node'
 function findDOMPoint(key, offset) {
   const el = findDOMNode(key)
   const window = getWindow(el)
+  let start = 0
+  let n
+  
+  // COMPAT: In IE, this method's arguments are not optional, so we have to 
+  // pass in all four even though the last two are defaults. (2017/10/25)
   const iterator = window.document.createNodeIterator(
     el,
     NodeFilter.SHOW_TEXT,
     () => NodeFilter.FILTER_ACCEPT,
     false
   )
-  let start = 0
-  let n
 
   while (n = iterator.nextNode()) {
     const { length } = n.textContent

--- a/packages/slate-react/src/utils/find-dom-point.js
+++ b/packages/slate-react/src/utils/find-dom-point.js
@@ -15,7 +15,12 @@ import findDOMNode from './find-dom-node'
 function findDOMPoint(key, offset) {
   const el = findDOMNode(key)
   const window = getWindow(el)
-  const iterator = window.document.createNodeIterator(el, NodeFilter.SHOW_TEXT)
+  const iterator = window.document.createNodeIterator(
+    el,
+    NodeFilter.SHOW_TEXT,
+    () => NodeFilter.FILTER_ACCEPT,
+    false
+  )
   let start = 0
   let n
 


### PR DESCRIPTION
`createNodeIterator` does not work at IE11 if you provide less than 4 arguments.

Also to make slate work with IE11 currently I use next hack (otherwise you cant focus editor)

```javascript
<Editor
  ref={ref => { ref_ =  ref; }}
  onFocus={() => { ref_.focus() }}
  ...
```

Without additional focus call as like as above, for unknown reason in IE11 this line is always called 
https://github.com/ianstormtaylor/slate/blob/6c42f6c9c30f6874ff1f20a916df36e922ef2f24/packages/slate-react/src/components/content.js#L137

Everything other looks like works fine.
