### PR TITLE
Continue normalize next child when and only when the node exists still

### DIFF
--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -91,7 +91,7 @@ function normalizeNodeAndChildren(change, node, schema) {
         child = null
       } else {
         path = change.value.document.refindPath(path, node.key)
-        child = node.nodes.find(c => normalizedKeys.indexOf(c.key) === -1)
+        child = node.nodes.find(c => !normalizedKeys.includes(c.key))
       }
     }
   }


### PR DESCRIPTION
Hi, this is a PR regarding:
1. https://github.com/ianstormtaylor/slate/issues/1537 and https://github.com/ianstormtaylor/slate/issues/1528
2. https://github.com/ianstormtaylor/slate/issues/1363 Not try to get the invalid node in parent stack
3. A bit change of code to make the `normalizeNodeAndChildren` shorter; Perhaps this change makes this function a bit more friendly to readers

If you like to have tests for the two issues; I would like to add one~

Thank you very much for your reviewing~