### PR TITLE
fix copying void nodes in Chrome

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -10,6 +10,7 @@ import EVENT_HANDLERS from '../constants/event-handlers'
 import HOTKEYS from '../constants/hotkeys'
 import Content from '../components/content'
 import cloneFragment from '../utils/clone-fragment'
+import copyVoidNode from '../utils/copy-void-node'
 import findDOMNode from '../utils/find-dom-node'
 import findNode from '../utils/find-node'
 import findPoint from '../utils/find-point'
@@ -103,6 +104,7 @@ function AfterPlugin() {
     debug('onCopy', { event })
 
     cloneFragment(event, change.value)
+    copyVoidNode(event, change.value)
   }
 
   /**
@@ -117,6 +119,8 @@ function AfterPlugin() {
     debug('onCut', { event })
 
     cloneFragment(event, change.value)
+    copyVoidNode(event, change.value)
+
     const window = getWindow(event.target)
 
     // Once the fake cut content has successfully been added to the clipboard,

--- a/packages/slate-react/src/utils/copy-void-node.js
+++ b/packages/slate-react/src/utils/copy-void-node.js
@@ -1,0 +1,31 @@
+/**
+ * If the node is a void node, copy it using `ClipboardEvent.clipboardData`.
+ *
+ * This is needed because Chrome doesn't copy the whole HTML markup we generate
+ * in `cloneFragment`, so the encoded Slate fragment will be not included.
+ *
+ * @param {Event} event
+ * @param {Value} value
+ */
+
+function copyVoidNode(event, value) {
+  const { endBlock, endInline } = value
+  const isVoidBlock = endBlock && endBlock.isVoid
+  const isVoidInline = endInline && endInline.isVoid
+  const isVoid = isVoidBlock || isVoidInline
+
+  if (isVoid) {
+    const range = window.getSelection().getRangeAt(0)
+    const contents = range.cloneContents()
+    const attach = contents.childNodes[0]
+    const clipboardData = event.nativeEvent.clipboardData
+
+    if (clipboardData && clipboardData.setData) {
+      clipboardData.setData('text/html', attach.innerHTML)
+      event.preventDefault()
+      return
+    }
+  }
+}
+
+export default copyVoidNode


### PR DESCRIPTION
When the node is a void node, it uses the `ClipboardEvent.clipboardData` API to directly copy the HTML markup to the clipboard.

Fixes https://github.com/ianstormtaylor/slate/issues/1449