### PR TITLE
Perhaps faster normalization: Never visit a descendant twice in normalizaton

### DIFF
--- a/packages/slate/benchmark/models/from-json-big.js
+++ b/packages/slate/benchmark/models/from-json-big.js
@@ -1,0 +1,66 @@
+/* eslint-disable react/jsx-key */
+
+import { Value } from '../..'
+
+export default function(json) {
+  Value.fromJSON(json)
+}
+
+export const input = {
+  document: {
+    nodes: Array.from(Array(100)).map(() => ({
+      type: 'list',
+      object: 'block',
+      isVoid: false,
+      data: {},
+      nodes: Array.from(Array(10)).map(() => ({
+        type: 'list-item',
+        object: 'block',
+        isVoid: false,
+        data: {},
+        nodes: [
+          {
+            leaves: [
+              {
+                object: 'leaf',
+                marks: [],
+                text: '',
+              },
+            ],
+            object: 'text',
+          },
+          {
+            type: 'link',
+            object: 'inline',
+            isVoid: false,
+            data: {
+              id: 1,
+            },
+            nodes: [
+              {
+                leaves: [
+                  {
+                    object: 'leaf',
+                    marks: [],
+                    text: 'Some text for a link',
+                  },
+                ],
+                object: 'text',
+              },
+            ],
+          },
+          {
+            leaves: [
+              {
+                object: 'leaf',
+                marks: [],
+                text: '',
+              },
+            ],
+            object: 'text',
+          },
+        ],
+      })),
+    })),
+  },
+}

--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -64,9 +64,11 @@ function normalizeNodeAndChildren(change, node, schema) {
     normalizeNode(change, node, schema)
     return
   }
+  if (!node.getFirstInvalidDescendantKey(schema)) {
+    return
+  }
 
-  const normalizedKeys = []
-  let child = node.nodes.first()
+  let child = node.nodes.find(c => c.getFirstInvalidDescendantKey(schema))
   let path = change.value.document.getPath(node.key)
 
   // We can't just loop the children and normalize them, because in the process
@@ -75,7 +77,6 @@ function normalizeNodeAndChildren(change, node, schema) {
   while (node && child) {
     const lastSize = change.operations.size
     normalizeNodeAndChildren(change, child, schema)
-    normalizedKeys.push(child.key)
 
     // PERF: if size is unchanged, then no operation happens
     // Therefore we can simply normalize the next child
@@ -89,7 +90,7 @@ function normalizeNodeAndChildren(change, node, schema) {
         child = null
       } else {
         path = change.value.document.refindPath(path, node.key)
-        child = node.nodes.find(c => !normalizedKeys.includes(c.key))
+        child = node.nodes.find(c => c.getFirstInvalidDescendantKey(schema))
       }
     }
   }

--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -64,34 +64,18 @@ function normalizeNodeAndChildren(change, node, schema) {
     normalizeNode(change, node, schema)
     return
   }
-  if (!node.getFirstInvalidDescendantKey(schema)) {
-    return
-  }
 
-  let child = node.nodes.find(c => c.getFirstInvalidDescendantKey(schema))
+  let child = node.getFirstInvalidDescendant(schema)
   let path = change.value.document.getPath(node.key)
