### PR TITLE
Fix getInsertMarksAtRangeAsArray for empty Text Node

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1109,6 +1109,9 @@ class Node {
 
     const text = this.getDescendant(range.startKey)
     const char = text.characters.get(range.startOffset)
+    if (!char) {
+      return []
+    }
     return char.marks.toArray()
   }
 


### PR DESCRIPTION
When `Text.text === ''`, for example after delete or by normalization around inline, the `getInsertMarksAtRangeAsArray` will throw an error.

This PR fixes that.
Fix https://github.com/ianstormtaylor/slate/issues/1613