### PR TITLE
Fix nodes validation with e.g. an optional first child

### DIFF
--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -355,6 +355,10 @@ class Schema extends Record(DEFAULTS) {
         if (max != null && offset == max) nextDef()
         return !!child
       }
+      function rewind() {
+        offset -= 1
+        index -= 1
+      }
 
       if (rule.nodes != null) {
         nextDef()
@@ -379,12 +383,18 @@ class Schema extends Record(DEFAULTS) {
           }
 
           if (def.kinds != null && !def.kinds.includes(child.kind)) {
-            if (offset >= min && nextDef()) continue
+            if (offset >= min && nextDef()) {
+              rewind()
+              continue
+            }
             return this.fail(CHILD_KIND_INVALID, { ...ctx, child, index })
           }
 
           if (def.types != null && !def.types.includes(child.type)) {
-            if (offset >= min && nextDef()) continue
+            if (offset >= min && nextDef()) {
+              rewind()
+              continue
+            }
             return this.fail(CHILD_TYPE_INVALID, { ...ctx, child, index })
           }
         }

--- a/packages/slate/test/schema/custom/child-kind-invalid-custom-optional-first.js
+++ b/packages/slate/test/schema/custom/child-kind-invalid-custom-optional-first.js
@@ -1,0 +1,42 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      nodes: [
+        { kinds: ['block'], types: ['image'], min: 0, max: 1 },
+        { kinds: ['block'], types: ['paragraph'], min: 1 }
+      ],
+      normalize: (change, reason, { node, child }) => {
+        if (reason == 'child_kind_invalid') {
+          change.wrapBlockByKey(child.key, 'paragraph')
+        }
+      }
+    }
+  }
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        text
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          text
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)


### PR DESCRIPTION
When moving to the next definition with `continue` `nextChild` gets called twice and skips over a child before it's proven valid.

This rewinds the index and offset before `continue`. Ensuring the current child gets validated with the next definition instead of being skipped.