### PR TITLE
Use absolute links in changelog so they render correctly in GitBook.

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -27,7 +27,7 @@
 - [Plugins](./general/plugins.md)
 - [Resources](./general/resources.md)
 - [Contributing](../Contributing.md)
-- [Changelog](../Changelog.md)
+- [Changelog](./general/changelog.md)
 - [FAQ](./general/faq.md)
 
 


### PR DESCRIPTION
Fixes #1507 