### PR TITLE
Save marks when creating native ranges in onNativeBeforeInput

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -304,14 +304,15 @@ class Content extends React.Component {
     event.preventDefault()
 
     const { editor, state } = this.props
+    const { selection } = state
     const range = findRange(targetRange, state)
 
     editor.change((change) => {
-      change.insertTextAtRange(range, text, range.marks)
+      change.insertTextAtRange(range, text, selection.marks)
 
       // If the text was successfully inserted, and the selection had marks on it,
       // unset the selection's marks.
-      if (range.marks && state.document != change.state.document) {
+      if (selection.marks && state.document != change.state.document) {
         change.select({ marks: null })
       }
     })

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -307,7 +307,7 @@ class Content extends React.Component {
     const range = findRange(targetRange, state)
 
     editor.change((change) => {
-      change.insertTextAtRange(range, text)
+      change.insertTextAtRange(range, text, range.marks)
     })
   }
 

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -308,6 +308,12 @@ class Content extends React.Component {
 
     editor.change((change) => {
       change.insertTextAtRange(range, text, range.marks)
+
+      // If the text was successfully inserted, and the selection had marks on it,
+      // unset the selection's marks.
+      if (range.marks && state.document != change.state.document) {
+        change.select({ marks: null })
+      }
     })
   }
 

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -44,7 +44,6 @@ function findRange(native, state) {
     focusOffset: focus.offset,
     isBackward: isCollapsed ? false : isBackward(native),
     isFocused: true,
-    marks: selection.marks
   })
 
   return range

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -35,6 +35,8 @@ function findRange(native, state) {
   const focus = isCollapsed ? anchor : findPoint(focusNode, focusOffset, state)
   if (!anchor || !focus) return null
 
+  const { selection } = state
+
   const range = Range.create({
     anchorKey: anchor.key,
     anchorOffset: anchor.offset,
@@ -42,6 +44,7 @@ function findRange(native, state) {
     focusOffset: focus.offset,
     isBackward: isCollapsed ? false : isBackward(native),
     isFocused: true,
+    marks: selection.marks
   })
 
   return range

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -35,8 +35,6 @@ function findRange(native, state) {
   const focus = isCollapsed ? anchor : findPoint(focusNode, focusOffset, state)
   if (!anchor || !focus) return null
 
-  const { selection } = state
-
   const range = Range.create({
     anchorKey: anchor.key,
     anchorOffset: anchor.offset,


### PR DESCRIPTION
When we used native ranges in onNativeBeforeInput, we weren't carrying
over the marks from Slate's selection. This made it impossible to know
that the next character typed should have a set of marks.

Fixes #1270.