### PR TITLE
handle native `selectionchange` event, closes #1135

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -12,6 +12,7 @@
     "is-in-browser": "^1.1.3",
     "is-window": "^1.0.2",
     "keycode": "^2.1.2",
+    "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8",
     "react-immutable-proptypes": "^2.1.0",
     "react-portal": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4154,6 +4154,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
This adds support for the native `selectionchange` event, which prevents people from having their selection blocks by concurrent changes being applied to the editor.