### PR TITLE
Render text inside void nodes with a zero-width space.

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -120,11 +120,15 @@ class Leaf extends React.Component {
    */
 
   renderText() {
-    const { block, node, text, index, leaves } = this.props
+    const { block, node, parent, text, index, leaves } = this.props
 
-    // COMPAT: If the text is empty otherwise, it's because it's on the edge of
-    // an inline void node, so we render a zero-width space so that the
-    // selection can be inserted next to it still.
+    // COMPAT: Render text inside void nodes with a zero-width space.
+    // So the node can contain selection but the text is not visible.
+    if (parent.isVoid) return <span data-slate-zero-width>{'\u200B'}</span>
+
+    // COMPAT: If the text is empty, it's because it's on the edge of an inline
+    // void node, so we render a zero-width space so that the selection can be
+    // inserted next to it still.
     if (text == '') return <span data-slate-zero-width>{'\u200B'}</span>
 
     // COMPAT: Browsers will collapse trailing new lines at the end of blocks,

--- a/packages/slate-react/test/rendering/fixtures/custom-block-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-void.js
@@ -32,7 +32,9 @@ export const output = `
   <div data-slate-void="true" contenteditable="false">
     <div contenteditable="true" data-slate-spacer="true" style="height:0;color:transparent;outline:none">
       <span>
-        <span></span>
+        <span>
+          <span data-slate-zero-width="true">&#x200B;</span>
+        </span>
       </span>
     </div>
     <div draggable="true">

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -40,7 +40,9 @@ export const output = `
     <span data-slate-void="true" contenteditable="false">
       <span contenteditable="true" data-slate-spacer="true" style="height:0;color:transparent;outline:none">
         <span>
-          <span></span>
+          <span>
+            <span data-slate-zero-width="true">&#x200B;</span>
+          </span>
         </span>
       </span>
       <span draggable="true">


### PR DESCRIPTION
Render text inside void nodes with a zero-width space.
So the node can contain selection but the text is not visible.