### PR TITLE
Fix drag and dropping an inline node "forward" in the document

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -264,11 +264,11 @@ function AfterPlugin() {
     }
 
     if (type == 'node' && Block.isBlock(node)) {
-      change.insertBlock(node).removeNodeByKey(node.key)
+      change.insertBlock(node.regenerateKey()).removeNodeByKey(node.key)
     }
 
     if (type == 'node' && Inline.isInline(node)) {
-      change.insertInline(node).removeNodeByKey(node.key)
+      change.insertInline(node.regenerateKey()).removeNodeByKey(node.key)
     }
 
     // COMPAT: React's onSelect event breaks after an onDrop event


### PR DESCRIPTION
When drag and dropping an inline node to a position earlier in the
document, the node is inserted and then removed right after.
Regenerate the key to make sure the old node is removed instead of the
new one.