### PR TITLE
Don't stop propagation of drop event

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -317,14 +317,15 @@ class Content extends React.Component {
       }
     }
 
-    // Don't handle drag events coming from embedded editors.
+    // Don't handle drag and drop events coming from embedded editors.
     if (
       handler == 'onDragEnd' ||
       handler == 'onDragEnter' ||
       handler == 'onDragExit' ||
       handler == 'onDragLeave' ||
       handler == 'onDragOver' ||
-      handler == 'onDragStart'
+      handler == 'onDragStart' ||
+      handler == 'onDrop'
     ) {
       const { target } = event
       const targetEditorNode = target.closest('[data-slate-editor]')

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -301,9 +301,6 @@ function BeforePlugin() {
    */
 
   function onDrop(event, change, editor) {
-    // Stop propagation so the event isn't visible to parent editors.
-    event.stopPropagation()
-
     // Nothing happens in read-only mode.
     if (editor.props.readOnly) return true
 


### PR DESCRIPTION
We mirrored the fix in PR #1278 (meant for #1277) but for drop event.
This fixed an issue I faced with Slate swallowing drop event, kind of breaking compatibility with react-dnd.

/cc @AlbertHilb