### PR TITLE
slate-html-serializer: consistent element.value lookups

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -37,13 +37,14 @@ const TEXT_RULE = {
     }
 
     if (el.nodeName == '#text') {
-      if (el.value && el.value.match(/<!--.*?-->/)) return
+      const value = getValue(el)
+      if (value && value.match(/<!--.*?-->/)) return
 
       return {
         kind: 'text',
         leaves: [{
           kind: 'leaf',
-          text: el.value || el.nodeValue
+          text: value
         }]
       }
     }
@@ -395,7 +396,7 @@ class Html {
    */
 
   cruftNewline = (element) => {
-    return !(element.nodeName === '#text' && element.value == '\n')
+    return !(element.nodeName === '#text' && getValue(element) == '\n')
   }
 
 }
@@ -411,6 +412,16 @@ let key = 0
 
 function addKey(element) {
   return React.cloneElement(element, { key: key++ })
+}
+
+/**
+ * Consistent value lookups on text nodes
+ *
+ * @param {Element} element
+ * @return {String} text
+*/
+function getValue(el) {
+  return el.value || el.nodeValue || ''
 }
 
 /**

--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -417,11 +417,12 @@ function addKey(element) {
 /**
  * Consistent value lookups on text nodes
  *
- * @param {Element} element
- * @return {String} text
-*/
-function getValue(el) {
-  return el.value || el.nodeValue || ''
+ * @param {Object} element
+ * @return {String}
+ */
+
+function getValue(element) {
+  return element.value || element.nodeValue || ''
 }
 
 /**

--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -37,14 +37,13 @@ const TEXT_RULE = {
     }
 
     if (el.nodeName == '#text') {
-      const value = getValue(el)
-      if (value && value.match(/<!--.*?-->/)) return
+      if (el.nodeValue && el.nodeValue.match(/<!--.*?-->/)) return
 
       return {
         kind: 'text',
         leaves: [{
           kind: 'leaf',
-          text: value
+          text: el.nodeValue
         }]
       }
     }
@@ -396,7 +395,7 @@ class Html {
    */
 
   cruftNewline = (element) => {
-    return !(element.nodeName === '#text' && getValue(element) == '\n')
+    return !(element.nodeName === '#text' && element.nodeValue == '\n')
   }
 
 }
@@ -412,17 +411,6 @@ let key = 0
 
 function addKey(element) {
   return React.cloneElement(element, { key: key++ })
-}
-
-/**
- * Consistent value lookups on text nodes
- *
- * @param {Object} element
- * @return {String}
- */
-
-function getValue(element) {
-  return element.value || element.nodeValue || ''
 }
 
 /**


### PR DESCRIPTION
`el.value` vs. `el.value || el.nodeValue` were inconsistently used when deserializing HTML.

This caused a specific bug in which html looked like:

```
<ul>
<li>Some text</li>
</ul>
```

The HTML parser was finding `'#text'` nodes with no `value` but with a `nodeValue`, which was causing them to not be filtered out, resulting in improper nodes (text nodes as direct children of the `<ul>`).
  
To reproduce, see this fiddle: https://jsfiddle.net/usf40krv/

Go to line 320 and change `el.value` -> `getValue(el)`.