### PR TITLE
fix scrolling on slate inside scrollable container that is not a window

### DIFF
--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -23,7 +23,7 @@ const OVERFLOWS = [
 function findScrollContainer(el) {
   const window = getWindow(el)
   let parent = el.parentNode
-  let scroller = window
+  let scroller
 
   while (!scroller) {
     if (!parent.parentNode) break
@@ -37,6 +37,8 @@ function findScrollContainer(el) {
 
     parent = parent.parentNode
   }
+
+  if (!scroller) return window
 
   return scroller
 }


### PR DESCRIPTION
previously findScrollerContainer always return window as scroller variable is assigned to window.
this fix the intended fix from https://github.com/ianstormtaylor/slate/pull/1165 