### PR TITLE
Trigger `onBlur` regardless of `relatedTarget`

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -71,27 +71,26 @@ function BeforePlugin() {
     const { value } = change
     const focusTarget = event.relatedTarget
 
-    // If focusTarget is null, the blur event is due to the window itself being
-    // blurred (eg. when changing tabs) so we should ignore the event, since we
-    // want to maintain focus when returning.
-    if (!focusTarget) return true
+    // focusTarget may be null when window itself being blurred
+    // (eg. when changing tabs), or when user clicks on elements
+    // without`tabindex` attribute.
+    if (focusTarget) {
+      const el = findDOMNode(editor)
+      // The event should be ignored if the focus returns to the editor from an
+      // embedded editable element (eg. an input element inside a void node).
+      if (focusTarget == el) return true
 
-    const el = findDOMNode(editor)
+      // when the focus moved from the editor to a void node spacer...
+      if (focusTarget.hasAttribute('data-slate-spacer')) return true
 
-    // The event should also be ignored if the focus returns to the editor from
-    // an embedded editable element (eg. an input element inside a void node),
-    if (focusTarget == el) return true
-
-    // when the focus moved from the editor to a void node spacer...
-    if (focusTarget.hasAttribute('data-slate-spacer')) return true
-
-    // or to an editable element inside the editor but not into a void node
-    // (eg. a list item of the check list example).
-    if (
-      el.contains(focusTarget) &&
-      !findNode(focusTarget, value).isVoid
-    ) {
-      return true
+      // or to an editable element inside the editor but not into a void node
+      // (eg. a list item of the check list example).
+      if (
+        el.contains(focusTarget) &&
+        !findNode(focusTarget, value).isVoid
+      ) {
+        return true
+      }
     }
 
     debug('onBlur', { event })


### PR DESCRIPTION
Closes #1341

`onBlur` events are not firing because the PERF code in before-plugin returns `true` when `event.relatedTarget` is null, preventing custom callbacks from being called.

This is somewhat overkill, since according to [this post](https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null), `event.relatedTarget` returns elements **only if this element can gain focus**, so clicking on plain `<div>` outside editor won't trigger `onBlur`, which is not very reasonable.

This patch removes this limitation and `onBlur` intuitively works. As for the side effect I can think of, this change may allow some `set_selection` pushed into history stack, causing focus change on undoing, but we already have #1330 handle this case.