### PR TITLE
Abort select() if only change is “forgetting” current marks (#1113)

### DIFF
--- a/packages/slate/src/changes/on-selection.js
+++ b/packages/slate/src/changes/on-selection.js
@@ -56,6 +56,13 @@ Changes.select = (change, properties, options = {}) => {
     return
   }
 
+  // If the only change is blowing away the current selection's marks, abort.
+  // To remove all marks, clear the set, don't set it to null.
+  const onlyMarks = Object.keys(props).length == 1 && props.hasOwnProperty('marks')
+  if (onlyMarks && props.marks == null) {
+    return
+  }
+
   // Apply the operation.
   change.applyOperation({
     type: 'set_selection',


### PR DESCRIPTION
This is a small fix for the issue discussed in #1113 that restores the behavior of `toggleMark`, et. al. on collapsed selections for me. I'm totally open to other solutions if there's a better approach!