### PR TITLE
Fix bugs when ctrl+backspace (mac) throws an error at the block start

### DIFF
--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -59,7 +59,7 @@ const isDeleteCharBackward = e => {
     isDeleteLineBackward,
     isDeleteLineForward,
     isDeleteWordBackward,
-    isDeleteLineForward,
+    isDeleteWordForward,
     isDeleteCharForward,
   ].find(fn => fn(e))
   return !other

--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -56,11 +56,13 @@ const isDeleteWordBackward = e =>
 const isDeleteWordForward = e =>
   IS_APPLE ? isDeleteWordForwardMac(e) : isDeleteWordForwardPC(e)
 
-const isDeleteCharBackward = e => {
-  if (isDeleteBackward(e) || (IS_APPLE && isDeleteCharBackwardMac(e)))
-    return true
+const isDeleteCharBackward = e =>
+  isDeleteBackward(e) || (IS_APPLE && isDeleteCharBackwardMac(e))
+
+const isUndefinedDelete = e => {
   if (e.key !== 'Backspace' && e.key !== 'Delete') return false
   const other = [
+    isDeleteCharBackward,
     isDeleteLineBackward,
     isDeleteLineForward,
     isDeleteWordBackward,
@@ -146,4 +148,5 @@ export default {
   isRedo,
   isSplitBlock,
   isUndo,
+  isUndefinedDelete,
 }

--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -59,7 +59,7 @@ const isDeleteWordForward = e =>
 const isDeleteCharBackward = e =>
   isDeleteBackward(e) || (IS_APPLE && isDeleteCharBackwardMac(e))
 
-const isUndefinedDelete = e => {
+const isOtherDelete = e => {
   if (e.key !== 'Backspace' && e.key !== 'Delete') return false
   const other = [
     isDeleteCharBackward,
@@ -106,6 +106,7 @@ const isContentEditable = e =>
   isDeleteLineForward(e) ||
   isDeleteWordBackward(e) ||
   isDeleteWordForward(e) ||
+  isOtherDelete(e) ||
   isItalic(e) ||
   isRedo(e) ||
   isSplitBlock(e) ||
@@ -148,5 +149,5 @@ export default {
   isRedo,
   isSplitBlock,
   isUndo,
-  isUndefinedDelete,
+  isDelete: isOtherDelete,
 }

--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -100,13 +100,10 @@ const isTransposeCharacter = e => IS_APPLE && isTransposeCharacterMac(e)
 
 const isContentEditable = e =>
   isBold(e) ||
-  isDeleteCharBackward(e) ||
   isDeleteCharForward(e) ||
-  isDeleteLineBackward(e) ||
   isDeleteLineForward(e) ||
-  isDeleteWordBackward(e) ||
-  isDeleteWordForward(e) ||
-  isOtherDelete(e) ||
+  e.key === 'Backspace' ||
+  e.key === 'Delete' ||
   isItalic(e) ||
   isRedo(e) ||
   isSplitBlock(e) ||

--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -39,9 +39,11 @@ const isDeleteLineBackwardMac = e =>
 const isDeleteLineBackwardPC = e =>
   isKeyHotkey('ctrl+shift+backspace', e) || isKeyHotkey('ctrl+backspace', e)
 const isDeleteLineForwardMac = isKeyHotkey('ctrl+k')
+const isDeleteLineForwardPC = isKeyHotkey('ctrl+shift+delete')
 const isDeleteLineBackward = e =>
   IS_APPLE ? isDeleteLineBackwardMac(e) : isDeleteLineBackwardPC(e)
-const isDeleteLineForward = e => IS_APPLE && isDeleteLineForwardMac(e)
+const isDeleteLineForward = e =>
+  IS_APPLE ? isDeleteLineForwardMac(e) : isDeleteLineForwardPC(e)
 
 const isDeleteWordBackwardMac = e =>
   isKeyHotkey('shift+option+backspace', e) || isKeyHotkey('option+backspace', e)

--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -31,8 +31,6 @@ const isDeleteForward = e => isDelete(e) || isShiftDelete(e)
 
 const isDeleteCharBackwardMac = isKeyHotkey('ctrl+h')
 const isDeleteCharForwardMac = isKeyHotkey('ctrl+d')
-const isDeleteCharBackward = e =>
-  isDeleteBackward(e) || (IS_APPLE && isDeleteCharBackwardMac(e))
 const isDeleteCharForward = e =>
   isDeleteForward(e) || (IS_APPLE && isDeleteCharForwardMac(e))
 
@@ -52,6 +50,20 @@ const isDeleteWordBackward = e =>
   IS_APPLE ? isDeleteWordBackwardMac(e) : isDeleteWordBackwardPC(e)
 const isDeleteWordForward = e =>
   IS_APPLE ? isDeleteWordForwardMac(e) : isDeleteWordForwardPC(e)
+
+const isDeleteCharBackward = e => {
+  if (isDeleteBackward(e) || (IS_APPLE && isDeleteCharBackwardMac(e)))
+    return true
+  if (e.key !== 'Backspace' && e.key !== 'Delete') return false
+  const other = [
+    isDeleteLineBackward,
+    isDeleteLineForward,
+    isDeleteWordBackward,
+    isDeleteLineForward,
+    isDeleteCharForward,
+  ].find(fn => fn(e))
+  return !other
+}
 
 const isExtendCharForward = isKeyHotkey('shift+right')
 const isExtendCharBackward = isKeyHotkey('shift+left')

--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -36,8 +36,11 @@ const isDeleteCharForward = e =>
 
 const isDeleteLineBackwardMac = e =>
   isKeyHotkey('cmd+shift+backspace', e) || isKeyHotkey('cmd+backspace', e)
+const isDeleteLineBackwardPC = e =>
+  isKeyHotkey('ctrl+shift+backspace', e) || isKeyHotkey('ctrl+backspace', e)
 const isDeleteLineForwardMac = isKeyHotkey('ctrl+k')
-const isDeleteLineBackward = e => IS_APPLE && isDeleteLineBackwardMac(e)
+const isDeleteLineBackward = e =>
+  IS_APPLE ? isDeleteLineBackwardMac(e) : isDeleteLineBackwardPC(e)
 const isDeleteLineForward = e => IS_APPLE && isDeleteLineForwardMac(e)
 
 const isDeleteWordBackwardMac = e =>

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -401,7 +401,7 @@ function AfterPlugin() {
       return change.deleteWordForward()
     }
 
-    if (event.key === 'Backspace') {
+    if (event.key === 'Backspace' || event.key === 'Delete') {
       event.preventDefault()
       return change.deleteCharBackward()
     }

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -377,7 +377,10 @@ function AfterPlugin() {
         : change.splitBlock()
     }
 
-    if (Hotkeys.isDeleteCharBackward(event) && !IS_IOS) {
+    if (
+      (Hotkeys.isDeleteCharBackward(event) && !IS_IOS) ||
+      Hotkeys.isUndefinedDelete(event)
+    ) {
       event.preventDefault()
       return change.deleteCharBackward()
     }

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -401,6 +401,11 @@ function AfterPlugin() {
       return change.deleteWordForward()
     }
 
+    if (event.key === 'Backspace') {
+      event.preventDefault()
+      return change
+    }
+
     if (Hotkeys.isRedo(event)) {
       return change.redo()
     }

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -403,7 +403,7 @@ function AfterPlugin() {
 
     if (event.key === 'Backspace') {
       event.preventDefault()
-      return change
+      return change.deleteCharBackward()
     }
 
     if (Hotkeys.isRedo(event)) {

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -379,9 +379,8 @@ function AfterPlugin() {
 
     if (
       (Hotkeys.isDeleteCharBackward(event) && !IS_IOS) ||
-      Hotkeys.isUndefinedDelete(event)
+      Hotkeys.isDelete(event)
     ) {
-      event.preventDefault()
       return change.deleteCharBackward()
     }
 

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -378,6 +378,7 @@ function AfterPlugin() {
     }
 
     if (Hotkeys.isDeleteCharBackward(event) && !IS_IOS) {
+      event.preventDefault()
       return change.deleteCharBackward()
     }
 
@@ -399,11 +400,6 @@ function AfterPlugin() {
 
     if (Hotkeys.isDeleteWordForward(event)) {
       return change.deleteWordForward()
-    }
-
-    if (event.key === 'Backspace' || event.key === 'Delete') {
-      event.preventDefault()
-      return change.deleteCharBackward()
     }
 
     if (Hotkeys.isRedo(event)) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bugs;



#### How does this change work?

Because ctrl+backspace is un-handled by the `onKeyDown`; it will create crazy `onInput` event, this PR aims to provides default behavior for un-handled backspace problems.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

### Does this fix any issues or need any specific reviewers?

Fixes: #1887
Reviewers: @
