### PR TITLE
IE 11 compatibility, use Selection.collapse/extend instead of Selection.setBaseAndExtent

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -193,13 +193,13 @@ class Content extends React.Component {
     // Otherwise, set the `isUpdatingSelection` flag and update the selection.
     this.tmp.isUpdatingSelection = true
     native.removeAllRanges()
+    native.addRange(range)
 
     // COMPAT: Again, since the DOM range has no concept of backwards/forwards
     // we need to check and do the right thing here.
     if (isBackward) {
-      native.setBaseAndExtent(endContainer, endOffset, startContainer, startOffset)
-    } else {
-      native.setBaseAndExtent(startContainer, startOffset, endContainer, endOffset)
+      native.collapse(range.endContainer, range.endOffset);
+      native.extend(range.startContainer, range.startOffset);
     }
 
     // Scroll to the selection, in case it's out of view.
@@ -344,7 +344,7 @@ class Content extends React.Component {
     const { inputType } = event
     if (inputType !== 'insertText' && inputType !== 'insertReplacementText') return
 
-    const [ targetRange ] = event.getTargetRanges()
+    const [targetRange] = event.getTargetRanges()
     if (!targetRange) return
 
     // `data` should have the text for the `insertText` input type and

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -134,7 +134,7 @@ class Content extends React.Component {
     const { isBackward } = selection
     const window = getWindow(this.element)
     const native = window.getSelection()
-    const { rangeCount, anchorNode, focusNode } = native
+    const { rangeCount, anchorNode } = native
 
     // If both selections are blurred, do nothing.
     if (!rangeCount && selection.isBlurred) return
@@ -175,16 +175,12 @@ class Content extends React.Component {
     if (current) {
       if (
         (
-          !isBackward &&
-          focusNode == current.startContainer &&
           startContainer == current.startContainer &&
           startOffset == current.startOffset &&
           endContainer == current.endContainer &&
           endOffset == current.endOffset
         ) ||
         (
-          isBackward &&
-          focusNode == current.endContainer &&
           startContainer == current.endContainer &&
           startOffset == current.endOffset &&
           endContainer == current.startContainer &&
@@ -197,10 +193,10 @@ class Content extends React.Component {
 
     // Otherwise, set the `isUpdatingSelection` flag and update the selection.
     this.tmp.isUpdatingSelection = true
+    native.removeAllRanges()
 
     // COMPAT: IE 11 does not support Selection.extend
     if (native.extend) {
-      native.removeAllRanges()
       // COMPAT: Since the DOM range has no concept of backwards/forwards
       // we need to check and do the right thing here.
       if (isBackward) {
@@ -210,9 +206,8 @@ class Content extends React.Component {
         native.collapse(range.startContainer, range.startOffset)
         native.extend(range.endContainer, range.endOffset)
       }
-    } else if (selection.isCollapsed) {
-      // COMPAT: IE 11, to follow the cursor while typing
-      native.removeAllRanges()
+    } else {
+      // COMPAT: IE 11 does not support Selection.extend, fallback to addRange
       native.addRange(range)
     }
 

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -198,8 +198,8 @@ class Content extends React.Component {
     // COMPAT: Again, since the DOM range has no concept of backwards/forwards
     // we need to check and do the right thing here.
     if (isBackward) {
-      native.collapse(range.endContainer, range.endOffset);
-      native.extend(range.startContainer, range.startOffset);
+      native.collapse(range.endContainer, range.endOffset)
+      native.extend(range.startContainer, range.startOffset)
     }
 
     // Scroll to the selection, in case it's out of view.
@@ -344,7 +344,7 @@ class Content extends React.Component {
     const { inputType } = event
     if (inputType !== 'insertText' && inputType !== 'insertReplacementText') return
 
-    const [targetRange] = event.getTargetRanges()
+    const [ targetRange ] = event.getTargetRanges()
     if (!targetRange) return
 
     // `data` should have the text for the `insertText` input type and

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -193,7 +193,7 @@ class Content extends React.Component {
     // Otherwise, set the `isUpdatingSelection` flag and update the selection.
     this.tmp.isUpdatingSelection = true
     native.removeAllRanges()
-    
+
     // COMPAT: Again, since the DOM range has no concept of backwards/forwards
     // we need to check and do the right thing here.
     if (isBackward) {

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -193,13 +193,15 @@ class Content extends React.Component {
     // Otherwise, set the `isUpdatingSelection` flag and update the selection.
     this.tmp.isUpdatingSelection = true
     native.removeAllRanges()
-    native.addRange(range)
-
+    
     // COMPAT: Again, since the DOM range has no concept of backwards/forwards
     // we need to check and do the right thing here.
     if (isBackward) {
       native.collapse(range.endContainer, range.endOffset)
       native.extend(range.startContainer, range.startOffset)
+    } else {
+      native.collapse(range.startContainer, range.startOffset)
+      native.extend(range.endContainer, range.endOffset)
     }
 
     // Scroll to the selection, in case it's out of view.

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -211,6 +211,11 @@ class Content extends React.Component {
         native.collapse(range.startContainer, range.startOffset)
         native.extend(range.endContainer, range.endOffset)
       }
+    } else if (selection.isCollapsed) {
+      // COMPAT: IE 11, to follow the cursor while typing
+      // (the expanded selection works as expected)
+      native.removeAllRanges()
+      native.addRange(range)
     }
 
     // Scroll to the selection, in case it's out of view.

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -197,7 +197,6 @@ class Content extends React.Component {
 
     // Otherwise, set the `isUpdatingSelection` flag and update the selection.
     this.tmp.isUpdatingSelection = true
-    // native.addRange(range)
 
     // COMPAT: IE 11 does not support Selection.extend
     if (native.extend) {
@@ -213,7 +212,6 @@ class Content extends React.Component {
       }
     } else if (selection.isCollapsed) {
       // COMPAT: IE 11, to follow the cursor while typing
-      // (the expanded selection works as expected)
       native.removeAllRanges()
       native.addRange(range)
     }


### PR DESCRIPTION
fixes #1385  
by using Selection.collapse/extend, we can preserve the backward/forward selection direction, and they are supported on IE 11

EDIT: Selection.extend is not available in IE11...