### PR TITLE
Switch to package.json "files" configuration rather than .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-.babelrc
-benchmark
-docs
-examples
-src
-test
-tmp

--- a/packages/slate-base64-serializer/.npmignore
+++ b/packages/slate-base64-serializer/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-base64-serializer/package.json
+++ b/packages/slate-base64-serializer/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "peerDependencies": {
     "slate": "^0.32.1"
   },

--- a/packages/slate-dev-logger/.npmignore
+++ b/packages/slate-dev-logger/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-dev-logger/package.json
+++ b/packages/slate-dev-logger/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "browserify": "^13.0.1",

--- a/packages/slate-html-serializer/.npmignore
+++ b/packages/slate-html-serializer/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-html-serializer/package.json
+++ b/packages/slate-html-serializer/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "dependencies": {
     "slate-dev-logger": "^0.1.36",
     "type-of": "^2.0.1"

--- a/packages/slate-hyperscript/.npmignore
+++ b/packages/slate-hyperscript/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "dependencies": {
     "is-empty": "^1.0.0",
     "is-plain-object": "^2.0.4",

--- a/packages/slate-plain-serializer/.npmignore
+++ b/packages/slate-plain-serializer/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-plain-serializer/package.json
+++ b/packages/slate-plain-serializer/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "dependencies": {
     "slate-dev-logger": "^0.1.36"
   },

--- a/packages/slate-prop-types/.npmignore
+++ b/packages/slate-prop-types/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-prop-types/package.json
+++ b/packages/slate-prop-types/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "dependencies": {
     "slate-dev-logger": "^0.1.36"
   },

--- a/packages/slate-react/.npmignore
+++ b/packages/slate-react/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "dependencies": {
     "debug": "^2.3.2",
     "get-window": "^1.1.1",

--- a/packages/slate-simulator/.npmignore
+++ b/packages/slate-simulator/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate-simulator/package.json
+++ b/packages/slate-simulator/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "peerDependencies": {
     "slate": "^0.32.1",
     "slate-dev-logger": "^0.1.23"

--- a/packages/slate/.npmignore
+++ b/packages/slate/.npmignore
@@ -1,7 +1,0 @@
-benchmark
-docs
-examples
-src
-test
-tmp
-.babelrc

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "./lib/index.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "dependencies": {
     "debug": "^2.3.2",
     "direction": "^0.1.5",


### PR DESCRIPTION
Note that npm [will include](https://docs.npmjs.com/files/package.json#files) the `package.json`, `Readme.md`, and `Changelog.md` regardless of whether it's in the `files` array.

Fixes #1442 