### PR TITLE
Fix image example's onPaste

### DIFF
--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -1,5 +1,5 @@
 
-import { Editor, getEventRange, getEventTransfer } from 'slate-react'
+import { Editor, getEventTransfer } from 'slate-react'
 import { Block, Value } from 'slate'
 
 import React from 'react'

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -1,5 +1,5 @@
 
-import { Editor, getEventTransfer } from 'slate-react'
+import { Editor, getEventRange, getEventTransfer } from 'slate-react'
 import { Block, Value } from 'slate'
 
 import React from 'react'
@@ -176,6 +176,9 @@ class Images extends React.Component {
    */
 
   onDropOrPaste = (event, change, editor) => {
+    const target = getEventRange(event, change.value)
+    if (!target && event.type == 'drop') return
+
     const transfer = getEventTransfer(event)
     const { type, text, files } = transfer
 
@@ -187,7 +190,7 @@ class Images extends React.Component {
 
         reader.addEventListener('load', () => {
           editor.change((c) => {
-            c.call(insertImage, reader.result)
+            c.call(insertImage, reader.result, target)
           })
         })
 
@@ -198,7 +201,7 @@ class Images extends React.Component {
     if (type == 'text') {
       if (!isUrl(text)) return
       if (!isImage(text)) return
-      change.call(insertImage, text)
+      change.call(insertImage, text, target)
     }
   }
 

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -110,7 +110,6 @@ class Images extends React.Component {
           value={this.state.value}
           schema={schema}
           onChange={this.onChange}
-          onDrop={this.onDrop}
           onPaste={this.onPaste}
           renderNode={this.renderNode}
         />
@@ -175,10 +174,7 @@ class Images extends React.Component {
    * @param {Editor} editor
    */
 
-  onDropOrPaste = (event, change, editor) => {
-    const target = getEventRange(event)
-    if (!target) return
-
+  onPaste = (event, change, editor) => {
     const transfer = getEventTransfer(event)
     const { type, text, files } = transfer
 
@@ -190,7 +186,7 @@ class Images extends React.Component {
 
         reader.addEventListener('load', () => {
           editor.change((c) => {
-            c.call(insertImage, reader.result, target)
+            c.call(insertImage, reader.result)
           })
         })
 
@@ -201,7 +197,7 @@ class Images extends React.Component {
     if (type == 'text') {
       if (!isUrl(text)) return
       if (!isImage(text)) return
-      change.call(insertImage, text, target)
+      change.call(insertImage, text)
     }
   }
 

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -110,7 +110,8 @@ class Images extends React.Component {
           value={this.state.value}
           schema={schema}
           onChange={this.onChange}
-          onPaste={this.onPaste}
+          onDrop={this.onDropOrPaste}
+          onPaste={this.onDropOrPaste}
           renderNode={this.renderNode}
         />
       </div>
@@ -174,7 +175,7 @@ class Images extends React.Component {
    * @param {Editor} editor
    */
 
-  onPaste = (event, change, editor) => {
+  onDropOrPaste = (event, change, editor) => {
     const transfer = getEventTransfer(event)
     const { type, text, files } = transfer
 


### PR DESCRIPTION
> This example shows images in action. It features two ways to add images. You can either add an image via the toolbar icon above, or if you want in on a little secret, copy an image URL to your keyboard and paste it anywhere in the editor!

Paste is broken on slatejs.org. on Paste event, getEventRange(event) always returns null because there is no clientX and clientY from the Clipboard event.