### PR TITLE
Fix normalize empty inline

### DIFF
--- a/packages/slate/src/constants/core-schema-rules.js
+++ b/packages/slate/src/constants/core-schema-rules.js
@@ -92,7 +92,7 @@ const CORE_SCHEMA_RULES = [
     },
   },
 
- /**
+  /**
    * Ensure that inline non-void nodes are never empty.
    *
    * This rule is applied to all blocks and inlines, because when they contain an empty
@@ -106,17 +106,17 @@ const CORE_SCHEMA_RULES = [
     validateNode(node) {
       if (node.object != 'inline' && node.object != 'block') return
 
-      function isEmpty(node) {
-        // text node is empty when text is empty        
-        if (node.object === 'text') {
-          return node.text === ''
-        } 
+      function isEmpty(n) {
+        // text node is empty when text is empty
+        if (n.object === 'text') {
+          return n.text === ''
+        }
         // void is always considered non-empty regardless of actual content
-        if (node.isVoid) return false
+        if (n.isVoid) return false
         // otherwise node is empty if all children are empty
-        return !node.nodes.some(child => !isEmpty(child))                
-      }      
-            
+        return !n.nodes.some(child => !isEmpty(child))
+      }
+
       const invalids = node.nodes.filter(
         child => child.object === 'inline' && isEmpty(child)
       )

--- a/packages/slate/src/constants/core-schema-rules.js
+++ b/packages/slate/src/constants/core-schema-rules.js
@@ -106,8 +106,19 @@ const CORE_SCHEMA_RULES = [
     validateNode(node) {
       if (node.object != 'inline' && node.object != 'block') return
 
+      function isEmpty(node) {
+        // text node is empty when text is empty        
+        if (node.object === 'text') {
+          return node.text === ''
+        } 
+        // void is always considered non-empty regardless of actual content
+        if (node.isVoid) return false
+        // otherwise node is empty if all children are empty
+        return !node.nodes.some(child => !isEmpty(child))                
+      }      
+            
       const invalids = node.nodes.filter(
-        n => n.object === 'inline' && n.isVoid === false && n.text === ''
+        child => child.object === 'inline' && isEmpty(child)
       )
 
       if (!invalids.size) return

--- a/packages/slate/src/constants/core-schema-rules.js
+++ b/packages/slate/src/constants/core-schema-rules.js
@@ -92,20 +92,19 @@ const CORE_SCHEMA_RULES = [
     },
   },
 
-  /**
+ /**
    * Ensure that inline non-void nodes are never empty.
    *
-   * This rule is applied to all blocks, because when they contain an empty
-   * inline, we need to remove the inline from that parent block. If `validate`
-   * was to be memoized, it should be against the parent node, not the inline
-   * themselves.
+   * This rule is applied to all blocks and inlines, because when they contain an empty
+   * inline, we need to remove the empty inline from that parent node. If `validate`
+   * was to be memoized, it should be against the parent node, not the empty inline itself.
    *
    * @type {Object}
    */
 
   {
     validateNode(node) {
-      if (node.object != 'block') return
+      if (node.object != 'inline' && node.object != 'block') return
 
       const invalids = node.nodes.filter(
         n => n.object === 'inline' && n.isVoid === false && n.text === ''

--- a/packages/slate/test/schema/core/preserve-inline-with-empty-void.js
+++ b/packages/slate/test/schema/core/preserve-inline-with-empty-void.js
@@ -1,0 +1,101 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          <inline isVoid type="" />
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'value',
+  document: {
+    object: 'document',
+    data: {},
+    nodes: [
+      {
+        object: 'block',
+        type: 'paragraph',
+        isVoid: false,
+        data: {},
+        nodes: [          
+          {
+            object: 'text',
+            leaves: [
+              {
+                object: 'leaf',
+                text: '',
+                marks: [],
+              }
+            ],
+          },          
+          {
+            object: 'inline',
+            type: 'link',
+            isVoid: false,
+            data: {},
+            nodes: [              
+              {
+                object: 'text',
+                leaves: [
+                  {
+                    object: 'leaf',
+                    text: '',
+                    marks: [],
+                  }
+                ],
+              },              
+              {
+                object: 'inline',
+                type: '',
+                isVoid: true,
+                data: {},
+                nodes: [                  
+                  {
+                    object: 'text',
+                    leaves: [
+                      {
+                        object: 'leaf',
+                        text: '',
+                        marks: [],
+                      }
+                    ],
+                  },
+                ],
+              },
+              {
+                object: 'text',
+                leaves: [
+                  {
+                    object: 'leaf',
+                    text: '',
+                    marks: [],
+                  }
+                ],
+              }
+            ],
+          },          
+          {
+            object: 'text',
+            leaves: [
+              {
+                object: 'leaf',
+                text: '',
+                marks: [],
+              }
+            ],
+          }
+        ],
+      },
+    ],
+  },
+}

--- a/packages/slate/test/schema/core/preserve-inline-with-empty-void.js
+++ b/packages/slate/test/schema/core/preserve-inline-with-empty-void.js
@@ -27,7 +27,7 @@ export const output = {
         type: 'paragraph',
         isVoid: false,
         data: {},
-        nodes: [          
+        nodes: [
           {
             object: 'text',
             leaves: [
@@ -35,15 +35,15 @@ export const output = {
                 object: 'leaf',
                 text: '',
                 marks: [],
-              }
+              },
             ],
-          },          
+          },
           {
             object: 'inline',
             type: 'link',
             isVoid: false,
             data: {},
-            nodes: [              
+            nodes: [
               {
                 object: 'text',
                 leaves: [
@@ -51,15 +51,15 @@ export const output = {
                     object: 'leaf',
                     text: '',
                     marks: [],
-                  }
+                  },
                 ],
-              },              
+              },
               {
                 object: 'inline',
                 type: '',
                 isVoid: true,
                 data: {},
-                nodes: [                  
+                nodes: [
                   {
                     object: 'text',
                     leaves: [
@@ -67,7 +67,7 @@ export const output = {
                         object: 'leaf',
                         text: '',
                         marks: [],
-                      }
+                      },
                     ],
                   },
                 ],
@@ -79,11 +79,11 @@ export const output = {
                     object: 'leaf',
                     text: '',
                     marks: [],
-                  }
+                  },
                 ],
-              }
+              },
             ],
