### PR TITLE
Fix hanging selection paste in insertFragmentAtRange

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -671,7 +671,11 @@ Changes.insertFragmentAtRange = (change, range, fragment, options = {}) => {
   // If the range is expanded, delete it first.
   if (range.isExpanded) {
     change.deleteAtRange(range, { normalize: false })
-    range = range.collapseToStart()
+    if (change.value.document.getDescendant(range.startKey)) {
+      range = range.collapseToStart()
+    } else {
+      range = range.collapseTo(range.endKey, 0)
+    }
   }
 
   // If the fragment is empty, there's nothing to do after deleting.

--- a/packages/slate/test/changes/at-current-range/insert-fragment/hanging-selection-single-block.js
+++ b/packages/slate/test/changes/at-current-range/insert-fragment/hanging-selection-single-block.js
@@ -1,0 +1,44 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+const fragment = (
+  <document>
+    <paragraph>fragment zero</paragraph>
+    <paragraph>fragment one</paragraph>
+    <paragraph>fragment two</paragraph>
+  </document>
+)
+export default function(change) {
+  change.insertFragment(fragment)
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>zero</paragraph>
+      <paragraph>
+        <anchor />one
+      </paragraph>
+      <quote>
+        <focus />two
+      </quote>
+    </document>
+  </value>
+)
+
+// The cursor position of insertFragment has some problems;
+// If you submit PR to fixed cursor position restore in insertFragment;
+// Please change this test as well
+export const output = (
+  <value>
+    <document>
+      <paragraph>zero</paragraph>
+      <quote>fragment zero</quote>
+      <paragraph>fragment one</paragraph>
+      <paragraph>
+        <cursor />fragment twotwo
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
## Problem:
We cannot paste on the hanging selection because deleteAtRange removes the startKey 
## Solution:
Use range.collapseToEnd() if startKey does not exists.

