### PR TITLE
Make serialize/deserialize dev friendlier

### DIFF
--- a/docs/walkthroughs/saving-and-loading-html-content.md
+++ b/docs/walkthroughs/saving-and-loading-html-content.md
@@ -103,27 +103,29 @@ const rules = [
     // Switch deserialize to handle more blocks...
     deserialize(el, next) {
       const type = BLOCK_TAGS[el.tagName.toLowerCase()]
-      if (!type) return
-      return {
-        object: 'block',
-        type: type,
-        nodes: next(el.childNodes),
+      if (type) {
+        return {
+          object: 'block',
+          type: type,
+          nodes: next(el.childNodes),
+        }
       }
     },
     // Switch serialize to handle more blocks...
     serialize(obj, children) {
-      if (obj.object != 'block') return
-      switch (obj.type) {
-        case 'paragraph':
-          return <p>{children}</p>
-        case 'quote':
-          return <blockquote>{children}</blockquote>
-        case 'code':
-          return (
-            <pre>
-              <code>{children}</code>
-            </pre>
-          )
+      if (obj.object == 'block') {
+        switch (obj.type) {
+          case 'paragraph':
+            return <p>{children}</p>
+          case 'quote':
+            return <blockquote>{children}</blockquote>
+          case 'code':
+            return (
+              <pre>
+                <code>{children}</code>
+              </pre>
+            )
+        }
       }
     },
   },
@@ -154,26 +156,28 @@ const rules = [
   {
     deserialize(el, next) {
       const type = BLOCK_TAGS[el.tagName.toLowerCase()]
-      if (!type) return
-      return {
-        object: 'block',
-        type: type,
-        nodes: next(el.childNodes),
+      if (type) {
+        return {
+          object: 'block',
+          type: type,
+          nodes: next(el.childNodes),
+        }
       }
     },
     serialize(obj, children) {
-      if (obj.object != 'block') return
-      switch (obj.type) {
-        case 'code':
-          return (
-            <pre>
-              <code>{children}</code>
-            </pre>
-          )
-        case 'paragraph':
-          return <p>{children}</p>
-        case 'quote':
-          return <blockquote>{children}</blockquote>
+      if (obj.object == 'block') {
+        switch (obj.type) {
+          case 'code':
+            return (
+              <pre>
+                <code>{children}</code>
+              </pre>
+            )
+          case 'paragraph':
+            return <p>{children}</p>
+          case 'quote':
+            return <blockquote>{children}</blockquote>
+        }
       }
     },
   },
@@ -181,22 +185,24 @@ const rules = [
   {
     deserialize(el, next) {
       const type = MARK_TAGS[el.tagName.toLowerCase()]
-      if (!type) return
-      return {
-        object: 'mark',
-        type: type,
-        nodes: next(el.childNodes),
+      if (type) {
+        return {
+          object: 'mark',
+          type: type,
+          nodes: next(el.childNodes),
+        }
       }
     },
     serialize(obj, children) {
-      if (obj.object != 'mark') return
-      switch (obj.type) {
-        case 'bold':
-          return <strong>{children}</strong>
-        case 'italic':
-          return <em>{children}</em>
-        case 'underline':
-          return <u>{children}</u>
+      if (obj.object == 'mark') {
+        switch (obj.type) {
+          case 'bold':
+            return <strong>{children}</strong>
+          case 'italic':
+            return <em>{children}</em>
+          case 'underline':
+            return <u>{children}</u>
+        }
       }
     },
   },

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -50,68 +50,73 @@ const RULES = [
   {
     deserialize(el, next) {
       const block = BLOCK_TAGS[el.tagName.toLowerCase()]
-      if (!block) return
-      return {
-        object: 'block',
-        type: block,
-        nodes: next(el.childNodes),
+      if (block) {
+        return {
+          object: 'block',
+          type: block,
+          nodes: next(el.childNodes),
+        }
       }
     },
   },
   {
     deserialize(el, next) {
       const mark = MARK_TAGS[el.tagName.toLowerCase()]
-      if (!mark) return
-      return {
-        object: 'mark',
-        type: mark,
-        nodes: next(el.childNodes),
+      if (mark) {
+        return {
+          object: 'mark',
+          type: mark,
+          nodes: next(el.childNodes),
+        }
       }
     },
   },
   {
     // Special case for code blocks, which need to grab the nested childNodes.
     deserialize(el, next) {
-      if (el.tagName.toLowerCase() != 'pre') return
-      const code = el.childNodes[0]
-      const childNodes =
-        code && code.tagName.toLowerCase() == 'code'
-          ? code.childNodes
-          : el.childNodes
+      if (el.tagName.toLowerCase() == 'pre') {
+        const code = el.childNodes[0]
+        const childNodes =
+          code && code.tagName.toLowerCase() == 'code'
+            ? code.childNodes
+            : el.childNodes
 
-      return {
-        object: 'block',
-        type: 'code',
-        nodes: next(childNodes),
+        return {
+          object: 'block',
+          type: 'code',
+          nodes: next(childNodes),
+        }
       }
     },
   },
   {
     // Special case for images, to grab their src.
     deserialize(el, next) {
-      if (el.tagName.toLowerCase() != 'img') return
-      return {
-        object: 'block',
-        type: 'image',
-        isVoid: true,
-        nodes: next(el.childNodes),
-        data: {
-          src: el.getAttribute('src'),
-        },
+      if (el.tagName.toLowerCase() == 'img') {
+        return {
+          object: 'block',
+          type: 'image',
+          isVoid: true,
+          nodes: next(el.childNodes),
+          data: {
+            src: el.getAttribute('src'),
+          },
+        }
       }
     },
   },
   {
     // Special case for links, to grab their href.
     deserialize(el, next) {
-      if (el.tagName.toLowerCase() != 'a') return
-      return {
-        object: 'inline',
-        type: 'link',
-        nodes: next(el.childNodes),
-        data: {
-          href: el.getAttribute('href'),
-        },
+      if (el.tagName.toLowerCase() == 'a') {
+        return {
+          object: 'inline',
+          type: 'link',
+          nodes: next(el.childNodes),
+          data: {
+            href: el.getAttribute('href'),
+          },
+        }
       }
     },
   },


### PR DESCRIPTION
It just switches the `!=` to `==`, thus removing an empty `return` for the default return in case the `if` is not matched, looks friendlier, easier to read, less confusion.