### PR TITLE
change.deleteNodesBetween: a change function to delete between nodes

### DIFF
--- a/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-at-different-level.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-at-different-level.js
@@ -1,0 +1,47 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>begin</paragraph>
+        <quote>
+          <image key="a">' '</image>
+          <paragraph>word1</paragraph>
+          <paragraph> another1</paragraph>
+        </quote>
+        <paragraph>begin1</paragraph>
+      </quote>
+      <paragraph />
+
+      <quote>
+        <paragraph>end1</paragraph>
+        <quote>
+          <paragraph>word2</paragraph>
+          <paragraph> another2</paragraph>
+          <image key="b">' '</image>
+        </quote>
+        <paragraph>end</paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>begin</paragraph>
+      </quote>
+      <quote>
+        <paragraph>end</paragraph>
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-same-ancestor.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-same-ancestor.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph key="a">word</paragraph>
+        <paragraph key="b">another</paragraph>
+      </quote>
+      <paragraph />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/at-same-key.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/at-same-key.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'a')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">word</paragraph>
+      <paragraph>another</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>another</paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/remove-document.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/remove-document.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">word</paragraph>
+      <paragraph key="b">another</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document />
+  </value>
+)


### PR DESCRIPTION
This change function is designed to 
1. simplify the `deleteAtRange` logic, a pre-procedure for rewriting the `deleteAtRange` to make that function 
2. simplify the common process deleting a lot of nodes like that `n.nodes.slice(begin, end).forEach(c => change.removeNodeByKey(c.key, {normalize: false})`
3. Provides another method for plugin developers, rather than `deleteAtRange`, to delete a lot of nodes without considering about `hanging` and `snapshot`.
