### PR TITLE
[models/node] implement getPreviousInline and getNextInline APIs

### DIFF
--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -1226,7 +1226,7 @@ class Node {
   }
 
   /**
-   * Get the block node before a descendant text node by `key`.
+   * Get the block node after a descendant node by `key`.
    *
    * @param {String} key
    * @return {Node|Null}
@@ -1247,6 +1247,30 @@ class Node {
     if (!next) return null
 
     return this.getClosestBlock(next.key)
+  }
+
+  /**
+   * Get the inline node after a descendant node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getNextInline(key) {
+    const child = this.assertDescendant(key)
+    let last
+
+    if (child.object == 'inline') {
+      last = child.getLastText()
+    } else {
+      const inline = this.getClosestInline(key)
+      last = inline.getLastText()
+    }
+
+    const next = this.getNextText(this.getNextText(last.key).key)
+    if (!next) return null
+
+    return this.getClosestInline(next.key)
   }
 
   /**
@@ -1439,7 +1463,7 @@ class Node {
   }
 
   /**
-   * Get the block node before a descendant text node by `key`.
+   * Get the block node before a descendant node by `key`.
    *
    * @param {String} key
    * @return {Node|Null}
@@ -1460,6 +1484,30 @@ class Node {
     if (!previous) return null
 
     return this.getClosestBlock(previous.key)
+  }
+
+  /**
+   * Get the inline node before a descendant node by `key`.
+   *
+   * @param {String} key
+   * @return {Node|Null}
+   */
+
+  getPreviousInline(key) {
+    const child = this.assertDescendant(key)
+    let first
+
+    if (child.object == 'inline') {
+      first = child.getFirstText()
+    } else {
+      const inline = this.getClosestInline(key)
+      first = inline.getFirstText()
+    }
+
+    const previous = this.getPreviousText(this.getPreviousText(first.key).key)
+    if (!previous) return null
+
+    return this.getClosestInline(previous.key)
   }
 
   /**

--- a/packages/slate/test/models/node/get-next-inline.js
+++ b/packages/slate/test/models/node/get-next-inline.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+import assert from 'assert'
+
+export default function() {
+  const { document } = (
+    <value>
+      <document>
+        <paragraph>
+          <link>http://slate.com</link>
+          <hashtag>#slate</hashtag>
+          <comment>Tests!</comment>
+        </paragraph>
+      </document>
+    </value>
+  )
+
+  const paragraph = document.nodes.first()
+  const firstInline = paragraph.nodes.get(1)
+  const secondInline = paragraph.nodes.get(3)
+  const thirdInline = paragraph.nodes.get(5)
+
+  assert.equal(document.getNextInline(firstInline.key), secondInline)
+  assert.equal(document.getNextInline(secondInline.key), thirdInline)
+  assert.equal(document.getNextInline(thirdInline.key), null)
+}

--- a/packages/slate/test/models/node/get-previous-inline.js
+++ b/packages/slate/test/models/node/get-previous-inline.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+import assert from 'assert'
+
+export default function() {
+  const { document } = (
+    <value>
+      <document>
+        <paragraph>
+          <link>http://slate.com</link>
+          <hashtag>#slate</hashtag>
+          <comment>Tests!</comment>
+        </paragraph>
+      </document>
+    </value>
+  )
+
+  const paragraph = document.nodes.first()
+  const firstInline = paragraph.nodes.get(1)
+  const secondInline = paragraph.nodes.get(3)
+  const thirdInline = paragraph.nodes.get(5)
+
+  assert.equal(document.getPreviousInline(firstInline.key), null)
+  assert.equal(document.getPreviousInline(secondInline.key), firstInline)
+  assert.equal(document.getPreviousInline(thirdInline.key), secondInline)
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug by adding previously undefined APIs.

#### What's the new behavior?

Previously, trying to use `document.getPreviousInline` and `document.getNextInline` were not defined, so using `value.previousInline` and `value.nextInline`, which depend on those methods, would cause a runtime error. Since the APIs were previously undefined, I don't think I should need to worry too much about backwards compatibility.

From https://github.com/ianstormtaylor/slate/issues/1794, https://jsfiddle.net/qmxu8ocy/ should start working. I also just wrote unit tests, which is how I developed/tested this.

#### How does this change work?

I used the preexisting getPreviousBlock/getNextBlock APIs as examples, which needed only minor adjustments to work for inlines.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1794 