### PR TITLE
fix calling onChange handler after Editor component unmount

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -158,6 +158,17 @@ class Editor extends React.Component {
   }
 
   /**
+   * When the component unmounts, clear flushTimeout if it has been set
+   * to avoid calling onChange after unmount.
+   */
+
+  componentWillUnmount = () => {
+    if (this.tmp.flushTimeout) {
+      clearTimeout(this.tmp.flushTimeout)
+    }
+  }
+
+  /**
    * Queue a `change` object, to be able to flush it later. This is required for
    * when a change needs to be applied to the value, but because of the React
    * lifecycle we can't apply that change immediately. So we cache it here and


### PR DESCRIPTION
This should fix #1395.

This is related to #1324. The `flushChange()` function in the Editor component sets a timeout for calling onChange, which means it can be called after the component has unmounted.

I added a `componentWillUnmount()` handler which simply clears the timeout if it exists.

I did some local testing by modifying one of the examples, and it seemed to work as expected. But I'm not sure how to write a test case for this, if it is needed...