### PR TITLE
Fix normalize range of the insertTextAtRange

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -896,8 +896,19 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
   if (normalize !== undefined) {
     normalize = range.isExpanded
   }
+  change.insertTextByKey(key, offset, text, marks, { normalize: false })
 
-  change.insertTextByKey(key, offset, text, marks, { normalize })
+  if (normalize) {
+    // normalize in the narrowest existing block that originally contains startKey and endKey
+    const commonAncestor = document.getCommonAncestor(startKey, range.endKey)
+    const ancestors = document
+      .getAncestors(commonAncestor.key)
+      .push(commonAncestor)
+    const normalizeAncestor = ancestors.findLast(n =>
+      change.value.document.getDescendant(n.key)
+    )
+    change.normalizeNodeByKey(normalizeAncestor.key)
+  }
 }
 
 /**


### PR DESCRIPTION
`insertTextAtRange` normalize the parent of startText, regardless of where the endText is.  (https://github.com/ianstormtaylor/slate/issues/1657) . This PR fixes the normalize range to normalize all affected nodes.