### PR TITLE
Avoid executing hotkeys while composing

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -371,11 +371,11 @@ function BeforePlugin() {
   function onKeyDown(event, change, editor) {
     if (editor.props.readOnly) return true
 
-    // When composing, these characters commit the composition but also move the
-    // selection before we're able to handle it, so prevent their default,
-    // selection-moving behavior.
-    if (isComposing && HOTKEYS.COMPOSING(event)) {
-      event.preventDefault()
+    // When composing, we need to prevent all hotkeys from executing while
+    // typing. However, certain characters also move the selection before
+    // we're able to handle it, so prevent their default behavior.
+    if (isComposing) {
+      if (HOTKEYS.COMPOSING(event)) event.preventDefault()
       return true
     }
 


### PR DESCRIPTION
This PR avoids executing _any_ hotkey shortcuts while in `isComposing` mode. This is needed because, in `master`, when hitting something like `mod+z` while composing will result in _both_ an undo event and `z` being inserted. To repro, enter some text, then type with IME, hit `mod+z` and `mod+shift+z`. You should see the data before the IME input changing and the characters being appended to the current IME ASCII text.

![](https://d26dzxoao6i3hh.cloudfront.net/items/44373P260V393D1R2x0H/Screen%20Recording%202017-10-31%20at%2002.42%20am.gif)

/cc @doodlewind I want to verify the behaviour of your custom IME input, because I can't tell why `HOTKEYS.COMPOSING` should exist otherwise. If it's to handle that, I'm happy to restore it and tidy the code up differently. 