### PR TITLE
InsertTextAtRange normalize

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -863,7 +863,7 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
   }
 
   // PERF: Unless specified, don't normalize if only inserting text.
-  if (normalize !== undefined) {
+  if (normalize === undefined) {
     normalize = range.isExpanded
   }
   change.insertTextByKey(key, offset, text, marks, { normalize: false })
@@ -877,7 +877,8 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
     const normalizeAncestor = ancestors.findLast(n =>
       change.value.document.getDescendant(n.key)
     )
-    change.normalizeNodeByKey(normalizeAncestor.key)
+    const normalizeKey = normalizeAncestor ? normalizeAncestor.key : startKey
+    change.normalizeNodeByKey(normalizeKey)
   }
 }
 

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -864,7 +864,7 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
 
   // PERF: Unless specified, don't normalize if only inserting text.
   if (normalize === undefined) {
-    normalize = range.isExpanded
+    normalize = range.isExpanded && marks.size !== 0
   }
   change.insertTextByKey(key, offset, text, marks, { normalize: false })
 

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -877,6 +877,8 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
     const normalizeAncestor = ancestors.findLast(n =>
       change.value.document.getDescendant(n.key)
     )
+    // it is possible that normalizeAncestor doesn't return any node
+    // on that case fallback to startKey to be normalized
     const normalizeKey = normalizeAncestor ? normalizeAncestor.key : startKey
     change.normalizeNodeByKey(normalizeKey)
   }

--- a/packages/slate/test/changes/at-current-range/insert-text/expanded-with-mark.js
+++ b/packages/slate/test/changes/at-current-range/insert-text/expanded-with-mark.js
@@ -1,0 +1,40 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+/*
+ * This test makes sure a normalization happens on insertText on expandedRange
+ */
+
+export default function(change) {
+  change.insertText('a')
+  change.insertText('b')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          <anchor />lorem
+        </b>
+        ipsum
+      </paragraph>
+      <paragraph>
+        ipsum<focus />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          ab<cursor />
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### Curent Behaviour
![inserttext not normalized mov](https://user-images.githubusercontent.com/18670101/40893152-b5fed202-67e3-11e8-8758-c8f35f899781.gif)


<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
![inserttext fix normalization mov](https://user-images.githubusercontent.com/18670101/40893153-bd86f59a-67e3-11e8-80df-2b88f4c0f636.gif)


<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
previously the *PERF* normalization check isn't checking the right thing and also text that has marks that potentially needs to be normalized due to schema isn't normalized as well.This change is basically fix the *PERF* check and putting the correct normalization flag when needed.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #1792 

Reviewers: @ianstormtaylor 
