### PR TITLE
Disable dropping in inline void node example

### DIFF
--- a/examples/emojis/index.js
+++ b/examples/emojis/index.js
@@ -18,6 +18,14 @@ const EMOJIS = [
 ]
 
 /**
+ * No ops.
+ *
+ * @type {Function}
+ */
+
+const noop = e => e.preventDefault()
+
+/**
  * The links example.
  *
  * @type {Component}
@@ -136,7 +144,16 @@ class Emojis extends React.Component {
       case 'emoji': {
         const { data } = node
         const code = data.get('code')
-        return <span className={`emoji ${isSelected ? 'selected' : ''}`} {...props.attributes} contentEditable={false}>{code}</span>
+        return (
+          <span
+            className={`emoji ${isSelected ? 'selected' : ''}`}
+            {...props.attributes}
+            contentEditable={false}
+            onDrop={noop}
+          >
+            {code}
+          </span>
+        )
       }
     }
   }


### PR DESCRIPTION
Fixes #1192.

For the emojis example, default dropping behavior may raise unexpected issue on corner cases. Simply `preventDefault` on drop fixes this.

This tweak does not affect current word DnD behavior in this example. When dropping on emojis, still can word inserted into text in correct order.