### PR TITLE
Replace IME `setTimeout` with `requestAnimationFrame`

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -139,7 +139,7 @@ function BeforePlugin() {
     // The `count` check here ensures that if another composition starts
     // before the timeout has closed out this one, we will abort unsetting the
     // `isComposing` flag, since a composition is still in affect.
-    setTimeout(() => {
+    window.requestAnimationFrame(() => {
       if (compositionCount > n) return
       isComposing = false
 


### PR DESCRIPTION
Currently we use a plain `setTimeout` to delay `onCompositionEnd`, while this timeout may be leaky for some IMEs.

In [workaround of Draft.js](https://github.com/facebook/draft-js/blob/master/src/component/handlers/composition/DraftEditorCompositionHandler.js#L74) there's an 'magic' constant timeout, while it'll be more semantic and COMPAT-proof with the `requestAnimationFrame` approach.

Smoke tested on Chinese / Japanese / Korean / French and no regression found.