### PR TITLE
Reshape `Void` component.

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -228,9 +228,16 @@ class Content extends React.Component {
       this.tmp.key++
     }
 
-    // If the `onSelect` handler fires while the `isUpdatingSelection` flag is
-    // set it's a result of updating the selection manually, so skip it.
-    if (handler == 'onSelect' && this.tmp.isUpdatingSelection) {
+    // Ignore `onBlur`, `onFocus` and `onSelect` events generated
+    // programmatically while updating selection.
+    if (
+      this.tmp.isUpdatingSelection &&
+      (
+        handler == 'onSelect' ||
+        handler == 'onBlur' ||
+        handler == 'onFocus'
+      )
+    ) {
       return
     }
 

--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -65,17 +65,31 @@ class Void extends React.Component {
     const Tag = node.kind == 'block' ? 'div' : 'span'
     const style = {
       height: '0',
-      color: 'transparent'
+      color: 'transparent',
+      outline: 'none'
     }
+    const spacer = (
+      <Tag
+        contentEditable
+        data-slate-spacer
+        suppressContentEditableWarning
+        style={style}
+      >
+        {this.renderText()}
+      </Tag>
+    )
 
     this.debug('render', { props })
 
     return (
-      <Tag data-slate-void data-key={node.key} draggable={readOnly ? null : true}>
-        {!readOnly && <Tag style={style}>
-          {this.renderText()}
-        </Tag>}
-        <Tag contentEditable={readOnly ? null : false}>
+      <Tag
+        data-slate-void
+        data-key={node.key}
+        draggable={readOnly ? null : true}
+        contentEditable={readOnly ? null : false}
+      >
+        {readOnly ? null : spacer }
+        <Tag>
           {children}
         </Tag>
       </Tag>

--- a/packages/slate-react/test/rendering/fixtures/custom-block-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-void.js
@@ -23,13 +23,13 @@ export const state = (
 
 export const output = `
 <div data-slate-editor="true" contenteditable="true" role="textbox">
-  <div data-slate-void="true" draggable="true">
-    <div style="height:0;color:transparent">
+  <div data-slate-void="true" draggable="true" contenteditable="false">
+    <div contenteditable="true" data-slate-spacer="true" style="height:0;color:transparent;outline:none">
       <span>
         <span></span>
       </span>
     </div>
-    <div contenteditable="false">
+    <div>
       <img src="https://example.com/image.png">
     </div>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -31,13 +31,13 @@ export const output = `
         <span data-slate-zero-width="true">&#x200A;</span>
       </span>
     </span>
-    <span data-slate-void="true" draggable="true">
-      <span style="height:0;color:transparent">
+    <span data-slate-void="true" draggable="true" contenteditable="false">
+      <span contenteditable="true" data-slate-spacer="true" style="height:0;color:transparent;outline:none">
         <span>
           <span></span>
         </span>
       </span>
-      <span contenteditable="false">
+      <span>
         <img>
       </span>
     </span>


### PR DESCRIPTION
Reshape `Void` component and prevent editor blur in some circumstances.

This fixes #1223 and #891 (at least on Chrome, Edge needs some extra work).