### PR TITLE
Limit melding behavior in `insertFragmentAtRange`

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -732,6 +732,13 @@ Changes.insertFragmentAtRange = (change, range, fragment, options = {}) => {
     return
   }
 
+  // If the fragment contains a single nested block, (e.g., table),
+  // simply insert this block to prevent the melding behavior
+  if (firstBlock != lastBlock && fragment.nodes.size == 1) {
+    change.insertBlockAtRange(range, fragment.nodes.first(), options)
+    return
+  }
+
   // If the first and last block aren't the same, we need to insert all of the
   // nodes after the fragment's first block at the index.
   if (firstBlock != lastBlock) {

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -732,10 +732,17 @@ Changes.insertFragmentAtRange = (change, range, fragment, options = {}) => {
     return
   }
 
-  // If the fragment contains a single nested block, (e.g., table),
-  // simply insert this block to prevent the melding behavior
-  if (firstBlock != lastBlock && fragment.nodes.size == 1) {
-    change.insertBlockAtRange(range, fragment.nodes.first(), options)
+  // If the fragment starts or ends with single nested block, (e.g., table),
+  // do not merge this fragment with existing blocks.
+  if (
+    firstBlock != lastBlock &&
+    Block.isBlock(fragment.nodes.first()) &&
+    Block.isBlock(fragment.nodes.last()) &&
+    (firstBlock != fragment.nodes.first() || lastBlock != fragment.nodes.last())
+  ) {
+    fragment.nodes.reverse().forEach((node) => {
+      change.insertBlockAtRange(range, node, options)
+    })
     return
   }
 


### PR DESCRIPTION
Closes #917
Closes #1364 

According to #639, for now when inserting fragment, Slate tries to merge first block node into the block at cursor position. This is great if the fragment contains multi 'flat' blocks, while with a case that we insert one root block with multi child blocks (e.g. table), it will change the nested structure of the fragment.

This can be optimized with the detection of *single nested block*, and fallback to `insertBlockAtRange` in this case, which can be pretty straightforward.

For the table case, `firstBlock` and `lastBlock` are different table cells, so they are naturally different nodes. If the fragment has only one child but its `firstBlock` and `lastBlock` are different, we can confirm that the fragment is consist of one nested block.

As for test cases, I found that the fragment created by `slate-hyperscript` automatically injects a text node at the end of `fragment.nodes`, while with `slate-html-deserializer` the fragment generated doesn't follow this. So it's a bit confusing for me to add test cases if needed.