### PR TITLE
Remove draggable attribute from void nodes

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -72,10 +72,7 @@ class Void extends React.Component {
     )
 
     const content = (
-      <Tag
-        contentEditable={readOnly ? null : false}
-        draggable={readOnly ? null : true}
-      >
+      <Tag contentEditable={readOnly ? null : false}>
         {children}
       </Tag>
     )

--- a/packages/slate-react/test/rendering/fixtures/custom-block-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-void.js
@@ -39,7 +39,7 @@ export const output = `
         </span>
       </span>
     </div>
-    <div contenteditable="false" draggable="true">
+    <div contenteditable="false">
       <img src="https://example.com/image.png">
     </div>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -44,7 +44,7 @@ export const output = `
           </span>
         </span>
       </span>
-      <span contenteditable="false" draggable="true">
+      <span contenteditable="false">
         <img>
       </span>
     </span>


### PR DESCRIPTION
As stated in https://github.com/ianstormtaylor/slate/issues/1726, having the `draggable` attribute set on the containers of void nodes can be a bit cumbersome when e.g. integrating with third party libs. This PR simply removes that attribute. I'm thinking it should be easy enough for people needing this to just add it to the actual nodes instead. 

As for the examples, DnD still works in the image example since the `<img>` element is draggable. Emojis though, are no longer draggable in the emojis example. I've opted not to add the `draggable` attribute to the emoji nodes since neither the dragging nor the dropping currently work properly (not sure it ever did?). For reference, this is what the dragging looks like before this PR:

![slate-emoji-dnd](https://user-images.githubusercontent.com/3599069/37997645-d033577c-321b-11e8-9842-e1cf75405b94.gif)