### PR TITLE
Use source-map-loader for more fine-grained sourcemaps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "slate-collapse-on-escape": "^0.6.0",
     "slate-soft-break": "^0.6.0",
     "slate-sugar": "^0.6.1",
+    "source-map-loader": "^0.2.3",
     "source-map-support": "^0.4.0",
     "style-loader": "^0.20.2",
     "to-camel-case": "^1.0.0",

--- a/support/rollup/factory.js
+++ b/support/rollup/factory.js
@@ -18,7 +18,6 @@ import { startCase } from 'lodash'
  */
 
 function configure(pkg, env, target) {
-  const isDev = env === 'development'
   const isProd = env === 'production'
   const isUmd = target === 'umd'
   const isModule = target === 'module'
@@ -106,13 +105,13 @@ function configure(pkg, env, target) {
         {
           file: `packages/${pkg.name}/${pkg.module}`,
           format: 'es',
-          sourcemap: isDev,
+          sourcemap: true,
         },
         {
           file: `packages/${pkg.name}/${pkg.main}`,
           format: 'cjs',
           exports: 'named',
-          sourcemap: isDev,
+          sourcemap: true,
         },
       ],
       // We need to explicitly state which modules are external, meaning that

--- a/support/webpack/config.js
+++ b/support/webpack/config.js
@@ -27,6 +27,11 @@ const config = {
     rules: [
       {
         test: /\.js?$/,
+        use: 'source-map-loader',
+        enforce: 'pre',
+      },
+      {
+        test: /\.js?$/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,7 +362,7 @@ async@1.5.2, async@^1.4.0, async@^1.5.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.4.1:
+async@^2.1.2, async@^2.4.1, async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -2732,7 +2732,7 @@ errno@^0.1.1, errno@~0.1.1:
   dependencies:
     prr "~1.0.1"
 
-errno@^0.1.3, errno@^0.1.4:
+errno@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -4925,7 +4925,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.15, loader-utils@^0.2.16:
+loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@~0.2.2:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -7117,7 +7117,7 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-schema-utils@^0.4.2, schema-utils@^0.4.3:
+schema-utils@^0.4.3:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:
@@ -7371,6 +7371,14 @@ sort-keys@^2.0.0:
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-map-loader@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.3.tgz#d4b0c8cd47d54edce3e6bfa0f523f452b5b0e521"
+  dependencies:
+    async "^2.5.0"
+    loader-utils "~0.2.2"
+    source-map "~0.6.1"
 
 source-map-resolve@^0.5.0:
   version "0.5.1"
@@ -7993,13 +8001,6 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-es@^3.3.4:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
-
 uglify-es@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.8.tgz#f2c68e6cff0d0f9dc9577e4da207151c2e753b7e"
@@ -8034,19 +8035,6 @@ uglifyjs-webpack-plugin@^0.4.6:
     source-map "^0.5.6"
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
-
-uglifyjs-webpack-plugin@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.8.tgz#1302fb9471a7daf3d0a5174da6d65f0f415e75ad"
-  dependencies:
-    cacache "^10.0.1"
-    find-cache-dir "^1.0.0"
-    schema-utils "^0.4.2"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-es "^3.3.4"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
 
 uid-number@^0.0.6:
   version "0.0.6"
@@ -8327,7 +8315,7 @@ webpack-dev-server@^2.11.1:
     webpack-dev-middleware "1.12.2"
     yargs "6.6.0"
 
-webpack-sources@^1.0.1, webpack-sources@^1.1.0:
+webpack-sources@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
@@ -8430,13 +8418,6 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.2.tgz#32b312e5dc3d5d45d79ef44acc2587491cd729ae"
-  dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
-
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -8496,7 +8477,7 @@ xtend@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Currently when an error happens, the console log looks like this:

<img width="1920" alt="screenshot 2018-02-21 21 29 47" src="https://user-images.githubusercontent.com/1896112/36518413-459e0ec2-1754-11e8-85ba-d3dcc318ec02.png">

Note the `slate.es.js:3166` on the right. Not too bad, it's the unminified ES build of Slate so we can read it pretty well and see what's going on. But it's all of Slate rolled up together, so it takes some hunting to figure out which original source file it came from. Also, if you click on the source, it looks like this:

<img width="639" alt="screenshot 2018-02-21 22 12 59" src="https://user-images.githubusercontent.com/1896112/36518478-8e938350-1754-11e8-97fb-74d53e8286aa.png">

which isn't exactly what the source looks like -- it's the source after it's been run through babel (so for example we get the `key/value` thing instead of an ES6 class).

There's a webpack loader, [source-map-loader](https://github.com/webpack-contrib/source-map-loader), which can help us do better. It consumes any sourcemaps in your "source" JS (in our case, the built `slate.es.js`) and rolls them together into the final sourcemaps output by your webpack build. So the above console log changes to:

<img width="1920" alt="screenshot 2018-02-21 21 39 21" src="https://user-images.githubusercontent.com/1896112/36518563-deb788ae-1754-11e8-9d6a-867eb2157a56.png">

where `node.js` is the actual original filename. And clicking on the line gives this:

<img width="581" alt="screenshot 2018-02-21 22 13 58" src="https://user-images.githubusercontent.com/1896112/36518571-ed35e47a-1754-11e8-948a-fcb5e3d46c66.png">

so we get the actual original code (in this case, an ES6 class).

To support this change, I changed the rollup build to always output sourcemaps for the module variants, not just when in development. (I figured we might as well ship the sourcemaps on npm so that end users can use `source-map-loader` in the same fashion if they'd like.)