### PR TITLE
Fix insertAtRange on Hanging Selections

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -97,7 +97,7 @@ Changes.deleteAtRange = (change, range, options = {}) => {
     startKey == startBlock.getFirstText().key &&
     endKey == endBlock.getFirstText().key
 
-  // If in insertFragment at range, a startKey must exists in the document;
+  // In insertFragmentAtRange, a startKey must exists in the document;
   // When the startBlock is removed and normalize is false, this text holder
   // will be inserted to the document
   const startKeyTextHolder = Text.create().set('key', startKey)

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -146,22 +146,16 @@ Changes.deleteAtRange = (change, range, options = {}) => {
   // If the start and end key are the same, and it was a hanging selection, we
   // can just remove the entire block.
   if (startKey == endKey && isHanging) {
-    const startParent = change.value.document.getParent(startBlock.key)
     const nextBlock = change.value.document.getNextBlock(startBlock.key)
     change.removeNodeByKey(startBlock.key, { normalize })
     if (
       nextBlock &&
-      !change.value.document.getDescendant(startTextAsHangingFix.key)
+      !change.value.document.getDescendant(startTextAsHangingFix.key) &&
+      !normalize
     ) {
       change.insertNodeByKey(nextBlock.key, 0, startTextAsHangingFix, {
         normalize: false,
       })
-    }
-    if (normalize) {
-      change.normalizeNodeByKey(startParent.key)
-      if (change.value.document.getDescendant(nextBlock.key)) {
-        change.normalizeNodeByKey(nextBlock.key)
-      }
     }
     return
   } else if (startKey == endKey) {
@@ -267,7 +261,8 @@ Changes.deleteAtRange = (change, range, options = {}) => {
         change.removeNodeByKey(startBlock.key, { normalize: false })
         if (
           nextBlock &&
-          !change.value.document.getDescendant(startTextAsHangingFix.key)
+          !change.value.document.getDescendant(startTextAsHangingFix.key) &&
+          !normalize
         ) {
           change.insertNodeByKey(nextBlock.key, 0, startTextAsHangingFix, {
             normalize: false,


### PR DESCRIPTION
This aims to fix the problem that `cmd+v` on a hanging selection, because the startBlock and startText is removed, the `insertFragmentAtRange` find no place to add. (Explained in https://github.com/ianstormtaylor/slate/issues/1624)

A problem of this PR is that, the normalization part is very very ugly.  I will provide a neater `deleteAtRange` in another PR.

