### PR TITLE
Use custom test error message for more useful output

### DIFF
--- a/packages/slate-plain-serializer/test/index.js
+++ b/packages/slate-plain-serializer/test/index.js
@@ -7,6 +7,7 @@ import assert from 'assert'
 import fs from 'fs'
 import { Value, resetKeyGenerator } from 'slate'
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../support/test/printValueErrorMessage'
 
 /**
  * Reset Slate's internal key generator state before each text.
@@ -35,7 +36,11 @@ describe('slate-plain-serializer', () => {
         const value = Plain.deserialize(input, options)
         const actual = Value.isValue(value) ? value.toJSON() : value
         const expected = Value.isValue(output) ? output.toJSON() : output
-        assert.deepEqual(actual, expected)
+        assert.deepEqual(
+          actual,
+          expected,
+          printValueErrorMessage('deepEqual', actual, expected)
+        )
       })
     }
   })
@@ -54,7 +59,11 @@ describe('slate-plain-serializer', () => {
         const string = Plain.serialize(input, options)
         const actual = string
         const expected = output
-        assert.deepEqual(actual, expected)
+        assert.deepEqual(
+          actual,
+          expected,
+          printValueErrorMessage('deepEqual', actual, expected)
+        )
       })
     }
   })

--- a/packages/slate-react/test/plugins/index.js
+++ b/packages/slate-react/test/plugins/index.js
@@ -5,6 +5,7 @@ import assert from 'assert'
 import fs from 'fs'
 import toCamel from 'to-camel-case' // eslint-disable-line import/no-extraneous-dependencies
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
 
 /**
  * Tests.
@@ -36,7 +37,11 @@ describe('plugins', () => {
 
             const actual = simulator.value.toJSON({ preserveSelection: true })
             const expected = output.toJSON({ preserveSelection: true })
-            assert.deepEqual(actual, expected)
+            assert.deepEqual(
+              actual,
+              expected,
+              printValueErrorMessage('deepEqual', actual, expected)
+            )
           })
         }
       })

--- a/packages/slate/test/changes/index.js
+++ b/packages/slate/test/changes/index.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import fs from 'fs-promise' // eslint-disable-line import/no-extraneous-dependencies
 import toCamel from 'to-camel-case' // eslint-disable-line import/no-extraneous-dependencies
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
 
 /**
  * Tests.
@@ -36,7 +37,11 @@ describe('changes', async () => {
               const opts = { preserveSelection: true, preserveData: true }
               const actual = change.value.toJSON(opts)
               const expected = output.toJSON(opts)
-              assert.deepEqual(actual, expected)
+              assert.deepEqual(
+                actual,
+                expected,
+                printValueErrorMessage('deepEqual', actual, expected)
+              )
             })
           }
         })

--- a/packages/slate/test/history/index.js
+++ b/packages/slate/test/history/index.js
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import fs from 'fs'
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
 
 /**
  * Tests.
@@ -31,7 +32,11 @@ describe('history', async () => {
           const opts = { preserveSelection: true, preserveData: true }
           const actual = next.toJSON(opts)
           const expected = output.toJSON(opts)
-          assert.deepEqual(actual, expected)
+          assert.deepEqual(
+            actual,
+            expected,
+            printValueErrorMessage('deepEqual', actual, expected)
+          )
         })
       }
     })

--- a/packages/slate/test/models/index.js
+++ b/packages/slate/test/models/index.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import fs from 'fs'
 import { Schema } from '../..'
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
 
 /**
  * Tests.
@@ -28,7 +29,11 @@ describe('models', () => {
             .withoutNormalization(customChange)
             .value.toJSON()
 
-          assert.deepEqual(actual, expected)
+          assert.deepEqual(
+            actual,
+            expected,
+            printValueErrorMessage('deepEqual', actual, expected)
+          )
         })
       }
     })

--- a/packages/slate/test/operations/index.js
+++ b/packages/slate/test/operations/index.js
@@ -3,6 +3,8 @@ import fs from 'fs-promise' // eslint-disable-line import/no-extraneous-dependen
 import toCamel from 'to-camel-case' // eslint-disable-line import/no-extraneous-dependencies
 import { basename, extname, resolve } from 'path'
 
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
+
 /**
  * Tests.
  */
@@ -36,7 +38,11 @@ describe('operations', async () => {
               const opts = { preserveSelection: true, preserveData: true }
               const actual = change.value.toJSON(opts)
               const expected = output.toJSON(opts)
-              assert.deepEqual(actual, expected)
+              assert.deepEqual(
+                actual,
+                expected,
+                printValueErrorMessage('deepEqual', actual, expected)
+              )
             })
           }
         })

