### PR TITLE
Document the `position` field of `merge_node`

### DIFF
--- a/docs/reference/slate/operation.md
+++ b/docs/reference/slate/operation.md
@@ -104,10 +104,11 @@ Insert a new `node` at `path`.
 {
   type: 'merge_node',
   path: Array,
+  position: Number
 }
 ```
 
-Merge the node at `path` with it's previously sibling.
+Merge the node at `path` with its previous sibling. The `position` refers to either the index in the child nodes of the previous sibling in the case of [`Block`](./block.md) or [`Inline`](./inline.md) nodes, and the index in the characters of the previous sibling in the case of [`Text`](./text.md) nodes.
 
 ### `move_node`
 


### PR DESCRIPTION
`merge_node` has a `position` field, which is exactly what I needed in order to transform some operations. It should be documented.