### PR TITLE
Remove `value` from `operation.fromJSON`

### DIFF
--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -125,6 +125,10 @@ class Operation extends Record(DEFAULTS) {
         v = Range.create(v)
       }
 
+      if (key == 'value') {
+        v = Value.create(v)
+      }
+
       if (key == 'properties' && type == 'set_mark') {
         v = Mark.createProperties(v)
       }

--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -103,6 +103,7 @@ class Operation extends Record(DEFAULTS) {
         // for providing the local-only invert behavior for the history stack.
         if (key == 'document') continue
         if (key == 'selection') continue
+        if (key == 'value') continue
         if (key == 'node' && type != 'insert_node') continue
 
         throw new Error(`\`Operation.fromJSON\` was passed a "${type}" operation without the required "${key}" attribute.`)
@@ -122,10 +123,6 @@ class Operation extends Record(DEFAULTS) {
 
       if (key == 'selection') {
         v = Range.create(v)
-      }
-
-      if (key == 'value') {
-        v = Value.create(v)
       }
 
       if (key == 'properties' && type == 'set_mark') {


### PR DESCRIPTION
Value is only used for local undo / redo, so it shouldn't be serialized along with the rest of the data. This fixes #1439.