### PR TITLE
Move contentEditable attr to content element

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -69,7 +69,6 @@ class Void extends React.Component {
 
     const spacer = (
       <Tag
-        contentEditable
         data-slate-spacer
         suppressContentEditableWarning
         style={style}
@@ -79,7 +78,7 @@ class Void extends React.Component {
     )
 
     const content = (
-      <Tag draggable={readOnly ? null : true}>
+      <Tag draggable={readOnly ? null : true} contentEditable={readOnly ? null : false}>
         {children}
       </Tag>
     )
@@ -90,7 +89,6 @@ class Void extends React.Component {
       <Tag
         data-slate-void
         data-key={node.key}
-        contentEditable={readOnly ? null : false}
       >
         {readOnly ? null : spacer}
         {content}


### PR DESCRIPTION
# Software versions
OS: macOS Sierra v10.12.3
Browser: Google Chrome 62.0.3202.94
slate: 0.31.5
slate-react: 0.10.20

# Problem
The newest slate version renders void nodes differently than older versions (in particular where the contenteditable attribute is applied has been changed). This causes the browser to fire blur and focus events, each time you move the caret from a void node to text or the other way around. This did not happen before. We believe the new behaviour is wrong. The user is not really leaving the editor, he is only moving the caret trough the editor (why should a blur event been fired?).

A short example how void nodes were rendered before and how they are rendered now.

Before:
```
<div data-slate-void="true" ...>
    <span ...>
        <!-- Zero width space -->
    </span>

    <div contenteditable="false">
        <!-- My custom void node contents --->
    </div>
</div>
```

Now:
```
<div data-slate-void="true" contenteditable="false" ...>
    <div data-slate-spacer="true" contenteditable="true" ...>
        <!-- Zero width space -->
    </div>

    <div draggable="true">
        <!-- My custom void node contents --->
    </div>
</div>
```

Since in the new version a `contenteditable="true"` is inside a `contenteditable="false"`, the browser kind of thinks the zero width space is a "new" editor and fires a blur event for the outer editor (the actual slate editor) and a focus event for the inner editor (zero width space) when moving the caret by using the keyboards arrow keys.

# Actual behaviour
When moving the caret through the editor and passing by void nodes, blur and focus events are fired.

# Desired behaviour
Blur and focus events should not be fired when moving the caret through the editor since we are not really leaving nor entering the editor. The focus stays within the editor during the whole process.

We have created a small test project to easily see the different behaviours. Just switch slate-react between the above mentioned version and this PR by using `npm link`:
https://github.com/DND-IT/slate-void-node-blur-showcase