### PR TITLE
fix: Editor[autoFocus] should work, close: #1669

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -263,6 +263,7 @@ class RichTextExample extends React.Component {
           renderNode={this.renderNode}
           renderMark={this.renderMark}
           spellCheck
+          autoFocus
         />
       </div>
     )

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -40,7 +40,6 @@ class Content extends React.Component {
 
   static propTypes = {
     autoCorrect: Types.bool.isRequired,
-    autoFocus: Types.bool.isRequired,
     children: Types.any.isRequired,
     className: Types.string,
     editor: Types.object.isRequired,
@@ -87,11 +86,9 @@ class Content extends React.Component {
    *
    *   - Add native DOM event listeners.
    *   - Update the selection, in case it starts focused.
-   *   - Focus the editor if `autoFocus` is set.
    */
 
   componentDidMount = () => {
-    const { editor } = this.props
     const window = getWindow(this.element)
 
     window.document.addEventListener(
@@ -105,10 +102,6 @@ class Content extends React.Component {
     }
 
     this.updateSelection()
-
-    if (this.props.autoFocus) {
-      editor.focus()
-    }
   }
 
   /**

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -145,11 +145,16 @@ class Editor extends React.Component {
   }
 
   /**
-   * When the component first mounts, flush any temporary changes.
+   * When the component first mounts, flush any temporary changes,
+   * and then, focus the editor if `autoFocus` is set.
    */
 
   componentDidMount = () => {
     this.flushChange()
+
+    if (this.props.autoFocus) {
+      this.focus()
+    }
   }
 
   /**

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -602,7 +602,6 @@ function AfterPlugin() {
       <Content
         {...handlers}
         autoCorrect={props.autoCorrect}
-        autoFocus={props.autoFocus}
         className={props.className}
         children={props.children}
         editor={editor}


### PR DESCRIPTION
Close: https://github.com/ianstormtaylor/slate/issues/1669

Currently, Editor will cache the value which is passed from outside

https://github.com/ianstormtaylor/slate/blob/4346ad0e3f4a956e40a71f3cfd36682be6f90f4a/packages/slate-react/src/components/editor.js#L92

And then flush it when mount

https://github.com/ianstormtaylor/slate/blob/4346ad0e3f4a956e40a71f3cfd36682be6f90f4a/packages/slate-react/src/components/editor.js#L152

This will make any changes between Editor's initialization and componentDidMount lost. Such as `.focus` in Content's componentDidMount

https://github.com/ianstormtaylor/slate/blob/4346ad0e3f4a956e40a71f3cfd36682be6f90f4a/packages/slate-react/src/components/content.js#L109-L111