### PR TITLE
Using the wrong property to access length of `change.operations`

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -178,7 +178,7 @@ class Editor extends React.Component {
    */
 
   queueChange = (change) => {
-    if (change.operations.length) {
+    if (change.operations.size) {
       debug('queueChange', { change })
       this.tmp.change = change
     }


### PR DESCRIPTION
As operations is now a `Immutable.List`, `length` will always be `undefined`, thus changes through `<Editor />` never get flushed.

I am quite reluctant to fix this bug but ensuring the correctness of the code first should be the highest priority.

I'll file a separate issue, but the problem I have with fixing this is that it will reintroduce an extra `onChange` event scheduled with `setTimeout()` when `<Editor />` first get created and mounted. (It is trying to queue/flush the changes.)

This actually hurt a muilti-editors environment.