### PR TITLE
Move selection to the offset of remove_text if it's in its bounds

### DIFF
--- a/packages/slate/src/operations/apply.js
+++ b/packages/slate/src/operations/apply.js
@@ -287,12 +287,20 @@ const APPLIERS = {
     const { anchorKey, focusKey, anchorOffset, focusOffset } = selection
     let node = document.assertPath(path)
 
-    if (anchorKey == node.key && anchorOffset >= rangeOffset) {
-      selection = selection.moveAnchor(-length)
+    if (anchorKey == node.key) {
+      if (anchorOffset >= rangeOffset) {
+        selection = selection.moveAnchor(-length)
+      } else if (anchorOffset > offset) {
+        selection = selection.moveAnchorTo(anchorKey, offset)
+      }
     }
 
-    if (focusKey == node.key && focusOffset >= rangeOffset) {
-      selection = selection.moveFocus(-length)
+    if (focusKey == node.key) {
+      if (focusOffset >= rangeOffset) {
+        selection = selection.moveFocus(-length)
+      } else if (focusOffset > offset) {
+        selection = selection.moveFocusTo(focusKey, offset)
+      }
     }
 
     node = node.removeText(offset, length)

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -20,6 +20,7 @@ describe('slate', () => {
   require('./schema')
   require('./changes')
   require('./history')
+  require('./operations')
 })
 
 /**

--- a/packages/slate/test/operations/apply/remove_text/cursor-inside-removed-text.js
+++ b/packages/slate/test/operations/apply/remove_text/cursor-inside-removed-text.js
@@ -2,15 +2,13 @@
 
 import h from '../../../helpers/h'
 
-export default function (change) {
-  return change.applyOperation({
-    type: 'remove_text',
-    path: [0, 0],
-    offset: 2,
-    text: 'is is some text inside ',
-    marks: []
-  })
-}
+export default [{
+  type: 'remove_text',
+  path: [0, 0],
+  offset: 2,
+  text: 'is is some text inside ',
+  marks: []
+}]
 
 export const input = (
   <value>

--- a/packages/slate/test/operations/apply/remove_text/cursor-inside-removed-text.js
+++ b/packages/slate/test/operations/apply/remove_text/cursor-inside-removed-text.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  return change.applyOperation({
+    type: 'remove_text',
+    path: [0, 0],
+    offset: 2,
+    text: 'is is some text inside ',
+    marks: []
+  })
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        This <cursor />is some text inside a paragraph.
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        Th<cursor />a paragraph.
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/operations/index.js
+++ b/packages/slate/test/operations/index.js
@@ -26,9 +26,9 @@ describe('operations', async () => {
             it(test, async () => {
               const module = require(resolve(testDir, test))
               const { input, output } = module
-              const fn = module.default
+              const operations = module.default
               const change = input.change()
-              fn(change)
+              change.applyOperations(operations)
               const opts = { preserveSelection: true, preserveData: true }
               const actual = change.value.toJSON(opts)
               const expected = output.toJSON(opts)

--- a/packages/slate/test/operations/index.js
+++ b/packages/slate/test/operations/index.js
@@ -1,0 +1,42 @@
+
+import assert from 'assert'
+import fs from 'fs-promise' // eslint-disable-line import/no-extraneous-dependencies
+import toCamel from 'to-camel-case' // eslint-disable-line import/no-extraneous-dependencies
+import { basename, extname, resolve } from 'path'
+
+/**
+ * Tests.
+ */
+
+describe('operations', async () => {
+  const dir = resolve(__dirname)
+  const categories = fs.readdirSync(dir).filter(c => c[0] != '.' && c != 'index.js')
+
+  for (const category of categories) {
+    describe(category, () => {
+      const categoryDir = resolve(dir, category)
+      const methods = fs.readdirSync(categoryDir).filter(c => c[0] != '.')
+
+      for (const method of methods) {
+        describe(toCamel(method), () => {
+          const testDir = resolve(categoryDir, method)
+          const tests = fs.readdirSync(testDir).filter(t => t[0] != '.' && !!~t.indexOf('.js')).map(t => basename(t, extname(t)))
+
+          for (const test of tests) {
+            it(test, async () => {
+              const module = require(resolve(testDir, test))
+              const { input, output } = module
+              const fn = module.default
+              const change = input.change()
+              fn(change)
+              const opts = { preserveSelection: true, preserveData: true }
+              const actual = change.value.toJSON(opts)
+              const expected = output.toJSON(opts)
+              assert.deepEqual(actual, expected)
+            })
+          }
+        })
+      }
+    })
+  }
+})


### PR DESCRIPTION
If selection is inside a block of text that's removed, the part of the selection that's inside the bounds should clamp to the offset of the removed text. 

For example, if your cursor is at offset 5, and you're deleting from 2-10, your cursor should end up at offset 2.

Here's a fiddle showing the broken behavior: https://jsfiddle.net/w1dxg25n/2/ Wait 5 seconds, and you should see an error in the console. 