### PR TITLE
Update benchmark to use Value

### DIFF
--- a/packages/slate-html-serializer/benchmark/html-serializer/serialize.js
+++ b/packages/slate-html-serializer/benchmark/html-serializer/serialize.js
@@ -35,7 +35,7 @@ export default function (state) {
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -45,5 +45,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate-plain-serializer/benchmark/plain-serializer/serialize.js
+++ b/packages/slate-plain-serializer/benchmark/plain-serializer/serialize.js
@@ -9,7 +9,7 @@ export default function (state) {
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -21,5 +21,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate-react/benchmark/rendering/normal.js
+++ b/packages/slate-react/benchmark/rendering/normal.js
@@ -6,13 +6,13 @@ import ReactDOM from 'react-dom/server'
 import h from '../../test/helpers/h'
 import { Editor } from '../..'
 
-export default function (state) {
-  const el = React.createElement(Editor, { state })
+export default function (value) {
+  const el = React.createElement(Editor, { value })
   ReactDOM.renderToStaticMarkup(el)
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -24,5 +24,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/delete-backward.js
+++ b/packages/slate/benchmark/changes/delete-backward.js
@@ -7,13 +7,13 @@ export default function (change) {
   change.deleteBackward()
 }
 
-export function before(state) {
-  const change = state.change()
+export function before(value) {
+  const change = value.change()
   return change
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -26,5 +26,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/delete-forward.js
+++ b/packages/slate/benchmark/changes/delete-forward.js
@@ -7,13 +7,13 @@ export default function (change) {
   change.deleteForward()
 }
 
-export function before(state) {
-  const change = state.change()
+export function before(value) {
+  const change = value.change()
   return change
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -26,5 +26,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/insert-text-by-key-multiple.js
+++ b/packages/slate/benchmark/changes/insert-text-by-key-multiple.js
@@ -10,15 +10,15 @@ export default function ({ change, keys }) {
   }
 }
 
-export function before(state) {
-  const change = state.change()
-  const keys = state.document.getTexts().toArray().map(t => t.key)
+export function before(value) {
+  const change = value.change()
+  const keys = value.document.getTexts().toArray().map(t => t.key)
   __clear()
   return { change, keys }
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -31,5 +31,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/insert-text-by-key.js
+++ b/packages/slate/benchmark/changes/insert-text-by-key.js
@@ -8,15 +8,15 @@ export default function ({ change, text }) {
   change.insertTextByKey(text.key, 0, 'a')
 }
 
-export function before(state) {
-  const change = state.change()
-  const text = state.document.getLastText()
+export function before(value) {
+  const change = value.change()
+  const text = value.document.getLastText()
   __clear()
   return { change, text }
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -29,5 +29,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/insert-text.js
+++ b/packages/slate/benchmark/changes/insert-text.js
@@ -7,13 +7,13 @@ export default function (change) {
   change.insertText('a')
 }
 
-export function before(state) {
-  const change = state.change()
+export function before(value) {
+  const change = value.change()
   return change
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -26,5 +26,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/normalize.js
+++ b/packages/slate/benchmark/changes/normalize.js
@@ -3,14 +3,16 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state
-    .change()
-    .normalize()
+export default function (change) {
+  change.normalize()
+}
+
+export function before(value) {
+  return value.change()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -23,5 +25,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/changes/split-block.js
+++ b/packages/slate/benchmark/changes/split-block.js
@@ -7,13 +7,13 @@ export default function (change) {
   change.splitBlock()
 }
 
-export function before(state) {
-  const change = state.change()
+export function before(value) {
+  const change = value.change()
   return change
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
         <quote>
@@ -26,5 +26,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/from-json.js
+++ b/packages/slate/benchmark/models/from-json.js
@@ -1,11 +1,9 @@
-/** @jsx h */
 /* eslint-disable react/jsx-key */
 
-import h from '../../test/helpers/h'
-import { State } from '../..'
+import { Value } from '../..'
 
 export default function (json) {
-  State.fromJSON(json)
+  Value.fromJSON(json)
 }
 
 export const input = {

--- a/packages/slate/benchmark/models/get-blocks-at-range.js
+++ b/packages/slate/benchmark/models/get-blocks-at-range.js
@@ -3,19 +3,19 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getBlocksAtRange(state.selection)
+export default function (value) {
+  value.document.getBlocksAtRange(value.selection)
 }
 
-export function before(state) {
-  return state
+export function before(value) {
+  return value
     .change()
     .selectAll()
-    .state
+    .value
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-blocks.js
+++ b/packages/slate/benchmark/models/get-blocks.js
@@ -3,12 +3,12 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getBlocks()
+export default function (value) {
+  value.document.getBlocks()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -20,5 +20,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-characters-at-range.js
+++ b/packages/slate/benchmark/models/get-characters-at-range.js
@@ -3,19 +3,19 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getCharactersAtRange(state.selection)
+export default function (value) {
+  value.document.getCharactersAtRange(value.selection)
 }
 
-export function before(state) {
-  return state
+export function before(value) {
+  return value
     .change()
     .selectAll()
-    .state
+    .value
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-characters.js
+++ b/packages/slate/benchmark/models/get-characters.js
@@ -3,12 +3,12 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getCharacters()
+export default function (value) {
+  value.document.getCharacters()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -20,5 +20,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-inlines-at-range.js
+++ b/packages/slate/benchmark/models/get-inlines-at-range.js
@@ -3,19 +3,19 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getInlinesAtRange(state.selection)
+export default function (value) {
+  value.document.getInlinesAtRange(value.selection)
 }
 
-export function before(state) {
-  return state
+export function before(value) {
+  return value
     .change()
     .selectAll()
-    .state
+    .value
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-inlines.js
+++ b/packages/slate/benchmark/models/get-inlines.js
@@ -3,12 +3,12 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getInlines()
+export default function (value) {
+  value.document.getInlines()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -20,5 +20,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-leaves.js
+++ b/packages/slate/benchmark/models/get-leaves.js
@@ -8,14 +8,14 @@ export default function (text) {
   text.getLeaves()
 }
 
-export function before(state) {
-  const text = state.document.getFirstText()
+export function before(value) {
+  const text = value.document.getFirstText()
   __clear()
   return text
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-marks-at-range.js
+++ b/packages/slate/benchmark/models/get-marks-at-range.js
@@ -3,19 +3,19 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getMarksAtRange(state.selection)
+export default function (value) {
+  value.document.getMarksAtRange(value.selection)
 }
 
-export function before(state) {
-  return state
+export function before(value) {
+  return value
     .change()
     .selectAll()
-    .state
+    .value
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-marks.js
+++ b/packages/slate/benchmark/models/get-marks.js
@@ -3,12 +3,12 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getMarks()
+export default function (value) {
+  value.document.getMarks()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -20,5 +20,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-path.js
+++ b/packages/slate/benchmark/models/get-path.js
@@ -4,18 +4,18 @@
 import h from '../../test/helpers/h'
 import { __clear } from '../../lib/utils/memoize'
 
-export default function ({ state, text }) {
-  state.document.getPath(text.key)
+export default function ({ value, text }) {
+  value.document.getPath(text.key)
 }
 
-export function before(state) {
-  const text = state.document.getLastText()
+export function before(value) {
+  const text = value.document.getLastText()
   __clear()
-  return { state, text }
+  return { value, text }
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-texts-at-range.js
+++ b/packages/slate/benchmark/models/get-texts-at-range.js
@@ -3,19 +3,19 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getTextsAtRange(state.selection)
+export default function (value) {
+  value.document.getTextsAtRange(value.selection)
 }
 
-export function before(state) {
-  return state
+export function before(value) {
+  return value
     .change()
     .selectAll()
-    .state
+    .value
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/get-texts.js
+++ b/packages/slate/benchmark/models/get-texts.js
@@ -3,12 +3,12 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.document.getTexts()
+export default function (value) {
+  value.document.getTexts()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -20,5 +20,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/has-node-multiple.js
+++ b/packages/slate/benchmark/models/has-node-multiple.js
@@ -4,20 +4,20 @@
 import h from '../../test/helpers/h'
 import { __clear } from '../../lib/utils/memoize'
 
-export default function ({ state, keys }) {
+export default function ({ value, keys }) {
   keys.forEach((key) => {
-    state.document.hasNode(key)
+    value.document.hasNode(key)
   })
 }
 
-export function before(state) {
-  const keys = state.document.getTexts().toArray().map(t => t.key)
+export function before(value) {
+  const keys = value.document.getTexts().toArray().map(t => t.key)
   __clear()
-  return { state, keys }
+  return { value, keys }
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -29,5 +29,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/has-node.js
+++ b/packages/slate/benchmark/models/has-node.js
@@ -4,18 +4,18 @@
 import h from '../../test/helpers/h'
 import { __clear } from '../../lib/utils/memoize'
 
-export default function ({ state, text }) {
-  state.document.hasNode(text.key)
+export default function ({ value, text }) {
+  value.document.hasNode(text.key)
 }
 
-export function before(state) {
-  const text = state.document.getLastText()
+export function before(value) {
+  const text = value.document.getLastText()
   __clear()
-  return { state, text }
+  return { value, text }
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -27,5 +27,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/to-json.js
+++ b/packages/slate/benchmark/models/to-json.js
@@ -3,12 +3,12 @@
 
 import h from '../../test/helpers/h'
 
-export default function (state) {
-  state.toJSON()
+export default function (value) {
+  value.toJSON()
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -20,5 +20,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )

--- a/packages/slate/benchmark/models/update-node.js
+++ b/packages/slate/benchmark/models/update-node.js
@@ -4,21 +4,21 @@
 import h from '../../test/helpers/h'
 import { __clear } from '../../lib/utils/memoize'
 
-export default function ({ state, next }) {
-  state.document.updateNode(next)
+export default function ({ value, next }) {
+  value.document.updateNode(next)
 }
 
-export function before(state) {
-  const texts = state.document.getTexts()
+export function before(value) {
+  const texts = value.document.getTexts()
   const { size } = texts
   const text = texts.get(Math.round(size / 2))
   const next = text.insertText(0, 'some text')
   __clear()
-  return { state, next }
+  return { value, next }
 }
 
 export const input = (
-  <state>
+  <value>
     <document>
       {Array.from(Array(10)).map(() => (
         <quote>
@@ -30,5 +30,5 @@ export const input = (
         </quote>
       ))}
     </document>
-  </state>
+  </value>
 )


### PR DESCRIPTION
This just fixes the benchmark to be run in the latest version.

```
  benchmarks
    html-serializer
      deserialize
        8.68 → 7.20 ops/sec
      serialize
        852.30 → 775.35 ops/sec
    plain-serializer
      deserialize
        254.89 → 247.64 ops/sec
      serialize
        7248.68 → 7343.98 ops/sec
    rendering
      normal
        78.13 → 78.87 ops/sec
    changes
      delete-backward
        72691.07 → 75240.82 ops/sec
      delete-forward
        13114.26 → 15398.91 ops/sec
      insert-text-by-key-multiple
        75.88 → 85.22 ops/sec
      insert-text-by-key
        1053.04 → 962.39 ops/sec
      insert-text
        952.91 → 1014.81 ops/sec
      normalize
        3037.60 → 3518.49 ops/sec
      split-block
        59.17 → 61.41 ops/sec
    models
      from-json
        118.76 → 126.34 ops/sec
      get-blocks-at-range
        549113.52 → 564613.16 ops/sec
      get-blocks
        2852520.48 → 2724271.59 ops/sec
      get-characters-at-range
        601222.96 → 589214.31 ops/sec
      get-characters
        2837836.98 → 2705111.14 ops/sec
      get-inlines-at-range
        604865.22 → 590231.48 ops/sec
      get-inlines
        2879718.43 → 2774580.39 ops/sec
      get-leaves
        1412061.43 → 1376369.53 ops/sec
      get-marks-at-range
        593833.83 → 593306.95 ops/sec
      get-marks
        2844220.51 → 2682124.81 ops/sec
      get-path
        657133.39 → 623939.48 ops/sec
      get-texts-at-range
        620414.28 → 611390.92 ops/sec
      get-texts
        2859405.29 → 2751465.12 ops/sec
      has-node-multiple
        76126.65 → 75901.32 ops/sec
      has-node
        679765.27 → 670295.53 ops/sec
      to-json
        2183.38 → 2405.11 ops/sec
      update-node
        15044.86 → 13560.42 ops/sec

✨  Done in 60.21s.
```