### PR TITLE
Change Validation for Plugins

### DIFF
--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -147,23 +147,22 @@ class Change {
   }
 
   get changesText() {
-    return this.insertsText ||
-           this.removesText
+    return this.insertsText || this.removesText
   }
 
   get changesMarks() {
-    return this.addsMarks ||
-           this.removesMarks ||
-           this.setsMarks
+    return this.addsMarks || this.removesMarks || this.setsMarks
   }
 
   get changesNodes() {
-    return this.insertsNodes ||
-           this.mergesNodes ||
-           this.movesNodes ||
-           this.removesNodes ||
-           this.setsNodes ||
-           this.splitsNodes
+    return (
+      this.insertsNodes ||
+      this.mergesNodes ||
+      this.movesNodes ||
+      this.removesNodes ||
+      this.setsNodes ||
+      this.splitsNodes
+    )
   }
 
   /**

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -44,12 +44,18 @@ class Change {
 
   constructor(attrs) {
     const { value } = attrs
-    this.value = value
-    this.operations = new List()
-    this.flags = {
-      normalize: true,
-      ...pick(attrs, ['merge', 'save', 'normalize']),
+
+    this.reset = () => {
+      this.original = value
+      this.value = value
+      this.operations = new List()
+      this.flags = {
+        normalize: true,
+        ...pick(attrs, ['merge', 'save', 'normalize']),
+      }
     }
+
+    this.reset()
   }
 
   /**

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -53,6 +53,24 @@ class Change {
         normalize: true,
         ...pick(attrs, ['merge', 'save', 'normalize']),
       }
+
+      this.metadata = {
+        operations: {
+          insert_text: false,
+          remove_text: false,
+          add_mark: false,
+          remove_mark: false,
+          set_mark: false,
+          insert_node: false,
+          merge_node: false,
+          move_node: false,
+          remove_node: false,
+          set_node: false,
+          split_node: false,
+          set_selection: false,
+          set_value: false,
+        },
+      }
     }
 
     this.reset()
@@ -74,6 +92,78 @@ class Change {
       'The `kind` property of Slate objects has been renamed to `object`.'
     )
     return this.object
+  }
+
+  get insertsText() {
+    return this.metadata.operations.insert_text
+  }
+
+  get removesText() {
+    return this.metadata.operations.remove_text
+  }
+
+  get addsMarks() {
+    return this.metadata.operations.add_mark
+  }
+
+  get removesMarks() {
+    return this.metadata.operations.remove_mark
+  }
+
+  get setsMarks() {
+    return this.metadata.operations.set_mark
+  }
+
+  get insertsNodes() {
+    return this.metadata.operations.insert_node
+  }
+
+  get mergesNodes() {
+    return this.metadata.operations.merge_node
+  }
+
+  get movesNodes() {
+    return this.metadata.operations.move_node
+  }
+
+  get removesNodes() {
+    return this.metadata.operations.remove_node
+  }
+
+  get setsNodes() {
+    return this.metadata.operations.set_node
+  }
+
+  get splitsNodes() {
+    return this.metadata.operations.split_node
+  }
+
+  get setsSelection() {
+    return this.metadata.operations.set_selection
+  }
+
+  get setsValue() {
+    return this.metadata.operations.set_value
+  }
+
+  get changesText() {
+    return this.insertsText ||
+           this.removesText
+  }
+
+  get changesMarks() {
+    return this.addsMarks ||
+           this.removesMarks ||
+           this.setsMarks
+  }
+
+  get changesNodes() {
+    return this.insertsNodes ||
+           this.mergesNodes ||
+           this.movesNodes ||
+           this.removesNodes ||
+           this.setsNodes ||
+           this.splitsNodes
   }
 
   /**
@@ -121,6 +211,7 @@ class Change {
     // Update the mutable change object.
     this.value = value
     this.operations = operations.push(operation)
+    this.metadata.operations[operation.type] = true
     return this
   }
 

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -55,23 +55,28 @@ class Change {
 
       this.operations = new List()
       this.operationsByType = {
-        'insert_text': new List(),
-        'remove_text': new List(),
+        insert_text: new List(),
+        remove_text: new List(),
+
+        add_mark: new List(),
+        remove_mark: new List(),
+        set_mark: new List(),
+
+        insert_node: new List(),
+        merge_node: new List(),
+        move_node: new List(),
+        remove_node: new List(),
+        set_node: new List(),
+        split_node: new List(),
+
+        set_selection: new List(),
+
+        set_value: new List(),
+
         '*_text': new List(),
-        'add_mark': new List(),
-        'remove_mark': new List(),
-        'set_mark': new List(),
         '*_mark': new List(),
-        'insert_node': new List(),
-        'merge_node': new List(),
-        'move_node': new List(),
-        'remove_node': new List(),
-        'set_node': new List(),
-        'split_node': new List(),
         '*_node': new List(),
-        'set_selection': new List(),
         '*_selection': new List(),
-        'set_value': new List(),
         '*_value': new List(),
       }
     }


### PR DESCRIPTION
From Slack:

> ianstormtaylor: @pvande but your point still stands, trying to prevent all possible merges/deletes is actually impossible purely from the event handler layer, when you consider that any other plugin could introduce new key bindings for the same behaviors and you’d never know it

> ianstormtaylor: I’m not sure if there’s a nicely-abstracted but still simple solution to that issue, but it doesn’t hurt to try to think one up. I’d imagine it as a layer right underneath the event handlers, actually one that feels similar to the current change methods

> ianstormtaylor: @pvande I’d be open to a PR for `validateChange` if you want to make one

During that conversation, I proposed a strawman based on a plugins providing an `onChange` function that could "rewrite" changes on the fly, and abort application of a change when that change would cause problems.  This strawman had at least two flaws:

* It was made without awareness that plugins could already supply an `onChange` handler.
* It was based on the assumption that Changes were immutable.

The conversation concluded after having discussed Schema-driven solutions, changes to the Change class, and a `validateNode` analog for Changes.

After looking through the code and shaking free a few misunderstandings, I realized that the `validateChange` function I was pursuing was already perfectly handled by the existing `onChange` functionality:

* `onChange` is already called on every change, and the resulting value is consumed.
* `onChange` leverages the same Stack handling as other callbacks, which can easily be short-circuited.
* Changes are mutable, so it's trivial to make additional changes to them.
* "Rewrites" are just a reset + additional changes.
* "Aborts" are just a reset + a non-null return.

The only substantial difference between the `validateChange` interface and the `onChange` interface is that `validateChange` (as discussed) would only be invoked for Changes with Operations.  Considering that we cannot easily deprecate the `onChange` interface, and adding `validateChange` would necessitate _at minimum_ walking through the plugin stack an additional time for every operational Change, it seemed reasonable to fall back to `onChange` as the appropriate place for this.

As discussed earlier, the biggest piece missing from this solution was the ability to "rollback" the Change object to its creation state.  The first commit in this PR handles this case by adding a `reset` method to instances of Change.  I chose to implement this by closing over the constructor arguments, ensuring that the reset state was immutable, and keeping the object free of bookkeeping data (though the original value is still exposed, for convenience).  The tradeoff is that the constructor is marginally more complicated, and populates a method in a less common way; I'm certainly willing to discuss the merits of this approach.

The second piece that was strongly desirable for this feature was a way to make snap decisions about whether to further validate a change.  Walking through every change's list of operations inside (potentially) every plugin sounds like a recipe for disaster, so the second commit in this PR exposes metadata about the Change.  This is simultaneously an area where I feel like I may have gone too far, and yet not far enough – Changes absolutely _must_ be responsible for handling bookkeeping about their contents, and there's so much more that would be useful to track (e.g. separate Operation lists for each type and/or subject), but I'm not sure whether the proliferation of computed "convenience" properties will be welcome.

### "Demonstration"

The existing Table example has an `onKeyDown` handler for `Backspace`, `Delete`, and `Enter`, in order to prevent table destruction through backwards- and forwards-deletions and Slate's default Block splitting functionality.  This handler, however, doesn't block the Apple-specific `Ctrl+D` binding in core, nor does it handle the automatic erasure when typing with a selection – both of which break the demo.

While JSFiddle obviously doesn't have this PR's code, [the example here](https://jsfiddle.net/0onkq9bg/) _does_ demonstrate the kind and volume of changes required to implement a substantially more robust protection using this PR's changes.  (I've opted to not include changes to the example in this PR, for easier consideration.)

This example, while simple, also showcases a couple of the remaining pain points (and likely my own lack of expertise with Slate).  In particular, Operations are still a bit tricky / verbose to work with – pre-filtered Operation lists (e.g. `change.moveNodeOperations`) could go a long way to helping with this.