### PR TITLE
Revert "Keep marks after splitting a block (#1273)"

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -474,15 +474,9 @@ function AfterPlugin(options = {}) {
     const { state } = change
 
     if (HOTKEYS.SPLIT_BLOCK(event)) {
-      if (state.isInVoid) {
-        return change.collapseToStartOfNextText()
-      } else {
-        change = change.splitBlock()
-        state.activeMarks.forEach((mark) => {
-          change = change.addMark(mark)
-        })
-        return change
-      }
+      return state.isInVoid
+        ? change.collapseToStartOfNextText()
+        : change.splitBlock()
     }
 
     if (HOTKEYS.DELETE_CHAR_BACKWARD(event)) {


### PR DESCRIPTION
This reverts commit 6f676d67712b15216cf611e01dead990ee0dd8c1.

This behavior should be in userland, because there isn't agreement
among text editors on how it should behave.

Resolves #1269.