### PR TITLE
Set position data-slate-spacer block

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -63,7 +63,7 @@ class Void extends React.Component {
       height: '0',
       color: 'transparent',
       outline: 'none',
-      position: 'absolute'
+      position: 'absolute',
     }
 
     const spacer = (

--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -63,6 +63,7 @@ class Void extends React.Component {
       height: '0',
       color: 'transparent',
       outline: 'none',
+      position: 'absolute'
     }
 
     const spacer = (

--- a/packages/slate-react/test/rendering/fixtures/custom-block-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-void.js
@@ -32,7 +32,7 @@ export const value = (
 export const output = `
 <div data-slate-editor="true" contenteditable="true" role="textbox">
   <div data-slate-void="true">
-    <div data-slate-spacer="true" style="height:0;color:transparent;outline:none">
+    <div data-slate-spacer="true" style="height:0;color:transparent;outline:none;position:absolute">
       <span>
         <span>
           <span data-slate-zero-width="z">&#x200B;</span>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -37,7 +37,7 @@ export const output = `
       </span>
     </span>
     <span data-slate-void="true">
-      <span data-slate-spacer="true" style="height:0;color:transparent;outline:none">
+      <span data-slate-spacer="true" style="height:0;color:transparent;outline:none;position:absolute">
         <span>
           <span>
             <span data-slate-zero-width="z">&#x200B;</span>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
 - Fixing a bug 

#### What's the new behavior?

Now the `data-slate-spacer` block have a `position: absolute` to fix margins collapse

#### How does this change work?

View issue #1858 to more details.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #1858
Reviewers: @ianstormtaylor 
