### PR TITLE
Allow html serialiser rules to return strings and arrays.

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -337,7 +337,7 @@ class Html {
    * Serialize a `node`.
    *
    * @param {Node} node
-   * @return {String}
+   * @return {React.Element|Array<React.Element|String>|String}
    */
 
   serializeNode = node => {
@@ -364,7 +364,7 @@ class Html {
    * Serialize a `leaf`.
    *
    * @param {Leaf} leaf
-   * @return {String}
+   * @return {React.Element|Array<React.Element|String>|String}
    */
 
   serializeLeaf = leaf => {

--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -352,7 +352,9 @@ class Html {
       if (!rule.serialize) continue
       const ret = rule.serialize(node, children)
       if (ret === null) return
-      if (ret) return addKey(ret)
+      if (ret !== undefined) {
+        return React.isValidElement(ret) ? addKey(ret) : ret;
+      }
     }
 
     throw new Error(`No serializer defined for node of type "${node.type}".`)
@@ -374,7 +376,9 @@ class Html {
         if (!rule.serialize) continue
         const ret = rule.serialize(mark, children)
         if (ret === null) return
-        if (ret) return addKey(ret)
+        if (ret !== undefined) {
+          return React.isValidElement(ret) ? addKey(ret) : ret;
+        }
       }
 
       throw new Error(`No serializer defined for mark of type "${mark.type}".`)

--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -353,7 +353,7 @@ class Html {
       const ret = rule.serialize(node, children)
       if (ret === null) return
       if (ret !== undefined) {
-        return React.isValidElement(ret) ? addKey(ret) : ret;
+        return React.isValidElement(ret) ? addKey(ret) : ret
       }
     }
 
@@ -377,7 +377,7 @@ class Html {
         const ret = rule.serialize(mark, children)
         if (ret === null) return
         if (ret !== undefined) {
-          return React.isValidElement(ret) ? addKey(ret) : ret;
+          return React.isValidElement(ret) ? addKey(ret) : ret
         }
       }
 


### PR DESCRIPTION
Currently the HTML serialiser seems to assume that serialisation rules
will always return a React element, which it then tries to clone and
add a `key` to.

However, it can be useful to have rules which return a plain
string (or array of strings and elements) - for instance serializing
fancy inlines (e.g. svg emoji) which when expressed as plain HTML should
just be text.  This changes the logic to only ever try to add keys to
React elements, and pass through strings/arrays/etc to renderToStaticMarkup
otherwise without changes.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Somewhere in between. It feels pretty buggy that a serialiser can't serialise nodes in your document to plain text, but it's probably a missing feature.

#### What's the new behavior?

You can now return strings (or arrays of strings & elements) from the `serialize` method of your custom HTML serializer rules - so they behave more like React render methods, and don't break mysteriously if you try to serialize a node to a plain string.

#### How does this change work?

The change is trivial.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

