### PR TITLE
Add key prop to <br /> elements in html-serializer

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -54,7 +54,7 @@ const TEXT_RULE = {
   serialize(obj, children) {
     if (obj.object === 'string') {
       return children.split('\n').reduce((array, text, i) => {
-        if (i != 0) array.push(<br />)
+        if (i != 0) array.push(<br key={i} />)
         array.push(text)
         return array
       }, [])


### PR DESCRIPTION
Get rid of "Each child in an array or iterator should have a unique "key" prop" warning when serializing with html-serializer.