### PR TITLE
add ability to click multiple emojis in example

### DIFF
--- a/examples/emojis/index.js
+++ b/examples/emojis/index.js
@@ -81,7 +81,7 @@ class Emojis extends React.Component {
       type: 'emoji',
       isVoid: true,
       data: { code },
-    })
+    }).collapseToStartOfNextText().focus()
 
     this.onChange(change)
   }

--- a/examples/emojis/index.js
+++ b/examples/emojis/index.js
@@ -77,11 +77,14 @@ class Emojis extends React.Component {
     const { value } = this.state
     const change = value.change()
 
-    change.insertInline({
-      type: 'emoji',
-      isVoid: true,
-      data: { code },
-    }).collapseToStartOfNextText().focus()
+    change
+      .insertInline({
+        type: 'emoji',
+        isVoid: true,
+        data: { code },
+      })
+      .collapseToStartOfNextText()
+      .focus()
 
     this.onChange(change)
   }


### PR DESCRIPTION
currently, after clicking one emoji, user needs to click in the editor before being able to add another emoji
this fixes that by jumping to next text block and focusing selection to make it obvious where next insertion will take place.

## Before
![current-behaviour-screencast 2018-02-08 12-40-13](https://user-images.githubusercontent.com/25991/35950981-6984b70a-0ccd-11e8-884c-ce512bacc726.gif)

## After
![slatejs-fix-screencast 2018-02-08 12-38-13](https://user-images.githubusercontent.com/25991/35950989-71cb5040-0ccd-11e8-85cc-c14d3c6fbc32.gif)
