### PR TITLE
Fix inserting text with hanging selection, issue #1189

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -867,12 +867,18 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
   const { value } = change
   const { document } = value
   const { startKey, startOffset } = range
+  let key = startKey
+  let offset = startOffset
   const parent = document.getParent(startKey)
 
   if (parent.isVoid) return
 
   if (range.isExpanded) {
     change.deleteAtRange(range, { normalize: false })
+
+    // Update range start after delete
+    key = change.value.startKey
+    offset = change.value.startOffset
   }
 
   // PERF: Unless specified, don't normalize if only inserting text.
@@ -880,7 +886,7 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
     normalize = range.isExpanded
   }
 
-  change.insertTextByKey(startKey, startOffset, text, marks, { normalize })
+  change.insertTextByKey(key, offset, text, marks, { normalize })
 }
 
 /**

--- a/packages/slate/test/changes/at-current-range/insert-text/hanging-selection-multiple-blocks.js
+++ b/packages/slate/test/changes/at-current-range/insert-text/hanging-selection-multiple-blocks.js
@@ -3,14 +3,21 @@
 import h from '../../../helpers/h'
 
 export default function (change) {
-  change.delete()
+  change.insertText('a')
 }
 
 export const input = (
   <value>
     <document>
-      <quote><anchor />one</quote>
-      <paragraph><focus />two</paragraph>
+      <paragraph>
+        <anchor />one
+      </paragraph>
+      <paragraph>
+        two
+      </paragraph>
+      <quote>
+        <focus />three
+      </quote>
     </document>
   </value>
 )
@@ -18,7 +25,9 @@ export const input = (
 export const output = (
   <value>
     <document>
-      <paragraph><cursor />two</paragraph>
+      <quote>
+        a<cursor />three
+      </quote>
     </document>
   </value>
 )

--- a/packages/slate/test/changes/at-current-range/insert-text/hanging-selection-single-block.js
+++ b/packages/slate/test/changes/at-current-range/insert-text/hanging-selection-single-block.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.insertText('a')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />one
+      </paragraph>
+      <quote>
+        <focus />two
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        a<cursor />two
+      </quote>
+    </document>
+  </value>
+)


### PR DESCRIPTION
Added 2 new tests to exploit the bug from #1189 :
changes/at-current-range/insert-text/hanging-selection-multiple-blocks.js
changes/at-current-range/insert-text/hanging-selection-single-block.js

removed test:
changes/at-current-range/delete/whole-block-with-other-block-type-below.js
which was just a duplicate of:
changes/at-current-range/delete/hanging-selection-single-block.js

implemented a fix for the 2 new failing test cases by updating `startKey` and `startOffset` after `deleteAtRange()` call.