### PR TITLE
Fix property access of undefined object in getActiveMarksAtRangeAsArray

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1091,7 +1091,7 @@ class Node {
     // If the range is collapsed, check the character before the start.
     if (range.isCollapsed) {
       const text = this.getDescendant(startKey)
-      if (text.characters.size === 0) return [];
+      if (text.characters.size === 0) return []
       const char = text.characters.get(range.startOffset - 1)
       return char.marks.toArray()
     }

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1091,6 +1091,7 @@ class Node {
     // If the range is collapsed, check the character before the start.
     if (range.isCollapsed) {
       const text = this.getDescendant(startKey)
+      if (text.characters.size === 0) return [];
       const char = text.characters.get(range.startOffset - 1)
       return char.marks.toArray()
     }


### PR DESCRIPTION
This situation is possible in following situation:
Create Inline as last element in a block, move cursor somewhere in other block, then set it at the end of previous block. If at every selection change you are trying to access `activeMarks` you'll got an error  `Uncaught TypeError: Cannot read property 'marks' of undefined at Document.getActiveMarksAtRangeAsArray`

Here is a gif:
![slate-inline](https://user-images.githubusercontent.com/5077042/32066345-1ee03a9a-ba88-11e7-9f4a-710945d1e083.gif)



