### PR TITLE
inline bug fixes related to #1285

### DIFF
--- a/packages/slate-react/src/utils/find-dom-range.js
+++ b/packages/slate-react/src/utils/find-dom-range.js
@@ -20,8 +20,8 @@ function findDOMRange(range) {
   const r = window.document.createRange()
   const start = isBackward ? focus : anchor
   const end = isBackward ? anchor : focus
-  r.setStart(start.node, start.offset)
-  r.setEnd(end.node, end.offset)
+  r.setStart(start.node, start.offset >= 0 ? start.offset : 0)
+  r.setEnd(end.node, end.offset >= 0 ? end.offset : 0)
   return r
 }
 

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1047,14 +1047,14 @@ class Node {
       const previous = this.getPreviousText(startKey)
       if (!previous || previous.text.length == 0) return []
       const char = previous.characters.get(previous.text.length - 1)
-      return char.marks.toArray()
+      return char ? char.marks.toArray() : []
     }
 
     // If the range is collapsed, check the character before the start.
     if (range.isCollapsed) {
       const text = this.getDescendant(startKey)
       const char = text.characters.get(range.startOffset - 1)
-      return char.marks.toArray()
+      return char ? char.marks.toArray() : []
     }
 
     // Otherwise, get a set of the marks for each character in the range.
@@ -1084,14 +1084,14 @@ class Node {
       const previous = this.getPreviousText(startKey)
       if (!previous || !previous.length) return []
       const char = previous.characters.get(previous.length - 1)
-      return char.marks.toArray()
+      return char ? char.marks.toArray() : []
     }
 
     // If the range is collapsed, check the character before the start.
     if (range.isCollapsed) {
       const text = this.getDescendant(startKey)
       const char = text.characters.get(range.startOffset - 1)
-      return char.marks.toArray()
+      return char ? char.marks.toArray() : []
     }
 
     // Otherwise, get a set of the marks for each character in the range.


### PR DESCRIPTION
After updating to master I am still having this error happen. (#1285) But now only happens to me when I have an inline void image node inside of an inline link node, and I attempt to use arrow keys to move back and forth over the edges, then the uncaught errors fire.

I applied @chemzqm's suggested fix and it resolved that problem but then I started getting another uncaught error within `find-dom-range.js` because the offsets were coming back as `-1`. I fixed this one by just checking if the offset is greater than or equal to zero.

> Not sure if best fix for issue I am hitting but this got me up and running without crashing the browser when using inline void image nodes within inline link nodes.