### PR TITLE
Fixed simulator handler argument order

### DIFF
--- a/packages/slate-simulator/src/index.js
+++ b/packages/slate-simulator/src/index.js
@@ -58,7 +58,7 @@ EVENT_HANDLERS.forEach((handler) => {
     const event = createEvent(e)
     const change = value.change()
 
-    stack.run(handler, change, editor, event)
+    stack.run(handler, event, change, editor)
     stack.run('onChange', change, editor)
 
     this.value = change.value


### PR DESCRIPTION
The Simulator was calling the handlers with the `change` argument as the first argument instead of the `event`. 