### PR TITLE
[Doc] Adding an unknown mark doesn't produce an error

### DIFF
--- a/docs/walkthroughs/applying-custom-formatting.md
+++ b/docs/walkthroughs/applying-custom-formatting.md
@@ -105,7 +105,7 @@ class App extends React.Component {
 }
 ```
 
-Okay, so we've got the hotkey handler setup... but! If you happen to now try selecting text and hitting `⌘-B`, you'll get an error in your console. That's because we haven't told Slate how to render a "bold" mark.
+Okay, so we've got the hotkey handler setup... but! If you happen to now try selecting text and hitting `⌘-B`, you won't notice any change. That's because we haven't told Slate how to render a "bold" mark.
 
 For every mark type you want to add to your schema, you need to give Slate a "renderer" for that mark, just like nodes. So let's define our `bold` mark:
 


### PR DESCRIPTION
The *Applying custom formatting* guide states that Slate outputs an error in the console when a mark is applied without a corresponding renderer but AFAIK, that's not the case in the current version. I'm guessing this is an old behaviour (I'm completely new to this library), hence the doc update.