### PR TITLE
Pass value down to validateNode functions

### DIFF
--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -92,9 +92,11 @@ Sometimes though, the declarative validation syntax isn't fine-grained enough to
 When you define a `validateNode` function, you either return nothing if the node's already valid, or you return a normalizer function that will make the node valid if it isn't. Here's an example:
 
 ```js
-function validateNode(node) {
+function validateNode(node, value) {
   if (node.object != 'block') return
   if (node.isVoid) return
+  const parent = value.document.getParent(node)
+  if (parent.object === 'document') return
 
   const { nodes } = node
   if (nodes.size != 3) return
@@ -107,7 +109,7 @@ function validateNode(node) {
 }
 ```
 
-This validation defines a very specific (honestly, useless) behavior, where if a node is block, non-void and has three children, the first and last of which are text nodes, it is removed. I don't know why you'd ever do that, but the point is that you can get very specific with your validations this way. Any property of the node can be examined.
+This validation defines a very specific (honestly, useless) behavior, where if a node is block that is not a direct child of the document, non-void and has three children, the first and last of which are text nodes, it is removed. I don't know why you'd ever do that, but the point is that you can get very specific with your validations this way. Any property of the node can be examined.
 
 When you need this level of specificity, using the `validateNode` property of the editor or plugins is handy.
 

--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -113,7 +113,7 @@ function normalizeNode(change, node, schema) {
   let iterations = 0
 
   function iterate(c, n) {
-    const normalize = n.validate(schema)
+    const normalize = n.validate(schema, change.value)
     if (!normalize) return
 
     // Run the `normalize` function to fix the node.

--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -113,7 +113,7 @@ function normalizeNode(change, node, schema) {
   let iterations = 0
 
   function iterate(c, n) {
-    const normalize = n.validate(schema, change.value)
+    const normalize = n.validate(schema, c.value)
     if (!normalize) return
 
     // Run the `normalize` function to fix the node.

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1970,8 +1970,8 @@ class Node {
    * @return {Function|Null}
    */
 
-  validate(schema) {
-    return schema.validateNode(this)
+  validate(schema, value) {
+    return schema.validateNode(this, value)
   }
 }
 

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1967,6 +1967,7 @@ class Node {
    * Validate the node against a `schema`.
    *
    * @param {Schema} schema
+   * @param {Value} value
    * @return {Function|Null}
    */
 

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -269,6 +269,7 @@ class Schema extends Record(DEFAULTS) {
    * invalid node, or void if the node is valid.
    *
    * @param {Node} node
+   * @param {Value} value
    * @return {Function|Void}
    */
 
@@ -291,10 +292,10 @@ class Schema extends Record(DEFAULTS) {
     if (rule.data != null) {
       for (const key in rule.data) {
         const fn = rule.data[key]
-        const value = node.data.get(key)
+        const dataValue = node.data.get(key)
 
-        if (!fn(value)) {
-          return this.fail(NODE_DATA_INVALID, { ...ctx, key, value })
+        if (!fn(dataValue)) {
+          return this.fail(NODE_DATA_INVALID, { ...ctx, key, dataValue })
         }
       }
     }

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -272,8 +272,8 @@ class Schema extends Record(DEFAULTS) {
    * @return {Function|Void}
    */
 
-  validateNode(node) {
-    const ret = this.stack.find('validateNode', node)
+  validateNode(node, value) {
+    const ret = this.stack.find('validateNode', node, value)
     if (ret) return ret
 
     if (node.object == 'text') return

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -489,6 +489,7 @@ class Text extends Record(DEFAULTS) {
    * Validate the text node against a `schema`.
    *
    * @param {Schema} schema
+   * @param {Value} value
    * @return {Object|Void}
    */
 

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -492,8 +492,8 @@ class Text extends Record(DEFAULTS) {
    * @return {Object|Void}
    */
 
-  validate(schema) {
-    return schema.validateNode(this)
+  validate(schema, value) {
+    return schema.validateNode(this, value)
   }
 }
 


### PR DESCRIPTION
(I apologize for reposting this, but I totally FUBAR'd the other PR by doing a merge XD)

This is a proof of concept for an issue #1563 where we pass down the value to `validateNode` calls. It is definitely up for debate whether this would be a positive change or not.

The primary use case for this feature is that it would allow for validation functions that need to analyze the hierarchy of the document. Currently, this is achievable but only if the document node is under validation (or if a block node that contains the blocks that one actually wants to validate is under validation, which is not always possible). Such validate node calls get called every single time any sort of change is made to state, which seems avoidable. It would be nice to be able to have similar rules that operate on the block that changed only, and allowed it to analyze siblings.

Thanks for your consideration :)