### PR TITLE
Remove zero-width space when pasting, fixes #1877

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -90,7 +90,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   // since the result is more predictable.
   if (event.clipboardData && event.clipboardData.setData) {
     event.preventDefault()
-    event.clipboardData.setData(TEXT, native.toString())
+    event.clipboardData.setData(TEXT, native.toString().replace(/\u200B/g, ''))
     event.clipboardData.setData(FRAGMENT, encoded)
     event.clipboardData.setData(HTML, div.innerHTML)
     return


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

See #1877 

#### How does this change work?

This fix looks kinda hacky to me, there may be a better solution I'm not aware of.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #1877 
Reviewers: @tobiasandersen (probably introduced by #1815)
