### PR TITLE
Fix native IME input at the beginning of a line

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -120,13 +120,7 @@ class Leaf extends React.Component {
    */
 
   renderText() {
-    const { block, node, parent, text, index, leaves } = this.props
-
-    // COMPAT: If the text is empty and it's the only child, we need to render a
-    // line break to get the block to have the proper height.
-    if (text == '' && parent.kind == 'block' && parent.text == '') {
-      return <span data-slate-empty-block>{'\n'}</span>
-    }
+    const { block, node, text, index, leaves } = this.props
 
     // COMPAT: If the text is empty otherwise, it's because it's on the edge of
     // an inline void node, so we render a zero-width space so that the

--- a/packages/slate-react/src/utils/find-dom-point.js
+++ b/packages/slate-react/src/utils/find-dom-point.js
@@ -39,16 +39,6 @@ function findDOMPoint(key, offset) {
     start = end
   }
 
-  // COMPAT: For empty blocks with only a single empty text node, we will have
-  // rendered a `<span>` with `\n` inside, instead of a text node.
-  if (
-    el.childNodes.length == 1 &&
-    el.childNodes[0].childNodes.length == 1 &&
-    el.childNodes[0].childNodes[0].hasAttributes('data-slate-empty-block')
-  ) {
-    return { node: el.childNodes[0], offset: 0 }
-  }
-
   return null
 }
 

--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -57,9 +57,14 @@ function findPoint(nativeNode, nativeOffset, value) {
   }
 
   // COMPAT: If the parent node is a Slate zero-width space, this is because the
-  // text node has no characters, so the offset can only be zero.
-  if (offset != 0 && parentNode.getAttribute('data-slate-zero-width')) {
-    offset = 0
+  // text node should have no characters. However, during IME composition the
+  // ASCII characters will be prepended to the zero-width space, so subtract 1
+  // from the offset to account for the zero-width space character.
+  if (
+    offset == node.textContent.length &&
+    parentNode.hasAttribute('data-slate-zero-width')
+  ) {
+    offset--
   }
 
   // Get the string value of the offset key attribute.

--- a/packages/slate-react/test/rendering/fixtures/empty-block-with-inline.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block-with-inline.js
@@ -20,7 +20,7 @@ export const output = `
     <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333"></span>
     <span>
       <span>
-        <span data-slate-empty-block="true">\n</span>
+        <span data-slate-zero-width="true">\u200B</span>
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/empty-block.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block.js
@@ -18,7 +18,7 @@ export const output = `
     <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333"></span>
     <span>
       <span>
-        <span data-slate-empty-block="true">\n</span>
+        <span data-slate-zero-width="true">\u200B</span>
       </span>
     </span>
   </div>


### PR DESCRIPTION
Closes https://github.com/ianstormtaylor/slate/issues/1340.
Related to https://github.com/ianstormtaylor/slate/pull/1322.

/cc @doodlewind, did you want to test your non-native pinyin input first? This works for the native macOS input.