### PR TITLE
Restore #1604: Use getAncestors in getDescendant

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -351,6 +351,7 @@ class Node {
 
     if (key == this.key) return List()
     if (this.hasChild(key)) return List([this])
+    if (!this.getDescendant(key)) return null
 
     let ancestors
     this.nodes.find(node => {
@@ -359,11 +360,7 @@ class Node {
       return ancestors
     })
 
-    if (ancestors) {
-      return ancestors.unshift(this)
-    } else {
-      return null
-    }
+    return ancestors.unshift(this)
   }
 
   /**
@@ -651,10 +648,20 @@ class Node {
 
   getDescendant(key) {
     key = assertKey(key)
-    // Use the cache by getAncestors
-    const ancestors = this.getAncestors(key)
-    if (!ancestors || ancestors.size === 0) return null
-    return ancestors.last().getChild(key)
+    let descendantFound = null
+
+    const found = this.nodes.find(node => {
+      if (node.key === key) {
+        return node
+      } else if (node.object !== 'text') {
+        descendantFound = node.getDescendant(key)
+        return descendantFound
+      } else {
+        return false
+      }
+    })
+
+    return descendantFound || found
   }
 
   /**

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -651,20 +651,10 @@ class Node {
 
   getDescendant(key) {
     key = assertKey(key)
-    let descendantFound = null
-
-    const found = this.nodes.find(node => {
-      if (node.key === key) {
-        return node
-      } else if (node.object !== 'text') {
-        descendantFound = node.getDescendant(key)
-        return descendantFound
-      } else {
-        return false
-      }
-    })
-
-    return descendantFound || found
+    // Use the cache by getAncestors
+    const ancestors = this.getAncestors(key)
+    if (!ancestors || ancestors.size === 0) return null
+    return ancestors.last().getChild(key)
   }
 
   /**

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -350,8 +350,8 @@ class Node {
     key = assertKey(key)
 
     if (key == this.key) return List()
-    if (this.hasChild(key)) return List([this])
     if (!this.getDescendant(key)) return null
+    if (this.hasChild(key)) return List([this])
 
     let ancestors
     this.nodes.find(node => {


### PR DESCRIPTION
PR #1589 overwrites #1604 PR.  I think it is because git text comparison fails to warn the conflict between PR 1589 and other PRs.  

This PR is to restore PR #1604 , which is to use getAncestors in getDescendant to speed up the getDescendant when getAncestors is cached.