### PR TITLE
Fix broken iOS UA sniff that identified iOS as macOS

### DIFF
--- a/packages/slate-react/src/constants/environment.js
+++ b/packages/slate-react/src/constants/environment.js
@@ -37,8 +37,8 @@ const EVENT_RULES = [
  */
 
 const OS_RULES = [
+  ['ios', /os ([\.\_\d]+) like mac os/i], // must be before the macos rule
   ['macos', /mac os x/i],
-  ['ios', /os ([\.\_\d]+) like mac os/i],
   ['android', /android/i],
   ['firefoxos', /mozilla\/[a-z\.\_\d]+ \((?:mobile)|(?:tablet)/i],
   ['windows', /windows\s*(?:nt)?\s*([\.\_\d]+)/i],

--- a/packages/slate-react/src/constants/hotkeys.js
+++ b/packages/slate-react/src/constants/hotkeys.js
@@ -1,7 +1,10 @@
 
 import { isKeyHotkey } from 'is-hotkey'
 
-import { IS_MAC } from './environment'
+import {
+  IS_IOS,
+  IS_MAC
+} from './environment'
 
 /**
  * Hotkeys.
@@ -25,44 +28,44 @@ const DELETE_FORWARD = e => DELETE(e) || SHIFT_DELETE(e)
 
 const DELETE_CHAR_BACKWARD_MAC = isKeyHotkey('ctrl+h')
 const DELETE_CHAR_FORWARD_MAC = isKeyHotkey('ctrl+d')
-const DELETE_CHAR_BACKWARD = e => DELETE_BACKWARD(e) || (IS_MAC && DELETE_CHAR_BACKWARD_MAC(e))
-const DELETE_CHAR_FORWARD = e => DELETE_FORWARD(e) || (IS_MAC && DELETE_CHAR_FORWARD_MAC(e))
+const DELETE_CHAR_BACKWARD = e => DELETE_BACKWARD(e) || ((IS_MAC || IS_IOS) && DELETE_CHAR_BACKWARD_MAC(e))
+const DELETE_CHAR_FORWARD = e => DELETE_FORWARD(e) || ((IS_MAC || IS_IOS) && DELETE_CHAR_FORWARD_MAC(e))
 
 const DELETE_LINE_BACKWARD_MAC = isKeyHotkey('cmd+backspace')
 const DELETE_LINE_FORWARD_MAC = isKeyHotkey('ctrl+k')
-const DELETE_LINE_BACKWARD = e => IS_MAC && DELETE_LINE_BACKWARD_MAC(e)
-const DELETE_LINE_FORWARD = e => IS_MAC && DELETE_LINE_FORWARD_MAC(e)
+const DELETE_LINE_BACKWARD = e => (IS_MAC || IS_IOS) && DELETE_LINE_BACKWARD_MAC(e)
+const DELETE_LINE_FORWARD = e => (IS_MAC || IS_IOS) && DELETE_LINE_FORWARD_MAC(e)
 
 const DELETE_WORD_BACKWARD_MAC = isKeyHotkey('option+backspace')
 const DELETE_WORD_BACKWARD_PC = isKeyHotkey('ctrl+backspace')
 const DELETE_WORD_FORWARD_MAC = isKeyHotkey('option+delete')
 const DELETE_WORD_FORWARD_PC = isKeyHotkey('ctrl+delete')
-const DELETE_WORD_BACKWARD = e => IS_MAC ? DELETE_WORD_BACKWARD_MAC(e) : DELETE_WORD_BACKWARD_PC(e)
-const DELETE_WORD_FORWARD = e => IS_MAC ? DELETE_WORD_FORWARD_MAC(e) : DELETE_WORD_FORWARD_PC(e)
+const DELETE_WORD_BACKWARD = e => IS_MAC || IS_IOS ? DELETE_WORD_BACKWARD_MAC(e) : DELETE_WORD_BACKWARD_PC(e)
+const DELETE_WORD_FORWARD = e => IS_MAC || IS_IOS ? DELETE_WORD_FORWARD_MAC(e) : DELETE_WORD_FORWARD_PC(e)
 
 const COLLAPSE_CHAR_FORWARD = isKeyHotkey('right')
 const COLLAPSE_CHAR_BACKWARD = isKeyHotkey('left')
 
 const COLLAPSE_LINE_BACKWARD_MAC = isKeyHotkey('option+up')
 const COLLAPSE_LINE_FORWARD_MAC = isKeyHotkey('option+down')
-const COLLAPSE_LINE_BACKWARD = e => IS_MAC && COLLAPSE_LINE_BACKWARD_MAC(e)
-const COLLAPSE_LINE_FORWARD = e => IS_MAC && COLLAPSE_LINE_FORWARD_MAC(e)
+const COLLAPSE_LINE_BACKWARD = e => (IS_MAC || IS_IOS) && COLLAPSE_LINE_BACKWARD_MAC(e)
+const COLLAPSE_LINE_FORWARD = e => (IS_MAC || IS_IOS) && COLLAPSE_LINE_FORWARD_MAC(e)
 
 const EXTEND_CHAR_FORWARD = isKeyHotkey('shift+right')
 const EXTEND_CHAR_BACKWARD = isKeyHotkey('shift+left')
 
 const EXTEND_LINE_BACKWARD_MAC = isKeyHotkey('option+shift+up')
 const EXTEND_LINE_FORWARD_MAC = isKeyHotkey('option+shift+down')
-const EXTEND_LINE_BACKWARD = e => IS_MAC && EXTEND_LINE_BACKWARD_MAC(e)
-const EXTEND_LINE_FORWARD = e => IS_MAC && EXTEND_LINE_FORWARD_MAC(e)
+const EXTEND_LINE_BACKWARD = e => (IS_MAC || IS_IOS) && EXTEND_LINE_BACKWARD_MAC(e)
+const EXTEND_LINE_FORWARD = e => (IS_MAC || IS_IOS) && EXTEND_LINE_FORWARD_MAC(e)
 
 const UNDO = isKeyHotkey('mod+z')
 const REDO_MAC = isKeyHotkey('mod+shift+z')
 const REDO_PC = isKeyHotkey('mod+y')
-const REDO = e => IS_MAC ? REDO_MAC(e) : REDO_PC(e)
+const REDO = e => IS_MAC || IS_IOS ? REDO_MAC(e) : REDO_PC(e)
 
 const TRANSPOSE_CHARACTER_MAC = isKeyHotkey('ctrl+t')
-const TRANSPOSE_CHARACTER = e => IS_MAC && TRANSPOSE_CHARACTER_MAC(e)
+const TRANSPOSE_CHARACTER = e => (IS_MAC || IS_IOS) && TRANSPOSE_CHARACTER_MAC(e)
 
 const CONTENTEDITABLE = e => (
   BOLD(e) ||


### PR DESCRIPTION
UA sniffing stops at the first match when trying to determine the client's OS. Since the macOS sniff always ran before the iOS sniff and matched the string "mac os x", which is also present in iOS Safari's user agent string, `IS_MAC` was always `true` for iOS Safari and `IS_IOS` was always `false`.

The iOS sniff now runs before the macOS sniff, which prevents false positives. Existing uses of `IS_MAC` that should also apply to iOS have been updated to check for `IS_MAC || IS_IOS`.

This also re-fixes #1176 and #1177, which regressed when a recent change added `IS_IOS` checks that inadvertently prevented code from running on iOS.