### PR TITLE
Removed early return in onDragOver

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -270,10 +270,10 @@ function BeforePlugin() {
     if (node.isVoid) event.preventDefault()
 
     // If a drag is already in progress, don't do this again.
-    if (isDragging) return true
-
-    isDragging = true
-    event.nativeEvent.dataTransfer.dropEffect = 'move'
+    if (!isDragging) {
+      isDragging = true
+      event.nativeEvent.dataTransfer.dropEffect = 'move'
+    }
 
     debug('onDragOver', { event })
   }


### PR DESCRIPTION
The early return prevents custom onDragOver functions from being executed.