### PR TITLE
Do not split void node by default

### DIFF
--- a/packages/slate/src/changes/by-key.js
+++ b/packages/slate/src/changes/by-key.js
@@ -564,6 +564,7 @@ Changes.splitDescendantsByKey = (
   }
 
   const normalize = change.getFlag('normalize', options)
+  const { splitVoid = false } = options
   const { value } = change
   const { document } = value
 
@@ -583,6 +584,7 @@ Changes.splitDescendantsByKey = (
     change.splitNodeByKey(node.key, index, {
       normalize: false,
       target: prevIndex,
+      splitVoid,
     })
   })
 

--- a/packages/slate/src/changes/by-key.js
+++ b/packages/slate/src/changes/by-key.js
@@ -515,11 +515,13 @@ Changes.setNodeByKey = (change, key, properties, options = {}) => {
  */
 
 Changes.splitNodeByKey = (change, key, position, options = {}) => {
-  const { normalize = true, target = null } = options
+  const normalize = change.getFlag('normalize', options)
+  const { target = null, splitVoid = false } = options
   const { value } = change
   const { document } = value
   const path = document.getPath(key)
   const node = document.getDescendantAtPath(path)
+  if (!splitVoid && node.isVoid) return
 
   change.applyOperation({
     type: 'split_node',


### PR DESCRIPTION
This PR add an option that by default `splitNodeByKey` will not split void blocks; it avoid duplication of void blocks in careless splitting. 