### PR TITLE
Avoid changing selection when deleting old content

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -465,9 +465,7 @@ function AfterPlugin() {
 
     // Change the current value to have the leaf's text replaced.
     change
-      .select(entire)
-      .delete()
-      .insertText(textContent, leaf.marks)
+      .insertTextAtRange(entire, textContent, leaf.marks)
       .select(corrected)
   }
 


### PR DESCRIPTION
Previously, `.select(entire)` would end up changing the selection to the entire line. When undoing, it results in an odd experience of the entire line selected instead of just the change (or wherever you were before in the case of Firefox). This avoids moving the selection when changing the content.

Before:

![](https://d26dzxoao6i3hh.cloudfront.net/items/3B1n3W1t3n0P1q3b2h13/Screen%20Recording%202017-10-31%20at%2010.17%20pm.gif?v=1175cf7b)

After:

![](https://d26dzxoao6i3hh.cloudfront.net/items/3e3R3l220w0c45330Z1p/Screen%20Recording%202017-10-31%20at%2010.18%20pm.gif?v=8584c749)