### PR TITLE
Omit focus change when traveling in history

### DIFF
--- a/packages/slate/src/changes/on-history.js
+++ b/packages/slate/src/changes/on-history.js
@@ -30,6 +30,12 @@ Changes.redo = (change) => {
 
   // Replay the next operations.
   next.forEach((op) => {
+    // When the operation mutates selection, omit its `isFocused` props to
+    // prevent editor focus changing during continuously redoing.
+    const { type, properties } = op
+    if (type === 'set_selection') {
+      delete properties.isFocused
+    }
     change.applyOperation(op, { save: false })
   })
 
@@ -60,8 +66,14 @@ Changes.undo = (change) => {
   redos = redos.push(previous)
 
   // Replay the inverse of the previous operations.
-  previous.slice().reverse().map(invert).forEach((inverse) => {
-    change.applyOperation(inverse, { save: false })
+  previous.slice().reverse().map(invert).forEach((inverseOp) => {
+    // When the operation mutates selection, omit its `isFocused` props to
+    // prevent editor focus changing during continuously undoing.
+    const { type, properties } = inverseOp
+    if (type === 'set_selection') {
+      delete properties.isFocused
+    }
+    change.applyOperation(inverseOp, { save: false })
   })
 
   // Update the history.

--- a/packages/slate/src/changes/on-history.js
+++ b/packages/slate/src/changes/on-history.js
@@ -33,10 +33,10 @@ Changes.redo = (change) => {
   next.forEach((op) => {
     // When the operation mutates selection, omit its `isFocused` props to
     // prevent editor focus changing during continuously redoing.
-    const { type } = op
-    const properties = (type === 'set_selection')
-      ? omit(op.properties, 'isFocused')
-      : op.properties
+    let { type, properties } = op
+    if (type === 'set_selection') {
+      properties = omit(properties, 'isFocused')
+    }
     change.applyOperation({ ...op, properties }, { save: false })
   })
 
@@ -70,10 +70,10 @@ Changes.undo = (change) => {
   previous.slice().reverse().map(invert).forEach((inverseOp) => {
     // When the operation mutates selection, omit its `isFocused` props to
     // prevent editor focus changing during continuously undoing.
-    const { type } = inverseOp
-    const properties = (type === 'set_selection')
-      ? omit(inverseOp.properties, 'isFocused')
-      : inverseOp.properties
+    let { type, properties } = inverseOp
+    if (type === 'set_selection') {
+      properties = omit(properties, 'isFocused')
+    }
     change.applyOperation({ ...inverseOp, properties }, { save: false })
   })
 

--- a/packages/slate/src/changes/on-history.js
+++ b/packages/slate/src/changes/on-history.js
@@ -1,5 +1,6 @@
 
 import invert from '../operations/invert'
+import omit from 'lodash/omit'
 
 /**
  * Changes.
@@ -32,11 +33,11 @@ Changes.redo = (change) => {
   next.forEach((op) => {
     // When the operation mutates selection, omit its `isFocused` props to
     // prevent editor focus changing during continuously redoing.
-    const { type, properties } = op
-    if (type === 'set_selection') {
-      delete properties.isFocused
-    }
-    change.applyOperation(op, { save: false })
+    const { type } = op
+    const properties = (type === 'set_selection')
+      ? omit(op.properties, 'isFocused')
+      : op.properties
+    change.applyOperation({ ...op, properties }, { save: false })
   })
 
   // Update the history.
@@ -69,11 +70,11 @@ Changes.undo = (change) => {
   previous.slice().reverse().map(invert).forEach((inverseOp) => {
     // When the operation mutates selection, omit its `isFocused` props to
     // prevent editor focus changing during continuously undoing.
-    const { type, properties } = inverseOp
-    if (type === 'set_selection') {
-      delete properties.isFocused
-    }
-    change.applyOperation(inverseOp, { save: false })
+    const { type } = inverseOp
+    const properties = (type === 'set_selection')
+      ? omit(inverseOp.properties, 'isFocused')
+      : inverseOp.properties
+    change.applyOperation({ ...inverseOp, properties }, { save: false })
   })
 
   // Update the history.


### PR DESCRIPTION
Closes #1305 

We've discussed an approach fixing the unaccessible history state issue:

> Instead of discarding only blurs, we actually change `undo/redo` to ignore all changes to isFocused, so that the focused state will never change when undoing, it will remain whatever it currently is.

This is a cool idea and this PR implements this by checking operation type during `undo/redo`. Now no matter `undo/redo` is triggered from toolbar button click or keyboard hotkey press, editor focus remains intact, making successive history traveling unhindered.