### PR TITLE
Fix invalid ranges in getEventRange

### DIFF
--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -36,9 +36,17 @@ function getEventRange(event, value) {
 
     const text = node.getFirstText()
     const range = Range.create()
-    return isPrevious
-      ? range.moveToEndOf(document.getPreviousText(text.key))
-      : range.moveToStartOf(document.getNextText(text.key))
+
+    if (isPrevious) {
+      const previousText = document.getPreviousText(text.key)
+
+      if (previousText) {
+        return range.moveToEndOf(previousText)
+      }
+    }
+
+    const nextText = document.getNextText(text.key)
+    return nextText ? range.moveToStartOf(nextText) : null
   }
 
   // Else resolve a range from the caret position where the drop occured.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing [a bug](https://github.com/ianstormtaylor/slate/pull/1838#issuecomment-389915570):

![kapture 2018-05-18 at 12 11 15](https://user-images.githubusercontent.com/3599069/40229777-912c16c0-5a95-11e8-939d-c112e5b9ffb9.gif)


#### What's the new behavior?
When dropping something onto the first node's top part, when that node is void, we currently try to return the previous text node's range. This text node doesn't exist, and results in an error being thrown. Now we instead try to return the next text node's range. And if that doesn't exist, we return null (unless you have a better idea?). 

![kapture 2018-05-18 at 12 26 32](https://user-images.githubusercontent.com/3599069/40230183-efbb7374-5a96-11e8-8bdd-263ad7fc41ac.gif)
#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
