### PR TITLE
Skip onNativeSelectionChange if Slate changed the selection

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -9,7 +9,6 @@ import {
   SUPPORTED_EVENTS,
 } from 'slate-dev-environment'
 import logger from 'slate-dev-logger'
-import throttle from 'lodash/throttle'
 
 import EVENT_HANDLERS from '../constants/event-handlers'
 import Node from './node'
@@ -427,7 +426,8 @@ class Content extends React.Component {
    * @param {Event} event
    */
 
-  onNativeSelectionChange = throttle(event => {
+  onNativeSelectionChange = event => {
+    if (this.tmp.isUpdatingSelection) return
     if (this.props.readOnly) return
 
     const window = getWindow(event.target)
@@ -435,7 +435,7 @@ class Content extends React.Component {
     if (activeElement !== this.element) return
 
     this.props.onSelect(event)
-  }, 100)
+  }
 
   /**
    * Render the editor content.


### PR DESCRIPTION
Just like the `onSelect` handler, the plugin `onSelect` shouldn't be called if the selection was changed through Slate's selection API.

Otherwise, depending on how a browser normalizes a selection, the following can occur:

- Slate changes `value.selection`
- `updateSelection` updates the browser selection with the Slate selection
- The browser normalizes the browser selection, changing it
- `onNativeSelectionChange` is called with the new browser selection, which is now different than `value.selection`
- `after.js` `onSelect` is called with that new selection, and calls `.select`
- `updateSelection` updates the browser selection
- ... and so on

In Safari, which normalizes offset 0 of a node to be offset `previousNode.length`, this can cause the selection to creep leftward across a void inline, making that node impossible to select.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

When clicking on a void inline in Safari, `anchorInline` will return the correct inline node.

#### How does this change work?

By blocking `onNativeSelectionChange` if `updateSelection` caused the native selection change, we avoid the native selection update from cycling back through into the Slate `Value`'s selection. This avoids problems with different browser selection normalization from affecting the Slate `Value`.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #1852
Reviewers: @ianstormtaylor 
