### PR TITLE
Fix for text value being null in an onDrop event

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -253,10 +253,12 @@ function AfterPlugin() {
         if (n) change.collapseToStartOf(n)
       }
 
-      text.split('\n').forEach((line, i) => {
-        if (i > 0) change.splitBlock()
-        change.insertText(line)
-      })
+      if (text) {
+        text.split('\n').forEach((line, i) => {
+          if (i > 0) change.splitBlock()
+          change.insertText(line)
+        })
+      }
     }
 
     if (type == 'fragment') {


### PR DESCRIPTION
Unfortunately I don't have much detail from our error reporting but I can see that a user on latest Chrome and MacOS had text as `null` and the stacktrace is entirely internal to slate / react (below).

An alternative fix might be to ensure that the `text` value returned from `getEventTransfer` is an empty string instead of `null`? Happy to change to that or something else.

```
TypeError Uncaught TypeError: Cannot read property 'split' of null 
    webpack:///node_modules/slate-react/lib/plugins/after.js:452 Object.d
    webpack:///node_modules/slate/lib/slate.js:9593 t.value
    webpack:///node_modules/slate-react/lib/components/editor.js:391 
    webpack:///node_modules/slate/lib/slate.js:13134 e.value
    webpack:///node_modules/slate-react/lib/components/editor.js:373 t.B.change
    webpack:///node_modules/slate-react/lib/components/editor.js:390 t.B.onEvent
    webpack:///node_modules/slate-react/lib/components/editor.js:129 Object.n.(anonymous function)
    webpack:///node_modules/slate-react/lib/components/content.js:427 t.value
    webpack:///node_modules/slate-react/lib/components/content.js:305 n.(anonymous function)
    webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:25:371 Object.l
```
