### PR TITLE
Fix Shift+Right selection behaviour on empty text nodes

### DIFF
--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -21,10 +21,11 @@ const VOID_SELECTOR = '[data-slate-void]'
  * @param {Element} nativeNode
  * @param {Number} nativeOffset
  * @param {Value} value
+ * @param {Object} options
  * @return {Object}
  */
 
-function findPoint(nativeNode, nativeOffset, value) {
+function findPoint(nativeNode, nativeOffset, value, options = {}) {
   const { node: nearestNode, offset: nearestOffset } = normalizeNodeAndOffset(
     nativeNode,
     nativeOffset
@@ -60,7 +61,9 @@ function findPoint(nativeNode, nativeOffset, value) {
   // text node should have no characters. However, during IME composition the
   // ASCII characters will be prepended to the zero-width space, so subtract 1
   // from the offset to account for the zero-width space character.
+  const { isAnchor = true } = options
   if (
+    isAnchor &&
     offset == node.textContent.length &&
     parentNode.hasAttribute(ZERO_WIDTH_ATTRIBUTE)
   ) {

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -42,7 +42,9 @@ function findRange(native, value) {
     isCollapsed,
   } = native
   const anchor = findPoint(anchorNode, anchorOffset, value)
-  const focus = isCollapsed ? anchor : findPoint(focusNode, focusOffset, value)
+  const focus = isCollapsed
+    ? anchor
+    : findPoint(focusNode, focusOffset, value, { isAnchor: false })
   if (!anchor || !focus) return null
 
   // COMPAT: ??? The Edge browser seems to have a case where if you select the


### PR DESCRIPTION
Attempt to fix the <kbd>Shift</kbd> + arrows bahaviour. See: https://github.com/ianstormtaylor/slate/issues/1658