### PR TITLE
Avoid rendering an empty placeholder by default

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -751,6 +751,7 @@ function AfterPlugin() {
 
   function renderPlaceholder(props) {
     const { editor, node } = props
+    if (!editor.props.placeholder) return
     if (editor.state.isComposing) return
     if (node.kind != 'block') return
     if (!Text.isTextList(node.nodes)) return

--- a/packages/slate-react/test/rendering/fixtures/empty-block-with-inline.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block-with-inline.js
@@ -17,7 +17,6 @@ export const value = (
 export const output = `
 <div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative">
-    <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333"></span>
     <span>
       <span>
         <span data-slate-empty-block="true">\n</span>

--- a/packages/slate-react/test/rendering/fixtures/empty-block.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block.js
@@ -15,7 +15,6 @@ export const value = (
 export const output = `
 <div data-slate-editor="true" contenteditable="true" role="textbox">
   <div style="position:relative">
-    <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333"></span>
     <span>
       <span>
         <span data-slate-empty-block="true">\n</span>


### PR DESCRIPTION
For some reason the rendering the empty placeholder `<span />` ends up making the caret render out of the element.

Before: 

![image](https://user-images.githubusercontent.com/1088987/32216586-a9a9e25e-bde2-11e7-9d75-52cf36ce60f5.png)

After:

![image](https://user-images.githubusercontent.com/1088987/32216518-71e33d0c-bde2-11e7-8f30-0f00b453b905.png)
