### PR TITLE
Update walkthrough documents' initial values

### DIFF
--- a/docs/reference/slate-html-serializer/index.md
+++ b/docs/reference/slate-html-serializer/index.md
@@ -108,7 +108,7 @@ The object should be one of:
 
 {
   kind: 'text',
-  ranges: Array
+  leaves: Array
 }
 ```
 

--- a/docs/walkthroughs/installing-slate.md
+++ b/docs/walkthroughs/installing-slate.md
@@ -41,7 +41,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             kind: 'text',
-            ranges: [
+            leaves: [
               {
                 text: 'A line of text in a paragraph.'
               }
@@ -71,7 +71,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             kind: 'text',
-            ranges: [
+            leaves: [
               {
                 text: 'A line of text in a paragraph.'
               }

--- a/docs/walkthroughs/saving-to-a-database.md
+++ b/docs/walkthroughs/saving-to-a-database.md
@@ -24,7 +24,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             kind: 'text',
-            ranges: [
+            leaves: [
               {
                 text: 'A line of text in a paragraph.'
               }
@@ -74,7 +74,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             kind: 'text',
-            ranges: [
+            leaves: [
               {
                 text: 'A line of text in a paragraph.'
               }
@@ -128,7 +128,7 @@ const initialValue = Value.fromJSON(existingValue || {
         nodes: [
           {
             kind: 'text',
-            ranges: [
+            leaves: [
               {
                 text: 'A line of text in a paragraph.'
               }
@@ -180,7 +180,7 @@ const initialValue = Value.fromJSON(existingValue || {
         nodes: [
           {
             kind: 'text',
-            ranges: [
+            leaves: [
               {
                 text: 'A line of text in a paragraph.'
               }


### PR DESCRIPTION
This appears to have been missed recently when `ranges` was renamed.

Strange because it seemed `ranges` had initially worked for me, and then stopped working later on in the day... :man_shrugging: