### PR TITLE
Fix flush change

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -181,10 +181,11 @@ class Editor extends React.Component {
   flushChange = () => {
     const { change } = this.tmp
 
-    if (change) {
+    if (change && !this.tmp.flushTimeout) {
       debug('flushChange', { change })
-      window.requestAnimationFrame(() => {
+      this.tmp.flushTimeout = setTimeout(() => {
         delete this.tmp.change
+        delete this.tmp.flushTimeout
         this.props.onChange(change)
       })
     }


### PR DESCRIPTION
Fixes #1318

Hey @lxcid this should fix the issue. The problem was that the editor was queue new changes, but timeouts were being set regardless of one was already upcoming or not. So now it will only ever have one timeout active at a time, so you should now see `onChange` called only once per editor in those cases when it is initialized.