### PR TITLE
Fix activeMarks at the beginning of a line

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1082,8 +1082,8 @@ class Node {
     // If the range is collapsed at the start of the node, check the previous.
     if (range.isCollapsed && startOffset == 0) {
       const previous = this.getPreviousText(startKey)
-      if (!previous || !previous.length) return []
-      const char = previous.characters.get(previous.length - 1)
+      if (!previous || previous.text.length == 0) return []
+      const char = previous.characters.get(previous.text.length - 1)
       return char.marks.toArray()
     }
 


### PR DESCRIPTION
If you move to the beginning of a text node, and the previous text
node has marks, `marks` is set but `activeMarks` is not. This was
caused by `getActiveMarksAtRangeAsArray` looking for a function that
didn't exist. With this change, `activeMarks` is brought in line with
how `marks` works for collapsed selections.