### PR TITLE
Fix cloneFragment to work with multiple Editor instances

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -96,7 +96,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   attach.setAttribute('data-slate-fragment', encoded)
 
   // Add the phony content to the DOM, and select it, so it will be copied.
-  const editor = window.document.querySelector('[data-slate-editor]')
+  const editor = event.target.closest('[data-slate-editor]')
   const div = window.document.createElement('div')
   div.setAttribute('contenteditable', true)
   div.style.position = 'absolute'


### PR DESCRIPTION
Currently when multiple instances of `<Editor />` are on one page `onCopy` silently fails for all but the first instance in the DOM. This PR makes the `cloneFragment` function use the DOM node of the editor instance it's being triggered in which solves this issue.

(Issue #1722)