### PR TITLE
Fix link to auto-markdown example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,7 +121,7 @@ To get a sense for how you might use Slate, check out a few of the examples:
 
 * [**Plain text**](./examples/plain-text) — showing the most basic case: a glorified `<textarea>`.
 * [**Rich text**](./examples/rich-text) — showing the features you'd expect from a basic editor.
-* [**Auto-markdown**](./examples/auto-markdown) — showing how to add key handlers for Markdown-like shortcuts.
+* [**Auto-markdown**](./examples/markdown-shortcuts) — showing how to add key handlers for Markdown-like shortcuts.
 * [**Links**](./examples/links) — showing how wrap text in inline nodes with associated data.
 * [**Images**](./examples/images) — showing how to use void (text-less) nodes to add images.
 * [**Hovering menu**](./examples/hovering-menu) — showing how a contextual hovering menu can be implemented.


### PR DESCRIPTION
Just fixed the link to the auto-markdown example in the readme file.