### PR TITLE
Fix splitBlock bug with hanging selection

### DIFF
--- a/packages/slate/src/changes/at-current-range.js
+++ b/packages/slate/src/changes/at-current-range.js
@@ -217,8 +217,12 @@ Changes.insertText = (change, text, marks) => {
 
 Changes.splitBlock = (change, depth = 1) => {
   const { value } = change
-  const { selection } = value
+  const { selection, document } = value
+  const marks = selection.marks || document.getInsertMarksAtRange(selection)
   change.splitBlockAtRange(selection, depth).collapseToEnd()
+  if (marks && marks.size !== 0) {
+    change.select({ marks })
+  }
 }
 
 /**

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -988,12 +988,7 @@ Changes.setInlineAtRange = (...args) => {
 Changes.splitBlockAtRange = (change, range, height = 1, options = {}) => {
   const normalize = change.getFlag('normalize', options)
 
-  if (range.isExpanded) {
-    change.deleteAtRange(range, { normalize })
-    range = range.collapseToStart()
-  }
-
-  const { startKey, startOffset } = range
+  const { startKey, startOffset, endOffset, endKey } = range
   const { value } = change
   const { document } = value
   let node = document.assertDescendant(startKey)
@@ -1006,7 +1001,19 @@ Changes.splitBlockAtRange = (change, range, height = 1, options = {}) => {
     h++
   }
 
-  change.splitDescendantsByKey(node.key, startKey, startOffset, { normalize })
+  change.splitDescendantsByKey(node.key, startKey, startOffset, {
+    normalize: normalize && range.isCollapsed,
+  })
+
+  if (range.isExpanded) {
+    if (range.isBackward) range = range.flip()
+    const nextBlock = change.value.document.getNextBlock(node.key)
+    range = range.moveAnchorToStartOf(nextBlock)
+    if (startKey === endKey) {
+      range = range.moveFocusTo(range.anchorKey, endOffset - startOffset)
+    }
+    change.deleteAtRange(range, { normalize })
+  }
 }
 
 /**

--- a/packages/slate/test/changes/at-current-range/split-block/with-delete-hanging-selection.js
+++ b/packages/slate/test/changes/at-current-range/split-block/with-delete-hanging-selection.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.splitBlock()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>zero</paragraph>
+      <paragraph>
+        <anchor />word
+      </paragraph>
+      <quote>
+        <focus />cat is cute
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>zero</paragraph>
+      <paragraph />
+      <quote>
+        <cursor />cat is cute
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/split-block/with-marks.js
+++ b/packages/slate/test/changes/at-current-range/split-block/with-marks.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change
+    .addMark('italic')
+    .splitBlock()
+    .insertText('cat is cute')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>word</b>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>word</b>
+        <cursor />
+      </paragraph>
+      <paragraph>
+        <i>
+          <b>cat is cute</b>
+        </i>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
## Problem:
With hanging selection, splitBlock cannot find startKey.

## Fix:
split and then delete.