### PR TITLE
Delete single void node when cutting

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -125,9 +125,9 @@ function AfterPlugin() {
       // If user cuts a void block or a void inline,
       // manually removes them since selection is collapsed in this case.
       const { value } = change
-      const { endBlock, endInline } = value
-      const isVoidBlock = endBlock && endBlock.isVoid
-      const isVoidInline = endInline && endInline.isVoid
+      const { endBlock, endInline, isCollapsed } = value
+      const isVoidBlock = endBlock && endBlock.isVoid && isCollapsed
+      const isVoidInline = endInline && endInline.isVoid && isCollapsed
 
       if (isVoidBlock) {
         editor.change(c => c.removeNodeByKey(endBlock.key))

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -122,7 +122,20 @@ function AfterPlugin() {
     // Once the fake cut content has successfully been added to the clipboard,
     // delete the content in the current selection.
     window.requestAnimationFrame(() => {
-      editor.change(c => c.delete())
+      // If user cuts a void block or a void inline,
+      // manually removes them since selection is collapsed in this case.
+      const { value } = change
+      const { endBlock, endInline } = value
+      const isVoidBlock = endBlock && endBlock.isVoid
+      const isVoidInline = endInline && endInline.isVoid
+
+      if (isVoidBlock) {
+        editor.change(c => c.removeNodeByKey(endBlock.key))
+      } else if (isVoidInline) {
+        editor.change(c => c.removeNodeByKey(endInline.key))
+      } else {
+        editor.change(c => c.delete())
+      }
     })
   }
 

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -122,8 +122,8 @@ function AfterPlugin() {
     // Once the fake cut content has successfully been added to the clipboard,
     // delete the content in the current selection.
     window.requestAnimationFrame(() => {
-      // If user cuts a void block or a void inline,
-      // manually removes them since selection is collapsed in this case.
+      // If user cuts a void block node or a void inline node,
+      // manually removes it since selection is collapsed in this case.
       const { value } = change
       const { endBlock, endInline, isCollapsed } = value
       const isVoidBlock = endBlock && endBlock.isVoid && isCollapsed


### PR DESCRIPTION
Closes #1335 

Currently when user click on a void block/inline node, this node appears in `value.blocks` or `value.inlines`, but selection is collapsed in this case. Then if user cuts it, we can't simple calling `change().delete()` to remove it, instead we manually remove it.

Since we still perform deletion through changes, undo/redo behaves just as what it is.