### PR TITLE
Add Test Reporting to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
   # Export the C++11 compiler.
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
-
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+  
 cache:
   # Cache yarn packages.
   yarn: true
@@ -25,4 +28,13 @@ script:
   # Build all of the packages so they are resolvable by each other.
   - yarn run build
   # Run testing or linting depending on the environment.
-  - yarn run $TEST_TYPE
+  - if [[ "${TEST_TYPE}" = "test" ]]; then
+       yarn run test --reporter xunit --reporter-options output=testresults.xml;
+    else
+       yarn run $TEST_TYPE;
+    fi
+
+after_script:
+  - if [[ "${TEST_TYPE}" = "test" ]]; then
+      testspace testresults.xml{packages};
+    fi


### PR DESCRIPTION
**Test Reporting for Travis using [Testspace.com](https://testspace.com)**

- view all your test results from a single dashboard
- triage and manage your test failures faster
- add more metrics
- leverage built-in analytics 
- get a [test badge](https://help.testspace.com/how-to:get-badge) 
[![Space Health](https://open.testspace.com/spaces/74893/badge?token=262bac38aa4bdb2dde44ed0d09948f8a331f2283)](https://open.testspace.com/spaces/74893?utm_campaign=badge&utm_medium=referral&utm_source=test "Test Cases")
 
Checkout **your** test results: https://open.testspace.com/projects/TryTestspace:slate from our fork.

**Why** we are doing this: https://blog.testspace.com/testspace-and-open-source 

----

**Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on subdomain selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users