### PR TITLE
Ensure cursor is shown after delete hanging selection

### DIFF
--- a/packages/slate/src/changes/at-current-range.js
+++ b/packages/slate/src/changes/at-current-range.js
@@ -40,6 +40,11 @@ PROXY_TRANSFORMS.forEach(method => {
     const { selection } = value
     const methodAtRange = `${method}AtRange`
     change[methodAtRange](selection, ...args)
+    if (method.match(/Backward$/)) {
+      change.collapseToStart()
+    } else if (method.match(/Forward$/)) {
+      change.collapseToEnd()
+    }
   }
 })
 

--- a/packages/slate/test/changes/at-current-range/delete-forward/start-text-middle-inline.js
+++ b/packages/slate/test/changes/at-current-range/delete-forward/start-text-middle-inline.js
@@ -23,9 +23,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />
         <link>
-          <focus />wo
+          <cursor />wo
         </link>
       </paragraph>
     </document>


### PR DESCRIPTION
Problem:
We cannot see a cursor blink after delete hanging selection with backspace.

Before fix:
![](http://g.recordit.co/RifYOowrb1.gif)
After fix:
![](http://g.recordit.co/cgqLuUmDNZ.gif)
