### PR TITLE
Store operations as plain JS objects in History

### DIFF
--- a/packages/slate/src/changes/on-history.js
+++ b/packages/slate/src/changes/on-history.js
@@ -1,5 +1,6 @@
 
 import invert from '../operations/invert'
+import Operation from '../models/operation'
 import omit from 'lodash/omit'
 
 /**
@@ -30,7 +31,7 @@ Changes.redo = (change) => {
   undos = undos.push(next)
 
   // Replay the next operations.
-  next.forEach((op) => {
+  next.map(json => Operation.fromJSON(json)).forEach((op) => {
     const { type, properties } = op
 
     // When the operation mutates the selection, omit its `isFocused` value to
@@ -69,7 +70,7 @@ Changes.undo = (change) => {
   redos = redos.push(previous)
 
   // Replay the inverse of the previous operations.
-  previous.slice().reverse().map(invert).forEach((inverse) => {
+  previous.slice().reverse().map(json => invert(Operation.fromJSON(json))).forEach((inverse) => {
     const { type, properties } = inverse
 
     // When the operation mutates the selection, omit its `isFocused` value to

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -121,6 +121,8 @@ class History extends Record(DEFAULTS) {
     const prevBatch = undos.peek()
     const prevOperation = prevBatch && prevBatch.last()
 
+    operation = operation.toJSON()
+
     if (skip == null) {
       skip = shouldSkip(operation, prevOperation)
     }

--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -103,7 +103,7 @@ class Operation extends Record(DEFAULTS) {
         // Skip keys for objects that should not be serialized, and are only used
         // for providing the local-only invert behavior for the history stack.
         if (key == 'document') continue
-        if (key == 'selection') continue
+        if (key == 'selection' && type != 'set_selection') continue
         if (key == 'value') continue
         if (key == 'node' && type != 'insert_node') continue
 
@@ -139,20 +139,7 @@ class Operation extends Record(DEFAULTS) {
       }
 
       if (key == 'properties' && type == 'set_selection') {
-        const { anchorKey, focusKey, ...rest } = v
-        v = Range.createProperties(rest)
-
-        if (anchorKey !== undefined) {
-          v.anchorPath = anchorKey === null
-            ? null
-            : value.document.getPath(anchorKey)
-        }
-
-        if (focusKey !== undefined) {
-          v.focusPath = focusKey === null
-            ? null
-            : value.document.getPath(focusKey)
-        }
+        v = Range.createProperties(v)
       }
 
       if (key == 'properties' && type == 'set_value') {
@@ -227,11 +214,11 @@ class Operation extends Record(DEFAULTS) {
       // Skip keys for objects that should not be serialized, and are only used
       // for providing the local-only invert behavior for the history stack.
       if (key == 'document') continue
-      if (key == 'selection') continue
+      if (key == 'selection' && type != 'set_selection') continue
       if (key == 'value') continue
       if (key == 'node' && type != 'insert_node') continue
 
-      if (key == 'mark' || key == 'marks' || key == 'node') {
+      if (key == 'mark' || key == 'marks' || key == 'node' || key == 'selection') {
         value = value.toJSON()
       }
 
@@ -252,10 +239,10 @@ class Operation extends Record(DEFAULTS) {
 
       if (key == 'properties' && type == 'set_selection') {
         const v = {}
+        if ('anchorKey' in value) v.anchorKey = value.anchorKey
         if ('anchorOffset' in value) v.anchorOffset = value.anchorOffset
-        if ('anchorPath' in value) v.anchorPath = value.anchorPath
+        if ('focusKey' in value) v.focusKey = value.focusKey
         if ('focusOffset' in value) v.focusOffset = value.focusOffset
-        if ('focusPath' in value) v.focusPath = value.focusPath
         if ('isBackward' in value) v.isBackward = value.isBackward
         if ('isFocused' in value) v.isFocused = value.isFocused
         if ('marks' in value) v.marks = value.marks == null ? null : value.marks.toJSON()

--- a/packages/slate/src/operations/invert.js
+++ b/packages/slate/src/operations/invert.js
@@ -170,39 +170,9 @@ function invertOperation(op) {
    */
 
   if (type == 'set_selection') {
-    const { properties, selection, value } = op
-    const { anchorPath, focusPath, ...props } = properties
-    const { document } = value
-
-    if (anchorPath !== undefined) {
-      props.anchorKey = anchorPath === null
-        ? null
-        : document.assertPath(anchorPath).key
-    }
-
-    if (focusPath !== undefined) {
-      props.focusKey = focusPath === null
-        ? null
-        : document.assertPath(focusPath).key
-    }
-
-    const inverseSelection = selection.merge(props)
-    const inverseProps = pick(selection, Object.keys(props))
-
-    if (anchorPath !== undefined) {
-      inverseProps.anchorPath = inverseProps.anchorKey === null
-        ? null
-        : document.getPath(inverseProps.anchorKey)
-      delete inverseProps.anchorKey
-    }
-
-    if (focusPath !== undefined) {
-      inverseProps.focusPath = inverseProps.focusKey === null
-        ? null
-        : document.getPath(inverseProps.focusKey)
-      delete inverseProps.focusKey
-    }
-
+    const { properties, selection } = op
+    const inverseSelection = selection.merge(properties)
+    const inverseProps = pick(selection, Object.keys(properties))
     const inverse = op.set('selection', inverseSelection).set('properties', inverseProps)
     return inverse
   }


### PR DESCRIPTION
Hey! This PR is a suggested mitigation for #1402 and reduces the memory overhead of keeping a large undo stack by converting the `Operation` objects in `History` to plain JS (and stripping the `__cache`  field used for memoization.)

In order to make this change, I removed the selection `paths` from the JSON representation in favor of the `keys` in the underlying `Range`. I'm not sure what the motivation is for storing them as paths (maybe an experiment toward #1408? maybe support for collaborative editing?) Because the serialized and deserialized Selection objects no longer have `value.document`, they can't perform the coercion from path to key and vice versa.

To implement this and keep the added benefits of using `paths`, I think the best move (long term at least) is to fully implement #1408, since using paths everywhere would also eliminate the need for `value.document` and the conversion.

**Outcomes**

Test Scenario:
- Launch app
- Open editor
- Start profiler
- Type "A" followed by "Backspace" 20 times
- Stop profiler

Note that in both results below the memory usage is growing because we haven't hit the undo limit, so we're storing more and more data with every keystroke. It's just that in the after scenario we're storing so little it appears it's not growing.

Before:
![screen shot 2018-01-30 at 4 29 16 pm](https://user-images.githubusercontent.com/1037212/35599290-e8290248-05dc-11e8-8308-ce7523e9e65c.png)

After:
![screen shot 2018-01-30 at 4 27 02 pm](https://user-images.githubusercontent.com/1037212/35599287-e03646ea-05dc-11e8-9eb3-724b411967fa.png)

