### PR TITLE
fix: make void node selectable for edge case, close: #1639

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -66,26 +66,24 @@ class Void extends React.Component {
     }
 
     const spacer = (
-      <Tag
-        contentEditable
-        data-slate-spacer
-        suppressContentEditableWarning
-        style={style}
-      >
+      <Tag data-slate-spacer style={style}>
         {this.renderText()}
       </Tag>
     )
 
-    const content = <Tag draggable={readOnly ? null : true}>{children}</Tag>
+    const content = (
+      <Tag
+        contentEditable={readOnly ? null : false}
+        draggable={readOnly ? null : true}
+      >
+        {children}
+      </Tag>
+    )
 
     this.debug('render', { props })
 
     return (
-      <Tag
-        data-slate-void
-        data-key={node.key}
-        contentEditable={readOnly ? null : false}
-      >
+      <Tag data-slate-void data-key={node.key}>
         {readOnly ? null : spacer}
         {content}
       </Tag>

--- a/packages/slate-react/test/rendering/fixtures/custom-block-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-void.js
@@ -31,15 +31,15 @@ export const value = (
 
 export const output = `
 <div data-slate-editor="true" contenteditable="true" role="textbox">
-  <div data-slate-void="true" contenteditable="false">
-    <div contenteditable="true" data-slate-spacer="true" style="height:0;color:transparent;outline:none">
+  <div data-slate-void="true">
+    <div data-slate-spacer="true" style="height:0;color:transparent;outline:none">
       <span>
         <span>
           <span data-slate-zero-width="z">&#x200B;</span>
         </span>
       </span>
     </div>
-    <div draggable="true">
+    <div contenteditable="false" draggable="true">
       <img src="https://example.com/image.png">
     </div>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -36,15 +36,15 @@ export const output = `
         <span data-slate-zero-width="z">&#x200B;</span>
       </span>
     </span>
-    <span data-slate-void="true" contenteditable="false">
-      <span contenteditable="true" data-slate-spacer="true" style="height:0;color:transparent;outline:none">
+    <span data-slate-void="true">
+      <span data-slate-spacer="true" style="height:0;color:transparent;outline:none">
         <span>
           <span>
             <span data-slate-zero-width="z">&#x200B;</span>
           </span>
         </span>
       </span>
-      <span draggable="true">
+      <span contenteditable="false" draggable="true">
         <img>
       </span>
     </span>


### PR DESCRIPTION
Close: https://github.com/ianstormtaylor/slate/issues/1639

In Slate, we render void node as `contentEditable=false`, it works fine under most circumstances. 

However, if the void node is the first child of Editor, the behavior of selection will be broken, e.g. the void node will not be select when we try to select all.

So, I just make void node's wrapper `contentEditable=true`, and make its content `contentEditable=false`, and then everything works fine.

