### PR TITLE
[onCutOrCopy] Creating the phony copy div at the same level as the real div

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -1,4 +1,3 @@
-
 import Base64 from 'slate-base64-serializer'
 import Debug from 'debug'
 import Plain from 'slate-plain-serializer'
@@ -245,6 +244,20 @@ function AfterPlugin(options = {}) {
     div.setAttribute('contenteditable', true)
     div.style.position = 'absolute'
     div.style.left = '-9999px'
+
+    // The snippet below is from `clipboard.js`
+    // Prevent zooming on iOS
+    div.style.fontSize = '12pt'
+    // Reset box model
+    div.style.border = '0'
+    div.style.padding = '0'
+    div.style.margin = '0'
+    // Creating the phony div at the same level as the real div so that
+    // the viewport doesn't jump (in Firefox)
+    const yPosition = window.pageYOffset ||
+                      window.document.documentElement.scrollTop
+    div.style.top = `${yPosition}px`
+
     div.appendChild(contents)
     body.appendChild(div)
 

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -245,15 +245,13 @@ function AfterPlugin(options = {}) {
     div.style.position = 'absolute'
     div.style.left = '-9999px'
 
-    // The snippet below is from `clipboard.js`
-    // Prevent zooming on iOS
-    div.style.fontSize = '12pt'
-    // Reset box model
+    // COMPAT: In Firefox, the viewport jumps to find the phony div. Hence it
+    // should be created at the current window scroll offset (setting
+    // 'style.top'). The box model attributes which can interact with 'top' are
+    // also reset.
     div.style.border = '0'
     div.style.padding = '0'
     div.style.margin = '0'
-    // Creating the phony div at the same level as the real div so that
-    // the viewport doesn't jump (in Firefox)
     const yPosition = window.pageYOffset ||
                       window.document.documentElement.scrollTop
     div.style.top = `${yPosition}px`

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -245,16 +245,13 @@ function AfterPlugin(options = {}) {
     div.style.position = 'absolute'
     div.style.left = '-9999px'
 
-    // COMPAT: In Firefox, the viewport jumps to find the phony div. Hence it
-    // should be created at the current window scroll offset (setting
-    // 'style.top'). The box model attributes which can interact with 'top' are
-    // also reset.
-    div.style.border = '0'
-    div.style.padding = '0'
-    div.style.margin = '0'
-    const yPosition = window.pageYOffset ||
-                      window.document.documentElement.scrollTop
-    div.style.top = `${yPosition}px`
+    // COMPAT: In Firefox, the viewport jumps to find the phony div, so it
+    // should be created at the current scroll offset with `style.top`.
+    // The box model attributes which can interact with 'top' are also reset.
+    div.style.border = '0px'
+    div.style.padding = '0px'
+    div.style.margin = '0px'
+    div.style.top = `${window.pageYOffset || window.document.documentElement.scrollTop}px`
 
     div.appendChild(contents)
     body.appendChild(div)

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -1,3 +1,4 @@
+
 import Base64 from 'slate-base64-serializer'
 import Debug from 'debug'
 import Plain from 'slate-plain-serializer'


### PR DESCRIPTION
The function `onCutOrCopy` in `after.js` plugin stack creates a phony div with encoded slate fragment in an attribute and selects it (to make the browser copy those contents instead of the actual selection). 

In Firefox this causes the viewport to jump to the bottom (if the window can scroll), to find the div (presumably). `clipboard.js` fixes this by creating the phony div at the same scroll offset as the current viewport.

(See attached issue for gif)

# Changelog
###### Fixed
- Creating phony div at the scroll offset as the window scroll offset 

Resolves #1339 