### PR TITLE
[On Development] Fix cycle reference in slate-core 

### DIFF
--- a/packages/slate/src/constants/model-types.js
+++ b/packages/slate/src/constants/model-types.js
@@ -22,6 +22,18 @@ const MODEL_TYPES = {
 }
 
 /**
+ * Export type identification function
+ *
+ * @param {string} type
+ * @param {any} any
+ * @return {boolean}
+ */
+
+export function isType(type, any) {
+  return !!(any && any[MODEL_TYPES[type]])
+}
+
+/**
  * Export.
  *
  * @type {Object}

--- a/packages/slate/src/models/block.js
+++ b/packages/slate/src/models/block.js
@@ -12,7 +12,7 @@ import isPlainObject from 'is-plain-object'
 import logger from 'slate-dev-logger'
 import { List, Map, Record } from 'immutable'
 
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import Node from './node'
 import generateKey from '../utils/generate-key'
 
@@ -128,9 +128,7 @@ class Block extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isBlock(any) {
-    return !!(any && any[MODEL_TYPES.BLOCK])
-  }
+  static isBlock = isType.bind(null, 'BLOCK')
 
   /**
    * Check if `any` is a block list.

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -4,7 +4,7 @@ import logger from 'slate-dev-logger'
 import pick from 'lodash/pick'
 import { List } from 'immutable'
 
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import Changes from '../changes'
 import Operation from './operation'
 import apply from '../operations/apply'
@@ -31,9 +31,7 @@ class Change {
    * @return {Boolean}
    */
 
-  static isChange(any) {
-    return !!(any && any[MODEL_TYPES.CHANGE])
-  }
+  static isChange = isType.bind(null, 'CHANGE')
 
   /**
    * Create a new `Change` with `attrs`.

--- a/packages/slate/src/models/document.js
+++ b/packages/slate/src/models/document.js
@@ -14,7 +14,7 @@ import logger from 'slate-dev-logger'
 import { List, Map, Record } from 'immutable'
 
 import Node from './node'
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import generateKey from '../utils/generate-key'
 
 /**
@@ -97,9 +97,7 @@ class Document extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isDocument(any) {
-    return !!(any && any[MODEL_TYPES.DOCUMENT])
-  }
+  static isDocument = isType.bind(null, 'DOCUMENT')
 
   /**
    * Object.

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -4,7 +4,7 @@ import isPlainObject from 'is-plain-object'
 import logger from 'slate-dev-logger'
 import { List, Record, Stack } from 'immutable'
 
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 
 /**
  * Debug.
@@ -84,9 +84,7 @@ class History extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isHistory(any) {
-    return !!(any && any[MODEL_TYPES.HISTORY])
-  }
+  static isHistory = isType.bind(null, 'HISTORY')
 
   /**
    * Object.

--- a/packages/slate/src/models/inline.js
+++ b/packages/slate/src/models/inline.js
@@ -13,7 +13,7 @@ import logger from 'slate-dev-logger'
 import { List, Map, Record } from 'immutable'
 
 import Node from './node'
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import generateKey from '../utils/generate-key'
 
 /**
@@ -128,9 +128,7 @@ class Inline extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isInline(any) {
-    return !!(any && any[MODEL_TYPES.INLINE])
-  }
+  static isInline = isType.bind(null, 'INLINE')
 
   /**
    * Check if `any` is a list of inlines.

--- a/packages/slate/src/models/leaf.js
+++ b/packages/slate/src/models/leaf.js
@@ -2,7 +2,7 @@ import isPlainObject from 'is-plain-object'
 import logger from 'slate-dev-logger'
 import { List, Record, Set } from 'immutable'
 
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import Character from './character'
 import Mark from './mark'
 
@@ -98,9 +98,7 @@ class Leaf extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isLeaf(any) {
-    return !!(any && any[MODEL_TYPES.LEAF])
-  }
+  static isLeaf = isType.bind(null, 'LEAF')
 
   /**
    * Check if `any` is a list of leaves.

--- a/packages/slate/src/models/mark.js
+++ b/packages/slate/src/models/mark.js
@@ -2,7 +2,7 @@ import isPlainObject from 'is-plain-object'
 import logger from 'slate-dev-logger'
 import { Map, Record, Set } from 'immutable'
 
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import Data from './data'
 import memoize from '../utils/memoize'
 
@@ -137,9 +137,7 @@ class Mark extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isMark(any) {
-    return !!(any && any[MODEL_TYPES.MARK])
-  }
+  static isMark = isType.bind(null, 'MARK')
 
   /**
    * Check if `any` is a set of marks.

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -7,6 +7,7 @@ import Block from './block'
 import Data from './data'
 import Document from './document'
 import Inline from './inline'
+import { isType } from '../constants/model-types'
 import Range from './range'
 import Text from './text'
 import generateKey from '../utils/generate-key'
@@ -165,11 +166,8 @@ class Node {
    */
 
   static isNode(any) {
-    return (
-      Block.isBlock(any) ||
-      Document.isDocument(any) ||
-      Inline.isInline(any) ||
-      Text.isText(any)
+    return !!['BLOCK', 'DOCUMENT', 'INLINE', 'TEXT'].find(type =>
+      isType(type, any)
     )
   }
 

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -5,7 +5,7 @@ import { List, OrderedSet, Record, Set, is } from 'immutable'
 import Character from './character'
 import Mark from './mark'
 import Leaf from './leaf'
-import MODEL_TYPES from '../constants/model-types'
+import MODEL_TYPES, { isType } from '../constants/model-types'
 import generateKey from '../utils/generate-key'
 import memoize from '../utils/memoize'
 
@@ -114,9 +114,7 @@ class Text extends Record(DEFAULTS) {
    * @return {Boolean}
    */
 
-  static isText(any) {
-    return !!(any && any[MODEL_TYPES.TEXT])
-  }
+  static isText = isType.bind(null, 'TEXT')
 
   /**
    * Check if `any` is a list of texts.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

There exists a cycle reference in the `packages/slate/src/models`, where `node` depends on `block`, `inline` and `document`, which of all three depneds on `node` as well.

Currently, the node is hacking the cycle reference by `alleviating function`, but I am not sure whether this hacking will be always working in future ES and babel.

#### What's the new behavior?
Remove the cycle reference

#### How does this change work?
put the fromJSON and isType logic in another file.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
