### PR TITLE
Fix correct-spell problem that crashing the slate

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -71,6 +71,7 @@ class Leaf extends React.Component {
 
   componentWillReceiveProps(props) {
     const { ref, firstChild } = this.leafRefs
+    // check if ref or its all contents are deleted by spell check
     if (!ref || ref.firstChild !== firstChild) {
       this.forceRegeneration()
       return

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -71,6 +71,10 @@ class Leaf extends React.Component {
     return false
   }
 
+  setRef = ref => {
+    this.spanRef = ref
+  }
+
   /**
    * Render the leaf.
    *
@@ -86,7 +90,11 @@ class Leaf extends React.Component {
       index,
     })
 
-    return <span data-offset-key={offsetKey}>{this.renderMarks()}</span>
+    return (
+      <span ref={this.setRef} data-offset-key={offsetKey}>
+        {this.renderMarks()}
+      </span>
+    )
   }
 
   /**

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -40,7 +40,7 @@ class Leaf extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      regenerateNum: 0,
+      regenerateKey: 0,
     }
   }
 
@@ -57,7 +57,7 @@ class Leaf extends React.Component {
 
   forceRegeneration = () => {
     this.setState(state => ({
-      regenerateNum: state.regenerateNum + 1,
+      regenerateKey: state.regenerateKey + 1,
     }))
   }
 
@@ -87,7 +87,7 @@ class Leaf extends React.Component {
     const queryString = `[data-offset-key="${offsetKey}"]`
     if (!window.document.querySelector(queryString)) {
       this.setState(state => ({
-        regenerateNum: state.regenerateNum + 1,
+        regenerateKey: state.regenerateKey + 1,
       }))
       return
     }
@@ -141,7 +141,7 @@ class Leaf extends React.Component {
       key: node.key,
       index,
     })
-    const key = `${offsetKey}:${this.state.regenerateNum}`
+    const key = `${offsetKey}:${this.state.regenerateKey}`
 
     return (
       <span key={key} ref={this.setRef} data-offset-key={offsetKey}>

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -84,6 +84,7 @@ class Leaf extends React.Component {
       this.forceRegeneration()
       return
     }
+
     for (let index = 0; index < childNodes.length; index++) {
       const child = childNodes[index]
       if (child.nodeName === '#text') {
@@ -91,6 +92,7 @@ class Leaf extends React.Component {
         return
       }
     }
+
     const { node, index } = this.props
     const offsetKey = OffsetKey.stringify({
       key: node.key,

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -55,11 +55,19 @@ class Leaf extends React.Component {
     debug(message, `${this.props.node.key}-${this.props.index}`, ...args)
   }
 
+  /*
+   * Remount the node by regenerate the key
+   */
+
   forceRegeneration = () => {
     this.setState(state => ({
       regenerateKey: state.regenerateKey + 1,
     }))
   }
+
+  /*
+   * Regenerate Key when spell check renders uncontrolled dom
+   */
 
   componentWillReceiveProps(props) {
     const { ref, firstChild } = this.leafRefs

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -66,18 +66,21 @@ class Leaf extends React.Component {
   }
 
   /*
-   * Regenerate Key when spell check renders uncontrolled dom
+   * Regenerate Key to unmount and remount
+   * Because spell check puts an uncontrolled dom, we detect spell check condition by
+   * 1. chiildNodes are removed
+   * 2. has a textNode as a child
+   * 3. itself is removed
    */
 
   componentWillReceiveProps(props) {
-    const { ref, firstChild } = this.leafRefs
-    // check if ref or its all contents are deleted by spell check
-    if (!ref || ref.firstChild !== firstChild) {
-      this.forceRegeneration()
+    const ref = this.leafRef
+    if (!ref) {
       return
     }
+
     const { childNodes } = ref
-    if (!childNodes) {
+    if (!childNodes || childNodes.length === 0) {
       this.forceRegeneration()
       return
     }
@@ -95,9 +98,7 @@ class Leaf extends React.Component {
     })
     const queryString = `[data-offset-key="${offsetKey}"]`
     if (!window.document.querySelector(queryString)) {
-      this.setState(state => ({
-        regenerateKey: state.regenerateKey + 1,
-      }))
+      this.forceRegeneration()
       return
     }
   }
@@ -125,15 +126,8 @@ class Leaf extends React.Component {
     return false
   }
 
-  componentWillUnmount() {
-    this.leafRefs = null
-  }
-
   setRef = ref => {
-    this.leafRefs = {
-      ref,
-      firstChild: ref ? ref.firstChild : null,
-    }
+    this.leafRef = ref
   }
 
   /**

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -96,6 +96,7 @@ class Text extends React.Component {
       this.forceRegeneration()
       return
     }
+
     for (let index = 0; index < childNodes.length; index++) {
       const child = childNodes[index]
       if (child.nodeName === '#text') {
@@ -104,6 +105,7 @@ class Text extends React.Component {
         return
       }
     }
+
     const { node } = this.props
     const { key } = node
     const queryString = `[data-key="${key}"]`

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -77,18 +77,22 @@ class Text extends React.Component {
   }
 
   /*
-   * Regenerate Key when spell check renders uncontrolled dom
+   * Regenerate Key to unmount and remount
+   * Because spell check puts an uncontrolled dom, we detect spell check condition by
+   * 1. chiildNodes are removed
+   * 2. has a textNode as a child
+   * 3. itself is removed
    */
 
   componentWillReceiveProps(props) {
-    const { ref, firstChild } = this.textRefs
+    const ref = this.textRef
     // check if ref or its all contents are deleted by spell check
-    if (!ref || ref.firstChild !== firstChild) {
-      this.forceRegeneration()
+    if (!ref) {
       return
     }
+
     const { childNodes } = ref
-    if (!childNodes) {
+    if (!childNodes || childNodes.length === 0) {
       this.forceRegeneration()
       return
     }
@@ -104,9 +108,7 @@ class Text extends React.Component {
     const { key } = node
     const queryString = `[data-key="${key}"]`
     if (!window.document.querySelector(queryString)) {
-      this.setState(state => ({
-        regenerateKey: state.regenerateKey + 1,
-      }))
+      this.forceRegeneration()
       return
     }
   }
@@ -147,10 +149,7 @@ class Text extends React.Component {
   }
 
   setRef = ref => {
-    this.textRefs = {
-      ref,
-      firstChild: ref ? ref.firstChild : null,
-    }
+    this.textRef = ref
   }
 
   /**

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -62,13 +62,13 @@ class Text extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      regenerateNum: 0,
+      regenerateKey: 0,
     }
   }
 
   forceRegeneration = () => {
     this.setState(state => ({
-      regenerateNum: state.regenerateNum + 1,
+      regenerateKey: state.regenerateKey + 1,
     }))
   }
 
@@ -96,7 +96,7 @@ class Text extends React.Component {
     const queryString = `[data-key="${key}"]`
     if (!window.document.querySelector(queryString)) {
       this.setState(state => ({
-        regenerateNum: state.regenerateNum + 1,
+        regenerateKey: state.regenerateKey + 1,
       }))
       return
     }
@@ -174,7 +174,7 @@ class Text extends React.Component {
       offset += leaf.text.length
       return child
     })
-    const reactKey = `text:${key}:${this.state.regenerateNum}`
+    const reactKey = `text:${key}:${this.state.regenerateKey}`
 
     return (
       <span ref={this.setRef} key={reactKey} data-key={key} style={style}>

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -82,6 +82,7 @@ class Text extends React.Component {
 
   componentWillReceiveProps(props) {
     const { ref, firstChild } = this.textRefs
+    // check if ref or its all contents are deleted by spell check
     if (!ref || ref.firstChild !== firstChild) {
       this.forceRegeneration()
       return

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -86,6 +86,7 @@ class Text extends React.Component {
     for (let index = 0; index < childNodes.length; index++) {
       const child = childNodes[index]
       if (child.nodeName === '#text') {
+        ref.removeChild(child)
         this.forceRegeneration()
         return
       }

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -66,11 +66,19 @@ class Text extends React.Component {
     }
   }
 
+  /*
+   * Remount the node by regenerate the key
+   */
+
   forceRegeneration = () => {
     this.setState(state => ({
       regenerateKey: state.regenerateKey + 1,
     }))
   }
+
+  /*
+   * Regenerate Key when spell check renders uncontrolled dom
+   */
 
   componentWillReceiveProps(props) {
     const { ref, firstChild } = this.textRefs

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -328,6 +328,7 @@ function AfterPlugin() {
 
     // Get the text information.
     const { text } = leaf
+
     let textContent = ''
 
     const { parentNode } = anchorNode
@@ -349,14 +350,8 @@ function AfterPlugin() {
     } else {
       textContent = parentNode.textContent
     }
-    if (!leaf.marks.size) {
-      if (parentNode.getAttribute('data-key')) {
-        parentNode.removeChild(anchorNode)
-      }
-      if (parentNode.getAttribute('data-offset-key')) {
-        parentNode.removeChild(anchorNode)
-        parentNode.removeChild(parentNode.firstChild)
-      }
+    if (leaf.marks.size) {
+      parentNode.removeChild(anchorNode)
     }
 
     // Determine what the selection should be after changing the text.

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -329,7 +329,9 @@ function AfterPlugin() {
     // Get the text information.
     const { text } = leaf
     let textContent = ''
-    if (!leaf.marks.size) {
+
+    const { parentNode } = anchorNode
+    if (!leaf.marks.size || parentNode.getAttribute('data-key')) {
       textContent = anchorNode.textContent
       const isLastText = node == lastText
       const isLastLeaf = leaf == lastLeaf
@@ -345,19 +347,15 @@ function AfterPlugin() {
       // If the text is no different, abort.
       if (textContent == text) return
     } else {
-      const textContentNode = anchorNode.parentNode
-      textContent = textContentNode.textContent
-      const { length } = textContentNode.childNodes
-      // Remove textNode if
-      // <span/>"spellcheck"
-      // Remove first chold and textNode if
-      // <span/>"spellcheck"<span/>
-      // Leave at least one child to let React re-use for render
-      if (length > 1) {
-        textContentNode.removeChild(anchorNode)
-        if (length > 2) {
-          textContentNode.removeChild(textContentNode.firstChild)
-        }
+      textContent = parentNode.textContent
+    }
+    if (!leaf.marks.size) {
+      if (parentNode.getAttribute('data-key')) {
+        parentNode.removeChild(anchorNode)
+      }
+      if (parentNode.getAttribute('data-offset-key')) {
+        parentNode.removeChild(anchorNode)
+        parentNode.removeChild(parentNode.firstChild)
       }
     }
 

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -328,20 +328,38 @@ function AfterPlugin() {
 
     // Get the text information.
     const { text } = leaf
-    let { textContent } = anchorNode
-    const isLastText = node == lastText
-    const isLastLeaf = leaf == lastLeaf
-    const lastChar = textContent.charAt(textContent.length - 1)
+    let textContent = ''
+    if (!leaf.marks.size) {
+      textContent = anchorNode.textContent
+      const isLastText = node == lastText
+      const isLastLeaf = leaf == lastLeaf
+      const lastChar = textContent.charAt(textContent.length - 1)
 
-    // COMPAT: If this is the last leaf, and the DOM text ends in a new line,
-    // we will have added another new line in <Leaf>'s render method to account
-    // for browsers collapsing a single trailing new lines, so remove it.
-    if (isLastText && isLastLeaf && lastChar == '\n') {
-      textContent = textContent.slice(0, -1)
+      // COMPAT: If this is the last leaf, and the DOM text ends in a new line,
+      // we will have added another new line in <Leaf>'s render method to account
+      // for browsers collapsing a single trailing new lines, so remove it.
+      if (isLastText && isLastLeaf && lastChar == '\n') {
+        textContent = textContent.slice(0, -1)
+      }
+
+      // If the text is no different, abort.
+      if (textContent == text) return
+    } else {
+      const textContentNode = anchorNode.parentNode
+      textContent = textContentNode.textContent
+      const { length } = textContentNode.childNodes
+      // Remove textNode if
+      // <span/>"spellcheck"
+      // Remove first chold and textNode if
+      // <span/>"spellcheck"<span/>
+      // Leave at least one child to let React re-use for render
+      if (length > 1) {
+        textContentNode.removeChild(anchorNode)
+        if (length > 2) {
+          textContentNode.removeChild(textContentNode.firstChild)
+        }
+      }
     }
-
-    // If the text is no different, abort.
-    if (textContent == text) return
 
     // Determine what the selection should be after changing the text.
     const delta = textContent.length - text.length

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -350,6 +350,7 @@ function AfterPlugin() {
       if (textContent == text) return
     } else {
       const result = findContent(anchorNode, value)
+      if (!result) return
       leaf = result.leaf
       start = result.start
       end = result.end

--- a/packages/slate-react/src/utils/find-content.js
+++ b/packages/slate-react/src/utils/find-content.js
@@ -1,0 +1,163 @@
+function getContent(anchorNode, value) {
+  const { document } = value
+  const { parentNode, previousSibling, nextSibling } = anchorNode
+  if (!parentNode) return {}
+  if (parentNode.getAttribute('data-offset-key')) {
+    return getContentInsideLeafSpan(anchorNode, value)
+  }
+  const key = parentNode.getAttribute('data-key')
+  if (!key) return {}
+  const node = document.getDescendant(key)
+  const leaves = node.getLeaves()
+  if (!node || node.object !== 'text') return {}
+
+  // If anchorNode is at the start
+  if (!previousSibling) {
+    const leaf = leaves.first()
+    const start = 0
+    const end = leaf.text.length
+    let { textContent } = anchorNode
+    // check if nextSibling is rendered by the first leaf
+    if (nextSibling) {
+      const offsetKey = nextSibling.getAttribute('data-offset-key')
+      if (offsetKey === `${key}:0`) {
+        textContent = textContent + nextSibling.textContent
+      }
+    }
+    return {
+      start,
+      end,
+      textContent,
+      leaf,
+      key,
+    }
+  }
+
+  // If anchorNode is at the end
+  if (!previousSibling) {
+    const leaf = leaves.last()
+    const { start, end } = findStartAndEnd(leaf, node)
+    let { textContent } = anchorNode
+    const index = leaves.size - 1
+    const offsetKey = previousSibling.getAttribute('data-offset-key')
+    if (offsetKey === `${key}:${index}`) {
+      textContent = previousSibling.textContent + textContent
+    }
+    return {
+      start,
+      end,
+      textContent,
+      leaf,
+      key,
+    }
+  }
+
+  const prevOffsetKey = previousSibling.getAttribute('data-offset-key')
+  const nextOffsetKey = nextSibling.getAttribute('data-offset-key')
+  const prevOffsetIndex = parseInt(prevOffsetKey.match(/[0-9]*$/)[0], 10)
+  if (prevOffsetIndex !== prevOffsetIndex) return {}
+  const nextOffsetIndex = parseInt(nextOffsetKey.match(/[0-9]*$/)[0], 10)
+
+  // If anchorNode splits a leaf
+  if (prevOffsetIndex === nextOffsetIndex) {
+    const leaf = leaves.get(prevOffsetIndex)
+    const { start, end } = findStartAndEnd(leaf, node)
+    const textContent =
+      previousSibling.textContent +
+      anchorNode.textContent +
+      nextSibling.textContent
+    return {
+      start,
+      end,
+      textContent,
+      leaf,
+      key,
+    }
+  }
+
+  // If anchorNode replace a leaf
+  if (nextOffsetIndex - prevOffsetIndex > 1) {
+    const leaf = leaves.get(prevOffsetIndex + 1)
+    const { start, end } = findStartAndEnd(leaf, node)
+    const { textContent } = anchorNode
+    return {
+      start,
+      end,
+      textContent,
+      leaf,
+      key,
+    }
+  }
+
+  // If anchorNode changes a leaf at start or end
+  const nextLeaf = leaves.get(nextOffsetIndex)
+
+  // If anchorNode changes a leaf at the start of nextSibling
+  if (nextLeaf.text !== nextSibling.textContent) {
+    const leaf = nextLeaf
+    const { start, end } = findStartAndEnd(leaf, node)
+    const textContent = anchorNode.textContent + nextSibling.textContent
+    return {
+      start,
+      end,
+      textContent,
+      leaf,
+      key,
+    }
+  }
+
+  // If anchorNode changes a leaf at the end of previousSibling
+  const leaf = leaves.get(prevOffsetIndex)
+  const { start, end } = findStartAndEnd(leaf, node)
+  const textContent = previousSibling.textContent + anchorNode.textContent
+  return {
+    start,
+    end,
+    textContent,
+    leaf,
+    key,
+  }
+}
+
+function getContentInsideLeafSpan(anchorNode, value) {
+  // After insert in masks, we can see:
+  // <b> Cat i cute </b>
+  // as
+  // <b> Cat </b>is <b>cute</b>
+  // The parentNode shall be rendered by text.js with data-offset-key
+  const { parentNode } = anchorNode
+  const { textContent } = parentNode
+  const offsetKey = parentNode.getAttribute('data-offset-key')
+  const matched = offsetKey.match(/[0-9]*$/)
+  const leafIndex = parseInt(matched[0], 10)
+  if (leafIndex !== leafIndex) return {}
+  const key = offsetKey.slice(0, matched.index - 1)
+  const { document } = value
+  const node = document.getDescendant(key)
+  if (node.object !== 'text') return {}
+  const leaves = node.getLeaves()
+  const leaf = leaves.get(leafIndex)
+  if (!leaf) return {}
+  const { start, end } = findStartAndEnd(leaf, node)
+  return {
+    start,
+    end,
+    textContent,
+    leaf,
+    key,
+  }
+}
+
+function findStartAndEnd(leaf, node) {
+  const leaves = node.getLeaves()
+  let start = 0
+  let end = 0
+  leaves.find(r => {
+    start = end
+    end += r.text.length
+    return r === leaf
+  })
+  return { start, end }
+}
+
+export default getContent

--- a/packages/slate-react/src/utils/find-content.js
+++ b/packages/slate-react/src/utils/find-content.js
@@ -8,6 +8,12 @@ function getContent(anchorNode, value) {
   const key = parentNode.getAttribute('data-key')
   if (!key) return {}
   const node = document.getDescendant(key)
+  if (node.object !== 'text') {
+    // PLease remind Jinxuan Zhu at https://github.com/ianstormtaylor/slate/pull/1695#issuecomment-376312742
+    // if you find this scenario is necessary
+    return undefined
+  }
+
   const leaves = node.getLeaves()
   if (!node || node.object !== 'text') return {}
 

--- a/packages/slate-react/src/utils/find-content.js
+++ b/packages/slate-react/src/utils/find-content.js
@@ -1,3 +1,14 @@
+/* After Spell Check, find the content of leaf after spell correction
+ * @param {HTMLNode} anchorNode
+ * @param {Value} value
+ * @return {Object|void}
+ *   @property {number} start
+ *   @property {number} end
+ *   @property {string} textContent
+ *   @property {Leaf} leaf
+ *   @property {string} key
+ * */
+
 function getContent(anchorNode, value) {
   const { document } = value
   const { parentNode, previousSibling, nextSibling } = anchorNode
@@ -9,8 +20,7 @@ function getContent(anchorNode, value) {
   if (!key) return {}
   const node = document.getDescendant(key)
   if (node.object !== 'text') {
-    // PLease remind Jinxuan Zhu at https://github.com/ianstormtaylor/slate/pull/1695#issuecomment-376312742
-    // if you find this scenario is necessary
+    // See https://github.com/ianstormtaylor/slate/pull/1695#issuecomment-376312742
     return undefined
   }
 

--- a/packages/slate-react/src/utils/find-content.js
+++ b/packages/slate-react/src/utils/find-content.js
@@ -34,12 +34,13 @@ function getContent(anchorNode, value) {
   }
 
   // If anchorNode is at the end
-  if (!previousSibling) {
+  if (!nextSibling) {
     const leaf = leaves.last()
     const { start, end } = findStartAndEnd(leaf, node)
     let { textContent } = anchorNode
     const index = leaves.size - 1
     const offsetKey = previousSibling.getAttribute('data-offset-key')
+    // Check if the previousSibling is rendered by the last leaf
     if (offsetKey === `${key}:${index}`) {
       textContent = previousSibling.textContent + textContent
     }


### PR DESCRIPTION
https://github.com/ianstormtaylor/slate/issues/1275 . 
## The description of Problem
Spell check can cause slateJS crash

## Reason and solution of the problem
The original onInput after.js assume the spell check works this way:
```html
<span data-offset-key="a:b"> Cat i cute </span>
```
after input event, before render
```html
<span data-offset-key="a:b"> Cat is cute </span>
```

But with marks, the html content after input event and before React rendering can be
#### spell check inside a mark:
```html
<span data-key="a"><span data-offset-key="a:b"><b>Cat i cute</b></span></span>
<!-- Becomes -->
<span data-key="a"><span data-offset-key="a:b"><b>Cat </b>i <b>cute</b></span></span>
<!-- or -->
<span data-key="a"><span data-offset-key="a:b"><b>Cat </b></span>i <span data-offset-key="a:b"><b>cute</b></span></span>
```
#### spell check replacing a mark:
```html
<span data-key="a"><span data-offset-key="a:0">Cat </span><span data-offset-key=a:1><b>i</b></span><span data-offset-key='a:2'> cute</span></span>
<!-- Becomes -->
<span data-key="a"><span data-offset-key="a:0">Cat </span>is<span data-offset-key='a:2'> cute</span></span>
```
The `span data-offset-key=a:1` is deleted

#### spell check at end of a mark
```html
<span data-key="a"><span data-offset-key="a:0"><b>Cat i</b></span><span data-offset-key='a:1'> cute</span></span>
<!-- Becomes -->
<span data-key="a"><span data-offset-key="a:0"><b>Cat </b></span>is <span data-offset-key='a:1'> cute</span></span>
```
`is` is outside of `span data-offset-key`

#### spell check at begin of a mark
```html
<span data-key="a"><span data-offset-key="a:0">Cat </span><span data-offset-key='a:1'><b>i cute</b></span></span>
<!-- Becomes -->
<span data-key="a"><span data-offset-key="a:0">Cat </span>is <span data-offset-key='a:1'><b>cute</b></span></span>
```
`is` is outside of `span data-offset-key`


4. spell check 

In this PR, I did 
1. write a `findContent` function to get `textContent` and `leaf` for the following scenarios
2. Force remount by regenerate React key, because anchorNode and splitted dom are not controlled by react;
3. remove anchorNode because it is not controlled by react
