### PR TITLE
Add default transferred text

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -581,7 +581,7 @@ function AfterPlugin() {
       change.insertFragment(fragment)
     }
 
-    if (type == 'text' || type == 'html') {
+    if ((type == 'text' || type == 'html') && text) {
       const { value } = change
       const { document, selection, startBlock } = value
       if (startBlock.isVoid) return

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -581,8 +581,8 @@ function AfterPlugin() {
       change.insertFragment(fragment)
     }
 
-    // Only allows pasting plain text or html, with valid text
-    if ((type == 'text' || type == 'html') && text) {
+    if (type == 'text' || type == 'html') {
+      if (!text) return
       const { value } = change
       const { document, selection, startBlock } = value
       if (startBlock.isVoid) return

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -581,6 +581,7 @@ function AfterPlugin() {
       change.insertFragment(fragment)
     }
 
+    // Only allows pasting plain text or html, with valid text
     if ((type == 'text' || type == 'html') && text) {
       const { value } = change
       const { document, selection, startBlock } = value

--- a/packages/slate-react/src/utils/get-event-transfer.js
+++ b/packages/slate-react/src/utils/get-event-transfer.js
@@ -42,7 +42,7 @@ function getEventTransfer(event) {
   let node = getType(transfer, NODE)
   const html = getType(transfer, HTML)
   const rich = getType(transfer, RICH)
-  let text = getType(transfer, TEXT)
+  let text = getType(transfer, TEXT) || ''
   let files
 
   // If there isn't a fragment, but there is HTML, check to see if the HTML is

--- a/packages/slate-react/src/utils/get-event-transfer.js
+++ b/packages/slate-react/src/utils/get-event-transfer.js
@@ -42,7 +42,7 @@ function getEventTransfer(event) {
   let node = getType(transfer, NODE)
   const html = getType(transfer, HTML)
   const rich = getType(transfer, RICH)
-  let text = getType(transfer, TEXT) || ''
+  let text = getType(transfer, TEXT)
   let files
 
   // If there isn't a fragment, but there is HTML, check to see if the HTML is


### PR DESCRIPTION
Closes #1332 

In current implementation, transferred text may be `null` instead of empty string, which may breaks deserializer. This PR fixes it.