### PR TITLE
[Improvement] Update `__cache` of ancestor keys

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -356,9 +356,6 @@ class Node {
     this.nodes.find(node => {
       if (node.object == 'text') return false
       ancestors = node.getAncestors(key)
-      if (!node.__cache.get('getAncestors')) {
-        throw new Error('Bad')
-      }
       return ancestors
     })
 

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -144,11 +144,12 @@ function setCacheNullWithBatchKeys(node, property, batchKeys) {
 
   const propertyMap = node.__cache.get(property)
 
-  batchKeys.forEach(k => {
-    if (!propertyMap.has(k)) {
-      const nullValue = new Map([[LEAF, null]]) // eslint-disable-line no-undef,no-restricted-globals
-      propertyMap.set(k, nullValue)
+  batchKeys.find(k => {
+    if (propertyMap.has(k)) {
+      return true
     }
+    const nullValue = new Map([[LEAF, null]]) // eslint-disable-line no-undef,no-restricted-globals
+    propertyMap.set(k, nullValue)
   })
 
   node.__cache.set(property, propertyMap)

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -117,6 +117,44 @@ function memoize(object, properties, options = {}) {
 }
 
 /**
+ *   Set expected cache values to null
+ * @param {Node} node
+ * @param {string} property
+ * @param {List<Array>} batchKeys
+ * @return {Promise}
+ **/
+
+function setCacheNullWithBatchKeys(node, property, batchKeys) {
+  if (IS_DEV) {
+    // If memoization is disabled, call into the original method.
+    if (!ENABLED) return null
+
+    // If the cache key is different, previous caches must be cleared.
+    if (CACHE_KEY !== node.__cache_key) {
+      node.__cache_key = CACHE_KEY
+      node.__cache = new Map([[property, new Map()]]) // eslint-disable-line no-undef,no-restricted-globals
+    }
+  }
+  if (!node.__cache) {
+    node.__cache = new Map([[property, new Map()]]) // eslint-disable-line no-undef,no-restricted-globals
+  }
+  if (!node.__cache.has(property)) {
+    node.__cache.set(property, new Map()) // eslint-disable-line no-undef,no-restricted-globals
+  }
+
+  const propertyMap = node.__cache.get(property)
+
+  batchKeys.forEach(k => {
+    if (!propertyMap.has(k)) {
+      const nullValue = new Map([[LEAF, null]]) // eslint-disable-line no-undef,no-restricted-globals
+      propertyMap.set(k, nullValue)
+    }
+  })
+
+  node.__cache.set(property, propertyMap)
+}
+
+/**
  * Get a value at a key path in a tree of Map.
  *
  * If not set, returns UNSET.
@@ -198,4 +236,4 @@ function useMemoization(enabled) {
  */
 
 export default memoize
-export { resetMemoization, useMemoization }
+export { resetMemoization, useMemoization, setCacheNullWithBatchKeys }


### PR DESCRIPTION
This PR provides a memerize feature to speed up `getAncestors(parent.key)`.  This PR is aimed to improve at-range functions, where includes logic like

```
const startBlock = document.getClosestBlock(startKey)
const parent = document.getParent(startBlock.key)
```

Because in the preceding nodes whose descendant do not include `startKey`, they will have `__cache.getIn(['getAncestors', startBlock.key]) === null`.  It would also speed up some operations about tables (and nested structures).

I am confused of the benchmark result. I do not think `from-JSON` expects such a great change....

```
yarn run v1.3.2
$ mkdir -p ./tmp && cross-env BABEL_ENV=test babel-node ./node_modules/.bin/_matcha --reporter ./support/benchmark/reporter ./packages/*/benchmark/index.js > ./tmp/benchmark-comparison.json && cross-env BABEL_ENV=test babel-node ./support/benchmark/compare

  benchmarks
    html-serializer
      deserialize
        9.35 → 8.90 ops/sec
      serialize
        1054.25 → 1051.44 ops/sec
    plain-serializer
      deserialize
        600.53 → 429.22 ops/sec
      serialize
        8928.75 → 11300.38 ops/sec
    rendering
      normal
        132.30 → 139.75 ops/sec
    changes
      delete-backward
        118222.24 → 146442.55 ops/sec
      delete-forward
        29101.50 → 26796.71 ops/sec
      insert-text-by-key-multiple
        105.15 → 93.79 ops/sec
      insert-text-by-key
        1010.07 → 1259.86 ops/sec
      insert-text
        1459.83 → 1169.89 ops/sec
      normalize
        2147.05 → 2098.38 ops/sec
      split-block
        31.89 → 27.66 ops/sec
    models
      from-json
        77.57 → 134.09 ops/sec (73% faster)
      get-blocks-at-range
        944141.08 → 743171.51 ops/sec
      get-blocks
        3440352.47 → 3137621.03 ops/sec
      get-characters-at-range
        972544.46 → 868053.33 ops/sec
      get-characters
        3542658.39 → 3172917.52 ops/sec
      get-inlines-at-range
        980157.30 → 875120.34 ops/sec
      get-inlines
        3448647.68 → 3064050.77 ops/sec
      get-leaves
        2327401.21 → 1918331.87 ops/sec
      get-marks-at-range
        971414.51 → 872247.14 ops/sec
      get-marks
        3423034.51 → 3008109.54 ops/sec
      get-path
        1058576.06 → 918596.50 ops/sec
      get-texts-at-range
        945193.79 → 949799.28 ops/sec
      get-texts
        3471349.62 → 3290949.34 ops/sec
      has-node-multiple
        136605.05 → 132585.69 ops/sec
      has-node
        1039672.82 → 1016833.12 ops/sec
      to-json
        4054.73 → 3484.43 ops/sec
      update-node
        22987.16 → 15801.38 ops/sec

✨  Done in 59.97s.
```