### PR TITLE
Fix a bug in normalizeNodeByKey

### DIFF
--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -47,7 +47,9 @@ Changes.normalizeNodeByKey = (change, key) => {
   if (!ancestors) return
 
   ancestors.forEach(ancestor => {
-    normalizeNode(change, ancestor, schema)
+    if (change.value.document.getDescendant(ancestor.key)) {
+      normalizeNode(change, ancestor, schema)
+    }
   })
 }
 


### PR DESCRIPTION
`normalizeNodeByKey` normalize all ancestors of the changed node.  However, an ancestor can by removed by `unwrapNodeByKey`, resulting an error in normalization.

This PR ensures that a `ancestor` is `normalized` when and only when it exists.
