### PR TITLE
Fix find-point.js when void node is input (in readOnly mode)

### DIFF
--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -52,6 +52,7 @@ function findPoint(nativeNode, nativeOffset, value) {
     const voidNode = parentNode.closest(VOID_SELECTOR)
     if (!voidNode) return null
     rangeNode = voidNode.querySelector(RANGE_SELECTOR)
+    if (!rangeNode) return null
     node = rangeNode
     offset = node.textContent.length
   }


### PR DESCRIPTION
<img width="476" alt="slate-find-node-error" src="https://user-images.githubusercontent.com/11925924/32329123-a0f53252-c00e-11e7-87f4-49432a3a74b3.png">

Error occurs when render `<input />` in readOnly mode

```js
function Input(props: any) {
  return (
    <input
      onFocus={(e) => {
        e.preventDefault()
        e.stopPropagation()
        // console.log(e)
      }}
    />
  )
}
```

```js
<Editor
  placeholder="Enter a title..."
  renderNode={this.renderNode}
  readOnly
/>
```

```js
renderNode = (props: any) => {
  const { node } = props
  const Component = {
    input: Input,
  }[node.type]

  if (!Component) return undefined

  return <Component {...props} />
}
```