### PR TITLE
Use cleaned up text content when copying into plain/text

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -90,7 +90,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   // since the result is more predictable.
   if (event.clipboardData && event.clipboardData.setData) {
     event.preventDefault()
-    event.clipboardData.setData(TEXT, native.toString())
+    event.clipboardData.setData(TEXT, div.textContent)
     event.clipboardData.setData(FRAGMENT, encoded)
     event.clipboardData.setData(HTML, div.innerHTML)
     return


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug.

#### What's the new behavior?
I was previously using the natively selected text when putting content into the `plain/text` register. That's problematic though since that text can contain zero width space characters. Since we already clean those up in our "dummy div", I just use the `textContent` of that div instead. 
