### PR TITLE
Fix slate-html-serializer: applyMark

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -299,7 +299,7 @@ class Html {
           leaf.marks.push({ type, data })
           return leaf
         })
-      } else {
+      } else if (node.nodes) {
         node.nodes = node.nodes.map(applyMark)
       }
 

--- a/packages/slate-html-serializer/test/deserialize/mark-void-inline.js
+++ b/packages/slate-html-serializer/test/deserialize/mark-void-inline.js
@@ -1,0 +1,53 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const config = {
+  rules: [
+    {
+      deserialize(el, next) {
+        switch (el.tagName.toLowerCase()) {
+          case 'p': {
+            return {
+              object: 'block',
+              type: 'paragraph',
+              nodes: next(el.childNodes),
+            }
+          }
+          case 'strong': {
+            return {
+              object: 'mark',
+              type: 'bold',
+              nodes: next(el.childNodes),
+            }
+          }
+          case 'br': {
+            return {
+              object: 'inline',
+              type: 'linebreak',
+              isVoid: true,
+            }
+          }
+        }
+      },
+    },
+  ],
+}
+
+export const input = `
+<p><strong>one<br/>two</strong></p>
+`.trim()
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          one
+          <linebreak />
+          two
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate-html-serializer/test/helpers/h.js
+++ b/packages/slate-html-serializer/test/helpers/h.js
@@ -25,6 +25,10 @@ const h = createHyperscript({
       type: 'emoji',
       isVoid: true,
     },
+    linebreak: {
+      type: 'linebreak',
+      isVoid: true,
+    },
   },
   marks: {
     b: 'bold',


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix the bug when a nested in mark node a "void" inline node is the cause of error in the applyMark method because always trying to get children nodes without any checking.

For example, if we copy text from MS Word/Pages, HTML in clipboard will look like `<strong>first line<br/>second line</strong>`. Probably, break line(as well as `image`) node will be a void inline node without children and it'll break deserializer in this case.

I added test case `mark-void-inline.js` and new inline type `linebreak` in helpers.