### PR TITLE
[Do not merge] An experiement Test about updateNodeAtPath

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1954,6 +1954,29 @@ class Node {
   }
 
   /**
+   * Set a new value for a child node by `key`
+   * A faster method by guessing path
+   * @param {Array<number>} path
+   * @param {Node} node
+   * @return {Node}
+   */
+
+  updateNodeAtPath(path, node) {
+    const nodeAtPath = this.getNodeAtPath(path)
+    if (nodeAtPath.key !== node.key) {
+      path = this.getPath(node)
+    }
+
+    const setInPath = []
+    for (const childIndex of path) {
+      setInPath.push('nodes')
+      setInPath.push(childIndex)
+    }
+    return this.setIn(setInPath, node)
+  }
+
+
+  /**
    * Validate the node against a `schema`.
    *
    * @param {Schema} schema

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -347,6 +347,25 @@ class Node {
   }
 
   /**
+   * Get the path of ancestors of a descendant node by `path`.
+   *
+   * @param {Array<number>} path
+   * @return {List<Node>}
+   */
+
+  getAncestorsByPath(path) {
+    let parent = this
+    return List(path).map((childIndex) => {
+      if (!parent) {
+        throw new Error(`Cannot find a descendant by path as ${path}`)
+      }
+      const result = parent
+      parent = parent.nodes.get(childIndex)
+      return result
+    })
+  }
+
+  /**
    * Get the leaf block descendants of the node.
    *
    * @return {List<Node>}
@@ -1963,16 +1982,19 @@ class Node {
 
   updateNodeAtPath(path, node) {
     const nodeAtPath = this.getNodeAtPath(path)
+
     if (nodeAtPath.key !== node.key) {
       path = this.getPath(node)
     }
 
-    const setInPath = []
-    for (const childIndex of path) {
-      setInPath.push('nodes')
-      setInPath.push(childIndex)
-    }
-    return this.setIn(setInPath, node)
+    const ancestors = this.getAncestorsByPath(path)
+    let child = node
+    ancestors.findLast((parent, index) => {
+      const childIndex = path[index]
+      child = parent.setIn(['nodes', childIndex], child)
+      return false
+    })
+    return child
   }
 
 

--- a/packages/slate/src/operations/apply.js
+++ b/packages/slate/src/operations/apply.js
@@ -340,7 +340,7 @@ const APPLIERS = {
     let { document } = value
     let node = document.assertPath(path)
     node = node.merge(properties)
-    document = document.updateNode(node)
+    document = document.updateNodeAtPath(path, node)
     value = value.set('document', document)
     return value
   },

--- a/packages/slate/src/operations/apply.js
+++ b/packages/slate/src/operations/apply.js
@@ -32,7 +32,7 @@ const APPLIERS = {
     let { document } = value
     let node = document.assertPath(path)
     node = node.addMark(offset, length, mark)
-    document = document.updateNode(node)
+    document = document.updateNodeAtPath(path, node)
     value = value.set('document', document)
     return value
   },
@@ -52,7 +52,7 @@ const APPLIERS = {
     let { document } = value
     let parent = document.assertPath(rest)
     parent = parent.insertNode(index, node)
-    document = document.updateNode(parent)
+    document = document.updateNodeAtPath(rest, parent)
     value = value.set('document', document)
     return value
   },
@@ -73,7 +73,7 @@ const APPLIERS = {
 
     // Update the document
     node = node.insertText(offset, text, marks)
-    document = document.updateNode(node)
+    document = document.updateNodeAtPath(path, node)
 
     // Update the selection
     if (anchorKey == node.key && anchorOffset >= offset) {
@@ -101,13 +101,14 @@ const APPLIERS = {
     let { document, selection } = value
     const one = document.assertPath(withPath)
     const two = document.assertPath(path)
-    let parent = document.getParent(one.key)
+    const rest = path.slice(0, -1)
+    let parent = document.assertPath(rest)
     const oneIndex = parent.nodes.indexOf(one)
     const twoIndex = parent.nodes.indexOf(two)
 
     // Perform the merge in the document.
     parent = parent.mergeNode(oneIndex, twoIndex)
-    document = document.updateNode(parent)
+    document = document.updateNodeAtPath(rest, parent)
 
     // If the nodes are text nodes and the selection is inside the second node
     // update it to refer to the first node instead.
@@ -153,9 +154,9 @@ const APPLIERS = {
     const node = document.assertPath(path)
 
     // Remove the node from its current parent.
-    let parent = document.getParent(node.key)
+    let parent = document.assertPath(oldParentPath)
     parent = parent.removeNode(oldIndex)
-    document = document.updateNode(parent)
+    document = document.updateNodeAtPath(oldParentPath, parent)
 
     // Find the new target...
     let target
@@ -186,7 +187,7 @@ const APPLIERS = {
 
     // Insert the new node to its new parent.
     target = target.insertNode(newIndex, node)
-    document = document.updateNode(target)
+    document = document.updateNodeAtPath(newParentPath, target)
     value = value.set('document', document)
     return value
   },
@@ -204,7 +205,7 @@ const APPLIERS = {
     let { document } = value
     let node = document.assertPath(path)
     node = node.removeMark(offset, length, mark)
-    document = document.updateNode(node)
+    document = document.updateNodeAtPath(path, node)
     value = value.set('document', document)
     return value
   },


### PR DESCRIPTION
This is an experiment trying to replace `updateNode(node)` with `updateNodeAtPath(path, node)`
It shows that the `memerize` of `getAncestors(key)` is so efficient that `updateNodeAtPath`, surprisingly, slow down the slateJS.

Benchmark
```
$ mkdir -p ./tmp && babel-node ./node_modules/.bin/_matcha --reporter ./support/benchmark-reporter ./packages/*/benchmark/index.js > ./tmp/benchmark-comparison.json && babel-node ./support/benchmark-compare

  benchmarks
    html-serializer
      deserialize
        9.67 → 9.56 ops/sec
      serialize
        1297.79 → 1278.01 ops/sec
    plain-serializer
      deserialize
        628.79 → 664.33 ops/sec
      serialize
        10893.18 → 9974.71 ops/sec
    rendering
      normal
        131.94 → 124.00 ops/sec
    changes
      delete-backward
        162376.05 → 142525.50 ops/sec
      delete-forward
        30069.68 → 32136.36 ops/sec
      insert-text-by-key-multiple
        110.94 → 105.38 ops/sec
      insert-text-by-key
        1448.67 → 1383.92 ops/sec
      insert-text
        1250.24 → 1278.05 ops/sec
      normalize
        2302.14 → 2272.59 ops/sec
      split-block
        31.68 → 30.26 ops/sec
    models
      from-json
        136.29 → 136.50 ops/sec
      get-blocks-at-range
        1186642.28 → 947325.76 ops/sec
      get-blocks
        4714482.86 → 3964856.56 ops/sec
      get-characters-at-range
        979130.16 → 989907.79 ops/sec
      get-characters
        3557471.76 → 3595061.79 ops/sec
      get-inlines-at-range
        1028974.03 → 1013665.48 ops/sec
      get-inlines
        3613919.73 → 3501082.30 ops/sec
      get-leaves
        2798395.10 → 2831306.75 ops/sec
      get-marks-at-range
        1010496.40 → 1016599.82 ops/sec
      get-marks
        3528662.99 → 3402724.27 ops/sec
      get-path
        1305148.78 → 1317090.30 ops/sec
      get-texts-at-range
        1150373.86 → 1243870.35 ops/sec
      get-texts
        3888650.71 → 4626783.06 ops/sec
      has-node-multiple
        176895.60 → 196075.94 ops/sec
      has-node
        1340035.87 → 1378576.69 ops/sec
      to-json
        3614.20 → 3624.90 ops/sec
      update-node
        16461.21 → 15012.86 ops/sec
```