### PR TITLE
[On Development] Do not call nested normalization in a cycle of normalization

### DIFF
--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -40,13 +40,22 @@ Changes.normalizeNodeByKey = (change, key) => {
   let { document, schema } = value
   if (change.__nextNormalizedKeys.length !== 0) {
     change.__nextNormalizedKeys.push(key)
+    return
   }
+  let firstRun = true
   change.__nextNormalizedKeys = [key]
   try {
     while (change.__nextNormalizedKeys.length !== 0) {
       key = change.__nextNormalizedKeys.shift()
-      const node = document.assertNode(key)
-      normalizeNodeAndChildren(change, node, schema)
+      document = change.value.document
+      if (firstRun) {
+        document.assertNode(key)
+        firstRun = false
+      }
+      const node = document.getNode(key)
+      if (node) {
+        normalizeNodeAndChildren(change, node, schema)
+      }
       document = change.value.document
       const ancestors = document.getAncestors(key)
       if (!ancestors) return

--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -105,7 +105,7 @@ function normalizeNode(change, node, schema) {
 
     // Run the `normalize` function to fix the node.
     let path = c.value.document.getPath(n.key)
-    normalize(c)
+    c.withoutNormalization(normalize)
 
     // Re-find the node reference, in case it was updated. If the node no longer
     // exists, we're done for this branch.

--- a/packages/slate/src/changes/with-schema.js
+++ b/packages/slate/src/changes/with-schema.js
@@ -105,7 +105,7 @@ function normalizeNode(change, node, schema) {
 
     // Run the `normalize` function to fix the node.
     let path = c.value.document.getPath(n.key)
-    c.withoutNormalization(normalize)
+    c.withoutNormalization(normalize, { normalize: false })
 
     // Re-find the node reference, in case it was updated. If the node no longer
     // exists, we're done for this branch.

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -50,6 +50,7 @@ class Change {
       normalize: true,
       ...pick(attrs, ['merge', 'save', 'normalize']),
     }
+    this.__nextNormalizedKeys = []
   }
 
   /**

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -151,13 +151,16 @@ class Change {
    * @return {Change}
    */
 
-  withoutNormalization(customChange) {
+  withoutNormalization(customChange, options = {}) {
     const original = this.flags.normalize
+    const { normalize = true } = options
     this.setOperationFlag('normalize', false)
     try {
       customChange(this)
       // if the change function worked then run normalization
-      this.normalizeDocument()
+      if (normalize) {
+        this.normalizeDocument()
+      }
     } finally {
       // restore the flag to whatever it was
       this.setOperationFlag('normalize', original)

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -152,16 +152,13 @@ class Change {
    * @return {Change}
    */
 
-  withoutNormalization(customChange, options = {}) {
+  withoutNormalization(customChange) {
     const original = this.flags.normalize
-    const { normalize = true } = options
     this.setOperationFlag('normalize', false)
     try {
       customChange(this)
       // if the change function worked then run normalization
-      if (normalize) {
-        this.normalizeDocument()
-      }
+      this.normalizeDocument()
     } finally {
       // restore the flag to whatever it was
       this.setOperationFlag('normalize', original)


### PR DESCRIPTION
We still needs to call `{normalize: false}` when writing validateNode, because normalization inside normalization is hard to understand the sequence.  

For example, we want to have a validateNode to set table alignment:
```
validateNode() {
  presetAlign = [...] // calculate presetAlign
return change => {
change.setNodeByKey(table.key, {data:presetAlign}) // Forget normalize: false here
table.nodes.forEach(row => row.nodes.forEach( (cell, index) => cell.data.normalizeNodeByKey(presetAlign[index], {normalize:false))
}
}
```
if the first {normalize:false} is missing, then the `valdiateNode` will run on this schema again and again if presetAlign has different array reference each time.

<del>This PR prevents nested normalize in a normalization, unless `{normalize: true}` is given.</del>
This PR use a FIFO to organize all normalizeNodeByKey tasks

@CameronAckermanSEL  Question: shall we still call normalizeDocument if change.flags.normalize is false before withoutMutations?