### PR TITLE
Edited `shouldNodeComponentUpdate` documentation

### DIFF
--- a/docs/reference/slate-react/custom-nodes.md
+++ b/docs/reference/slate-react/custom-nodes.md
@@ -86,14 +86,4 @@ Whether the editor is in "read-only" mode, where all of the rendering is the sam
 
 ## `shouldNodeComponentUpdate`
 
-By default, Slate implements a `shouldComponentUpdate` preventing useless re-renders for node components. While the default implementation covers most use cases, you can customize the logic to fit your needs. For example:
-
-```js
-class CustomNode extends React.Component {
-  static shouldNodeComponentUpdate(previousProps, nextProps) {
-    // return true here to trigger a re-render
-  }
-}
-```
-
-If `shouldNodeComponentUpdate` returns false, Slate will still figure out whether a re-render is needed or not.
+By default, Slate implements a `shouldComponentUpdate` preventing useless re-renders for node components. While the default implementation covers most use cases, you can customize the logic to fit your needs. See [`shouldNodeComponentUpdate`](../slate-react/plugins.md#shouldNodeComponentUpdate)

--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -32,6 +32,7 @@ export default function MySlatePlugin(options) {
   onKeyUp: Function,
   onPaste: Function,
   onSelect: Function
+  shouldNodeComponentUpdate: Function
 }
 ```
 
@@ -112,6 +113,9 @@ _Note: This is **not** Slate's internal selection representation (although it mi
 ```js
 {
   onChange: Function
+  renderEditor: Function
+  schema: Function
+  shouldNodeComponentUpdate: Function
 }
 ```
 
@@ -132,3 +136,23 @@ The `renderEditor` property allows you to define higher-order-component-like beh
 `Object`
 
 The `schema` property allows you to define a set of rules that will be added to the editor's schema. The rules from each of the schemas returned by the plugins are collected into a single schema for the editor.
+
+### `shouldNodeComponentUpdate`
+
+`Function shouldNodeComponentUpdate(props: Object, nextProps: Object) => boolean || null`
+
+To everride slate's default `shouldComponentUpdate` behavior, add this property in and define any custom logic. For example:
+
+```js
+{
+  shouldNodeComponentUpdate: (props, nextProps) => {
+    if (props.node.type === 'my-custom-type') {
+      return true;
+    }
+    
+    return null;
+  }
+}
+```
+
+If `shouldNodeComponentUpdate` returns false, Slate will still figure out whether a re-render is needed or not.

--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -31,7 +31,7 @@ export default function MySlatePlugin(options) {
   onKeyDown: Function,
   onKeyUp: Function,
   onPaste: Function,
-  onSelect: Function
+  onSelect: Function,
   shouldNodeComponentUpdate: Function
 }
 ```
@@ -112,9 +112,9 @@ _Note: This is **not** Slate's internal selection representation (although it mi
 
 ```js
 {
-  onChange: Function
-  renderEditor: Function
-  schema: Function
+  onChange: Function,
+  renderEditor: Function,
+  schema: Function,
   shouldNodeComponentUpdate: Function
 }
 ```
@@ -141,7 +141,7 @@ The `schema` property allows you to define a set of rules that will be added to 
 
 `Function shouldNodeComponentUpdate(props: Object, nextProps: Object) => boolean || null`
 
-To everride slate's default `shouldComponentUpdate` behavior, add this property in and define any custom logic. For example:
+To override slate's default `shouldComponentUpdate` behavior, add this property in and define any custom logic. For example:
 
 ```js
 {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
It's a minor document editing.
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
The actual place where `shouldNodeComponentUpdate` function hooks in was wrongly documented as `static shouldNodeComponentUpdate(props, nextProps)` in [Custom nodes](docs/reference/slate-react/custom-nodes.md) documentation.
I've edited and linked the documentation to [Plugins](docs/refererence/slate-react/plugins.md) page since that's where the function is really called.
<!-- 
Please include at least one of the following: 

  - A GIF showing the new behavior in action.
  - A code sample showing the new API in action.
  - A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
As I looked through the implementation in [node.js](https://github.com/ianstormtaylor/slate/blob/3339d088e14ad0bf04a674c14834179403ae369f/packages/slate-react/src/components/node.js#L66), the function was found from the plugin's `stack` instead of the `component`'s static property and that's why having `static shouldNodeComponentUpdate(props, nextProps)` in your own component won't work.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

Fixes: #

Reviewers: @
