### PR TITLE
Node use a parent map for performance

### DIFF
--- a/benchmark-results.txt
+++ b/benchmark-results.txt
@@ -1,0 +1,67 @@
+
+  benchmarks
+    html-serializer
+      deserialize
+        7.52 → 7.59 ops/sec
+      serialize
+        799.19 → 770.50 ops/sec
+    plain-serializer
+      deserialize
+        254.29 → 243.54 ops/sec
+      serialize
+        6361.44 → 4317.70 ops/sec
+    rendering
+      normal
+        76.80 → 57.52 ops/sec
+    changes
+      delete-backward
+        33566.02 → 26689.58 ops/sec
+      delete-forward
+        4732.58 → 3950.77 ops/sec
+      insert-text-by-key-multiple
+        65.16 → 92.48 ops/sec (42% faster)
+      insert-text-by-key
+        871.62 → 572.61 ops/sec (34% slower)
+      insert-text
+        1095.37 → 952.57 ops/sec
+      normalize
+        71389.81 → 75804.18 ops/sec
+      split-block
+        63.31 → 76.51 ops/sec
+    models
+      from-json-big
+        2.19 → 2.22 ops/sec
+      from-json
+        115.77 → 117.47 ops/sec
+      get-blocks-at-range
+        24593.08 → 24263.87 ops/sec
+      get-blocks
+        573926.72 → 547490.89 ops/sec
+      get-characters-at-range
+        11343.84 → 10889.83 ops/sec
+      get-characters
+        11810.52 → 11572.59 ops/sec
+      get-inlines-at-range
+        161176.72 → 169514.27 ops/sec
+      get-inlines
+        1017884.49 → 925047.30 ops/sec
+      get-leaves
+        11034836.47 → 10723100.04 ops/sec
+      get-marks-at-range
+        1391.25 → 1243.05 ops/sec
+      get-marks
+        1126.99 → 1345.93 ops/sec
+      get-path
+        429087.40 → 554933.62 ops/sec
+      get-texts-at-range
+        311569.89 → 265181.51 ops/sec
+      get-texts
+        662274.94 → 501818.13 ops/sec
+      has-node-multiple
+        72346.99 → 60184.15 ops/sec
+      has-node
+        565016.94 → 560211.79 ops/sec
+      to-json
+        2604.46 → 2289.03 ops/sec
+      update-node
+        14278.60 → 12166.05 ops/sec

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1,7 +1,7 @@
 import direction from 'direction'
 import isPlainObject from 'is-plain-object'
 import logger from 'slate-dev-logger'
-import { List, OrderedSet, Set, Map } from 'immutable'
+import { List, OrderedSet, Set, OrderedMap } from 'immutable'
 
 import Block from './block'
 import Data from './data'
@@ -198,7 +198,6 @@ class Node {
     first = assertKey(first)
     second = assertKey(second)
 
-    // TODO optimize getKeysAsArray
     const keys = this.getKeysAsArray()
     const firstIndex = keys.indexOf(first)
     const secondIndex = keys.indexOf(second)
@@ -944,13 +943,9 @@ class Node {
    */
 
   getKeysAsArray() {
-    const keys = []
-
-    this.forEachDescendant(desc => {
-      keys.push(desc.key)
-    })
-
-    return keys
+    return this.getParentMap()
+      .keySeq()
+      .toArray()
   }
 
   /**
@@ -960,7 +955,7 @@ class Node {
    */
 
   getKeys() {
-    const keys = this.getKeysAsArray()
+    const keys = this.getParentMap().keySeq()
     return new Set(keys)
   }
 
@@ -1339,18 +1334,16 @@ class Node {
 
   /**
    * Get the parent map of this node
-   * @return {Map<String, Node>} Map<key, parentNode>
+   * @return {OrderedMap<String, Node>} OrderedMap<key, parentNode>
+   *   the order is the same than the order of forEachDescendant
    */
 
   getParentMap() {
     if (this.object === 'text') {
-      return Map()
+      return OrderedMap()
     }
 
-    return Map().withMutations(map => {
-      if (!this.nodes) {
-        console.log(this.toObject())
-      }
+    return OrderedMap().withMutations(map => {
       this.nodes.forEach(child => {
         map.set(child.key, this)
         if (child.object !== 'text') {


### PR DESCRIPTION
For fun, I wanted to explore a different approach for node finding and parent/ancestors computations on Nodes, and start a discussion around it.

The idea is to implement a general-purpose method `node.getParentMap` that returns an `OrderedMap<key, parentNode>` of all their descendants. Then a lot of other methods reuse this map and become trivial or more efficient.

I was running the benchmarks, but then gave up on them once I realized that running the same benchmark twice could randomly show ±80% changes with no reason.

What I like about this approach is that we can memoize this single method, and skip memoization for a lot of methods that become trivial after relying on `getParentMap`.

`getParentMap` could return a `Map` instead of `OrderedMap`, which has better performance, but then `getKeysAsArray` cannot benefit from it.
