### PR TITLE
Fix a hyperscript bug in perserving text-key

### DIFF
--- a/packages/slate-hyperscript/src/index.js
+++ b/packages/slate-hyperscript/src/index.js
@@ -264,7 +264,8 @@ function createChildren(children, options = {}) {
   let length = 0
 
   // When creating the new node, try to preserve a key if one exists.
-  const firstText = children.find(c => Text.isText(c))
+  const firstNodeOrText = children.find(c => typeof c !== 'string')
+  const firstText = Text.isText(firstNodeOrText) ? firstNodeOrText : null
   const key = options.key ? options.key : firstText ? firstText.key : undefined
   let node = Text.create({ key })
 

--- a/packages/slate-hyperscript/test/default/perserve-keys-in-right-text.js
+++ b/packages/slate-hyperscript/test/default/perserve-keys-in-right-text.js
@@ -12,7 +12,8 @@ export const input = (
     </block>
   </document>
 )
-export function assertation() {
+
+export function test() {
   const block = input.nodes.first()
   assert.notEqual(block.nodes.first().key, 'a')
   assert.equal(block.nodes.last().key, 'a')

--- a/packages/slate-hyperscript/test/default/perserve-keys-in-right-text.js
+++ b/packages/slate-hyperscript/test/default/perserve-keys-in-right-text.js
@@ -1,0 +1,72 @@
+/** @jsx h */
+
+import assert from 'assert'
+
+import h from '../..'
+
+export const input = (
+  <document>
+    <block type="paragraph">
+      Cat <inline type="link">is</inline>
+      <text key="a"> cute</text>
+    </block>
+  </document>
+)
+export function assertation() {
+  const block = input.nodes.first()
+  assert.notEqual(block.nodes.first().key, 'a')
+  assert.equal(block.nodes.last().key, 'a')
+}
+
+export const output = {
+  object: 'document',
+  data: {},
+  nodes: [
+    {
+      object: 'block',
+      type: 'paragraph',
+      isVoid: false,
+      data: {},
+      nodes: [
+        {
+          object: 'text',
+          leaves: [
+            {
+              object: 'leaf',
+              text: 'Cat ',
+              marks: [],
+            },
+          ],
+        },
+        {
+          object: 'inline',
+          type: 'link',
+          data: {},
+          isVoid: false,
+          nodes: [
+            {
+              object: 'text',
+              leaves: [
+                {
+                  object: 'leaf',
+                  text: 'is',
+                  marks: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          object: 'text',
+          leaves: [
+            {
+              object: 'leaf',
+              text: ' cute',
+              marks: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/packages/slate-hyperscript/test/index.js
+++ b/packages/slate-hyperscript/test/index.js
@@ -27,6 +27,7 @@ describe('slate-hyperscript', () => {
         const actual = input.toJSON()
         const expected = Value.isValue(output) ? output.toJSON() : output
         assert.deepEqual(actual, expected)
+        if (module.assertation) module.assertation()
       })
     }
   })

--- a/packages/slate-hyperscript/test/index.js
+++ b/packages/slate-hyperscript/test/index.js
@@ -27,7 +27,7 @@ describe('slate-hyperscript', () => {
         const actual = input.toJSON()
         const expected = Value.isValue(output) ? output.toJSON() : output
         assert.deepEqual(actual, expected)
-        if (module.assertation) module.assertation()
+        if (module.test) module.test()
       })
     }
   })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix a bug;
For example, the following hyper-script 
```
<block>
"cat"
<inline/>
<text key="a">is cute</text>
</block>
```
will produce result like
```<block>
<text key="a">"cat"</text>
<inline/>
<text key="a">is cute</text>
</block>
```

#### What's the new behavior?
Fix that bug