### PR TITLE
Document: add `change.snapshotSelection` in the change.md

### DIFF
--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -474,3 +474,9 @@ Move forward one step in the history.
 `undo() => Change`
 
 Move backward one step in the history.
+
+
+### `snapshotSelection`
+`snapshotSelection() => Change`
+
+snapshot `value.selection` for `undo` purpose,  useful with delete operations like `removeNodeByKey(focusBlock.key).undo()`

--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -475,8 +475,7 @@ Move forward one step in the history.
 
 Move backward one step in the history.
 
-
 ### `snapshotSelection`
 `snapshotSelection() => Change`
 
-snapshot `value.selection` for `undo` purpose,  useful with delete operations like `removeNodeByKey(focusBlock.key).undo()`
+Snapshot `value.selection` for `undo` purposes, useful with delete operations like `removeNodeByKey(focusBlock.key).undo()`


### PR DESCRIPTION
Hi, I think `change.snapshotSelection` is useful in developing some packages with `removeNode`, for example, in the case of https://github.com/GitbookIO/slate-edit-table/issues/40

Therefore, I think it might be better if we have list the api in the document.