### PR TITLE
Fix range.moveToRangeOf when range is a backward range;

### DIFF
--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -657,11 +657,8 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveToRangeOf(start, end = start) {
-    if (this.isBackward) {
-      return this.moveAnchorToEndOf(end).moveFocusToStartOf(start)
-    }
-    return this
-      .moveAnchorToStartOf(start)
+    const range = this.isBackward ? this.flip() : this
+    return range.moveAnchorToStartOf(start)
       .moveFocusToEndOf(end)
   }
 

--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -658,7 +658,8 @@ class Range extends Record(DEFAULTS) {
 
   moveToRangeOf(start, end = start) {
     const range = this.isBackward ? this.flip() : this
-    return range.moveAnchorToStartOf(start)
+    return range
+      .moveAnchorToStartOf(start)
       .moveFocusToEndOf(end)
   }
 

--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -657,6 +657,9 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveToRangeOf(start, end = start) {
+    if (this.isBackward) {
+      return this.moveAnchorToEndOf(end).moveFocusToStartOf(start)
+    }
     return this
       .moveAnchorToStartOf(start)
       .moveFocusToEndOf(end)

--- a/packages/slate/test/changes/at-current-range/unwrap-block/middle-child-blocks-with-backward-selection.js
+++ b/packages/slate/test/changes/at-current-range/unwrap-block/middle-child-blocks-with-backward-selection.js
@@ -1,0 +1,64 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function (change) {
+  change.unwrapBlock('quote')
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          one
+        </paragraph>
+        <paragraph>
+          two
+        </paragraph>
+        <paragraph>
+          <focus />three
+        </paragraph>
+        <paragraph>
+          <anchor />four
+        </paragraph>
+        <paragraph>
+          five
+        </paragraph>
+        <paragraph>
+          six
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          one
+        </paragraph>
+        <paragraph>
+          two
+        </paragraph>
+      </quote>
+      <paragraph>
+        <focus />three
+      </paragraph>
+      <paragraph>
+        <anchor />four
+      </paragraph>
+      <quote>
+        <paragraph>
+          five
+        </paragraph>
+        <paragraph>
+          six
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+


### PR DESCRIPTION
@CameronAckermanSEL   Can you have a test whether unwrapBlock is good after this PR?

It should fix https://github.com/ianstormtaylor/slate/issues/1500
The problem is that moveToRangeOf does not consider the case `Range.isBackward`.  I think there can be two options:
1. `moveToRangeOf` always return with `isBackward: false`
2. `moveToRangeOf` keep `isBackward`, but switch anchor and focus if necessary.

In this PR, I choose the second solution