### PR TITLE
Removed `data` argument from simulator event handlers

### DIFF
--- a/packages/slate-simulator/src/index.js
+++ b/packages/slate-simulator/src/index.js
@@ -1,4 +1,3 @@
-
 import { Stack } from 'slate'
 
 /**
@@ -50,16 +49,15 @@ class Simulator {
 EVENT_HANDLERS.forEach((handler) => {
   const method = getMethodName(handler)
 
-  Simulator.prototype[method] = function (e, data) {
+  Simulator.prototype[method] = function (e) {
     if (e == null) e = {}
-    if (data == null) data = {}
 
     const { stack, state } = this
     const editor = createEditor(this)
     const event = createEvent(e)
     const change = state.change()
 
-    stack.handle(handler, change, editor, event, data)
+    stack.handle(handler, change, editor, event)
     stack.handle('onBeforeChange', change, editor)
     stack.handle('onChange', change, editor)
 


### PR DESCRIPTION
In `slate-react@0.6.0`: The data argument to event handlers has been removed...

The event handlers generated in the slate-simulator `Simalator` object was
still passing a data argument. This data argument got passed as the `change` argument to the plugin handlers because of:

```javascript
  handle(handler, change, editor, ...args) {
    debug(handler)

    for (let k = 0; k < this.plugins.length; k++) {
      const plugin = this.plugins[k]
      if (!plugin[handler]) continue
      const next = plugin[handler](...args, change, editor)
      if (next != null) break
    }
  }
```

which was called as `handle(handler, change, editor, event, data)`. 
