### PR TITLE
Handle readOnly inside contentEditable check list

### DIFF
--- a/examples/check-lists/index.js
+++ b/examples/check-lists/index.js
@@ -31,7 +31,7 @@ class CheckListItem extends React.Component {
    */
 
   render() {
-    const { attributes, children, node } = this.props
+    const { attributes, children, node, readOnly } = this.props
     const checked = node.data.get('checked')
     return (
       <div
@@ -42,7 +42,7 @@ class CheckListItem extends React.Component {
         <span>
           <input type="checkbox" checked={checked} onChange={this.onChange} />
         </span>
-        <span contentEditable suppressContentEditableWarning>
+        <span contentEditable={!readOnly} suppressContentEditableWarning>
           {children}
         </span>
       </div>


### PR DESCRIPTION
The check list example is a very important example for me to understand how to handle similar scenarios. So even it's already working as this example itself is not read-only, I think it still worth pointing out we may need to have the value of `contentEditable` accordingly to the `readOnly` property.