### PR TITLE
Restore Selection after replaceNodeByKey

### DIFF
--- a/packages/slate/src/changes/by-key.js
+++ b/packages/slate/src/changes/by-key.js
@@ -424,11 +424,13 @@ Changes.replaceNodeByKey = (change, key, newNode, options = {}) => {
   const parent = document.getParent(key)
   const index = parent.nodes.indexOf(node)
   change.removeNodeByKey(key, { normalize: false })
-  change.insertNodeByKey(parent.key, index, newNode, options)
+  change.insertNodeByKey(parent.key, index, newNode, { normalize })
+
+  // Restore the selection after replaceNode
   const { anchorKey, focusKey } = selection
   newNode = change.value.document.getDescendant(newNode.key)
-
-  if (newNode && anchorKey !== change.value.anchorKey) {
+  if (!newNode) return undefined
+  if (anchorKey !== change.value.anchorKey) {
     const { anchorOffset } = selection
     const anchorText = refindByKey(anchorKey, node, newNode)
     if (anchorText) {
@@ -436,17 +438,13 @@ Changes.replaceNodeByKey = (change, key, newNode, options = {}) => {
       change.moveAnchorTo(anchorText.key, newOffset)
     }
   }
-  if (newNode && focusKey !== change.value.focusKey) {
+  if (focusKey !== change.value.focusKey) {
     const { focusOffset } = selection
     const focusText = refindByKey(focusKey, node, newNode)
     if (focusText) {
       const newOffset = Math.min(focusText.text.length, focusOffset)
       change.moveFocusTo(focusText.key, newOffset)
     }
-  }
-
-  if (normalize) {
-    change.normalizeNodeByKey(parent.key)
   }
 }
 

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -241,6 +241,17 @@ class Text extends Record(DEFAULTS) {
   }
 
   /**
+   * Whether this Text node is the one we are trying to find
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getDescendant(key) {
+    return this.key === key ? this : null
+  }
+
+  /**
    * Derive the leaves for a list of `characters`.
    *
    * @param {Array|Void} decorations (optional)

--- a/packages/slate/src/utils/refind-by-key.js
+++ b/packages/slate/src/utils/refind-by-key.js
@@ -1,0 +1,29 @@
+/**
+ * When the oldNode is replaced by the newNode, try to refind oldNode texts based on key and path structure in old node and new node;
+ *
+ * @param {string} key
+ * @param {Node|Text} oldNode
+ * @param {Node|Text} newNode
+ * @returns {Boolean}
+ *
+ */
+
+function refindByKey(key, oldNode, newNode) {
+  const oldText = oldNode.getDescendant(key)
+  if (!oldText) return null
+  if (newNode.getDescendant(key)) {
+    const result = newNode.getDescendant(key)
+    return result.object === 'text' ? result : result.getFirsttext()
+  }
+  if (oldNode.object === 'text') {
+    if (newNode.object === 'text') {
+      return newNode
+    }
+    return newNode.getFirstText()
+  }
+  const oldPath = oldNode.getPath(key)
+  const result = newNode.getDescendantAtPath(oldPath)
+  if (!result) return null
+  return result.object === 'text' ? result : result.getFirstText()
+}
+export default refindByKey

--- a/packages/slate/test/changes/by-key/replace-node-by-key/inline.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/inline.js
@@ -14,7 +14,10 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        one <link key="a">two</link>
+        one{' '}
+        <link key="a">
+          two<cursor />
+        </link>
       </paragraph>
     </document>
   </value>
@@ -24,7 +27,11 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        one <emoji />
+        one{' '}
+        <emoji>
+          {' '}
+          <cursor />
+        </emoji>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/changes/by-key/replace-node-by-key/inline.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/inline.js
@@ -29,7 +29,6 @@ export const output = (
       <paragraph>
         one{' '}
         <emoji>
-          {' '}
           <cursor />
         </emoji>
       </paragraph>

--- a/packages/slate/test/changes/by-key/replace-node-by-key/text.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/text.js
@@ -11,7 +11,9 @@ export const input = (
     <document>
       <paragraph>one</paragraph>
       <paragraph>
-        <text key="a">one</text>
+        <text key="a">
+          one<cursor />
+        </text>
       </paragraph>
     </document>
   </value>
@@ -21,7 +23,9 @@ export const output = (
   <value>
     <document>
       <paragraph>one</paragraph>
-      <paragraph>three</paragraph>
+      <paragraph>
+        thr<cursor />ee
+      </paragraph>
     </document>
   </value>
 )

--- a/packages/slate/test/changes/by-key/replace-node-by-key/the-different-key-restore.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/the-different-key-restore.js
@@ -3,7 +3,14 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.replaceNodeByKey('a', { object: 'block', type: 'quote' })
+  const { startBlock } = change.value
+  const nextBlock = startBlock
+    .merge({
+      type: 'quote',
+    })
+    .mapDescendants(n => n.regenerateKey())
+    .regenerateKey()
+  change.replaceNodeByKey(startBlock.key, nextBlock)
 }
 
 export const input = (
@@ -11,7 +18,7 @@ export const input = (
     <document>
       <paragraph>one</paragraph>
       <paragraph key="a">
-        two<cursor />
+        t<cursor />wo
       </paragraph>
     </document>
   </value>
@@ -22,7 +29,7 @@ export const output = (
     <document>
       <paragraph>one</paragraph>
       <quote>
-        <cursor />
+        t<cursor />wo
       </quote>
     </document>
   </value>

--- a/packages/slate/test/changes/by-key/replace-node-by-key/the-same-key.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/the-same-key.js
@@ -3,7 +3,12 @@
 import h from '../../../helpers/h'
 
 export default function(change) {
-  change.replaceNodeByKey('a', { object: 'block', type: 'quote' })
+  const { startBlock, startText } = change.value
+  const nextBlock = startBlock.merge({
+    type: 'quote',
+    nodes: startBlock.nodes.push(startText.regenerateKey()),
+  })
+  change.replaceNodeByKey(startBlock.key, nextBlock)
 }
 
 export const input = (
@@ -11,7 +16,7 @@ export const input = (
     <document>
       <paragraph>one</paragraph>
       <paragraph key="a">
-        two<cursor />
+        t<cursor />wo
       </paragraph>
     </document>
   </value>
@@ -21,8 +26,8 @@ export const output = (
   <value>
     <document>
       <paragraph>one</paragraph>
-      <quote>
-        <cursor />
+      <quote key="a">
+        t<cursor />wotwo
       </quote>
     </document>
   </value>

--- a/packages/slate/test/changes/by-key/replace-node-by-key/the-same-text-key.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/the-same-text-key.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  const { startText } = change.value
+  change.replaceNodeByKey(startText.key, startText)
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph key="a">
+        t<cursor />wo
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = input


### PR DESCRIPTION
Problem:
When someone calculate a new node with `Immutable` methods, and then update the node with `replaceNodeByKey`, the selection is not restored:


For example: erasing all text contents in a Row:
```
const nextRow = row.set('nodes', row.nodes.map(cell => {
      const cellTexts = cell.getTexts().map( t => t.set('characters', List()));
      return cell.set('nodes', cellTexts);
   }))
change.replaceNodeByKey(nextRow.key, nextRow, {normalize: false})
```

However, the current `replaceNodeByKey` will move cursor around the the cursor is inside the block. Therefore, I add some codes to restore the cursor~