### PR TITLE
Edge browser selection edge case

### DIFF
--- a/packages/slate-react/src/constants/environment.js
+++ b/packages/slate-react/src/constants/environment.js
@@ -91,6 +91,7 @@ export const IS_CHROME = BROWSER === 'chrome'
 export const IS_FIREFOX = BROWSER === 'firefox'
 export const IS_SAFARI = BROWSER === 'safari'
 export const IS_IE = BROWSER === 'ie'
+export const IS_EDGE = BROWSER === 'edge'
 
 export const IS_ANDROID = OS === 'android'
 export const IS_IOS = OS === 'ios'

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -4,6 +4,8 @@ import isBackward from 'selection-is-backward'
 import { Range } from 'slate'
 
 import findPoint from './find-point'
+import findDOMPoint from './find-dom-point'
+import { IS_IE, IS_EDGE } from '../constants/environment'
 
 /**
  * Find a Slate range from a DOM `native` selection.
@@ -35,7 +37,22 @@ function findRange(native, value) {
   const focus = isCollapsed ? anchor : findPoint(focusNode, focusOffset, value)
   if (!anchor || !focus) return null
 
-  const range = Range.create({
+  // COMPAT: ??? The Edge browser seems to have a case where if you select the
+  // last word of a span, it sets the endContainer to the containing span.
+  // `selection-is-backward` doesn't handle this case.
+  if (IS_IE || IS_EDGE) {
+    const domAnchor = findDOMPoint(anchor.key, anchor.offset)
+    const domFocus = findDOMPoint(focus.key, focus.offset)
+
+    native = {
+      anchorNode: domAnchor.node,
+      anchorOffset: domAnchor.offset,
+      focusNode: domFocus.node,
+      focusOffset: domFocus.offset,
+    }
+  }
+
+  let range = Range.create({
     anchorKey: anchor.key,
     anchorOffset: anchor.offset,
     focusKey: focus.key,

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -52,7 +52,7 @@ function findRange(native, value) {
     }
   }
 
-  let range = Range.create({
+  const range = Range.create({
     anchorKey: anchor.key,
     anchorOffset: anchor.offset,
     focusKey: focus.key,


### PR DESCRIPTION
The Edge browser (41) has a weird edge case when selecting. If you double click to select the last word in a block, and it's the last text in the block, it sets the `endContainer` of the selection range to the surrounding node. The `selection-is-backward` lib doesn't handle cases where node's are contained. 

The current effect is that `findRange` get's `isBackward` wrong, and the range collapses to the start when creating a native `Range`.

![example](https://user-images.githubusercontent.com/451488/35587104-a553183a-05b1-11e8-94e9-b0840914400d.gif)
