### PR TITLE
Fix focus after redo/undo triggered by hotkey

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -479,11 +479,15 @@ function AfterPlugin() {
     }
 
     if (HOTKEYS.REDO(event)) {
-      return change.redo()
+      // Keeps focus after redo triggered by hotkeys, such that user can always
+      // perform redo without being disturbed if any change blurred the editor.
+      return change.redo().focus()
     }
 
     if (HOTKEYS.UNDO(event)) {
-      return change.undo()
+      // Keeps focus after undo triggered by hotkeys, such that user can always
+      // perform undo without being disturbed if any change blurred the editor.
+      return change.undo().focus()
     }
 
     // COMPAT: Certain browsers don't handle the selection updates properly. In

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -130,7 +130,8 @@ class History extends Record(DEFAULTS) {
     debug('save', { operation, merge })
 
     // If the `merge` flag is true, add the operation to the previous batch.
-    if (merge) {
+    // When chaining other changes after `undo`, previous batch can be void.
+    if (merge && prevBatch) {
       const batch = prevBatch.slice()
       batch.push(operation)
       undos = undos.pop()


### PR DESCRIPTION
Closes #1305 

User may continuously press `cmd-z`, during which if any state loses focus, states before can't be found by `cmd-z` then. this PR fixes it.