### PR TITLE
fix for #1487

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -1351,7 +1351,7 @@ Changes.wrapInlineAtRange = (change, range, inline, options = {}) => {
     const startNode = inline.regenerateKey()
     const endNode = inline.regenerateKey()
 
-    change.insertNodeByKey(startBlock.key, startIndex - 1, startNode, { normalize: false })
+    change.insertNodeByKey(startBlock.key, startIndex + 1, startNode, { normalize: false })
     change.insertNodeByKey(endBlock.key, endIndex, endNode, { normalize: false })
 
     startInlines.forEach((child, i) => {

--- a/packages/slate/test/history/undo/wrap-inline-across-blocks.js
+++ b/packages/slate/test/history/undo/wrap-inline-across-blocks.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function (value) {
+  return value
+    .change()
+    .wrapInline('hashtag')
+    .value
+    .change()
+    .undo()
+    .value
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />rd
+      </paragraph>
+      <paragraph>
+        an<focus />other
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = input


### PR DESCRIPTION
Fixes #1487 

The problem was that `startIndex - 1` usually equalled -1, which worked with `Immutable.List.insert` to insert the new inline at the end of the startNode, but this messed up inverting the operation so that inserted inline node remained.