### PR TITLE
[fix/html-serializer-docs-add-class-name-example] add example to the …

### DIFF
--- a/docs/walkthroughs/saving-and-loading-html-content.md
+++ b/docs/walkthroughs/saving-and-loading-html-content.md
@@ -49,7 +49,7 @@ const rules = [
           object: 'block',
           type: 'paragraph',
           data: {
-            className: el.getAttribute('class')
+            className: el.getAttribute('class'),
           },
           nodes: next(el.childNodes),
         }
@@ -72,7 +72,7 @@ const rules = [
           object: 'block',
           type: 'paragraph',
           data: {
-            className: el.getAttribute('class')
+            className: el.getAttribute('class'),
           },
           nodes: next(el.childNodes),
         }
@@ -114,7 +114,7 @@ const rules = [
           object: 'block',
           type: type,
           data: {
-            className: el.getAttribute('class')
+            className: el.getAttribute('class'),
           },
           nodes: next(el.childNodes),
         }
@@ -170,7 +170,7 @@ const rules = [
           object: 'block',
           type: type,
           data: {
-            className: el.getAttribute('class')
+            className: el.getAttribute('class'),
           },
           nodes: next(el.childNodes),
         }

--- a/docs/walkthroughs/saving-and-loading-html-content.md
+++ b/docs/walkthroughs/saving-and-loading-html-content.md
@@ -48,6 +48,9 @@ const rules = [
         return {
           object: 'block',
           type: 'paragraph',
+          data: {
+            className: el.getAttribute('class')
+          },
           nodes: next(el.childNodes),
         }
       }
@@ -68,6 +71,9 @@ const rules = [
         return {
           object: 'block',
           type: 'paragraph',
+          data: {
+            className: el.getAttribute('class')
+          },
           nodes: next(el.childNodes),
         }
       }
@@ -75,7 +81,7 @@ const rules = [
     // Add a serializing function property to our rule...
     serialize(obj, children) {
       if (obj.object == 'block' && obj.type == 'paragraph') {
-        return <p>{children}</p>
+        return <p className={obj.data.get('className')}>{children}</p>
       }
     },
   },
@@ -107,6 +113,9 @@ const rules = [
         return {
           object: 'block',
           type: type,
+          data: {
+            className: el.getAttribute('class')
+          },
           nodes: next(el.childNodes),
         }
       }
@@ -116,7 +125,7 @@ const rules = [
       if (obj.object == 'block') {
         switch (obj.type) {
           case 'paragraph':
-            return <p>{children}</p>
+            return <p className={obj.data.get('className')}>{children}</p>
           case 'quote':
             return <blockquote>{children}</blockquote>
           case 'code':
@@ -160,6 +169,9 @@ const rules = [
         return {
           object: 'block',
           type: type,
+          data: {
+            className: el.getAttribute('class')
+          },
           nodes: next(el.childNodes),
         }
       }
@@ -174,7 +186,7 @@ const rules = [
               </pre>
             )
           case 'paragraph':
-            return <p>{children}</p>
+            return <p className={obj.data.get('className')}>{children}</p>
           case 'quote':
             return <blockquote>{children}</blockquote>
         }
@@ -260,7 +272,11 @@ class App extends React.Component {
           </pre>
         )
       case 'paragraph':
-        return <p {...props.attributes}>{props.children}</p>
+        return (
+          <p {...props.attributes} className={node.data.get('className')}>
+            {props.children}
+          </p>
+        )
       case 'quote':
         return <blockquote {...props.attributes}>{props.children}</blockquote>
     }


### PR DESCRIPTION
This PR adds an example to the HTML serializer docs on how to use element attributes when serializing and deserializing. I spent a lot of time figuring this out myself so hopefully will save others from having to go through the same process!

#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving the HTML serializer docs so the HTML serializer is easier to use in future.

#### What's the new behavior?

I've added some extra information to the docs to make it clearer how you pass HTML attributes back and forth while serializing and deserializing, and finally rendering in the Slate editor. **No code changes have been made.**

#### How does this change work?

N/A

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

I don't think so.
