### PR TITLE
Fix issue with pasting in IE11

### DIFF
--- a/packages/slate-react/src/utils/get-event-transfer.js
+++ b/packages/slate-react/src/utils/get-event-transfer.js
@@ -1,5 +1,5 @@
 import Base64 from 'slate-base64-serializer'
-
+import { IS_IE } from 'slate-dev-environment'
 import TRANSFER_TYPES from '../constants/transfer-types'
 
 /**
@@ -26,7 +26,10 @@ const FRAGMENT_MATCHER = / data-slate-fragment="([^\s"]+)"/
  */
 
 function getEventTransfer(event) {
-  if (event.nativeEvent) {
+  // COMPAT: IE 11 doesn't populate nativeEvent with either 
+  // dataTransfer or clipboardData. We'll need to use the base event
+  // object (2018/14/6)
+  if (!IS_IE && event.nativeEvent) {
     event = event.nativeEvent
   }
 

--- a/packages/slate-react/src/utils/get-event-transfer.js
+++ b/packages/slate-react/src/utils/get-event-transfer.js
@@ -26,7 +26,7 @@ const FRAGMENT_MATCHER = / data-slate-fragment="([^\s"]+)"/
  */
 
 function getEventTransfer(event) {
-  // COMPAT: IE 11 doesn't populate nativeEvent with either 
+  // COMPAT: IE 11 doesn't populate nativeEvent with either
   // dataTransfer or clipboardData. We'll need to use the base event
   // object (2018/14/6)
   if (!IS_IE && event.nativeEvent) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

Fixing the issue where dataTransfer or clipboardData are not populated in IE 11 under event.NativeEvent. Instead, if we are using IE11, use the base event object which contains a valid dataTransfer/clipboardData object.

#### How does this change work?

Adding to the `event.nativeEvent` check in `getEventTransfer.js` to prevent reassigning `event` with `nativeEvent` in IE11.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #897 