### PR TITLE
Fix selection replacement and marks

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -488,7 +488,7 @@ function AfterPlugin() {
       if (startBlock.isVoid) return
 
       const defaultBlock = startBlock
-      const defaultMarks = document.getMarksAtRange(selection.collapseToStart())
+      const defaultMarks = document.getInsertMarksAtRange(selection)
       const frag = Plain.deserialize(text, { defaultBlock, defaultMarks }).document
       change.insertFragment(frag)
     }

--- a/packages/slate/src/changes/at-current-range.js
+++ b/packages/slate/src/changes/at-current-range.js
@@ -189,7 +189,7 @@ Changes.insertInline = (change, inline) => {
 Changes.insertText = (change, text, marks) => {
   const { value } = change
   const { document, selection } = value
-  marks = marks || value.marks
+  marks = marks || selection.marks || document.getInsertMarksAtRange(selection)
   change.insertTextAtRange(selection, text, marks)
 
   // If the text was successfully inserted, and the selection had marks on it,

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -881,8 +881,10 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
     change.deleteAtRange(range, { normalize: false })
 
     // Update range start after delete
-    key = change.value.startKey
-    offset = change.value.startOffset
+    if (change.value.startKey !== key) {
+      key = change.value.startKey
+      offset = change.value.startOffset
+    }
   }
 
   // PERF: Unless specified, don't normalize if only inserting text.

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1009,6 +1009,18 @@ class Node {
    * Get a set of the marks in a `range`.
    *
    * @param {Range} range
+   * @return {Set<Mark>}
+   */
+
+  getInsertMarksAtRange(range) {
+    const array = this.getInsertMarksAtRangeAsArray(range)
+    return new Set(array)
+  }
+
+  /**
+   * Get a set of the marks in a `range`.
+   *
+   * @param {Range} range
    * @return {OrderedSet<Mark>}
    */
 
@@ -1039,26 +1051,55 @@ class Node {
   getMarksAtRangeAsArray(range) {
     range = range.normalize(this)
     if (range.isUnset) return []
+    if (range.isCollapsed) return this.getMarksAtCollaspsedRangeAsArray(range)
+
+    return this
+      .getCharactersAtRange(range)
+      .reduce((memo, char) => {
+        char.marks.toArray().forEach(c => memo.push(c))
+        return memo
+      }, [])
+  }
+
+  /**
+   * Get a set of the marks in a `range` for insertion behavior.
+   *
+   * @param {Range} range
+   * @return {Array}
+   */
+
+  getInsertMarksAtRangeAsArray(range) {
+    range = range.normalize(this)
+    if (range.isUnset) return []
+    if (range.isCollapsed) return this.getMarksAtCollaspsedRangeAsArray(range)
+
+    const text = this.getDescendant(range.startKey)
+    const char = text.characters.get(range.startOffset)
+    return char.marks.toArray()
+  }
+
+  /**
+   * Get a set of marks in a `range`, by treating it as collapsed.
+   *
+   * @param {Range} range
+   * @return {Array}
+   */
+
+  getMarksAtCollaspsedRangeAsArray(range) {
+    if (range.isUnset) return []
 
     const { startKey, startOffset } = range
 
-    // If the range is collapsed at the start of the node, check the previous.
-    if (range.isCollapsed && startOffset == 0) {
+    if (startOffset == 0) {
       const previous = this.getPreviousText(startKey)
       if (!previous || previous.text.length == 0) return []
       const char = previous.characters.get(previous.text.length - 1)
       return char.marks.toArray()
     }
 
-    // If the range is collapsed, check the character before the start.
-    if (range.isCollapsed) {
-      const text = this.getDescendant(startKey)
-      const char = text.characters.get(startOffset - 1)
-      return char.marks.toArray()
-    }
-
-    // Otherwise, return the marks of the first character in the range.
-    return this.getCharactersAtRange(range).first().marks.toArray()
+    const text = this.getDescendant(startKey)
+    const char = text.characters.get(startOffset - 1)
+    return char.marks.toArray()
   }
 
   /**
@@ -1071,23 +1112,7 @@ class Node {
   getActiveMarksAtRangeAsArray(range) {
     range = range.normalize(this)
     if (range.isUnset) return []
-
-    const { startKey, startOffset } = range
-
-    // If the range is collapsed at the start of the node, check the previous.
-    if (range.isCollapsed && startOffset == 0) {
-      const previous = this.getPreviousText(startKey)
-      if (!previous || previous.text.length == 0) return []
-      const char = previous.characters.get(previous.text.length - 1)
-      return char.marks.toArray()
-    }
-
-    // If the range is collapsed, check the character before the start.
-    if (range.isCollapsed) {
-      const text = this.getDescendant(startKey)
-      const char = text.characters.get(range.startOffset - 1)
-      return char.marks.toArray()
-    }
+    if (range.isCollapsed) return this.getMarksAtCollaspsedRangeAsArray(range)
 
     // Otherwise, get a set of the marks for each character in the range.
     const chars = this.getCharactersAtRange(range)
@@ -1963,8 +1988,10 @@ memoize(Node.prototype, [
   'getInlinesByType',
   'getInlinesByTypeAsArray',
   'getMarksAtRange',
+  'getInsertMarksAtRange',
   'getOrderedMarksAtRange',
   'getMarksAtRangeAsArray',
+  'getInsertMarksAtRangeAsArray',
   'getMarksByType',
   'getOrderedMarksByType',
   'getMarksByTypeAsArray',

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1053,17 +1053,12 @@ class Node {
     // If the range is collapsed, check the character before the start.
     if (range.isCollapsed) {
       const text = this.getDescendant(startKey)
-      const char = text.characters.get(range.startOffset - 1)
+      const char = text.characters.get(startOffset - 1)
       return char.marks.toArray()
     }
 
-    // Otherwise, get a set of the marks for each character in the range.
-    return this
-      .getCharactersAtRange(range)
-      .reduce((memo, char) => {
-        char.marks.toArray().forEach(c => memo.push(c))
-        return memo
-      }, [])
+    // Otherwise, return the marks of the first character in the range.
+    return this.getCharactersAtRange(range).first().marks.toArray()
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/ianstormtaylor/slate/issues/1470. Also encountered and fixed an issue with marks being incorrectly applied (basically anything that was in the target text becomes an active mark). Behaviour is based on native document editing behaviour of marks (e.g. Word, Pages).

## Before

![](https://cl.ly/230B2p242x2k/Screen%20Recording%202017-12-14%20at%2012.30%20am.gif)
![](https://cl.ly/1e1m3V3G2E1o/Screen%20Recording%202017-12-14%20at%2012.31%20am.gif)
![](https://cl.ly/210d2k2C0p1T/Screen%20Recording%202017-12-14%20at%2001.01%20am.gif)

## After

![](https://cl.ly/1B021i2U3r2T/download/Screen%20Recording%202017-12-14%20at%2012.30%20am.gif)
![](https://cl.ly/3G2a2e2w0o3C/Screen%20Recording%202017-12-14%20at%2001.00%20am.gif)
![](https://cl.ly/3d1s1z3A3C0r/Screen%20Recording%202017-12-14%20at%2001.01%20am.gif)