### PR TITLE
fix: ensure that offset is positive in findDomRange

### DIFF
--- a/packages/slate-react/src/utils/find-dom-point.js
+++ b/packages/slate-react/src/utils/find-dom-point.js
@@ -29,7 +29,7 @@ function findDOMPoint(key, offset, win = window) {
 
     if (offset <= end) {
       const o = offset - start
-      return { node: n, offset: o }
+      return { node: n, offset: o >= 0 ? o : 0 }
     }
 
     start = end


### PR DESCRIPTION
Adds remaining fix in PR #1400, as the null `char` possibility was taken care of.

Based on this comment: https://github.com/ianstormtaylor/slate/pull/1400/files#r151273901