### PR TITLE
Use pageXOffset instead of scrollX in hover menu example

### DIFF
--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -126,9 +126,9 @@ class HoveringMenu extends React.Component {
     const range = selection.getRangeAt(0)
     const rect = range.getBoundingClientRect()
     menu.style.opacity = 1
-    menu.style.top = `${rect.top + window.scrollY - menu.offsetHeight}px`
+    menu.style.top = `${rect.top + window.pageYOffset - menu.offsetHeight}px`
     menu.style.left = `${rect.left +
-      window.scrollX -
+      window.pageXOffset -
       menu.offsetWidth / 2 +
       rect.width / 2}px`
   }


### PR DESCRIPTION
`scrollX`/`scrollY` do not work on some browsers, using `pageXOffset`/`pageYOffset` instead: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX#Notes.

This makes the hovering menu example work on IE11:
<img width="1048" alt="screen shot 2018-02-13 at 16 18 30" src="https://user-images.githubusercontent.com/18262197/36157217-999c54a6-10d9-11e8-9a04-0d6ea28b0fa6.png">

Before:
<img width="1035" alt="screen shot 2018-02-13 at 16 19 35" src="https://user-images.githubusercontent.com/18262197/36157292-c02424c8-10d9-11e8-87f6-98bd5c573430.png">
