### PR TITLE
Don't attempt to remove event listeners from non-existent window

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -117,7 +117,9 @@ class Content extends React.Component {
   componentWillUnmount() {
     const window = getWindow(this.element)
 
-    window.document.removeEventListener('selectionchange', this.onNativeSelectionChange)
+    if (window) {
+      window.document.removeEventListener('selectionchange', this.onNativeSelectionChange)
+    }
 
     // COMPAT: Restrict scope of `beforeinput` to mobile.
     if ((IS_IOS || IS_ANDROID) && SUPPORTED_EVENTS.beforeinput) {


### PR DESCRIPTION
```
<IFrameComponent>
  <SlateEditor {...props} />
</IFrameComponent>
```

Since react unmounts from top down, `IFrameComponent` will unmount first (destroying its window), then `SlateEditor` will unmount and attempt to access the iframe window (which no longer exists) throwing `Uncaught TypeError: Cannot read property 'document' of undefined`.

It should be safe to skip removing event listeners from windows that no longer exist since they will be garbage collected upon destruction of the window anyway