### PR TITLE
Convert setBlock and setInline to plurals for more intuitive naming.

### DIFF
--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -135,19 +135,19 @@ Insert a string of `text` at the current selection. If the selection is expanded
 
 Add a [`mark`](./mark.md) to the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
-### `setBlock`
+### `setBlocks`
 
-`setBlock(properties: Object) => Change` <br/>
-`setBlock(type: String) => Change`
+`setBlocks(properties: Object) => Change` <br/>
+`setBlocks(type: String) => Change`
 
-Set the `properties` of the [`Block`](./block.md) in the current selection. For convenience, you can pass a `type` string to set the blocks's type only.
+Set the `properties` of the [`Blocks`](./block.md) in the current selection. For convenience, you can pass a `type` string to set the blocks' type only.
 
-### `setInline`
+### `setInlines`
 
-`setInline(properties: Object) => Change` <br/>
-`setInline(type: String) => Change`
+`setInlines(properties: Object) => Change` <br/>
+`setInlines(type: String) => Change`
 
-Set the `properties` of the [`Inline`](./inline.md) nodes in the current selection. For convenience, you can pass a `type` string to set the inline's type only.
+Set the `properties` of the [`Inlines`](./inline.md) nodes in the current selection. For convenience, you can pass a `type` string to set the inline nodes' type only.
 
 ### `splitBlock`
 
@@ -368,19 +368,19 @@ Insert a string of `text` at a `range`. If the selection is expanded, it will be
 
 Add a [`mark`](./mark.md) to the characters in a `range`. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
-### `setBlockAtRange`
+### `setBlocksAtRange`
 
-`setBlockAtRange(range: Range, properties: Object) => Change` <br/>
-`setBlock(range: Range, type: String) => Change`
+`setBlocksAtRange(range: Range, properties: Object) => Change` <br/>
+`setBlocks(range: Range, type: String) => Change`
 
-Set the `properties` of the [`Block`](./block.md) in a `range`. For convenience, you can pass a `type` string to set the blocks's type only.
+Set the `properties` of the [`Blocks`](./block.md) in a `range`. For convenience, you can pass a `type` string to set the blocks' type only.
 
-### `setInlineAtRange`
+### `setInlinesAtRange`
 
-`setInlineAtRange(range: Range, properties: Object) => Change` <br/>
-`setInline(range: Range, type: String) => Change`
+`setInlinesAtRange(range: Range, properties: Object) => Change` <br/>
+`setInlines(range: Range, type: String) => Change`
 
-Set the `properties` of the [`Inline`](./inline.md) nodes in a `range`. For convenience, you can pass a `type` string to set the inline's type only.
+Set the `properties` of the [`Inlines`](./inline.md) nodes in a `range`. For convenience, you can pass a `type` string to set the inline nodes' type only.
 
 ### `splitBlockAtRange`
 

--- a/docs/walkthroughs/applying-custom-formatting.md
+++ b/docs/walkthroughs/applying-custom-formatting.md
@@ -25,7 +25,7 @@ class App extends React.Component {
     event.preventDefault()
     const isCode = change.value.blocks.some(block => block.type == 'code')
 
-    change.setBlock(isCode ? 'paragraph' : 'code')
+    change.setBlocks(isCode ? 'paragraph' : 'code')
     return true
   }
 
@@ -76,7 +76,7 @@ class App extends React.Component {
       case '`': {
         const isCode = change.value.blocks.some(block => block.type == 'code')
         event.preventDefault()
-        change.setBlock(isCode ? 'paragraph' : 'code')
+        change.setBlocks(isCode ? 'paragraph' : 'code')
         return true
       }
     }
@@ -143,7 +143,7 @@ class App extends React.Component {
       case '`': {
         const isCode = change.value.blocks.some(block => block.type == 'code')
         event.preventDefault()
-        value.setBlock(isCode ? 'paragraph' : 'code')
+        value.setBlocks(isCode ? 'paragraph' : 'code')
         return true
       }
     }

--- a/docs/walkthroughs/defining-custom-block-nodes.md
+++ b/docs/walkthroughs/defining-custom-block-nodes.md
@@ -139,7 +139,7 @@ class App extends React.Component {
     event.preventDefault()
 
     // Otherwise, set the currently selected blocks type to "code".
-    change.setBlock('code')
+    change.setBlocks('code')
     return true
   }
 
@@ -196,7 +196,7 @@ class App extends React.Component {
     const isCode = change.value.blocks.some(block => block.type == 'code')
 
     // Toggle the block type depending on `isCode`.
-    change.setBlock(isCode ? 'paragraph' : 'code')
+    change.setBlocks(isCode ? 'paragraph' : 'code')
     return true
   }
 

--- a/examples/check-lists/index.js
+++ b/examples/check-lists/index.js
@@ -95,7 +95,7 @@ class CheckLists extends React.Component {
     const { value } = change
 
     if (event.key == 'Enter' && value.startBlock.type == 'check-list-item') {
-      change.splitBlock().setBlock({ data: { checked: false } })
+      change.splitBlock().setBlocks({ data: { checked: false } })
       return true
     }
 
@@ -105,7 +105,7 @@ class CheckLists extends React.Component {
       value.startBlock.type == 'check-list-item' &&
       value.selection.startOffset == 0
     ) {
-      change.setBlock('paragraph')
+      change.setBlocks('paragraph')
       return true
     }
   }

