### PR TITLE
Managing History limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lint": "eslint packages/*/src packages/*/test examples/*/*.js examples/dev/*/*.js",
     "open": "open http://localhost:8080/dev.html",
     "release": "yarn run test && yarn run lint && lerna publish && yarn run gh-pages",
-    "start": "http-server ./examples",
+    "start": "http-server -p 8082 ./examples",
     "test": "mocha --compilers js:babel-core/register ./packages/*/test/index.js",
     "watch": "npm-run-all --parallel --print-label watch:examples watch:packages start",
     "watch:examples": "watchify --debug --transform babelify ./examples/index.js -o ./examples/build.dev.js -v",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lint": "eslint packages/*/src packages/*/test examples/*/*.js examples/dev/*/*.js",
     "open": "open http://localhost:8080/dev.html",
     "release": "yarn run test && yarn run lint && lerna publish && yarn run gh-pages",
-    "start": "http-server -p 8082 ./examples",
+    "start": "http-server ./examples",
     "test": "mocha --compilers js:babel-core/register ./packages/*/test/index.js",
     "watch": "npm-run-all --parallel --print-label watch:examples watch:packages start",
     "watch:examples": "watchify --debug --transform babelify ./examples/index.js -o ./examples/build.dev.js -v",

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -143,7 +143,7 @@ class History extends Record(DEFAULTS) {
     }
 
     // Constrain the history to 100 entries for memory's sake.
-    if (undos.length > 100) {
+    if (undos.size > 100) {
       undos = undos.take(100)
     }
 


### PR DESCRIPTION
Undos are measured in `.size` rather than `.length`; previously Slate would allow for unlimited undos _(see screenshot below)_. This patch fixes that.

I am looking for help to implement an API that would allow the user to control the max history step size. It's very easy for me to replace `100` with a variable, but I don't understand how the `options:{}` work - where the values come from and whether the user has any control over it.

Should it be like `value.history.undos.set({max: 20})`?
Your insights are appreciated :)

***
<img width="400" alt="Unlimited history stack bug" src="https://user-images.githubusercontent.com/8587882/32989363-51c98c3c-cd47-11e7-840f-fb01ba2ca0c8.png">