### PR TITLE
Warn during normalization when range offsets are not numbers

### DIFF
--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -674,6 +674,12 @@ class Range extends Record(DEFAULTS) {
     const range = this
     let { anchorKey, anchorOffset, focusKey, focusOffset, isBackward } = range
 
+    const anchorOffsetType = typeof anchorOffset
+    const focusOffsetType = typeof focusOffset
+    if (anchorOffsetType != 'number' || focusOffsetType != 'number') {
+      logger.warn(`The range offsets should be numbers, but they were of type "${anchorOffsetType}" and "${focusOffsetType}".`)
+    }
+
     // If the range is unset, make sure it is properly zeroed out.
     if (anchorKey == null || focusKey == null) {
       return range.merge({


### PR DESCRIPTION
Feel free to take or leave this, but I just spent a fair amount of time trying to understand why `change.addMarkAtRange()` was extending my mark to the end of each text node. Turns out, I was reading the offsets straight into a Range from window.location, and in `change.addMarkByKey()`, it was doing `offset + length` as `"13" + 158` giving `"13158"` instead of the expected `171` for the end of the range.  JavaScript 🙄.

Figured that normalizing offsets in `range.normalize` was a reasonable approach, and that it might save someone the same trouble later.

Happy to write tests for this, but couldn't see any locations that models were being tested, nor a specific `tests/changes/on-document` section either. If you let me know the right location, I can write one.