### PR TITLE
[Feature] Semantic `isStartByKey` and `isEndByKey`

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1775,6 +1775,50 @@ class Node {
   }
 
   /**
+   * Check whether the node is start by another node, considering the empty text before and after inlines
+   * @param {string} key
+   * @returns {Boolean}
+   */
+
+  isStartByKey(key) {
+    const child = this.getDescendant(key)
+    if (!child) return false
+    if (child.object !== 'text') {
+      return this.isStartByKey(child.getFirstText().key)
+    }
+    if (child === this.getFirstText()) return true
+    const firstValid = this.nodes.find(
+      n => n.object !== 'text' || n.text.length > 0 || n.key === key
+    )
+    if (!firstValid) return false
+    if (firstValid.key === key) return true
+    if (firstValid.object === 'text') return false
+    return firstValid.isStartByKey(key)
+  }
+
+  /**
+   * Check whether the node is end by another node, considering the empty text before and after inlines
+   * @param {string} key
+   * @returns {Boolean}
+   */
+
+  isEndByKey(key) {
+    const child = this.getDescendant(key)
+    if (!child) return false
+    if (child.object !== 'text') {
+      return this.isEndByKey(child.getLastText().key)
+    }
+    if (child === this.getLastText()) return true
+    const lastValid = this.nodes.findLast(
+      n => n.object !== 'text' || n.text.length > 0 || n.key === key
+    )
+    if (!lastValid) return false
+    if (lastValid.key === key) return true
+    if (lastValid.object === 'text') return false
+    return lastValid.isEndByKey(key)
+  }
+
+  /**
    * Merge a children node `first` with another children node `second`.
    * `first` and `second` will be concatenated in that order.
    * `first` and `second` must be two Nodes or two Text.


### PR DESCRIPTION
Considering the empty text nodes surrounding the inlines, or some un-normalized empty text nodes, it is helpful to provide two function that 
```
 <paragraph key=p1>
    <text />
    <inline key=i2> .... </inline>
  </paragraph>
```

Because of the empty text nodes surrounding the inline. we cannot do it like `p1.getFirstText() === i2.getFirstText()`.  This PR provides a convenient way to check whether the inline is at the "semantic" start of the paragraph like
```
document.getNode('p1').isStartByKey('p2') === true
```