### PR TITLE
fix(at-range): if cant assertDescendant, assume empty block

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -984,7 +984,20 @@ Changes.splitBlockAtRange = (change, range, height = 1, options = {}) => {
   const { startKey, startOffset } = range
   const { value } = change
   const { document } = value
-  let node = document.assertDescendant(startKey)
+
+  let node = null
+
+  try {
+    node = document.assertDescendant(startKey)
+  } catch (err) {
+    // if we can't assertDescendant, we assume it's an empty block.
+    change.insertBlock({
+      kind: 'block',
+      type: 'PARAGRAPH',
+    })
+    return
+  }
+
   let parent = document.getClosestBlock(node.key)
   let h = 0
 


### PR DESCRIPTION
Should fix #1452 