### PR TITLE
Fix table example

### DIFF
--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -101,9 +101,9 @@ class Tables extends React.Component {
     }
 
     switch (event.key) {
-      case 'Backspace': return this.onBackspace(event, state)
-      case 'Delete': return this.onDelete(event, state)
-      case 'Enter': return this.onEnter(event, state)
+      case 'Backspace': return this.onBackspace(event, change)
+      case 'Delete': return this.onDelete(event, change)
+      case 'Enter': return this.onEnter(event, change)
     }
   }
 


### PR DESCRIPTION
Handlers in table example are passed in `state` instead of `change`, leading to bug when press delete or backspace key in table. this PR simply fixes it:

![table-bug](https://user-images.githubusercontent.com/7312949/32036785-7d26a5b8-b9e7-11e7-8681-165b60f30e27.gif)
