### PR TITLE
Faster search text in example

### DIFF
--- a/examples/search-highlighting/index.js
+++ b/examples/search-highlighting/index.js
@@ -40,27 +40,32 @@ class SearchHighlighting extends React.Component {
   onInputChange = event => {
     const { value } = this.state
     const string = event.target.value
+    if (string === '') {
+      const change = value
+        .change()
+        .setOperationFlag('save', false)
+        .setValue({ decorations: [] })
+        .setOperationFlag('save', true)
+      this.onChange(change)
+      return
+    }
     const texts = value.document.getTexts()
     const decorations = []
 
     texts.forEach(node => {
       const { key, text } = node
-      const parts = text.split(string)
-      let offset = 0
-
-      parts.forEach((part, i) => {
-        if (i != 0) {
-          decorations.push({
-            anchorKey: key,
-            anchorOffset: offset - string.length,
-            focusKey: key,
-            focusOffset: offset,
-            marks: [{ type: 'highlight' }],
-          })
-        }
-
-        offset = offset + part.length + string.length
-      })
+      let offset = text.indexOf(string)
+      while (offset !== -1) {
+        decorations.push({
+          anchorKey: key,
+          anchorOffset: offset,
+          focusKey: key,
+          focusOffset: offset + string.length,
+          marks: [{ type: 'highlight' }],
+        })
+        offset += string.length
+        offset = text.indexOf(string, offset)
+      }
     })
 
     // setting the `save` option to false prevents this change from being added

--- a/examples/search-highlighting/index.js
+++ b/examples/search-highlighting/index.js
@@ -55,7 +55,11 @@ class SearchHighlighting extends React.Component {
     texts.forEach(node => {
       const { key, text } = node
       let offset = text.indexOf(string)
-      while (offset !== -1) {
+      for (
+        offset = text.indexOf(string);
+        offset !== -1;
+        offset = text.indexOf(string, offset + string.length)
+      ) {
         decorations.push({
           anchorKey: key,
           anchorOffset: offset,
@@ -63,8 +67,6 @@ class SearchHighlighting extends React.Component {
           focusOffset: offset + string.length,
           marks: [{ type: 'highlight' }],
         })
-        offset += string.length
-        offset = text.indexOf(string, offset)
       }
     })
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

1. when `text===''` in search box, we will have a lot of empty decorations
2. text.split is slower than indexOf