### PR TITLE
Fixing the bug that getMarks steals mark from the previous block

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1130,6 +1130,11 @@ class Node {
     if (startOffset == 0) {
       const previous = this.getPreviousText(startKey)
       if (!previous || previous.text.length == 0) return []
+      if (
+        this.getClosestBlock(startKey) !== this.getClosestBlock(previous.key)
+      ) {
+        return []
+      }
       const char = previous.characters.get(previous.text.length - 1)
       return char.marks.toArray()
     }


### PR DESCRIPTION
Fix https://github.com/ianstormtaylor/slate/issues/1561 that when the end of previous block is marked, then cursor at the block start is also marked.

