### PR TITLE
Prevent history mutation during initialization

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -102,15 +102,10 @@ function BeforePlugin() {
 
     // If the value's schema isn't the editor's schema, update it. This can
     // happen on the initialization of the editor, or if the schema changes.
+    // Since only schema is updated, don't save this change into history.
     if (value.schema != editor.schema) {
-      // When change on initialization, don't save change into history, making
-      // this schema as default and history clean after initialization ends.
-      const isInit = (
-        value.history.undos.size === 0 &&
-        value.history.redos.size === 0
-      )
       change
-        .setValue({ schema: editor.schema }, { save: !isInit })
+        .setValue({ schema: editor.schema }, { save: false })
         .normalize()
     }
 

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -102,7 +102,7 @@ function BeforePlugin() {
 
     // If the value's schema isn't the editor's schema, update it. This can
     // happen on the initialization of the editor, or if the schema changes.
-    // Since only schema is updated, don't save this change into history.
+    // This change isn't save into history since only schema is updated.
     if (value.schema != editor.schema) {
       change
         .setValue({ schema: editor.schema }, { save: false })

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -103,8 +103,14 @@ function BeforePlugin() {
     // If the value's schema isn't the editor's schema, update it. This can
     // happen on the initialization of the editor, or if the schema changes.
     if (value.schema != editor.schema) {
+      // When change on initialization, don't save change into history, making
+      // this schema as default and history clean after initialization ends.
+      const isInit = (
+        value.history.undos.size === 0 &&
+        value.history.redos.size === 0
+      )
       change
-        .setValue({ schema: editor.schema })
+        .setValue({ schema: editor.schema }, { save: !isInit })
         .normalize()
     }
 

--- a/packages/slate/src/changes/on-value.js
+++ b/packages/slate/src/changes/on-value.js
@@ -14,9 +14,10 @@ const Changes = {}
  *
  * @param {Change} change
  * @param {Object|Value} properties
+ * @param {Object} options
  */
 
-Changes.setValue = (change, properties) => {
+Changes.setValue = (change, properties, options = {}) => {
   properties = Value.createProperties(properties)
   const { value } = change
 
@@ -24,7 +25,7 @@ Changes.setValue = (change, properties) => {
     type: 'set_value',
     properties,
     value,
-  })
+  }, options)
 }
 
 /**


### PR DESCRIPTION
Fixes #1327 
Fixes #1328 

Currently there are two weird history stack behaviors:

1. When popping up last undo item, redo stack is cleared.
2. After initialization, `undos.size` is 1 instead of 0.

According to existing comments, during initialization, `editor.schema` will change once, then `onChange` in before-plugin triggers `change.setValue`, this saves to history by default, making undo stack's size 1 instead of 0.

Then when popping up this undo item, a redundant `setValue` operation is performed as inverse, this operation contains `{ save: true }`, so it fills undo stack again, which is makes undo stack behaves as alway 'remaining' one sole item.

This screenshot demonstrates the process described above when trying to pop up last undo item:

<img width="1081" alt="redo-clear-marked" src="https://user-images.githubusercontent.com/7312949/32142228-8660325e-bc60-11e7-8966-47a1007e82a2.png">

As as solution, this PR detects history stack size when we tries to update `editor.schema`, setting the `save` args to false for initialization, in this way both issue can be solved.

A side effect I can think of is that we'll now keep the first passed in schema as 'default', this seems to be reasonable. If schema changes afterward, it'll still be recorded into history stack and still undoable.