### PR TITLE
Revert #1383 "corrects overscroll issue inside scrollable containers"

### DIFF
--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -71,11 +71,10 @@ function scrollToSelection(selection) {
     xOffset = pageXOffset
   } else {
     const { offsetWidth, offsetHeight, scrollTop, scrollLeft } = scroller
-    const scrollerRect = scroller.getBoundingClientRect()
     width = offsetWidth
     height = offsetHeight
-    yOffset = scrollTop - scrollerRect.top
-    xOffset = scrollLeft - scrollerRect.left
+    yOffset = scrollTop
+    xOffset = scrollLeft
   }
 
   const top = (backward ? rect.top : rect.bottom) + yOffset


### PR DESCRIPTION
Related to #1032, #1382.

This reverts commit b973580c54be4cfddd3e7b61e6c7f4222d6ee5b2 due to regression of scroll behavior outlined in #1416.

Closes #1416.