### PR TITLE
Add history example

### DIFF
--- a/examples/history/index.js
+++ b/examples/history/index.js
@@ -46,18 +46,6 @@ class History extends React.Component {
   }
 
   /**
-   * On delete selected text.
-   *
-   */
-
-  onClickDelete = (event) => {
-    event.preventDefault()
-    const { value } = this.state
-    const change = value.change().delete()
-    this.onChange(change)
-  }
-
-  /**
    * On redo in history.
    *
    */
@@ -106,7 +94,6 @@ class History extends React.Component {
     const { value } = this.state
     return (
       <div className="menu toolbar-menu">
-        <ToolbarButton icon="delete" onMouseDown={this.onClickDelete} />
         <ToolbarButton icon="undo" onMouseDown={this.onClickUndo} />
         <ToolbarButton icon="redo" onMouseDown={this.onClickRedo} />
         <span className="button">

--- a/examples/history/index.js
+++ b/examples/history/index.js
@@ -18,7 +18,7 @@ const ToolbarButton = props => (
 )
 
 /**
- * The history stack example.
+ * The history example.
  *
  * @type {Component}
  */
@@ -97,10 +97,10 @@ class History extends React.Component {
         <ToolbarButton icon="undo" onMouseDown={this.onClickUndo} />
         <ToolbarButton icon="redo" onMouseDown={this.onClickRedo} />
         <span className="button">
-          Redos: {value.history.redos.size}
+          Undos: {value.history.undos.size}
         </span>
         <span className="button">
-          Undos: {value.history.undos.size}
+          Redos: {value.history.redos.size}
         </span>
       </div>
     )

--- a/examples/history/index.js
+++ b/examples/history/index.js
@@ -1,0 +1,146 @@
+
+import { Value } from 'slate'
+import { Editor } from 'slate-react'
+
+import React from 'react'
+import initialValue from './value.json'
+
+/**
+ * Toolbar button component.
+ *
+ * @type {Function}
+ */
+
+const ToolbarButton = props => (
+  <span className="button" onMouseDown={props.onMouseDown}>
+    <span className="material-icons">{props.icon}</span>
+  </span>
+)
+
+/**
+ * The history stack example.
+ *
+ * @type {Component}
+ */
+
+class History extends React.Component {
+
+  /**
+   * Deserialize the initial editor value.
+   *
+   * @type {Object}
+   */
+
+  state = {
+    value: Value.fromJSON(initialValue)
+  }
+
+  /**
+   * On change.
+   *
+   * @param {Change} change
+   */
+
+  onChange = ({ value }) => {
+    this.setState({ value })
+  }
+
+  /**
+   * On delete selected text.
+   *
+   */
+
+  onClickDelete = (event) => {
+    event.preventDefault()
+    const { value } = this.state
+    const change = value.change().delete()
+    this.onChange(change)
+  }
+
+  /**
+   * On redo in history.
+   *
+   */
+
+  onClickRedo = (event) => {
+    event.preventDefault()
+    const { value } = this.state
+    const change = value.change().redo()
+    this.onChange(change)
+  }
+
+  /**
+   * On undo in history.
+   *
+   */
+
+  onClickUndo = (event) => {
+    event.preventDefault()
+    const { value } = this.state
+    const change = value.change().undo()
+    this.onChange(change)
+  }
+
+  /**
+   * Render the editor.
+   *
+   * @return {Component} component
+   */
+
+  render() {
+    return (
+      <div className="editor">
+        {this.renderToolbar()}
+        {this.renderEditor()}
+      </div>
+    )
+  }
+
+  /**
+   * Render the toolbar.
+   *
+   * @return {Element}
+   */
+
+  renderToolbar = () => {
+    const { value } = this.state
+    return (
+      <div className="menu toolbar-menu">
+        <ToolbarButton icon="delete" onMouseDown={this.onClickDelete} />
+        <ToolbarButton icon="undo" onMouseDown={this.onClickUndo} />
+        <ToolbarButton icon="redo" onMouseDown={this.onClickRedo} />
+        <span className="button">
+          Redos: {value.history.redos.size}
+        </span>
+        <span className="button">
+          Undos: {value.history.undos.size}
+        </span>
+      </div>
+    )
+  }
+
+  /**
+   * Render the Slate editor.
+   *
+   * @return {Element}
+   */
+
+  renderEditor = () => {
+    return (
+      <div className="editor">
+        <Editor
+          placeholder="Enter some text..."
+          value={this.state.value}
+          onChange={this.onChange}
+        />
+      </div>
+    )
+  }
+
+}
+
+/**
+ * Export.
+ */
+
+export default History

--- a/examples/history/value.json
+++ b/examples/history/value.json
@@ -9,7 +9,7 @@
             "kind": "text",
             "leaves": [
               {
-                "text": "Editor maintains its own history stack. For custom components and changes, history operations are automatically handled, no need implementing their undo/redo methods by yourself!"
+                "text": "Slate editors save all changes to an internal \"history\" automatically, so you don't need to implement undo/redo yourself. And the editor automatically binds to the browser's default undo/redo keyboard shortcuts."
               }
             ]
           }
@@ -23,7 +23,7 @@
             "kind": "text",
             "leaves": [
               {
-                "text": "Try it out yourself! Editing via keyboard and toolbar are both undoable."
+                "text": "Try it out for yourself! Make any changes you'd like then press \"cmd+z\"."
               }
             ]
           }

--- a/examples/history/value.json
+++ b/examples/history/value.json
@@ -1,0 +1,34 @@
+{
+  "document": {
+    "nodes": [
+      {
+        "kind": "block",
+        "type": "paragraph",
+        "nodes": [
+          {
+            "kind": "text",
+            "leaves": [
+              {
+                "text": "Editor maintains its own history stack. For custom components and changes, history operations are automatically handled, no need implementing their undo/redo methods by yourself!"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "block",
+        "type": "paragraph",
+        "nodes": [
+          {
+            "kind": "text",
+            "leaves": [
+              {
+                "text": "Try it out yourself! Editing via keyboard and toolbar are both undoable."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/index.js
+++ b/examples/index.js
@@ -8,6 +8,7 @@ import CodeHighlighting from './code-highlighting'
 import Embeds from './embeds'
 import Emojis from './emojis'
 import ForcedLayout from './forced-layout'
+import History from './history'
 import HoveringMenu from './hovering-menu'
 import HugeDocument from './huge-document'
 import Images from './images'
@@ -51,6 +52,7 @@ const EXAMPLES = [
   ['Plugins', Plugins, '/plugins'],
   ['Forced Layout', ForcedLayout, '/forced-layout'],
   ['Huge Document', HugeDocument, '/huge-document'],
+  ['History', History, '/history'],
 ]
 
 /**


### PR DESCRIPTION
Slate's examples are awesome for quick prototyping and bug reporting. For history-stack-related issues, it'll be more efficient tracking and reporting them with a live example. The more user playing with this, the easier to expose related bugs.

Another major point for adding this example is that to my knowledge, each example shipped with Slate demonstrates one major feature.  For custom components and changes, one great advantage of Slate is that their history operations are handled automatically, without the need implementing their own undo/redo method. So from this point of view, adding it as a standalone example also makes sense.

Currently this example looks like below:

<img width="742" alt="history-demo" src="https://user-images.githubusercontent.com/7312949/32142750-7c99dea4-bc6b-11e7-82bb-8bacee0a6b98.png">

Willing to update whatever needed 😀