### PR TITLE
Allow null return values, which will skip serializing that node

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -325,7 +325,7 @@ class Html {
 
   serialize = (value, options = {}) => {
     const { document } = value
-    const elements = document.nodes.map(this.serializeNode)
+    const elements = document.nodes.map(this.serializeNode).filter(el => el)
     if (options.render === false) return elements
 
     const html = renderToStaticMarkup(<body>{elements}</body>)
@@ -351,6 +351,7 @@ class Html {
     for (const rule of this.rules) {
       if (!rule.serialize) continue
       const ret = rule.serialize(node, children)
+      if (ret === null) return
       if (ret) return addKey(ret)
     }
 
@@ -372,6 +373,7 @@ class Html {
       for (const rule of this.rules) {
         if (!rule.serialize) continue
         const ret = rule.serialize(mark, children)
+        if (ret === null) return
         if (ret) return addKey(ret)
       }
 

--- a/packages/slate-html-serializer/test/serialize/null-rule.js
+++ b/packages/slate-html-serializer/test/serialize/null-rule.js
@@ -1,0 +1,41 @@
+/** @jsx h */
+
+import React from 'react'
+import h from '../helpers/h'
+
+export const rules = [
+  {
+    serialize(obj, children) {
+      if (obj.object == 'block' && obj.type == 'paragraph') {
+        return React.createElement('p', {}, children)
+      }
+
+      if (obj.object == 'inline' && obj.type == 'link') {
+        return React.createElement('a', {}, children)
+      }
+
+      if (obj.object == 'inline' && obj.type == 'comment') {
+        return null
+      }
+
+      if (obj.object == 'block' && obj.type == 'quote') {
+        return null
+      }
+    },
+  },
+]
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        Something <comment>skipped</comment> Here
+      </paragraph>
+      <quote>Skipped</quote>
+    </document>
+  </value>
+)
+
+export const output = `
+<p>Something  Here</p>
+`.trim()


### PR DESCRIPTION
Sometimes, I have nodes that only make sense temporarily, so it doesn't make sense to serialize them. Following the pattern in React, explicitly returning `null` from a serialization rule should result in that node (and its children) not making it into the serialized document.