### PR TITLE
Properly invert `merge_node` operations

### DIFF
--- a/packages/slate/src/operations/invert.js
+++ b/packages/slate/src/operations/invert.js
@@ -48,7 +48,34 @@ function invertOperation(op) {
 
   if (type == 'move_node') {
     const { newPath, path } = op
-    const inverse = op.set('path', newPath).set('newPath', path)
+    let inversePath = newPath
+    let inverseNewPath = path
+
+    const pathLast = path.length - 1
+    const newPathLast = newPath.length - 1
+
+    // If the node's old position was a left sibling of an ancestor of
+    // its new position, we need to adjust part of the path by -1.
+    if (path.length < inversePath.length &&
+        path.slice(0, pathLast).every((e, i) => e == inversePath[i]) &&
+        path[pathLast] < inversePath[pathLast]) {
+      inversePath = inversePath.slice(0, pathLast)
+        .concat([inversePath[pathLast] - 1])
+        .concat(inversePath.slice(pathLast + 1, inversePath.length))
+    }
+
+    // If the node's new position is an ancestor of the old position,
+    // or a left sibling of an ancestor of its old position, we need
+    // to adjust part of the path by 1.
+    if (newPath.length < inverseNewPath.length &&
+        newPath.slice(0, newPathLast).every((e, i) => e == inverseNewPath[i]) &&
+        newPath[newPathLast] <= inverseNewPath[newPathLast]) {
+      inverseNewPath = inverseNewPath.slice(0, newPathLast)
+        .concat([inverseNewPath[newPathLast] + 1])
+        .concat(inverseNewPath.slice(newPathLast + 1, inverseNewPath.length))
+    }
+
+    const inverse = op.set('path', inversePath).set('newPath', inverseNewPath)
     return inverse
   }
 

--- a/packages/slate/test/history/undo/move-node-affecting-path.js
+++ b/packages/slate/test/history/undo/move-node-affecting-path.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function (value) {
+  return value
+    .change()
+    .moveNodeByKey('c', 'd', 1)
+    .value
+    .change()
+    .undo()
+    .value
+}
+
+export const input = (
+  <value>
+    <document key="a">
+      <paragraph key="b">
+        one
+      </paragraph>
+      <paragraph key="c">
+        two
+      </paragraph>
+      <paragraph key="d">
+        <paragraph key="e">
+        three
+        </paragraph>
+      </paragraph>
+      <paragraph key="f">
+        four
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = input

--- a/packages/slate/test/history/undo/move-node-before-itself.js
+++ b/packages/slate/test/history/undo/move-node-before-itself.js
@@ -1,0 +1,47 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function (value) {
+  return value
+    .change()
+    .moveNodeByKey('h', 'a', 0)
+    .value
+    .change()
+    .undo()
+    .value
+}
+
+export const input = (
+  <value>
+    <document key="a">
+      <paragraph key="b">
+        one
+      </paragraph>
+      <paragraph key="c">
+        <paragraph key="d">
+          two
+        </paragraph>
+        <paragraph key="e">
+          <paragraph key="f">
+          three
+          </paragraph>
+          <paragraph key="g">
+          four
+          </paragraph>
+          <paragraph key="h">
+          five
+          </paragraph>
+        </paragraph>
+      </paragraph>
+      <paragraph key="i">
+        six
+      </paragraph>
+      <paragraph key="j">
+        seven
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = input


### PR DESCRIPTION
When inverting a merge operation, we need to take into account the structure change caused by the merge operation. I can come up with two places where this happens:

* If you're moving from a left sibling of an ancestor of the new position, we need to adjust part of the new position by -1.
* If you're moving to an ancestor of the original position, or a left sibling of an ancestor of the original position, we need to adjust part of the path by 1.

I added tests for each of these, and have some other examples that could make good low-level test cases. Is there a good place to put those? I didn't see any tests on operations.

This fixes #1469. 