### PR TITLE
slate-hyperscript: Fix extra empty text at the end of children

### DIFF
--- a/packages/slate-hyperscript/src/index.js
+++ b/packages/slate-hyperscript/src/index.js
@@ -184,13 +184,15 @@ function createChildren(children, options = {}) {
     node = next
   }
 
-  children.forEach((child) => {
+  children.forEach((child, index) => {
+    const isLast = index === children.length - 1
+
     // If the child is a non-text node, push the current node and the new child
     // onto the array, then creating a new node for future selection tracking.
     if (Node.isNode(child) && !Text.isText(child)) {
       if (node.text.length || node.__anchor != null || node.__focus != null) array.push(node)
       array.push(child)
-      node = Text.create()
+      node = isLast ? null : Text.create()
       length = 0
     }
 
@@ -230,7 +232,9 @@ function createChildren(children, options = {}) {
   })
 
   // Make sure the most recent node is added.
-  array.push(node)
+  if (node != null) {
+    array.push(node)
+  }
 
   return array
 }

--- a/packages/slate-hyperscript/test/index.js
+++ b/packages/slate-hyperscript/test/index.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../'
+import assert from 'assert'
+import { Document, Block, Text } from 'slate'
+
+
+describe('slate-hyperscript', () => {
+  it('should create a document with a single block', () => {
+    const output = (
+        <document>
+            <block type="paragraph">
+                Single block
+            </block>
+        </document>
+    )
+    const expected = Document.create({
+      nodes: [
+        Block.create({
+          type: 'paragraph',
+          nodes: [
+            Text.createFromString('Single block')
+          ]
+        })
+      ]
+    })
+
+    assert.deepEqual(output.toJSON(), expected.toJSON())
+  })
+})

--- a/packages/slate-hyperscript/test/index.js
+++ b/packages/slate-hyperscript/test/index.js
@@ -19,7 +19,7 @@ describe('slate-hyperscript', () => {
         Block.create({
           type: 'paragraph',
           nodes: [
-            Text.createFromString('Single block')
+            Text.create('Single block')
           ]
         })
       ]


### PR DESCRIPTION
This fixes #1154 

Extra empty texts were added in blocks. They are not visible if created using `<value>...</value>` because of normalization.

But sometimes I want to just build a document, and avoid normalization on purpose.