### PR TITLE
Keep marks after splitting a block

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -474,9 +474,15 @@ function AfterPlugin(options = {}) {
     const { state } = change
 
     if (HOTKEYS.SPLIT_BLOCK(event)) {
-      return state.isInVoid
-        ? change.collapseToStartOfNextText()
-        : change.splitBlock()
+      if (state.isInVoid) {
+        return change.collapseToStartOfNextText()
+      } else {
+        change = change.splitBlock()
+        state.activeMarks.forEach((mark) => {
+          change = change.addMark(mark)
+        })
+        return change
+      }
     }
 
     if (HOTKEYS.DELETE_CHAR_BACKWARD(event)) {


### PR DESCRIPTION
If you have, for example, a bold mark, and you hit "Enter", the new
block won't carry over the formatting. Instead, it should (at least if
you start typing right away).

Fixes #1269.