### PR TITLE
fix(updateSelection): make sure there is a node to extend from

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -213,10 +213,16 @@ class Content extends React.Component {
       // we need to check and do the right thing here.
       if (isBackward) {
         native.collapse(range.endContainer, range.endOffset)
-        native.extend(range.startContainer, range.startOffset)
+
+        if (native.anchorNode) {
+          native.extend(range.startContainer, range.startOffset)
+        }
       } else {
         native.collapse(range.startContainer, range.startOffset)
-        native.extend(range.endContainer, range.endOffset)
+
+        if (native.anchorNode) {
+          native.extend(range.endContainer, range.endOffset)
+        }
       }
     } else {
       // COMPAT: IE 11 does not support Selection.extend, fallback to addRange

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -207,22 +207,24 @@ class Content extends React.Component {
     this.tmp.isUpdatingSelection = true
     native.removeAllRanges()
 
-    // COMPAT: IE 11 does not support Selection.extend
-    if (native.extend) {
+    // COMPAT: IE 11 does not support Selection.setBaseAndExtent
+    if (native.setBaseAndExtent) {
       // COMPAT: Since the DOM range has no concept of backwards/forwards
       // we need to check and do the right thing here.
       if (isBackward) {
-        native.collapse(range.endContainer, range.endOffset)
-
-        if (native.anchorNode) {
-          native.extend(range.startContainer, range.startOffset)
-        }
+        native.setBaseAndExtent(
+          range.endContainer,
+          range.endOffset,
+          range.startContainer,
+          range.startOffset
+        )
       } else {
-        native.collapse(range.startContainer, range.startOffset)
-
-        if (native.anchorNode) {
-          native.extend(range.endContainer, range.endOffset)
-        }
+        native.setBaseAndExtent(
+          range.startContainer,
+          range.startOffset,
+          range.endContainer,
+          range.endOffset
+        )
       }
     } else {
       // COMPAT: IE 11 does not support Selection.extend, fallback to addRange


### PR DESCRIPTION
`Selection.collapse()` can fail at setting the anchor point, but it does so without throwing. So when we do the following in `updateSelection`:
```
native.collapse(range.startContainer, range.startOffset)
native.extend(range.endContainer, range.endOffset)
```

`extend()` will throw if `collapse()` wasn't successful (since there's nothing to extend from). I haven't been able to figure out why it fails, but we can reproduce it consistently in our app (on Chrome). I can't find any info on when it could fail etc.

This PR just adds a safety check before running `extend` so that an error isn't thrown. What's interesting in our app is that it behaves as expected with this even when it can't set the anchor point. 