### PR TITLE
Fix `deleteLineBackward` when first node is void inline

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -296,8 +296,26 @@ Changes.deleteLineBackwardAtRange = (change, range, options) => {
   const { startKey, startOffset } = range
   const startBlock = document.getClosestBlock(startKey)
   const offset = startBlock.getOffset(startKey)
-  const o = offset + startOffset
+  const startWithVoidInline = (
+    startBlock.nodes.size > 1 &&
+    startBlock.nodes.get(0).text == '' &&
+    startBlock.nodes.get(1).kind == 'inline'
+  )
+
+  let o = offset + startOffset
+
+  // If line starts with an void inline node, the text node inside this inline
+  // node disturbs the offset. Ignore this inline node and delete it afterwards.
+  if (startWithVoidInline) {
+    o -= 1
+  }
+
   change.deleteBackwardAtRange(range, o, options)
+
+  // Delete the remaining first inline node if needed.
+  if (startWithVoidInline) {
+    change.deleteBackward()
+  }
 }
 
 /**

--- a/packages/slate/test/changes/at-current-range/delete-line-backward/inline-middle-emoji.js
+++ b/packages/slate/test/changes/at-current-range/delete-line-backward/inline-middle-emoji.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.deleteLineBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        one <link>wo📛rd</link><cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/delete-line-backward/inline-multi-voids.js
+++ b/packages/slate/test/changes/at-current-range/delete-line-backward/inline-multi-voids.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.deleteLineBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji>😊</emoji>
+        one
+        <emoji>😊</emoji>
+        two
+        <emoji>😀</emoji>
+        three
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/delete-line-backward/inline-void-first.js
+++ b/packages/slate/test/changes/at-current-range/delete-line-backward/inline-void-first.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.deleteLineBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji>😊</emoji>one two three<cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/delete-line-backward/text-end.js
+++ b/packages/slate/test/changes/at-current-range/delete-line-backward/text-end.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.deleteLineBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        one two three<cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/delete-line-backward/word-middle.js
+++ b/packages/slate/test/changes/at-current-range/delete-line-backward/word-middle.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.deleteLineBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        one two thr<cursor />ee
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />ee
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
Fixes #1199 

`Change.deleteLineBackward` is generally called by `cmd-del`, which deletes the whole line before cursor. This method fails if first node in the line is an void inline node, e.g. `<emoji />`.

Reason for this issue is that when we calculate the offset to delete, the void inline node has an empty text child node, which disturbs the offset.

Say we'd like to delete such a line:

```
<p>
  <emoji />
  hello world
</p>
```

The actual structure is somewhat like following:

``` html
<p>
  <text key="1" />
  <emoji key="2">
    <text key="3"/>
  </emoji>
  <text key="4">hello world</text>
</p>
```

Currently when we attempt to find the beginning text node, we loop from end of the line, and eventually try finding previous text node of "hello world", which is `3` in this example. But the "actual" previous text node is `1`. This results to an error.

In this case we detect *whether first node in the line is an void inline node*, omit it in `deleteLineBackwardAtRange`, then perform a simple `deleteBackward` as a workaround. This approach does not mutate any underlying delete changes, so neither will it introduce too much complexity.

Test cases for `deleteLineBackward` was missing, this PR also complements them.