### PR TITLE
[examples] fix rich text editor active block logic

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -235,7 +235,13 @@ class RichTextExample extends React.Component {
    */
 
   renderBlockButton = (type, icon) => {
-    const isActive = this.hasBlock(type)
+    let isActive = this.hasBlock(type)
+
+    if (['numbered-list', 'bulleted-list'].includes(type)) {
+      const { value } = this.state
+      const parent = value.document.getParent(value.blocks.first().key)
+      isActive = this.hasBlock('list-item') && parent && parent.type === type
+    }
     const onMouseDown = event => this.onClickBlock(event, type)
 
     return (


### PR DESCRIPTION
Just a small fix to the rich text editor example - when you use the numbered list/unordered list block level buttons, then focus within the block, the buttons were not previously properly reflecting an active state.

This is outlined in https://github.com/ianstormtaylor/slate/issues/1800

Thanks! Digging Slate so far.