### PR TITLE
Fix insertFragment: undefined newText

### DIFF
--- a/packages/slate/src/changes/at-current-range.js
+++ b/packages/slate/src/changes/at-current-range.js
@@ -168,7 +168,7 @@ Changes.insertFragment = (change, fragment) => {
   const newTexts = document.getTexts().filter(n => !keys.includes(n.key))
   const newText = isAppending ? newTexts.last() : newTexts.takeLast(2).first()
 
-  if ((newText && lastInline) || isInserting) {
+  if (newText && (lastInline || isInserting)) {
     change.select(selection.collapseToEndOf(newText))
   } else if (newText) {
     change.select(


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug introduced in https://github.com/GitbookIO/slate/commit/f07fc92f2e31a355a91f19ca080c2e380f883dae

In production, we have tracked this error several times already.

```
TypeError: Cannot read property 'object' of undefined
  at getLast(./node_modules/slate/lib/slate.es.js:1756:1)
  at apply(./node_modules/slate/lib/slate.es.js:1208:1)
  at apply(./node_modules/slate/lib/slate.es.js:1687:1)
  at collapseToEndOf(./node_modules/slate/lib/slate.es.js:1733:1)
  at apply(./node_modules/slate/lib/slate.es.js:6167:1)
  at call(./node_modules/slate/lib/slate.es.js:13116:1)
  at insertFragment(./node_modules/slate/lib/slate.es.js:13220:1)
  at apply(./node_modules/slate-react/lib/slate-react.es.js:3191:1)
  at run(./node_modules/slate/lib/slate.es.js:9592:1)
  at apply(./node_modules/slate-react/lib/slate-react.es.js:4160:1)
  at call(./node_modules/slate/lib/slate.es.js:13116:1)
  at change(./node_modules/slate-react/lib/slate-react.es.js:4142:1)
  at apply(./node_modules/slate-react/lib/slate-react.es.js:4159:1)
  at handler(./node_modules/slate-react/lib/slate-react.es.js:3910:1)
  at onEvent(./node_modules/slate-react/lib/slate-react.es.js:2084:1)
  at apply(./node_modules/slate-react/lib/slate-react.es.js:1967:1)
```

I could not write a failing test for the existing code. But the error happens when `newText` is undefined here https://github.com/ianstormtaylor/slate/blob/f07fc92f2e31a355a91f19ca080c2e380f883dae/packages/slate/src/changes/at-current-range.js#L171
Any idea to reproduce @ianstormtaylor ?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

