### PR TITLE
Faster is`Type`

### DIFF
--- a/packages/slate/src/models/block.js
+++ b/packages/slate/src/models/block.js
@@ -129,7 +129,11 @@ class Block extends Record(DEFAULTS) {
    */
 
   static isBlock(any) {
-    return !!(any && any[MODEL_TYPES.BLOCK])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.BLOCK)
+    }
+    return !!any[MODEL_TYPES.BLOCK]
   }
 
   /**

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -32,7 +32,11 @@ class Change {
    */
 
   static isChange(any) {
-    return !!(any && any[MODEL_TYPES.CHANGE])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.CHANGE)
+    }
+    return !!any[MODEL_TYPES.CHANGE]
   }
 
   /**

--- a/packages/slate/src/models/document.js
+++ b/packages/slate/src/models/document.js
@@ -98,7 +98,11 @@ class Document extends Record(DEFAULTS) {
    */
 
   static isDocument(any) {
-    return !!(any && any[MODEL_TYPES.DOCUMENT])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.DOCUMENT)
+    }
+    return !!any[MODEL_TYPES.DOCUMENT]
   }
 
   /**

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -85,7 +85,11 @@ class History extends Record(DEFAULTS) {
    */
 
   static isHistory(any) {
-    return !!(any && any[MODEL_TYPES.HISTORY])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.HISTORY)
+    }
+    return !!any[MODEL_TYPES.HISTORY]
   }
 
   /**

--- a/packages/slate/src/models/inline.js
+++ b/packages/slate/src/models/inline.js
@@ -129,7 +129,11 @@ class Inline extends Record(DEFAULTS) {
    */
 
   static isInline(any) {
-    return !!(any && any[MODEL_TYPES.INLINE])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.INLINE)
+    }
+    return !!any[MODEL_TYPES.INLINE]
   }
 
   /**

--- a/packages/slate/src/models/mark.js
+++ b/packages/slate/src/models/mark.js
@@ -138,7 +138,11 @@ class Mark extends Record(DEFAULTS) {
    */
 
   static isMark(any) {
-    return !!(any && any[MODEL_TYPES.MARK])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.MARK)
+    }
+    return !!any[MODEL_TYPES.MARK]
   }
 
   /**

--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -192,7 +192,11 @@ class Operation extends Record(DEFAULTS) {
    */
 
   static isOperation(any) {
-    return !!(any && any[MODEL_TYPES.OPERATION])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.OPERATION)
+    }
+    return !!any[MODEL_TYPES.OPERATION]
   }
 
   /**

--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -151,8 +151,12 @@ class Range extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isRange(obj) {
-    return !!(obj && obj[MODEL_TYPES.RANGE])
+  static isRange(any) {
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.RANGE)
+    }
+    return !!any[MODEL_TYPES.RANGE]
   }
 
   /**

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -125,7 +125,11 @@ class Schema extends Record(DEFAULTS) {
    */
 
   static isSchema(any) {
-    return !!(any && any[MODEL_TYPES.SCHEMA])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.SCHEMA)
+    }
+    return !!any[MODEL_TYPES.SCHEMA]
   }
 
   /**

--- a/packages/slate/src/models/stack.js
+++ b/packages/slate/src/models/stack.js
@@ -41,7 +41,11 @@ class Stack extends Record(DEFAULTS) {
    */
 
   static isStack(any) {
-    return !!(any && any[MODEL_TYPES.STACK])
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.STACK)
+    }
+    return !!any[MODEL_TYPES.STACK]
   }
 
   /**

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -147,8 +147,12 @@ class Value extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isValue(value) {
-    return !!(value && value[MODEL_TYPES.VALUE])
+  static isValue(any) {
+    if (!any || !any.__proto__) return false
+    if (any.__proto__.hasOwnProperty) {
+      return any.__proto__.hasOwnProperty(MODEL_TYPES.VALUE)
+    }
+    return !!any[MODEL_TYPES.VALUE]
   }
 
   /**


### PR DESCRIPTION
Improve a feature

#### What's the new behavior?

The previous isXX use `any[Type]`, and it will try to search on the prototype chain when any does not have the type.  In this change, we use `hasOwnProperty` instead to ensure the search does not recursively go through the prototype chain, but search exactly on the prototype object.  It should make the `isXXX` a bit faster

Here I intentionally left Text.isText, Leaf.isLeaf unchanged, because I do not want to cause conflict with on working characters/leaf PRs