-
-  // We can't just loop the children and normalize them, because in the process
-  // of normalizing one child, we might end up creating another. Instead, we
-  // have to normalize one at a time, and check for new children along the way.
   while (node && child) {
-    const lastSize = change.operations.size
     normalizeNodeAndChildren(change, child, schema)
-
-    // PERF: if size is unchanged, then no operation happens
-    // Therefore we can simply normalize the next child
-    if (lastSize === change.operations.size) {
-      const nextIndex = node.nodes.indexOf(child) + 1
-      child = node.nodes.get(nextIndex)
+    node = change.value.document.refindNode(path, node.key)
+    if (!node) {
+      path = []
+      child = null
     } else {
-      node = change.value.document.refindNode(path, node.key)
-      if (!node) {
-        path = []
-        child = null
-      } else {
-        path = change.value.document.refindPath(path, node.key)
-        child = node.nodes.find(c => c.getFirstInvalidDescendantKey(schema))
-      }
+      path = change.value.document.refindPath(path, node.key)
+      child = node.getFirstInvalidDescendant(schema)
     }
   }
 

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1992,17 +1992,14 @@ class Node {
    * The first descendant key requiring validation
    *
    * @param {Schema} schema
-   * @return {String|Null}
+   * @return {Node|Text|Null}
    */
 
-  getFirstInvalidDescendantKey(schema) {
-    if (this.validate(schema)) {
-      return this.key
-    }
+  getFirstInvalidDescendant(schema) {
     let result = null
     this.nodes.find(n => {
-      result = n.getFirstInvalidDescendantKey(schema)
-      return typeof result === 'string'
+      result = n.validate(schema) ? n : n.getFirstInvalidDescendant(schema)
+      return result
     })
     return result
   }
@@ -2091,7 +2088,7 @@ memoize(
     'getTextAtOffset',
     'getTextsAtRangeAsArray',
     'validate',
-    'getFirstInvalidDescendantKey',
+    'getFirstInvalidDescendant',
   ],
   {
     takesArguments: true,

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1989,7 +1989,7 @@ class Node {
   }
 
   /**
-   * The first descendant key requiring validation
+   * Get the first invalid descendant
    *
    * @param {Schema} schema
    * @return {Node|Text|Null}

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1987,6 +1987,25 @@ class Node {
   validate(schema) {
     return schema.validateNode(this)
   }
+
+  /**
+   * The first descendant key requiring validation
+   *
+   * @param {Schema} schema
+   * @return {String|Null}
+   */
+
+  getFirstInvalidDescendantKey(schema) {
+    if (this.validate(schema)) {
+      return this.key
+    }
+    let result = null
+    this.nodes.find(n => {
+      result = n.getFirstInvalidDescendantKey(schema)
+      return typeof result === 'string'
+    })
+    return result
+  }
 }
 
 /**
@@ -2072,6 +2091,7 @@ memoize(
     'getTextAtOffset',
     'getTextsAtRangeAsArray',
     'validate',
+    'getFirstInvalidDescendantKey',
   ],
   {
     takesArguments: true,

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -495,6 +495,17 @@ class Text extends Record(DEFAULTS) {
   validate(schema) {
     return schema.validateNode(this)
   }
+
+  /**
+   * The first descendant key requiring validation
+   *
+   * @param {Schema} schema
+   * @returns {String|Null}
+   */
+
+  getFirstInvalidDescendantKey(schema) {
+    return this.validate(schema) ? this.key : null
+  }
 }
 
 /**

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -498,13 +498,14 @@ class Text extends Record(DEFAULTS) {
 
   /**
    * The first descendant key requiring validation
+   * PREF: Do not cache this method; because it can cause cycle reference
    *
    * @param {Schema} schema
-   * @returns {String|Null}
+   * @returns {Text|Null}
    */
 
-  getFirstInvalidDescendantKey(schema) {
-    return this.validate(schema) ? this.key : null
+  getFirstInvalidDescendant(schema) {
+    return this.validate(schema) ? this : null
   }
 }
 

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -497,7 +497,7 @@ class Text extends Record(DEFAULTS) {
   }
 
   /**
-   * The first descendant key requiring validation
+   * Get the first invalid descendant
    * PREF: Do not cache this method; because it can cause cycle reference
    *
    * @param {Schema} schema

--- a/packages/slate/test/schema/core/remove-empty-inline.js
+++ b/packages/slate/test/schema/core/remove-empty-inline.js
@@ -7,11 +7,9 @@ export const schema = {}
 export const input = (
   <value>
     <document>
-      <quote>
-        <paragraph>
-          <link />
-        </paragraph>
-      </quote>
+      <paragraph>
+        <link />
+      </paragraph>
     </document>
   </value>
 )
@@ -24,25 +22,17 @@ export const output = {
     nodes: [
       {
         object: 'block',
-        type: 'quote',
-        data: {},
+        type: 'paragraph',
         isVoid: false,
+        data: {},
         nodes: [
           {
-            object: 'block',
-            type: 'paragraph',
-            isVoid: false,
-            data: {},
-            nodes: [
+            object: 'text',
+            leaves: [
               {
-                object: 'text',
-                leaves: [
-                  {
-                    object: 'leaf',
-                    text: '',
-                    marks: [],
-                  },
-                ],
+                object: 'leaf',
+                text: '',
+                marks: [],
               },
             ],
           },

--- a/packages/slate/test/schema/core/remove-empty-inline.js
+++ b/packages/slate/test/schema/core/remove-empty-inline.js
@@ -7,9 +7,11 @@ export const schema = {}
 export const input = (
   <value>
     <document>
-      <paragraph>
-        <link />
-      </paragraph>
+      <quote>
+        <paragraph>
+          <link />
+        </paragraph>
+      </quote>
     </document>
   </value>
 )
@@ -22,17 +24,25 @@ export const output = {
     nodes: [
       {
         object: 'block',
-        type: 'paragraph',
-        isVoid: false,
+        type: 'quote',
         data: {},
+        isVoid: false,
         nodes: [
           {
-            object: 'text',
-            leaves: [
+            object: 'block',
+            type: 'paragraph',
+            isVoid: false,
+            data: {},
+            nodes: [
               {
-                object: 'leaf',
-                text: '',
-                marks: [],
+                object: 'text',
+                leaves: [
+                  {
+                    object: 'leaf',
+                    text: '',
+                    marks: [],
+                  },
+                ],
               },
             ],
           },


### PR DESCRIPTION
I see @czechdave  say that normalization potentially slows down the Value.fromJSON; And I think perhaps it is a result from `normalizeKeys.includes`, a O(childNodes^2) comparison.  

This PR take advantage of cache and validate to ensure speed up normalization.

I am not confident about the benchmark running on my laptop.  Could anyone help me rerun the benchmark in their own computer?
```
benchmarks
    html-serializer
      deserialize
        8.98 → 11.02 ops/sec
      serialize
        1057.71 → 1185.42 ops/sec
    plain-serializer
      deserialize
        553.52 → 536.36 ops/sec
      serialize
        9107.18 → 9525.40 ops/sec
    rendering
      normal
        111.93 → 126.17 ops/sec
    changes
      delete-backward
        105548.40 → 144896.70 ops/sec (37% faster)
      delete-forward
        19318.61 → 30794.16 ops/sec (59% faster)
      insert-text-by-key-multiple
        85.57 → 97.89 ops/sec
      insert-text-by-key
        1045.61 → 1251.19 ops/sec
      insert-text
        1071.37 → 1150.59 ops/sec
      normalize
        1435.06 → 215908.18 ops/sec (14945% faster) 😱
      split-block
        22.43 → 83.04 ops/sec (270% faster) 🙌
    models
      from-json
        126.48 → 221.79 ops/sec (75% faster)
      get-blocks-at-range
        515597.57 → 691750.84 ops/sec (34% faster)
      get-blocks
        2389340.86 → 2876387.07 ops/sec
      get-characters-at-range
        675896.57 → 780662.25 ops/sec
      get-characters
        2906877.93 → 3160090.06 ops/sec
      get-inlines-at-range
        715855.63 → 848482.59 ops/sec
      get-inlines
        2821376.68 → 3106357.04 ops/sec
      get-leaves
        1591780.52 → 1837992.19 ops/sec
      get-marks-at-range
        800173.93 → 890650.77 ops/sec
      get-marks
        3167696.93 → 3177520.59 ops/sec
      get-path
        975600.69 → 910776.69 ops/sec
      get-texts-at-range
        937712.33 → 924806.06 ops/sec
      get-texts
        3334330.56 → 3305250.49 ops/sec
      has-node-multiple
        128830.81 → 123509.47 ops/sec
      has-node
        985303.14 → 930603.71 ops/sec
      to-json
        3584.00 → 3341.62 ops/sec
      update-node
        18095.09 → 14661.38 ops/sec
```