### PR TITLE
Add a missing test case for wrapping an inline inside an inline

### DIFF
--- a/packages/slate/test/changes/at-current-range/wrap-inline/inside-inline.js
+++ b/packages/slate/test/changes/at-current-range/wrap-inline/inside-inline.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.wrapInline('hashtag')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>w<anchor />or<focus />d</link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <link>w<hashtag><anchor />or<focus /></hashtag>d</link>
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
Just stumbled into this unexpected behavior with `wrapInline()` method inside a single inline parent.
The current behavior splits the parent inline into 3 inlines and wraps the middle into the one supplied to the method. Is that really the expected result?

@ianstormtaylor please let me know if this is indeed intentional, otherwise I can put some effort into changing the behavior to pass this test.