### PR TITLE
Adding normalize false to the moveNodeByKey call in deleteAtRange

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -236,7 +236,7 @@ Changes.deleteAtRange = (change, range, options = {}) => {
 
       // Move the end block to be right after the start block.
       if (endParentIndex != startParentIndex + 1) {
-        change.moveNodeByKey(endBlock.key, startParent.key, startParentIndex + 1)
+        change.moveNodeByKey(endBlock.key, startParent.key, startParentIndex + 1, { normalize: false })
       }
 
       // If the selection is hanging, just remove the start block, otherwise


### PR DESCRIPTION
Currently the `moveNodeByKey` call in `change.deleteAtRange` normalizes the output.  This is problematic because this allows normalizers to modify the change object, potentially removing the endBlock node.

If that happens, we don't update our endKey, and that causes the `mergeNodeByKey` call afterwards to fail.  I think it's better if we just don't normalize any of the operations, and then normalize all at once at the end.

@ianstormtaylor This sounds like pretty common behavior to not want to normalize on a string of changes.  I wonder if this warrants some kind of flag?