### PR TITLE
Handle pasting image in `Paste HTML` example

### DIFF
--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -87,7 +87,7 @@ const RULES = [
     }
   },
   {
-    // Special case for images, to grab their srs.
+    // Special case for images, to grab their src.
     deserialize(el, next) {
       if (el.tagName.toLowerCase() != 'img') return
       return {

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -87,6 +87,21 @@ const RULES = [
     }
   },
   {
+    // Special case for images, to grab their srs.
+    deserialize(el, next) {
+      if (el.tagName.toLowerCase() != 'img') return
+      return {
+        kind: 'block',
+        type: 'image',
+        isVoid: true,
+        nodes: next(el.childNodes),
+        data: {
+          src: el.getAttribute('src')
+        }
+      }
+    }
+  },
+  {
     // Special case for links, to grab their href.
     deserialize(el, next) {
       if (el.tagName.toLowerCase() != 'a') return
@@ -182,7 +197,7 @@ class PasteHtml extends React.Component {
    */
 
   renderNode = (props) => {
-    const { attributes, children, node } = props
+    const { attributes, children, node, isSelected } = props
     switch (node.type) {
       case 'quote': return <blockquote {...attributes}>{children}</blockquote>
       case 'code': return <pre><code {...attributes}>{children}</code></pre>
@@ -199,6 +214,14 @@ class PasteHtml extends React.Component {
         const { data } = node
         const href = data.get('href')
         return <a href={href} {...attributes}>{children}</a>
+      }
+      case 'image': {
+        const src = node.data.get('src')
+        const className = isSelected ? 'active' : null
+        const style = { display: 'block' }
+        return (
+          <img src={src} className={className} style={style} {...attributes} />
+        )
       }
     }
   }


### PR DESCRIPTION
Currently when testing paste feature, the `Paste HTML` example mainly supports:

* Block nodes with text, like `h1` and `paragraph`.
* Block nodes with text but is 'flat', like `code`.
* Void Inline nodes, like `link`.

So how about **void block nodes** like `image`? IMHO supporting image makes sense, since we can copy image from the `Images` example and paste it then, making it easier for smoke tests.

This PR simply adds this functionality.