### PR TITLE
Expose core plugins

### DIFF
--- a/docs/reference/slate-react/core-plugins.md
+++ b/docs/reference/slate-react/core-plugins.md
@@ -1,7 +1,7 @@
 
 # Core Plugin
 
-Slate's editor is very unopinionated. The only logic it handles by default is logic associated with the `contenteditable` functionality itself—managing text, selections, etc. That logic in contained in two plugin, called the "core" plugins. One runs before all other plugins, and one runs after.
+Slate's editor is very unopinionated. The only logic it handles by default is logic associated with the `contenteditable` functionality itself—managing text, selections, etc. That logic is contained in two plugins, called the "core" plugins. One runs before all other plugins, and one runs after.
 
 
 ## Default Behavior

--- a/docs/reference/slate-simulator/index.md
+++ b/docs/reference/slate-simulator/index.md
@@ -5,7 +5,7 @@
 import Simulator from 'slate-simulator'
 ```
 
-A simulator to help writing tests for Slate editors and plugins.
+A simulator to help writing tests for Slate editors and plugins. By default the simulator does not include the core plugins as they have a lot of dependencies on browser-specific globals, so running them in CI environments is very hard. If you need the core plugins for your use case you need to import them manually.
 
 
 ## Example
@@ -30,6 +30,16 @@ simulator
 const newValue = simulator.value
 ```
 
+## Example with core plugins
+
+```js
+import Simulator from 'slate-simulator'
+import { BeforePlugin, AfterPlugin } from 'slate-react'
+
+const value = ...
+const plugins = [ BeforePlugin(), ... , AfterPlugin() ]
+const simulator = new Simulator({ value, plugins })
+```
 
 ## Methods
 

--- a/packages/slate-react/src/index.js
+++ b/packages/slate-react/src/index.js
@@ -8,6 +8,8 @@ import findRange from './utils/find-range'
 import getEventRange from './utils/get-event-range'
 import getEventTransfer from './utils/get-event-transfer'
 import setEventTransfer from './utils/set-event-transfer'
+import AfterPlugin from './plugins/after'
+import BeforePlugin from './plugins/before'
 
 /**
  * Export.
@@ -25,6 +27,8 @@ export {
   getEventRange,
   getEventTransfer,
   setEventTransfer,
+  AfterPlugin,
+  BeforePlugin,
 }
 
 export default {
@@ -37,4 +41,6 @@ export default {
   getEventRange,
   getEventTransfer,
   setEventTransfer,
+  AfterPlugin,
+  BeforePlugin,
 }


### PR DESCRIPTION
In some scenarios we would like to use the core plugins inside tests with `slate-simulator`. That is currently not possible. This PR exposes the core plugins so we can import them on case by case basis.