### PR TITLE
Fixed scroll-to-selection jumping to top on iOS

### DIFF
--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -1,7 +1,7 @@
 
 import getWindow from 'get-window'
 import isBackward from 'selection-is-backward'
-import { IS_SAFARI } from '../constants/environment'
+import { IS_SAFARI, IS_IOS } from '../constants/environment'
 
 /**
  * CSS overflow values that would cause scrolling.
@@ -58,6 +58,7 @@ function findScrollContainer(el, window) {
  */
 
 function scrollToSelection(selection) {
+  if (IS_IOS) return
   if (!selection.anchorNode) return
 
   const window = getWindow(selection.anchorNode)

--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -16,6 +16,12 @@ const OVERFLOWS = [
 ]
 
 /**
+ * Detect whether we are running IOS version 11
+ */
+
+const IS_IOS_11 = IS_IOS && !!window.navigator.userAgent.match(/os 11_/i)
+
+/**
  * Find the nearest parent with scrolling, or window.
  *
  * @param {el} Element
@@ -52,30 +58,13 @@ function findScrollContainer(el, window) {
 }
 
 /**
- * Get the current iOS version. Assumes that an IOS check was conducted
- * prior to calling.
- */
-
-const IOS_VERSION_REGEX = /OS (\d+)_/
-
-function getMajorIOSVersion() {
-  const { userAgent } = window.navigator
-  const matches = userAgent.match(IOS_VERSION_REGEX)
-  return matches ? parseInt(matches[1]) : null
-}
-
-/**
  * Scroll the current selection's focus point into view if needed.
  *
  * @param {Selection} selection
  */
 
 function scrollToSelection(selection) {
-  if (IS_IOS) {
-    const majorIOSVersion = getMajorIOSVersion()
-    if (majorIOSVersion && majorIOSVersion == 11) return
-  }
-
+  if (IS_IOS_11) return
   if (!selection.anchorNode) return
 
   const window = getWindow(selection.anchorNode)

--- a/packages/slate-react/src/utils/scroll-to-selection.js
+++ b/packages/slate-react/src/utils/scroll-to-selection.js
@@ -52,13 +52,30 @@ function findScrollContainer(el, window) {
 }
 
 /**
+ * Get the current iOS version. Assumes that an IOS check was conducted
+ * prior to calling.
+ */
+
+const IOS_VERSION_REGEX = /OS (\d+)_/
+
+function getMajorIOSVersion() {
+  const { userAgent } = window.navigator
+  const matches = userAgent.match(IOS_VERSION_REGEX)
+  return matches ? parseInt(matches[1]) : null
+}
+
+/**
  * Scroll the current selection's focus point into view if needed.
  *
  * @param {Selection} selection
  */
 
 function scrollToSelection(selection) {
-  if (IS_IOS) return
+  if (IS_IOS) {
+    const majorIOSVersion = getMajorIOSVersion()
+    if (majorIOSVersion && majorIOSVersion == 11) return
+  }
+
   if (!selection.anchorNode) return
 
   const window = getWindow(selection.anchorNode)


### PR DESCRIPTION
This code simply disables the scroll to selection on all iOS devices.

The reason why is because on the iPad, any typing in the editor causes a scroll back to the top of the page. On other iOS devices, it appears the scroll to selection might not do anything anyways.

It's a bit brute force but it makes the editor usable if not necessarily convenient. Right now, it is unusable on the iPad.

The full discussion is here:

https://github.com/ianstormtaylor/slate/issues/1513