### PR TITLE
Enable insert in the start of table cell

### DIFF
--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -92,6 +92,8 @@ class Tables extends React.Component {
         if (['Backspace', 'Delete', 'Enter'].includes(event.key)) {
           event.preventDefault()
           return true
+        } else {
+          return
         }
       }
     }

--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -89,8 +89,10 @@ class Tables extends React.Component {
       const prevBlock = document.getClosestBlock(previous.key)
 
       if (prevBlock.type == 'table-cell') {
-        event.preventDefault()
-        return true
+        if (['Backspace', 'Delete', 'Enter'].includes(event.key)) {
+          event.preventDefault()
+          return true
+        }
       }
     }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug; In the table-cell example, users cannot insert at the beginning of the cell.
Fix: https://github.com/ianstormtaylor/slate/issues/1571

#### What's the new behavior?
People can insert in the start of the cell

#### How does this change work?
Only blocks enter, backspace and delete at the beginning of the cell

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #1571
Reviewers: @amitm2
