### PR TITLE
refactor: remove useless .indexOf to improve perf

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1854,13 +1854,12 @@ class Node {
   mapDescendants(iterator) {
     let { nodes } = this
 
-    nodes.forEach((node, i) => {
+    nodes.forEach((node, index) => {
       let ret = node
       if (ret.object != 'text') ret = ret.mapDescendants(iterator)
-      ret = iterator(ret, i, this.nodes)
+      ret = iterator(ret, index, this.nodes)
       if (ret == node) return
 
-      const index = nodes.indexOf(node)
       nodes = nodes.set(index, ret)
     })
 


### PR DESCRIPTION
Ref: https://github.com/ianstormtaylor/slate/issues/1768

When we try to paste something into editor, the call stack:

```bash
plugin.onPaste => change.insertFragment => change. insertFragmentAtRange => node.mapDescendants
```

We need `node.mapDescendants` to re-generate keys. But the implementation of `node.mapDescendants` is extremely slow:

https://github.com/ianstormtaylor/slate/blob/a943eada8534ccdff05a770ad84ac599bd7b3682/packages/slate/src/models/node.js#L1854-L1868

If we paste a long list, the algorithm complexity will be almost O(n^2), for we need to `.forEach` n nodes and `.indexOf` n nodes.