### PR TITLE
Fix "Could not find a node with key ${key}"

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -239,13 +239,7 @@ Changes.deleteAtRange = (change, range, options = {}) => {
         change.moveNodeByKey(endBlock.key, startParent.key, startParentIndex + 1)
       }
 
-      // If the selection is hanging, just remove the start block, otherwise
-      // merge the end block into it.
-      if (isHanging) {
-        change.removeNodeByKey(startBlock.key, { normalize: false })
-      } else {
-        change.mergeNodeByKey(endBlock.key, { normalize: false })
-      }
+      change.mergeNodeByKey(endBlock.key, { normalize: false })
 
       // If nested empty blocks are left over above the end block, remove them.
       if (lonely) {

--- a/packages/slate/test/changes/at-current-range/delete/hanging-selection-multiple-blocks.js
+++ b/packages/slate/test/changes/at-current-range/delete/hanging-selection-multiple-blocks.js
@@ -25,9 +25,9 @@ export const input = (
 export const output = (
   <value>
     <document>
-      <quote>
+      <paragraph>
         <cursor />three
-      </quote>
+      </paragraph>
     </document>
   </value>
 )

--- a/packages/slate/test/changes/at-current-range/delete/hanging-selection-single-block.js
+++ b/packages/slate/test/changes/at-current-range/delete/hanging-selection-single-block.js
@@ -22,9 +22,9 @@ export const input = (
 export const output = (
   <value>
     <document>
-      <quote>
+      <paragraph>
         <cursor />two
-      </quote>
+      </paragraph>
     </document>
   </value>
 )

--- a/packages/slate/test/changes/at-current-range/delete/whole-block-with-other-block-type-below.js
+++ b/packages/slate/test/changes/at-current-range/delete/whole-block-with-other-block-type-below.js
@@ -18,7 +18,7 @@ export const input = (
 export const output = (
   <value>
     <document>
-      <paragraph><cursor />two</paragraph>
+      <quote><cursor />two</quote>
     </document>
   </value>
 )


### PR DESCRIPTION
This PR is to fix the case like this:

![kapture 2017-11-13 at 11 34 50](https://user-images.githubusercontent.com/986480/32708787-26e455b8-c867-11e7-83f8-1ad826c50152.gif)
---

Hi, @ianstormtaylor , when I insertText, it will throw the error "Could not find a node with key ${key}". Because it have selection when insertText (should remove selection content and insert new text), but the `deleteAtRange` function remove the startBlock, so it lost the current node and throw error when `insertText`.  

I think `merge` is better then `remove`, but I'm not sure if there are any other scenarios.