### PR TITLE
[slate-react] Pass renderEditor prop through into editor plugin

### DIFF
--- a/packages/slate-react/src/constants/plugin-props.js
+++ b/packages/slate-react/src/constants/plugin-props.js
@@ -10,6 +10,7 @@ const PLUGIN_PROPS = [
   ...EVENT_HANDLERS,
   'decorateNode',
   'onChange',
+  'renderEditor',
   'renderMark',
   'renderNode',
   'renderPlaceholder',


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Previously, the `renderEditor` prop was only applied when defined on a plugin, not when it was passed as a prop to the top-level Slate Editor component. Now, the `renderEditor` prop will be invoked.

#### How does this change work?

There was just a whitelist of plugin props that gets applied to the Editor component, `renderEditor` needed to be on the list

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1841