--- a/packages/slate/test/schema/index.js
+++ b/packages/slate/test/schema/index.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import fs from 'fs'
 import { Schema } from '../..'
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
 
 /**
  * Tests.
@@ -27,7 +28,11 @@ describe('schema', () => {
           .normalize()
           .value.toJSON()
 
-        assert.deepEqual(actual, expected)
+        assert.deepEqual(
+          actual,
+          expected,
+          printValueErrorMessage('deepEqual', actual, expected)
+        )
       })
     }
   })
@@ -51,7 +56,11 @@ describe('schema', () => {
           .normalize()
           .value.toJSON()
 
-        assert.deepEqual(actual, expected)
+        assert.deepEqual(
+          actual,
+          expected,
+          printValueErrorMessage('deepEqual', actual, expected)
+        )
       })
     }
   })

--- a/packages/slate/test/serializers/index.js
+++ b/packages/slate/test/serializers/index.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import fs from 'fs'
 import { Value } from '../..'
 import { basename, extname, resolve } from 'path'
+import printValueErrorMessage from '../../../../support/test/printValueErrorMessage'
 
 /**
  * Tests.
@@ -22,7 +23,11 @@ describe('serializers', () => {
           const { input, output, options } = module
           const actual = Value.fromJSON(input, options).toJSON()
           const expected = output.toJSON()
-          assert.deepEqual(actual, expected)
+          assert.deepEqual(
+            actual,
+            expected,
+            printValueErrorMessage('deepEqual', actual, expected)
+          )
         })
       }
     })
@@ -40,7 +45,11 @@ describe('serializers', () => {
           const { input, output, options } = module
           const actual = input.toJSON(options)
           const expected = output
-          assert.deepEqual(actual, expected)
+          assert.deepEqual(
+            actual,
+            expected,
+            printValueErrorMessage('deepEqual', actual, expected)
+          )
         })
       }
     })

--- a/support/test/printValueErrorMessage.js
+++ b/support/test/printValueErrorMessage.js
@@ -1,0 +1,73 @@
+import isEqual from 'lodash/isEqual'
+
+const GLOBAL_INDENT = '      '
+
+function insertCursor(text, offset) {
+  return [text.slice(0, offset), '|', text.slice(offset)].join('')
+}
+
+function printSlateNode(node, selection, indent = '', path = []) {
+  if (!node) return ''
+
+  const isTextNode = node.object === 'text'
+  const type = node.type ? `.${node.type}` : ''
+  let print = ''
+
+  let data =
+    typeof node.data === 'object' &&
+    Object.keys(node.data).length &&
+    JSON.stringify(node.data)
+  data = data ? ` data=${data}` : ''
+
+  let text = isTextNode ? `${node.leaves.map(l => l.text).join('')}` : ''
+
+  let selectionCursor = ''
+  if (selection) {
+    const anchor = isEqual(selection.anchorPath, path)
+    const focus = isEqual(selection.focusPath, path)
+
+    if (anchor && focus) {
+      selectionCursor = ' <- cursor'
+      text = insertCursor(text, selection.anchorOffset)
+    } else if (anchor) {
+      selectionCursor = ' <- anchor'
+      text = insertCursor(text, selection.anchorOffset)
+    } else if (focus) {
+      selectionCursor = ' <- focus'
+      text = insertCursor(text, selection.focusOffset)
+    }
+  }
+
+  print += `${GLOBAL_INDENT}${indent}<${node.object}${type}${data}>${text}${
+    isTextNode ? '' : '\n'
+  }`
+
+  if (node.nodes) {
+    node.nodes.forEach((n, i) => {
+      const nodePath = path.concat([i])
+      print += printSlateNode(n, selection, `${indent}|  `, nodePath)
+    })
+  }
+
+  print += `${isTextNode ? '' : `${GLOBAL_INDENT}${indent}`}</${
+    node.object
+  }>${selectionCursor}\n`
+
+  return print
+}
+
+function printValueErrorMessage(assertion, actual, expected) {
+  // Using try {} catch {} here to prevent any errors thrown here influencing test runs
+  try {
+    return `
+    Expected actual Value:
+${printSlateNode(actual.document, actual.selection)}
+    to ${assertion} expected Value:
+${printSlateNode(expected.document, expected.selection)}
+  `
+  } catch (e) {
+    return
+  }
+}
+
+export default printValueErrorMessage


### PR DESCRIPTION
I have recently written a lot of tests for my Slate project and one thing that was annoying me the most was the default error message:
```
      AssertionError [ERR_ASSERTION]: { object: 'value',
  document: { object: 'document', data: {}, nodes: [ [Object] ] } } deepEqual { object: 'value',
  document: { object: 'document', data: {}, nodes: [ [Object] ] } }
```
So I decided to sharpen my axe a little before cutting down the forest and implemented a custom error message:
```
      AssertionError [ERR_ASSERTION]: 
    Expected actual Value:
      <document>
      |  <block.list>
      |  |  <block.item>
      |  |  |  <text>|</text> <- cursor
      |  |  </block>
      |  </block>
      </document>

    to deepEqual expected Value:
      <document>
      |  <block.paragraph>
      |  |  <block.list data={"data":{"id":1}}>
      |  |  |  <block.item>
      |  |  |  |  <text>word|</text> <- cursor
      |  |  |  </block>
      |  |  </block>
      |  </block>
      </document>
```
Thought others might benefit from this too so here it is up for grabs!