### PR TITLE
Fix broken links on docs

### DIFF
--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -66,7 +66,7 @@ There are two core plugins: the "before plugin" and the "after plugin". They get
 
 For the most part you don't need to worry about the core plugins. The before plugin helps to pave over editing inconsistencies, and the after plugin serves as a fallback, to implement the default behavior in the event that your own plugins choose not to handle a specific event.
 
-_To learn more, check out the [Core Plugin reference](../reference/slate-react/core-plugin.md)._
+_To learn more, check out the [Core Plugin reference](../reference/slate-react/core-plugins.md)._
 
 
 ## The "Editor" Plugin
@@ -138,7 +138,7 @@ const plugins = [
 ]
 ```
 
-These types of plugins are critical to keeping your code maintainable. And they're good candidates for open-sourcing for others to use. A few examples of plugins like this in the wild are [`slate-auto-replace`](https://github.com/ianstormtaylor/slate-auto-replace), [`slate-prism`](https://github.com/GitbookIO/slate-prism), [`slate-collapse-on-escape`](https://github.com/ianstormtaylor/slate-collapse-on-escape), etc.
+These types of plugins are critical to keeping your code maintainable. And they're good candidates for open-sourcing for others to use. A few examples of plugins like this in the wild are [`slate-auto-replace`](https://github.com/ianstormtaylor/slate-plugins/tree/master/packages/slate-auto-replace), [`slate-prism`](https://github.com/GitbookIO/slate-prism), [`slate-collapse-on-escape`](https://github.com/ianstormtaylor/slate-plugins/tree/master/packages/slate-collapse-on-escape), etc.
 
 There's almost no piece of logic too small to abstract out and share, as long as it's reusable.
 


### PR DESCRIPTION
@ianstormtaylor plugins + typo in core-plugins link

Scope creep:
- `slate-mentions` and `slate-suggestions` referenced in the root `README.md` are no longer maintained/broken cause of the last months breaking changes, I did not remove the links cause at the moment I'm not sure I can offer an alternative solution (I have built a working one with latest specs but it is stored on a private repository for my company, I need to check if it can be open sourced).