### PR TITLE
setValue do not write history stack.

### DIFF
--- a/packages/slate/src/changes/on-value.js
+++ b/packages/slate/src/changes/on-value.js
@@ -19,6 +19,8 @@ const Changes = {}
 Changes.setValue = (change, properties, options = {}) => {
   properties = Value.createProperties(properties)
   const { value } = change
+  // By default, do not change history stacks
+  const { save = false } = options
 
   change.applyOperation(
     {
@@ -26,7 +28,7 @@ Changes.setValue = (change, properties, options = {}) => {
       properties,
       value,
     },
-    options
+    { save, ...options }
   )
 }
 


### PR DESCRIPTION
> The { save: false } shouldn't be recommended. It sounds like there's just a bug in the setValue undo logic instead.

I am not sure whether I misunderstood @ianstormtaylor 's idea.  Here this PR is to avoid {save:false} in setValue.
https://github.com/ianstormtaylor/slate/pull/1670