### PR TITLE
Use babel-preset-env instead of babel-preset-es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    "env",
     "react",
     "stage-0"
   ]

--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -474,3 +474,9 @@ Move forward one step in the history.
 `undo() => Change`
 
 Move backward one step in the history.
+
+
+### `snapshotSelection`
+`snapshotSelection() => Change`
+
+snapshot `value.selection` for `undo` purpose,  useful with delete operations like `removeNodeByKey(focusBlock.key).undo()`

--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -475,8 +475,7 @@ Move forward one step in the history.
 
 Move backward one step in the history.
 
-
 ### `snapshotSelection`
 `snapshotSelection() => Change`
 
-snapshot `value.selection` for `undo` purpose,  useful with delete operations like `removeNodeByKey(focusBlock.key).undo()`
+Snapshot `value.selection` for `undo` purposes, useful with delete operations like `removeNodeByKey(focusBlock.key).undo()`

--- a/docs/reference/slate/schema.md
+++ b/docs/reference/slate/schema.md
@@ -214,30 +214,13 @@ Returns a JSON representation of the schema.
 
 ## Invalid Reasons
 
-When supplying your own `normalize` property for a schema rule, it will be called with `(change, reason, context)`. The `reason` will be one of a set of reasons, and `context` will vary depending on the reason. Here's the full set:
+When supplying your own `normalize` property for a schema rule, it will be called with `(change, reason, context)`. The `reason` will be one of a set of reasons, and `context` will vary depending on the reason. Invalid reason constants are available through the`SchemaViolations` object.
 
-### `child_object_invalid`
+`import { SchemaViolations } from 'slate'`
 
-```js
-{
-  child: Node,
-  index: Number,
-  node: Node,
-  rule: Object,
-}
-```
+Here's the full set:
 
