### PR TITLE
[Improvement & Bug Fix]More modularized change.deleteAtRange and fix problem of pasting on a hanging selection

### DIFF
--- a/packages/slate/src/changes/by-key.js
+++ b/packages/slate/src/changes/by-key.js
@@ -347,6 +347,129 @@ Changes.removeNodeByKey = (change, key, options = {}) => {
 }
 
 /**
+ * Delete Nodes between startKey and endKey, including nodes of startKey and endKey
+ *
+ * @param {Change} change
+ * @param {string} startKey
+ * @param {string} endKey
+ * @param {Object} options
+ *   @property {Boolean} normalize
+ */
+
+Changes.deleteNodesBetween = (change, startKey, endKey, options = {}) => {
+  const normalize = change.getFlag('normalize', options)
+  const { document } = change.value
+
+  const startText = document.getDescendant(startKey)
+  if (startText.object !== 'text') {
+    return change.deleteNodesBetween(
+      startText.getFirstText().key,
+      endKey,
+      options
+    )
+  }
+  const endText = document.getDescendant(endKey)
+  if (endText.object !== 'text') {
+    return change.deleteNodesBetween(
+      startKey,
+      endText.getLastText().key,
+      options
+    )
+  }
+
+  if (startKey === endKey) {
+    const lonely = document.getFurthestOnlyChildAncestor(startKey)
+    const removalKey =
+      lonely === document
+        ? document.getFurthestAncestor(startKey).key
+        : lonely ? lonely.key : startKey
+    return change.removeNodeByKey(removalKey, { normalize })
+  }
+
+  if (!document.areDescendantsSorted(startKey, endKey)) {
+    return change.deleteNodesBetween(endKey, startKey, options)
+  }
+
+  const commonAncestor = document.getCommonAncestor(startKey, endKey)
+  if (
+    commonAncestor.isStartByKey(startKey) &&
+    commonAncestor.isEndByKey(endKey)
+  ) {
+    if (commonAncestor.object === 'document') {
+      document.nodes.forEach(n =>
+        change.removeNodeByKey(n.key, { normalize: false })
+      )
+      if (normalize) {
+        change.normalize()
+      }
+      return
+    }
+    return change.removeNodeByKey(commonAncestor.key, { normalize })
+  }
+
+  let startNode = startText
+  commonAncestor.getAncestors(startKey).findLast(n => {
+    if (!n.isStartByKey(startNode.key)) {
+      return true
+    }
+    if (n.getDescendant(endKey)) {
+      return true
+    }
+    startNode = n
+    return false
+  })
+  let endNode = endText
+  commonAncestor.getAncestors(endKey).findLast(n => {
+    if (!n.isEndByKey(endKey)) {
+      return true
+    }
+    if (n.getDescendant(startKey)) {
+      return true
+    }
+    endNode = n
+    return false
+  })
+
+  const startAncestors = commonAncestor.getAncestors(startNode.key)
+  // Delete Nodes at the start
+  change.removeNodeByKey(startNode.key, { normalize: false })
+  startAncestors.findLast((n, index) => {
+    if (index === 0) return true
+    const child =
+      index + 1 < startAncestors.size
+        ? startAncestors.get(index + 1)
+        : startNode
+    n.nodes
+      .skip(n.nodes.indexOf(child) + 1)
+      .forEach(c => change.removeNodeByKey(c.key, { normalize: false }))
+  })
+  // Delete Nodes in middle
+  const startChild = commonAncestor.getFurthestAncestor(startKey)
+  const endChild = commonAncestor.getFurthestAncestor(endKey)
+  const middleNodes = commonAncestor.nodes.slice(
+    commonAncestor.nodes.indexOf(startChild) + 1,
+    commonAncestor.nodes.indexOf(endChild)
+  )
+  middleNodes.forEach(c => change.removeNodeByKey(c.key, { normalize: false }))
+
+  // Delete Nodes at the end
+  const endAncestors = commonAncestor.getAncestors(endNode.key)
+  endAncestors.find((n, index) => {
+    if (index === 0) return false
+    const child =
+      index + 1 < endAncestors.size ? endAncestors.get(index + 1) : endNode
+    n.nodes
+      .take(n.nodes.indexOf(child))
+      .forEach(c => change.removeNodeByKey(c.key, { normalize: false }))
+  })
+  change.removeNodeByKey(endNode.key, { normalize: false })
+  if (normalize) {
+    change.normalizeNodeByKey(commonAncestor.key)
+  }
+  return
+}
+
+/**
  * Remove text at `offset` and `length` in node by `key`.
  *
  * @param {Change} change

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1775,6 +1775,50 @@ class Node {
   }
 
   /**
+   * Check whether the node is start by another node, considering the empty text before and after inlines
+   * @param {string} key
+   * @returns {Boolean}
+   */
+
+  isStartByKey(key) {
+    const child = this.getDescendant(key)
+    if (!child) return false
+    if (child.object !== 'text') {
+      return this.isStartByKey(child.getFirstText().key)
+    }
+    if (child === this.getFirstText()) return true
+    const firstValid = this.nodes.find(
+      n => n.object !== 'text' || n.text.length > 0 || n.key === key
+    )
+    if (!firstValid) return false
+    if (firstValid.key === key) return true
+    if (firstValid.object === 'text') return false
+    return firstValid.isStartByKey(key)
+  }
+
+  /**
+   * Check whether the node is end by another node, considering the empty text before and after inlines
+   * @param {string} key
+   * @returns {Boolean}
+   */
+
+  isEndByKey(key) {
+    const child = this.getDescendant(key)
+    if (!child) return false
+    if (child.object !== 'text') {
+      return this.isEndByKey(child.getLastText().key)
+    }
+    if (child === this.getLastText()) return true
+    const lastValid = this.nodes.findLast(
+      n => n.object !== 'text' || n.text.length > 0 || n.key === key
+    )
+    if (!lastValid) return false
+    if (lastValid.key === key) return true
+    if (lastValid.object === 'text') return false
+    return lastValid.isEndByKey(key)
+  }
+
+  /**
    * Merge a children node `first` with another children node `second`.
    * `first` and `second` will be concatenated in that order.
    * `first` and `second` must be two Nodes or two Text.

--- a/packages/slate/test/changes/at-current-range/insert-fragment/insert-at-hanging-paragraph.js
+++ b/packages/slate/test/changes/at-current-range/insert-fragment/insert-at-hanging-paragraph.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.insertFragment(
+    <document>
+      <quote>fragment</quote>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />word
+      </paragraph>
+      <paragraph>
+        <focus />is a word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />fragmentis a word
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/across-blocks-and-inlines.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/across-blocks-and-inlines.js
@@ -1,0 +1,44 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>begin</paragraph>
+        <paragraph>
+          <emoji key="a">' '</emoji>
+          begin1
+        </paragraph>
+      </quote>
+      <paragraph />
+
+      <quote>
+        <paragraph>end1</paragraph>
+        <paragraph>
+          another2
+          <emoji key="b">' '</emoji>
+        </paragraph>
+        <paragraph>end</paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>begin</paragraph>
+      </quote>
+      <quote>
+        <paragraph>end</paragraph>
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-at-different-level.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-at-different-level.js
@@ -1,0 +1,47 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>begin</paragraph>
+        <quote>
+          <image key="a">' '</image>
+          <paragraph>word1</paragraph>
+          <paragraph> another1</paragraph>
+        </quote>
+        <paragraph>begin1</paragraph>
+      </quote>
+      <paragraph />
+
+      <quote>
+        <paragraph>end1</paragraph>
+        <quote>
+          <paragraph>word2</paragraph>
+          <paragraph> another2</paragraph>
+          <image key="b">' '</image>
+        </quote>
+        <paragraph>end</paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>begin</paragraph>
+      </quote>
+      <quote>
+        <paragraph>end</paragraph>
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-same-ancestor.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/at-different-key-same-ancestor.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph key="a">word</paragraph>
+        <paragraph key="b">another</paragraph>
+      </quote>
+      <paragraph />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/at-same-key.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/at-same-key.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'a')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">word</paragraph>
+      <paragraph>another</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>another</paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/by-key/delete-between-nodes/remove-document.js
+++ b/packages/slate/test/changes/by-key/delete-between-nodes/remove-document.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.deleteNodesBetween('a', 'b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">word</paragraph>
+      <paragraph key="b">another</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document />
+  </value>
+)


### PR DESCRIPTION
This PR aims to:
1. fix the problem that paste in hanging selection or other things cause on error  (Issue: https://github.com/ianstormtaylor/slate/issues/1624).  The method is, when the normalize is false, try everything possible to keep the startText.
2. delete on hanging selected block will lose selection
3. modularize the `change.deleteAtRange`, makes it easier to be modified for future debugging


This PR depends on the PR of https://github.com/ianstormtaylor/slate/pull/1633 and of https://github.com/ianstormtaylor/slate/pull/1632