-          },          
+          },
           {
             object: 'text',
             leaves: [
@@ -91,9 +91,9 @@ export const output = {
                 object: 'leaf',
                 text: '',
                 marks: [],
-              }
+              },
             ],
-          }
+          },
         ],
       },
     ],

--- a/packages/slate/test/schema/core/remove-nested-empty-inline.js
+++ b/packages/slate/test/schema/core/remove-nested-empty-inline.js
@@ -1,0 +1,75 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          one
+          <link />
+          two
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'value',
+  document: {
+    object: 'document',
+    data: {},
+    nodes: [
+      {
+        object: 'block',
+        type: 'paragraph',
+        isVoid: false,
+        data: {},
+        nodes: [
+          {
+            object: 'text',
+            leaves: [
+              {
+                object: 'leaf',
+                text: '',
+                marks: [],
+              }
+            ],
+          },
+          {
+            object: 'inline',
+            type: 'link',
+            isVoid: false,
+            data: {},
+            nodes: [
+              {
+                object: 'text',
+                leaves: [
+                  {
+                    object: 'leaf',
+                    text: 'onetwo',
+                    marks: [],
+                  }
+                ],
+              }
+            ],
+          },
+          {
+            object: 'text',
+            leaves: [
+              {
+                object: 'leaf',
+                text: '',
+                marks: [],
+              }
+            ],
+          }
+        ],
+      },
+    ],
+  },
+}

--- a/packages/slate/test/schema/core/remove-nested-empty-inline.js
+++ b/packages/slate/test/schema/core/remove-nested-empty-inline.js
@@ -37,7 +37,7 @@ export const output = {
                 object: 'leaf',
                 text: '',
                 marks: [],
-              }
+              },
             ],
           },
           {
@@ -53,9 +53,9 @@ export const output = {
                     object: 'leaf',
                     text: 'onetwo',
                     marks: [],
-                  }
+                  },
                 ],
-              }
+              },
             ],
           },
           {
@@ -65,9 +65,9 @@ export const output = {
                 object: 'leaf',
                 text: '',
                 marks: [],
-              }
+              },
             ],
-          }
+          },
         ],
       },
     ],


### PR DESCRIPTION
This PR attempts to fix 2 problems related to normalization of empty inlines:

1) [Nested empty inlines](https://github.com/urugator/slate/commit/64e84a14dfc8628c5ec52f22286742d63136de2c) not being removed  by normalization.

2) Since `0.33.0` void nodes can contain empty string `''`. This means that `inline.text === ''` is no longer a valid indicator of "emptiness". 
Consider: `<a><void/></a>` then `a.text === ''` , but `<a>` isn't actually empty and shouldn't be removed by normalization. This PR [changes the way](https://github.com/urugator/slate/commit/ddfb71f68f57a04e057ac00bb4daf6d3b31cb32e) how empty inlines are detected.