### PR TITLE
corrects overscroll issue inside scrollable containers (#1032)

### DIFF
--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -62,8 +62,6 @@ function scrollToSelection(selection) {
   let height
   let yOffset
   let xOffset
-  let scrollerYOffset;
-  let scrollerXOffset;
 
   if (isWindow) {
     const { innerWidth, innerHeight, pageYOffset, pageXOffset } = scroller
@@ -73,19 +71,15 @@ function scrollToSelection(selection) {
     xOffset = pageXOffset
   } else {
     const { offsetWidth, offsetHeight, scrollTop, scrollLeft } = scroller
+    const scrollerRect = scroller.getBoundingClientRect()
     width = offsetWidth
     height = offsetHeight
-    yOffset = scrollTop
-    xOffset = scrollLeft
-    scrollerYOffset = scroller.getBoundingClientRect().top;
-    scrollerXOffset = scroller.getBoundingClientRect().left;
+    yOffset = scrollTop - scrollerRect.top
+    xOffset = scrollLeft - scrollerRect.left
   }
 
   const top = (backward ? rect.top : rect.bottom) + yOffset
   const left = (backward ? rect.left : rect.right) + xOffset
-
-  top -= scrollerYOffset;
-  left -= scrollerXOffset
 
   const x = left < yOffset || (width + xOffset) < left
     ? left - width / 2

--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -62,6 +62,8 @@ function scrollToSelection(selection) {
   let height
   let yOffset
   let xOffset
+  let scrollerYOffset;
+  let scrollerXOffset;
 
   if (isWindow) {
     const { innerWidth, innerHeight, pageYOffset, pageXOffset } = scroller
@@ -75,10 +77,15 @@ function scrollToSelection(selection) {
     height = offsetHeight
     yOffset = scrollTop
     xOffset = scrollLeft
+    scrollerYOffset = scroller.getBoundingClientRect().top;
+    scrollerXOffset = scroller.getBoundingClientRect().left;
   }
 
   const top = (backward ? rect.top : rect.bottom) + yOffset
   const left = (backward ? rect.left : rect.right) + xOffset
+
+  top -= scrollerYOffset;
+  left -= scrollerXOffset
 
   const x = left < yOffset || (width + xOffset) < left
     ? left - width / 2


### PR DESCRIPTION
After recent fix to scrolling within scrollable containers, the editor now scrolls the scroller container to the end on every key press. Seems to be doing this because it is not subtracting the distance between the top of the window and the scrollable container. (I have mine within an absolute position modal.)

I fixed the issue for myself by subtracting that top distance from `top` var before calculating the final `y` to scroll to within `scroll-to-selection.js`.