### PR TITLE
Ignore the build file in examples/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 build/
 dist/
 lib/
+examples/build.dev.js
+examples/build.prod.js
 
 # Temporary files.
 tmp/


### PR DESCRIPTION
The exmaples/build.{dev, prod}.js are not in .gitignore.