### PR TITLE
Include Array.prototype.includes polyfill

### DIFF
--- a/examples/dev.html
+++ b/examples/dev.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <main></main>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Array.prototype.includes"></script>
     <script>
       /* eslint-disable */
       // Dynamically creates the script and link tag and adds the current time

--- a/examples/dev.html
+++ b/examples/dev.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <main></main>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Array.prototype.includes"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,es7"></script>
     <script>
       /* eslint-disable */
       // Dynamically creates the script and link tag and adds the current time

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <main></main>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Array.prototype.includes"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,es7"></script>
     <script src="build.prod.js"></script>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <main></main>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Array.prototype.includes"></script>
     <script src="build.prod.js"></script>
   </body>
 </html>


### PR DESCRIPTION
In 070a700, the `default` feature set was added and the `Array.prototype.includes` feature removed from the polyfill.io request. I think it's great to include the `default` feature set, but `Array.prototype.includes` is not included in the `default` set, so we have to explicitly request it. IE 11 needs an `Array.prototype.includes` polyfill in order for the examples to work. Without it, IE 11 gets this error:
![TypeError: Object doesn't support property or method 'includes'](https://user-images.githubusercontent.com/821397/32063588-cf1957ce-ba34-11e7-83b6-a9382c0c1fe3.png)

