### PR TITLE
scroll to the correct position

### DIFF
--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -80,19 +80,19 @@ function scrollToSelection(selection) {
   const top = (backward ? rect.top : rect.bottom) + yOffset
   const left = (backward ? rect.left : rect.right) + xOffset
 
-  const x = left < yOffset || innerWidth + xOffset < left
+  const x = left < yOffset || (width + xOffset) < left
     ? left - width / 2
     : xOffset
 
-  const y = top < yOffset || height + yOffset < top
+  const y = top < yOffset || (height + yOffset) < top
     ? top - height / 2
     : yOffset
 
   if (isWindow) {
     window.scrollTo(x, y)
   } else {
-    scroller.scrollTop = scroller.scrollTop + y
-    scroller.scrollLeft = scroller.scrollLeft + x
+    scroller.scrollTop = y
+    scroller.scrollLeft = x
   }
 }
 


### PR DESCRIPTION
previous scrolling fix works fine if we're typing at the end of the document. if the edited text is at the middle or beginning of the document, it's unusable.