### PR TITLE
Faster (but also safe) method about re-find node by path

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1352,6 +1352,41 @@ class Node {
   }
 
   /**
+   * Refind the path of node if path is changed.
+   *
+   * @param {Array} path
+   * @param {String} key
+   * @return {Array}
+   */
+
+  refindPath(path, key) {
+    const node = this.getDescendantAtPath(path)
+    if (node && node.key === key) {
+      return path
+    }
+
+    return this.getPath(key)
+  }
+
+  /**
+   *
+   * Refind the node with the same node.key after change.
+   *
+   * @param {Array} path
+   * @param {String} key
+   * @return {Node|Void}
+   */
+
+  refindNode(path, key) {
+    const node = this.getDescendantAtPath(path)
+    if (node && node.key === key) {
+      return node
+    }
+
+    return this.getDescendant(key)
+  }
+
+  /**
    * Get the placeholder for the node from a `schema`.
    *
    * @param {Schema} schema


### PR DESCRIPTION
Hi, this is related to https://github.com/ianstormtaylor/slate/issues/1408, last two commits by https://github.com/ianstormtaylor/slate/pull/1538;  The path provides two methods to update node/path after change happens.

Cheers,
Jinxuan Zhu