### PR TITLE
Inline Void block cursor

### DIFF
--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -78,7 +78,11 @@ class Void extends React.Component {
     this.debug('render', { props })
 
     return (
-      <Tag data-slate-void data-key={node.key} contentEditable={false}>
+      <Tag
+        data-slate-void
+        data-key={node.key}
+        contentEditable={readOnly || node.object == 'block' ? null : false}
+      >
         {readOnly ? null : spacer}
         {content}
       </Tag>

--- a/packages/slate-react/src/components/void.js
+++ b/packages/slate-react/src/components/void.js
@@ -78,7 +78,7 @@ class Void extends React.Component {
     this.debug('render', { props })
 
     return (
-      <Tag data-slate-void data-key={node.key}>
+      <Tag data-slate-void data-key={node.key} contentEditable={false}>
         {readOnly ? null : spacer}
         {content}
       </Tag>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -36,7 +36,7 @@ export const output = `
         <span data-slate-zero-width="z">&#x200B;</span>
       </span>
     </span>
-    <span data-slate-void="true">
+    <span data-slate-void="true" contenteditable="false">
       <span data-slate-spacer="true" style="height:0;color:transparent;outline:none">
         <span>
           <span>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing cursor being rendered on an inline void block where you won't be able to type anything inside

#### Current behavior?
![contenteditablenull mov](https://user-images.githubusercontent.com/18670101/41201330-21377bae-6cf9-11e8-9096-03908dfdaedf.gif)

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
cursor is not rendered on an inline void block
![contenteditablefalse mov](https://user-images.githubusercontent.com/18670101/41201349-9d0b08ae-6cf9-11e8-8352-758ed9f2f1c6.gif)


<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
adding `contentEditable={false}` on inline void node only. Previously this was the case for both block and inline void. It had problem mentioned in #1639 that was fixed on #1734 but introduced unnecessary cursor on an inline void. as this only do `contentEditable={false}` only on inline void, issue from #1639 is not there as well 👍 
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?
a check from @benjycui would be great to make sure that #1639 issue is not reggressed
Fixes: #
Reviewers: @benjycui 
