### PR TITLE
Request Array.prototype.includes polyfill

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <main></main>
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,Array.prototype.includes"></script>
     <script src="build.prod.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Slate uses `Array.prototype.includes` in at least one place:
https://github.com/ianstormtaylor/slate/blob/b558872/packages/slate/src/schemas/core.js#L62

So, request an `Array.prototype.includes` polyfill from polyfill.io if the user's browser needs it, which is the case with IE 11. I discovered this need when looking at the examples on slatejs.org to see how well Slate works in IE 11.

Also requests minified JavaScript, since this code is used for the slatejs.org website, and there's no need to serve non-minified code there.