### PR TITLE
Issues in IE 11

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -121,6 +121,8 @@ class Html {
    */
 
   deserialize = (html, options = {}) => {
+    // Provides default value to make it working in IE 11.
+    html = html || '<p></p>'
     const { toJSON = false } = options
     const { defaultBlock, parseHtml } = this
     const fragment = parseHtml(html)
@@ -327,8 +329,8 @@ class Html {
     const { document } = value
     const elements = document.nodes.map(this.serializeNode).filter(el => el)
     if (options.render === false) return elements
-
-    const html = renderToStaticMarkup(<body>{elements}</body>)
+    // Converts List to Array to support IE 11.
+    const html = renderToStaticMarkup(<body>{elements.toArray()}</body>)
     const inner = html.slice(6, -7)
     return inner
   }
@@ -343,14 +345,17 @@ class Html {
   serializeNode = node => {
     if (node.object === 'text') {
       const leaves = node.getLeaves()
-      return leaves.map(this.serializeLeaf)
+      const children = leaves.map(this.serializeLeaf);
+      // Converts List to Array to support IE 11.
+      return children.toArray()
     }
 
     const children = node.nodes.map(this.serializeNode)
 
     for (const rule of this.rules) {
       if (!rule.serialize) continue
-      const ret = rule.serialize(node, children)
+      // Converts List to Array to support IE 11.
+      const ret = rule.serialize(node, children.toArray())
       if (ret === null) return
       if (ret) return addKey(ret)
     }

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -124,9 +124,10 @@ class Text extends React.Component {
       return child
     })
 
+    // Converts List to Array to support IE 11.
     return (
       <span data-key={key} style={style}>
-        {children}
+        {children.toArray()}
       </span>
     )
   }


### PR DESCRIPTION
Fixes for several issues in IE 11 we found during slate integration:
```
Objects are not valid as a React child (found: object with keys {size, _origin, _capacity, _level, _root, _tail, ownerID, hash, __altered}). If you meant to render a collection of children, use an array instead. in span (at text.js:130)
```

```
Unable to get property 'childNodes' of undefined or null reference
```

```
Objects are not valid as a React child (found: List [ [object Object] ]). If you meant to render a collection of children, use an array instead.
```