-### `child_required`
-
-```js
-{
-  index: Number,
-  node: Node,
-  rule: Object,
-}
-```
-
-### `child_type_invalid`
+### `SchemaViolations.ChildObjectInvalid`
 
 ```js
 {
@@ -248,7 +231,17 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `child_unknown`
+### `SchemaViolations.ChildRequired`
+
+```js
+{
+  index: Number,
+  node: Node,
+  rule: Object,
+}
+```
+
+### `SchemaViolations.ChildTypeInvalid`
 
 ```js
 {
@@ -259,7 +252,18 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `first_child_object_invalid`
+### `SchemaViolations.ChildUnknown`
+
+```js
+{
+  child: Node,
+  index: Number,
+  node: Node,
+  rule: Object,
+}
+```
+
+### `SchemaViolations.FirstChildObjectInvalid`
 
 ```js
 {
@@ -269,7 +273,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `first_child_type_invalid`
+### `SchemaViolations.FirstChildTypeInvalid`
 
 ```js
 {
@@ -279,7 +283,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `last_child_object_invalid`
+### `SchemaViolations.LastChildObjectInvalid`
 
 ```js
 {
@@ -289,7 +293,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `last_child_type_invalid`
+### `SchemaViolations.LastChildTypeInvalid`
 
 ```js
 {
@@ -299,7 +303,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `node_data_invalid`
+### `SchemaViolations.NodeDataInvalid`
 
 ```js
 {
@@ -310,7 +314,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `node_is_void_invalid`
+### `SchemaViolations.NodeIsVoidInvalid`
 
 ```js
 {
@@ -319,7 +323,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `node_object_invalid`
+### `SchemaViolations.NodeObjectInvalid`
 
 ```js
 {
@@ -328,7 +332,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `node_mark_invalid`
+### `SchemaViolations.NodeMarkInvalid`
 
 ```js
 {
@@ -338,7 +342,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `node_text_invalid`
+### `SchemaViolations.NodeTextInvalid`
 
 ```js
 {
@@ -348,7 +352,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `parent_object_invalid`
+### `SchemaViolations.ParentObjectInvalid`
 
 ```js
 {
@@ -358,7 +362,7 @@ When supplying your own `normalize` property for a schema rule, it will be calle
 }
 ```
 
-### `parent_type_invalid`
+### `SchemaViolations.ParentTypeInvalid`
 
 ```js
 {

--- a/examples/forced-layout/index.js
+++ b/examples/forced-layout/index.js
@@ -1,6 +1,6 @@
 
 import { Editor } from 'slate-react'
-import { Block, Value } from 'slate'
+import { Block, Value, SchemaViolations } from 'slate'
 
 import React from 'react'
 import initialValue from './value.json'
@@ -19,10 +19,10 @@ const schema = {
     ],
     normalize: (change, reason, { node, child, index }) => {
       switch (reason) {
-        case 'child_type_invalid': {
+        case SchemaViolations.ChildTypeInvalid: {
           return change.setNodeByKey(child.key, index == 0 ? 'title' : 'paragraph')
         }
-        case 'child_required': {
+        case SchemaViolations.ChildRequired: {
           const block = Block.create(index == 0 ? 'title' : 'paragraph')
           return change.insertNodeByKey(node.key, index, block)
         }

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -1,6 +1,6 @@
 
 import { Editor, getEventRange, getEventTransfer } from 'slate-react'
-import { Block, Value } from 'slate'
+import { Block, Value, SchemaViolations } from 'slate'
 
 import React from 'react'
 import initialValue from './value.json'
@@ -38,7 +38,7 @@ const schema = {
     last: { types: ['paragraph'] },
     normalize: (change, reason, { node, child }) => {
       switch (reason) {
-        case 'last_child_type_invalid': {
+        case SchemaViolations.LastChildTypeInvalid: {
           const paragraph = Block.create('paragraph')
           return change.insertNodeByKey(node.key, node.nodes.size, paragraph)
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.1.0",
     "babel-polyfill": "^6.16.0",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babelify": "^7.3.0",

--- a/packages/slate/src/index.js
+++ b/packages/slate/src/index.js
@@ -12,7 +12,7 @@ import Node from './models/node'
 import Operation from './models/operation'
 import Operations from './operations'
 import Range from './models/range'
-import Schema from './models/schema'
+import Schema, { SchemaViolations } from './models/schema'
 import Stack from './models/stack'
 import Text from './models/text'
 import Value from './models/value'
@@ -39,6 +39,7 @@ export {
   Operations,
   Range,
   Schema,
+  SchemaViolations,
   Stack,
   Text,
   Value,
@@ -61,6 +62,7 @@ export default {
   Operations,
   Range,
   Schema,
+  SchemaViolations,
   Stack,
   Text,
   Value,

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -31,6 +31,23 @@ const NODE_TEXT_INVALID = 'node_text_invalid'
 const PARENT_OBJECT_INVALID = 'parent_object_invalid'
 const PARENT_TYPE_INVALID = 'parent_type_invalid'
 
+export const SchemaViolations = Object.freeze({
+  ChildObjectInvalid: CHILD_OBJECT_INVALID,
+  ChildRequired: CHILD_REQUIRED,
+  ChildTypeInvalid: CHILD_TYPE_INVALID,
+  ChildUnknown: CHILD_UNKNOWN,
+  FirstChildObjectInvalid: FIRST_CHILD_OBJECT_INVALID,
+  FirstChildTypeInvalid: FIRST_CHILD_TYPE_INVALID,
+  LastChildObjectInvalid: LAST_CHILD_OBJECT_INVALID,
+  LastChildTypeInvalid: LAST_CHILD_TYPE_INVALID,
+  NodeDataInvalid: NODE_DATA_INVALID,
+  NodeIsVoidInvalid: NODE_IS_VOID_INVALID,
+  NodeMarkInvalid: NODE_MARK_INVALID,
+  NodeTextInvalid: NODE_TEXT_INVALID,
+  ParentObjectInvalid: PARENT_OBJECT_INVALID,
+  ParentTypeInvalid: PARENT_TYPE_INVALID,
+})
+
 /**
  * Debug.
  *

--- a/packages/slate/test/schema/custom/child-kind-invalid-custom-optional-first.js
+++ b/packages/slate/test/schema/custom/child-kind-invalid-custom-optional-first.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -11,7 +12,7 @@ export const schema = {
         { objects: ['block'], types: ['paragraph'], min: 1 }
       ],
       normalize: (change, reason, { node, child }) => {
-        if (reason == 'child_object_invalid') {
+        if (reason == SchemaViolations.ChildObjectInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/child-kind-invalid-custom.js
+++ b/packages/slate/test/schema/custom/child-kind-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -10,7 +11,7 @@ export const schema = {
         { objects: ['block'] },
       ],
       normalize: (change, reason, { child }) => {
-        if (reason == 'child_object_invalid') {
+        if (reason == SchemaViolations.ChildObjectInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/child-required-custom.js
+++ b/packages/slate/test/schema/custom/child-required-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -10,7 +11,7 @@ export const schema = {
         { types: ['paragraph'], min: 2 },
       ],
       normalize: (change, reason, { node, index }) => {
-        if (reason == 'child_required') {
+        if (reason == SchemaViolations.ChildRequired) {
           change.insertNodeByKey(node.key, index, { object: 'block', type: 'paragraph' })
         }
       }

--- a/packages/slate/test/schema/custom/child-type-invalid-custom.js
+++ b/packages/slate/test/schema/custom/child-type-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -10,7 +11,7 @@ export const schema = {
         { types: ['paragraph'] },
       ],
       normalize: (change, reason, { child }) => {
-        if (reason == 'child_type_invalid') {
+        if (reason == SchemaViolations.ChildTypeInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/child-unknown-custom.js
+++ b/packages/slate/test/schema/custom/child-unknown-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -10,7 +11,7 @@ export const schema = {
         { types: ['paragraph'], max: 1 },
       ],
       normalize: (change, reason, { node, child, index }) => {
-        if (reason == 'child_unknown') {
+        if (reason == SchemaViolations.ChildUnknown) {
           const previous = node.getPreviousSibling(child.key)
           const offset = previous.nodes.size
           child.nodes.forEach((n, i) => change.moveNodeByKey(n.key, previous.key, offset + i, { normalize: false }))

--- a/packages/slate/test/schema/custom/first-child-kind-invalid-custom.js
+++ b/packages/slate/test/schema/custom/first-child-kind-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -8,7 +9,7 @@ export const schema = {
     quote: {
       first: { objects: ['block'] },
       normalize: (change, reason, { child }) => {
-        if (reason == 'first_child_object_invalid') {
+        if (reason == SchemaViolations.FirstChildObjectInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/first-child-type-invalid-custom.js
+++ b/packages/slate/test/schema/custom/first-child-type-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -8,7 +9,7 @@ export const schema = {
     quote: {
       first: { types: ['paragraph'] },
       normalize: (change, reason, { child }) => {
-        if (reason == 'first_child_type_invalid') {
+        if (reason == SchemaViolations.FirstChildTypeInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/last-child-kind-invalid-custom.js
+++ b/packages/slate/test/schema/custom/last-child-kind-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -8,7 +9,7 @@ export const schema = {
     quote: {
       last: { objects: ['block'] },
       normalize: (change, reason, { child }) => {
-        if (reason == 'last_child_object_invalid') {
+        if (reason == SchemaViolations.LastChildObjectInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/last-child-type-invalid-custom.js
+++ b/packages/slate/test/schema/custom/last-child-type-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -8,7 +9,7 @@ export const schema = {
     quote: {
       last: { types: ['paragraph'] },
       normalize: (change, reason, { child }) => {
-        if (reason == 'last_child_type_invalid') {
+        if (reason == SchemaViolations.LastChildTypeInvalid) {
           change.wrapBlockByKey(child.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/node-data-invalid-custom.js
+++ b/packages/slate/test/schema/custom/node-data-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -9,7 +10,7 @@ export const schema = {
         thing: v => v == 'value'
       },
       normalize: (change, reason, { node, key }) => {
-        if (reason == 'node_data_invalid') {
+        if (reason == SchemaViolations.NodeDataInvalid) {
           change.setNodeByKey(node.key, { data: { thing: 'value' }})
         }
       }

--- a/packages/slate/test/schema/custom/node-is-void-invalid-custom.js
+++ b/packages/slate/test/schema/custom/node-is-void-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -7,7 +8,7 @@ export const schema = {
     paragraph: {
       isVoid: false,
       normalize: (change, reason, { node }) => {
-        if (reason == 'node_is_void_invalid') {
+        if (reason == SchemaViolations.NodeIsVoidInvalid) {
           change.removeNodeByKey(node.key, 'paragraph')
         }
       }

--- a/packages/slate/test/schema/custom/node-mark-invalid-custom.js
+++ b/packages/slate/test/schema/custom/node-mark-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -7,7 +8,7 @@ export const schema = {
     paragraph: {
       marks: [{ type: 'bold' }],
       normalize: (change, reason, { node }) => {
-        if (reason == 'node_mark_invalid') {
+        if (reason == SchemaViolations.NodeMarkInvalid) {
           node.nodes.forEach(n => change.removeNodeByKey(n.key))
         }
       }

--- a/packages/slate/test/schema/custom/node-text-invalid-custom.js
+++ b/packages/slate/test/schema/custom/node-text-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -7,7 +8,7 @@ export const schema = {
     paragraph: {
       text: /^\d*$/,
       normalize: (change, reason, { node }) => {
-        if (reason == 'node_text_invalid') {
+        if (reason == SchemaViolations.NodeTextInvalid) {
           node.nodes.forEach(n => change.removeNodeByKey(n.key))
         }
       }

--- a/packages/slate/test/schema/custom/parent-kind-invalid-custom.js
+++ b/packages/slate/test/schema/custom/parent-kind-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -7,7 +8,7 @@ export const schema = {
     link: {
       parent: { objects: ['block'] },
       normalize: (change, reason, { node }) => {
-        if (reason == 'parent_object_invalid') {
+        if (reason == SchemaViolations.ParentObjectInvalid) {
           change.unwrapNodeByKey(node.key)
         }
       }

--- a/packages/slate/test/schema/custom/parent-type-invalid-custom.js
+++ b/packages/slate/test/schema/custom/parent-type-invalid-custom.js
@@ -1,5 +1,6 @@
 /** @jsx h */
 
+import { SchemaViolations } from '../../..'
 import h from '../../helpers/h'
 
 export const schema = {
@@ -8,7 +9,7 @@ export const schema = {
     item: {
       parent: { types: ['list'] },
       normalize: (change, reason, { node }) => {
-        if (reason == 'parent_type_invalid') {
+        if (reason == SchemaViolations.ParentTypeInvalid) {
           change.wrapBlockByKey(node.key, 'list')
         }
       }


### PR DESCRIPTION
Related to https://github.com/ianstormtaylor/slate/issues/936

I have not yet add babel-runtime https://babeljs.io/docs/plugins/transform-runtime/ in this PR.  Do you think adding `babel-runtime` as dependency instead of devDependency is a good idea?  I will update the PR if you think add babel-runtime as dependency is a good idea.

Cheers,
Jinxuan Zhu