### PR TITLE
[WIP] Flush change immediately (Proposal fix for #1479)

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -158,17 +158,6 @@ class Editor extends React.Component {
   }
 
   /**
-   * When the component unmounts, clear flushTimeout if it has been set
-   * to avoid calling onChange after unmount.
-   */
-
-  componentWillUnmount = () => {
-    if (this.tmp.flushTimeout) {
-      clearTimeout(this.tmp.flushTimeout)
-    }
-  }
-
-  /**
    * Queue a `change` object, to be able to flush it later. This is required for
    * when a change needs to be applied to the value, but because of the React
    * lifecycle we can't apply that change immediately. So we cache it here and
@@ -192,13 +181,10 @@ class Editor extends React.Component {
   flushChange = () => {
     const { change } = this.tmp
 
-    if (change && !this.tmp.flushTimeout) {
+    if (change) {
       debug('flushChange', { change })
-      this.tmp.flushTimeout = setTimeout(() => {
-        delete this.tmp.change
-        delete this.tmp.flushTimeout
-        this.props.onChange(change)
-      })
+      delete this.tmp.change
+      this.props.onChange(change)
     }
   }
 


### PR DESCRIPTION
Propose to flush change immediately instead of delaying it using `setTimeout()`.

- Flushing change is only use for `props.onChange()` callback and invoked at the end of render lifecycle (didMount/didUpdate), can't find the rationale for delaying it.
- `setTimeout()` delay are not dependable for a predictive behaviour
- `onChange()` is an important callback for a controlled component, delaying it can cause race condition. e.g. any changes outside of the component lifecycle that happen between the delay of flushing change will be overridden

@ianstormtaylor I like to check with you on this proposal to see what you think of it

Ref #1479