### PR TITLE
Replace <br /> with line break

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -123,8 +123,10 @@ class Leaf extends React.Component {
     const { block, node, parent, text, index, leaves } = this.props
 
     // COMPAT: If the text is empty and it's the only child, we need to render a
-    // <br/> to get the block to have the proper height.
-    if (text == '' && parent.kind == 'block' && parent.text == '') return <br />
+    // line break to get the block to have the proper height.
+    if (text == '' && parent.kind == 'block' && parent.text == '') {
+      return <span data-slate-empty-block>{'\n'}</span>
+    }
 
     // COMPAT: If the text is empty otherwise, it's because it's on the edge of
     // an inline void node, so we render a zero-width space so that the

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -81,7 +81,7 @@ class Text extends React.Component {
     if (n.node != p.node) return true
 
     // If the node parent is a block node, and it was the last child of the
-    // block, re-render to cleanup extra `<br/>` or `\n`.
+    // block, re-render to cleanup extra `\n`.
     if (n.parent.kind == 'block') {
       const pLast = p.parent.nodes.last()
       const nLast = n.parent.nodes.last()

--- a/packages/slate-react/src/utils/find-dom-point.js
+++ b/packages/slate-react/src/utils/find-dom-point.js
@@ -40,11 +40,11 @@ function findDOMPoint(key, offset) {
   }
 
   // COMPAT: For empty blocks with only a single empty text node, we will have
-  // rendered a `<br/>` instead of a text node.
+  // rendered a `<span>` with `\n` inside, instead of a text node.
   if (
     el.childNodes.length == 1 &&
     el.childNodes[0].childNodes.length == 1 &&
-    el.childNodes[0].childNodes[0].tagName == 'BR'
+    el.childNodes[0].childNodes[0].hasAttributes('data-slate-empty-block')
   ) {
     return { node: el.childNodes[0], offset: 0 }
   }

--- a/packages/slate-react/test/rendering/fixtures/empty-block-with-inline.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block-with-inline.js
@@ -19,7 +19,9 @@ export const output = `
   <div style="position:relative">
     <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333"></span>
     <span>
-      <span><br></span>
+      <span>
+        <span data-slate-empty-block="true">\n</span>
+      </span>
     </span>
   </div>
 </div>

--- a/packages/slate-react/test/rendering/fixtures/empty-block.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block.js
@@ -17,7 +17,9 @@ export const output = `
   <div style="position:relative">
     <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333"></span>
     <span>
-      <span><br></span>
+      <span>
+        <span data-slate-empty-block="true">\n</span>
+      </span>
     </span>
   </div>
 </div>


### PR DESCRIPTION
Closes #1229 

When inserting new line in Slate with IME, browser automatically removes `<br />` generated for rendering empty block, then the mapping from Slate Value => React vDOM => DOM is broken, React then throws error, page is stopped.

#1316 introduces a workaround but is reverted, this PR is a leaner version as a replacement, with related assumptions updated.

BTW, currently I can see many other cases that IME's native behavior breaks the sync from vDOM to DOM, resulting in serious error thrown by React. Any ideas for a universal workaround?