### PR TITLE
Append copied fragment to editor DOM node instead of page body

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -92,7 +92,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   attach.setAttribute('data-slate-fragment', encoded)
 
   // Add the phony content to the DOM, and select it, so it will be copied.
-  const editor = window.document.querySelector('[data-slate-editor]');
+  const editor = window.document.querySelector('[data-slate-editor]')
   const div = window.document.createElement('div')
   div.setAttribute('contenteditable', true)
   div.style.position = 'absolute'

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -92,7 +92,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   attach.setAttribute('data-slate-fragment', encoded)
 
   // Add the phony content to the DOM, and select it, so it will be copied.
-  const body = window.document.querySelector('body')
+  const editor = window.document.querySelector('[data-slate-editor]');
   const div = window.document.createElement('div')
   div.setAttribute('contenteditable', true)
   div.style.position = 'absolute'
@@ -107,7 +107,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   div.style.top = `${window.pageYOffset || window.document.documentElement.scrollTop}px`
 
   div.appendChild(contents)
-  body.appendChild(div)
+  editor.appendChild(div)
 
   // COMPAT: In Firefox, trying to use the terser `native.selectAllChildren`
   // throws an error, so we use the older `range` equivalent. (2016/06/21)
@@ -118,7 +118,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
 
   // Revert to the previous selection right after copying.
   window.requestAnimationFrame(() => {
-    body.removeChild(div)
+    editor.removeChild(div)
     native.removeAllRanges()
     native.addRange(range)
   })


### PR DESCRIPTION
Fixes #1484, which caused pasted material to retain styles (such as background color) from the page body.

Instead of appending the cloned fragment to the `<body>`, append it to the editor element instead.

Before:
![before](https://user-images.githubusercontent.com/13112590/34922340-5a2d3aea-f943-11e7-89fc-03d501b87be8.gif)

After:
![fixed](https://user-images.githubusercontent.com/13112590/34922342-5df84822-f943-11e7-8db9-35f1916b7961.gif)
