### PR TITLE
When rendering a `Leaf` use `parent.isVoid` to check if it is inside a void node

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -120,12 +120,11 @@ class Leaf extends React.Component {
    */
 
   renderText() {
-    const { block, node, text, index, leaves } = this.props
+    const { block, parent, node, text, index, leaves } = this.props
 
-    // COMPAT: If the text is empty otherwise, it's because it's on the edge of
-    // an inline void node, so we render a zero-width space so that the
-    // selection can be inserted next to it still.
-    if (text == '') return <span data-slate-zero-width>{'\u200B'}</span>
+    // COMPAT: Render empty text inside void nodes with a zero-width space so
+    // that the selection can be inserted next to it still.
+    if (parent.isVoid) return <span data-slate-zero-width>{'\u200B'}</span>
 
     // COMPAT: Browsers will collapse trailing new lines at the end of blocks,
     // so we need to add an extra trailing new lines to prevent that.


### PR DESCRIPTION
At moment, empty text inside void nodes is renderer with a normal space and not, as it should be, with a zero-width space.
This happens because the [zero-width space rendering code][1] is triggered by an empty string text but actually the text content of void nodes is made by a single normal space (is it a bug?).

To fix that issue, use `parent.isVoid` instead when checking if the text to be rendered is inside a void node.

[1]: https://github.com/ianstormtaylor/slate/blob/0afe15fa7694e53bad1d9843a15486a56d0ad91e/packages/slate-react/src/components/leaf.js#L128