--- a/examples/markdown-shortcuts/index.js
+++ b/examples/markdown-shortcuts/index.js
@@ -153,7 +153,7 @@ class MarkdownShortcuts extends React.Component {
     if (type == 'list-item' && startBlock.type == 'list-item') return
     event.preventDefault()
 
-    change.setBlock(type)
+    change.setBlocks(type)
 
     if (type == 'list-item') {
       change.wrapBlock('bulleted-list')
@@ -180,7 +180,7 @@ class MarkdownShortcuts extends React.Component {
     if (startBlock.type == 'paragraph') return
 
     event.preventDefault()
-    change.setBlock('paragraph')
+    change.setBlocks('paragraph')
 
     if (startBlock.type == 'list-item') {
       change.unwrapBlock('bulleted-list')
@@ -219,7 +219,7 @@ class MarkdownShortcuts extends React.Component {
     }
 
     event.preventDefault()
-    change.splitBlock().setBlock('paragraph')
+    change.splitBlock().setBlocks('paragraph')
     return true
   }
 }

--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -137,11 +137,11 @@ class RichTextExample extends React.Component {
 
       if (isList) {
         change
-          .setBlock(isActive ? DEFAULT_NODE : type)
+          .setBlocks(isActive ? DEFAULT_NODE : type)
           .unwrapBlock('bulleted-list')
           .unwrapBlock('numbered-list')
       } else {
-        change.setBlock(isActive ? DEFAULT_NODE : type)
+        change.setBlocks(isActive ? DEFAULT_NODE : type)
       }
     } else {
       // Handle the extra wrapping required for list buttons.
@@ -152,7 +152,7 @@ class RichTextExample extends React.Component {
 
       if (isList && isType) {
         change
-          .setBlock(DEFAULT_NODE)
+          .setBlocks(DEFAULT_NODE)
           .unwrapBlock('bulleted-list')
           .unwrapBlock('numbered-list')
       } else if (isList) {
@@ -162,7 +162,7 @@ class RichTextExample extends React.Component {
           )
           .wrapBlock(type)
       } else {
-        change.setBlock('list-item').wrapBlock(type)
+        change.setBlocks('list-item').wrapBlock(type)
       }
     }
 

--- a/packages/slate/src/changes/at-current-range.js
+++ b/packages/slate/src/changes/at-current-range.js
@@ -1,3 +1,4 @@
+import logger from 'slate-dev-logger'
 import Block from '../models/block'
 import Inline from '../models/inline'
 import Mark from '../models/mark'
@@ -24,8 +25,8 @@ const PROXY_TRANSFORMS = [
   'deleteCharForward',
   'deleteWordForward',
   'deleteLineForward',
-  'setBlock',
-  'setInline',
+  'setBlocks',
+  'setInlines',
   'splitInline',
   'unwrapBlock',
   'unwrapInline',
@@ -41,6 +42,22 @@ PROXY_TRANSFORMS.forEach(method => {
     change[methodAtRange](selection, ...args)
   }
 })
+
+Changes.setBlock = (...args) => {
+  logger.deprecate(
+    'slate@0.33.0',
+    'The `setBlock` method of Slate changes has been renamed to `setBlocks`.'
+  )
+  Changes.setBlocks(...args)
+}
+
+Changes.setInline = (...args) => {
+  logger.deprecate(
+    'slate@0.33.0',
+    'The `setInline` method of Slate changes has been renamed to `setInlines`.'
+  )
+  Changes.setInlines(...args)
+}
 
 /**
  * Add a `mark` to the characters in the current selection.

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -1,4 +1,5 @@
 import { List } from 'immutable'
+import logger from 'slate-dev-logger'
 
 import Block from '../models/block'
 import Inline from '../models/inline'
@@ -942,7 +943,7 @@ Changes.removeMarkAtRange = (change, range, mark, options = {}) => {
  *   @property {Boolean} normalize
  */
 
-Changes.setBlockAtRange = (change, range, properties, options = {}) => {
+Changes.setBlocksAtRange = (change, range, properties, options = {}) => {
   const normalize = change.getFlag('normalize', options)
   const { value } = change
   const { document } = value
@@ -972,6 +973,14 @@ Changes.setBlockAtRange = (change, range, properties, options = {}) => {
   })
 }
 
+Changes.setBlockAtRange = (...args) => {
+  logger.deprecate(
+    'slate@0.33.0',
+    'The `setBlockAtRange` method of Slate changes has been renamed to `setBlocksAtRange`.'
+  )
+  Changes.setBlocksAtRange(...args)
+}
+
 /**
  * Set the `properties` of inline nodes in a `range`.
  *
@@ -982,7 +991,7 @@ Changes.setBlockAtRange = (change, range, properties, options = {}) => {
  *   @property {Boolean} normalize
  */
 
-Changes.setInlineAtRange = (change, range, properties, options = {}) => {
+Changes.setInlinesAtRange = (change, range, properties, options = {}) => {
   const normalize = change.getFlag('normalize', options)
   const { value } = change
   const { document } = value
@@ -991,6 +1000,14 @@ Changes.setInlineAtRange = (change, range, properties, options = {}) => {
   inlines.forEach(inline => {
     change.setNodeByKey(inline.key, properties, { normalize })
   })
+}
+
+Changes.setInlineAtRange = (...args) => {
+  logger.deprecate(
+    'slate@0.33.0',
+    'The `setInlineAtRange` method of Slate changes has been renamed to `setInlinesAtRange`.'
+  )
+  Changes.setInlinesAtRange(...args)
 }
 
 /**

--- a/packages/slate/test/changes/at-current-range/set-block/across-blocks.js
+++ b/packages/slate/test/changes/at-current-range/set-block/across-blocks.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({ type: 'code' })
+  change.setBlocks({ type: 'code' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/across-inlines.js
+++ b/packages/slate/test/changes/at-current-range/set-block/across-inlines.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({ type: 'code' })
+  change.setBlocks({ type: 'code' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/data-only.js
+++ b/packages/slate/test/changes/at-current-range/set-block/data-only.js
@@ -5,7 +5,7 @@ import h from '../../../helpers/h'
 import { Data } from '../../../..'
 
 export default function(change) {
-  change.setBlock({ data: Data.create({ thing: 'value' }) })
+  change.setBlocks({ data: Data.create({ thing: 'value' }) })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/hanging-selection.js
+++ b/packages/slate/test/changes/at-current-range/set-block/hanging-selection.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({ type: 'code' })
+  change.setBlocks({ type: 'code' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/nested-block.js
+++ b/packages/slate/test/changes/at-current-range/set-block/nested-block.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({ type: 'code' })
+  change.setBlocks({ type: 'code' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/single-block-string-shorthand.js
+++ b/packages/slate/test/changes/at-current-range/set-block/single-block-string-shorthand.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock('code')
+  change.setBlocks('code')
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/single-block.js
+++ b/packages/slate/test/changes/at-current-range/set-block/single-block.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({ type: 'code' })
+  change.setBlocks({ type: 'code' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-block/with-data-as-map.js
+++ b/packages/slate/test/changes/at-current-range/set-block/with-data-as-map.js
@@ -4,7 +4,7 @@ import h from '../../../helpers/h'
 import { Data } from '../../../..'
 
 export default function(change) {
-  change.setBlock({
+  change.setBlocks({
     type: 'code',
     data: Data.create({ thing: 'value' }),
   })

--- a/packages/slate/test/changes/at-current-range/set-block/with-data-as-object.js
+++ b/packages/slate/test/changes/at-current-range/set-block/with-data-as-object.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({
+  change.setBlocks({
     type: 'code',
     data: { thing: 'value' },
   })

--- a/packages/slate/test/changes/at-current-range/set-block/with-is-void.js
+++ b/packages/slate/test/changes/at-current-range/set-block/with-is-void.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setBlock({
+  change.setBlocks({
     type: 'image',
     isVoid: true,
   })

--- a/packages/slate/test/changes/at-current-range/set-inline/across-inlines.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/across-inlines.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setInline({ type: 'hashtag' })
+  change.setInlines({ type: 'hashtag' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-inline/data-only.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/data-only.js
@@ -4,7 +4,7 @@ import h from '../../../helpers/h'
 import { Data } from '../../../..'
 
 export default function(change) {
-  change.setInline({ data: Data.create({ thing: 'value' }) })
+  change.setInlines({ data: Data.create({ thing: 'value' }) })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-inline/nested-inline.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/nested-inline.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setInline({ type: 'comment' })
+  change.setInlines({ type: 'comment' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-inline/single-inline-string-shorthand.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/single-inline-string-shorthand.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setInline('hashtag')
+  change.setInlines('hashtag')
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-inline/single-inline.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/single-inline.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setInline({ type: 'hashtag' })
+  change.setInlines({ type: 'hashtag' })
 }
 
 export const input = (

--- a/packages/slate/test/changes/at-current-range/set-inline/with-data-object.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/with-data-object.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setInline({
+  change.setInlines({
     type: 'hashtag',
     data: { thing: 'value' },
   })

--- a/packages/slate/test/changes/at-current-range/set-inline/with-data.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/with-data.js
@@ -4,7 +4,7 @@ import h from '../../../helpers/h'
 import { Data } from '../../../..'
 
 export default function(change) {
-  change.setInline({
+  change.setInlines({
     type: 'hashtag',
     data: Data.create({ thing: 'value' }),
   })

--- a/packages/slate/test/changes/at-current-range/set-inline/with-is-void.js
+++ b/packages/slate/test/changes/at-current-range/set-inline/with-is-void.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.setInline({
+  change.setInlines({
     type: 'emoji',
     isVoid: true,
   })


### PR DESCRIPTION
Fixes #567 