### PR TITLE
fix(slate-react/components/content): do not use range.extend on Safari Desktop/iOS

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -12,6 +12,7 @@ import findDOMRange from '../utils/find-dom-range'
 import findRange from '../utils/find-range'
 import scrollToSelection from '../utils/scroll-to-selection'
 import {
+  IS_SAFARI,
   IS_FIREFOX,
   IS_IOS,
   IS_ANDROID,
@@ -146,6 +147,11 @@ class Content extends React.Component {
     const native = window.getSelection()
     const { rangeCount, anchorNode } = native
 
+    if (IS_SAFARI) {
+      if (native.anchorNode.textContent.endsWith(' ')) {
+        native.anchorNode.textContent = native.anchorNode.textContent.replace(' ', '\u00a0')
+      }
+    }
     // If both selections are blurred, do nothing.
     if (!rangeCount && selection.isBlurred) return
 

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -207,7 +207,7 @@ class Content extends React.Component {
     native.removeAllRanges()
 
     // COMPAT: IE 11 does not support Selection.extend
-    if ((native.extend && IS_IOS) && (native.extend && IS_SAFARI)) {
+    if ((native.extend && !IS_IOS) && (native.extend && !IS_SAFARI)) {
       // COMPAT: Since the DOM range has no concept of backwards/forwards
       // we need to check and do the right thing here.
       if (isBackward) {

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -207,7 +207,7 @@ class Content extends React.Component {
     native.removeAllRanges()
 
     // COMPAT: IE 11 does not support Selection.extend
-    if ((native.extend && !IS_IOS) && (native.extend && !IS_SAFARI)) {
+    if (native.extend && !(IS_SAFARI || IS_IOS)) {
       // COMPAT: Since the DOM range has no concept of backwards/forwards
       // we need to check and do the right thing here.
       if (isBackward) {

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -147,11 +147,6 @@ class Content extends React.Component {
     const native = window.getSelection()
     const { rangeCount, anchorNode } = native
 
-    if (IS_SAFARI) {
-      if (native.anchorNode.textContent.endsWith(' ')) {
-        native.anchorNode.textContent = native.anchorNode.textContent.replace(' ', '\u00a0')
-      }
-    }
     // If both selections are blurred, do nothing.
     if (!rangeCount && selection.isBlurred) return
 
@@ -212,7 +207,7 @@ class Content extends React.Component {
     native.removeAllRanges()
 
     // COMPAT: IE 11 does not support Selection.extend
-    if (native.extend) {
+    if ((native.extend && IS_IOS) && (native.extend && IS_SAFARI)) {
       // COMPAT: Since the DOM range has no concept of backwards/forwards
       // we need to check and do the right thing here.
       if (isBackward) {

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -206,7 +206,7 @@ class Content extends React.Component {
     this.tmp.isUpdatingSelection = true
     native.removeAllRanges()
 
-    // COMPAT: IE 11 does not support Selection.extend
+    // COMPAT: IE 11/Safari does not support Selection.extend
     if (native.extend && !(IS_SAFARI || IS_IOS)) {
       // COMPAT: Since the DOM range has no concept of backwards/forwards
       // we need to check and do the right thing here.


### PR DESCRIPTION
…Content ends in whitespace, replace it with unicode no-break space

Fix for #1481 