### PR TITLE
Improvements to developer experience with building packages

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -72,6 +72,8 @@ To keep the source rebuilding on every file change, you need to run an additiona
 yarn run watch
 ```
 
+If you're not using the examples in-browser (and only running the tests against the watched source), you can instead run `yarn watch:packages` for faster rebuilds.
+
 If you need to debug something, you can add a `debugger` line to the source, and then run `yarn run test debug`. 
 
 If you only want to run a specific test or tests, you can run `yarn run test --fgrep="slate-react rendering"` flag which will filter the tests being run by grepping for the string in each test.

--- a/package.json
+++ b/package.json
@@ -80,9 +80,10 @@
     "lint": "eslint packages/*/src packages/*/test examples/*/*.js examples/dev/*/*.js",
     "open": "open http://localhost:8080/dev.html",
     "release": "yarn test && yarn lint && lerna publish && yarn gh-pages",
-    "start": "http-server ./examples",
+    "server": "http-server ./examples",
+    "start": "npm-run-all --parallel --print-label watch server",
     "test": "cross-env BABEL_ENV=test mocha --require babel-core/register ./packages/*/test/index.js",
-    "watch": "npm-run-all --parallel --print-label watch:rollup start",
-    "watch:rollup": "rollup --config --watch"
+    "watch": "rollup --config --watch",
+    "watch:packages": "cross-env SKIP_EXAMPLES=true yarn watch"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ import slateReact from './packages/slate-react/package.json'
 import slateSchemaViolations from './packages/slate-schema-violations/package.json'
 import slateSimulator from './packages/slate-simulator/package.json'
 
-export default [
+const configurations = [
   ...factory(slate),
   ...factory(slateBase64Serializer),
   ...factory(slateDevLogger),
@@ -22,5 +22,10 @@ export default [
   ...factory(slateReact),
   ...factory(slateSchemaViolations),
   ...factory(slateSimulator),
-  ...examplesConfig,
 ]
+
+if (!process.env.SKIP_EXAMPLES) {
+  configurations.push(...examplesConfig)
+}
+
+export default configurations

--- a/support/rollup/factory.js
+++ b/support/rollup/factory.js
@@ -115,6 +115,11 @@ export default (pkg) => {
         format: 'es',
         sourcemap: environment === 'development',
       },
+      {
+        file: `packages/${pkgName}/${output.cjs}`,
+        format: 'cjs',
+        exports: 'named',
+      },
     ],
     external: isExternalDependency,
     plugins: [
@@ -146,14 +151,9 @@ export default (pkg) => {
   const configurations = [moduleConfig]
 
   if (environment === 'production') {
-    // In development, we only build the ES version to
+    // In development, we only build the module version to
     // reduce rebuild times. In production, we add the
-    // configs for the other variants here.
-    moduleConfig.output.push({
-      file: `packages/${pkgName}/${output.cjs}`,
-      format: 'cjs',
-      exports: 'named',
-    })
+    // configs for the UMD variants here.
     configurations.push(umdConfig, umdConfigMin)
   }
 


### PR DESCRIPTION
Based on the conversation in #1593 

1. Default to emitting both CJS and ES even in development/watch mode, as CJS is used by the tests so this allows for auto rebuilds that the tests can be run against

2. Move the `http-server` command to `yarn server` and change `yarn start` to both start the rollup watch and also start the http server. This is for a slightly more intuitive experience getting up and running -- you expect `yarn start` to be the default command to get started in development, rather than needing to either build first or run `yarn watch` instead.

3. Add a `watch:packages` command that builds & watches the packages (but not the examples), for super fast auto rebuilds when you are developing on a package and running tests against it but not using the examples.

Closes #1593 