### PR TITLE
Improve getFurthestAncestor

### DIFF
--- a/packages/slate/benchmark/models/get-furthest-ancestor.js
+++ b/packages/slate/benchmark/models/get-furthest-ancestor.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+/* eslint-disable react/jsx-key */
+
+import h from '../../test/helpers/h'
+import { __clear } from '../../lib/utils/memoize'
+
+export default function ({ value, text }) {
+  value.document.getFurthestAncestor(text.key)
+}
+
+export function before(value) {
+  const text = value.document.getLastText()
+  __clear()
+  return { value, text }
+}
+
+export const input = (
+  <value>
+    <document>
+      {Array.from(Array(10)).map(() => (
+        <quote>
+          <paragraph>
+            <paragraph>
+              This is editable <b>rich</b> text, <i>much</i> better than a textarea!
+            </paragraph>
+          </paragraph>
+        </quote>
+      ))}
+    </document>
+  </value>
+)

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -788,12 +788,7 @@ class Node {
    */
 
   getFurthestAncestor(key) {
-    key = assertKey(key)
-    return this.nodes.find((node) => {
-      if (node.key == key) return true
-      if (node.kind == 'text') return false
-      return node.hasDescendant(key)
-    })
+    return this.getFurthest(key, node => true)
   }
 
   /**


### PR DESCRIPTION
Fix #1136 
I added a benchmark. The performances should be the same, or better once we take memoization in account.

I wanted to use `getAncestors` to implement `getFurthestAncestor`. But `getFurthestAncestor` is misleading in its implementation, because it returns the descendant itself if it has no ancestors, unlike the other `getFurthest*` methods. This is because it was called `getHighestChild` before.

So we can't use `getAncestors` directly because, right now:

```jsx
- a
  - b

a.getAncestors('b')  -> List []
a.getFurthestAncestor('b') -> b
```


We can't change all ancestor methods to include the node itself. This would break a lot of things and the naming would be misleading.

So I think we should fix `getFurthestAncestor` to be consistent...

# Fix `getFurthestAncestor`

We fix `getFurthestAncestor` to not include the descendant itself:

```jsx
- a
  - b
    - c

a.getFurthestAncestor('b') -> null
a.getFurthestAncestor('c') -> b
```

In this case we should also implement `getDescendants` which is the same as `getAncestors` but returns the descendant node itself, so that we can reimplement the old `getHighestChild` as `getHighestDescendant`. 

```jsx
- a
  - b
    - c

a.getAncestors('c') -> List [a, b]
a.getDescendants('c') -> List [b, c]
```

All ancestors methods would then rely on `getDescendants` implementation. Only `getDescendants` would be memoized, not `getAncestors`. Because `getAncestors` is simply written as:

```jsx
getAncestors(key) {
  const descendants = this.getDescendants(key)
  return descendants
    ? null
    : descendants.butLast().unshift(this)
}
```
