### PR TITLE
fix decoration rendering

### DIFF
--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -312,7 +312,7 @@ class Text extends Record(DEFAULTS) {
         if (index >= this.text.length) return
 
         if (index !== 0 || length < this.text.length) {
-          const [before, bundle] = Leaf.splitLeaves(this.leaves, index)
+          const [before, bundle] = Leaf.splitLeaves(leaves, index)
           const [middle, after] = Leaf.splitLeaves(bundle, length)
           leaves = before.concat(middle.map(x => x.addMarks(marks)), after)
           return


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->
#### Current behaviour?
only last decorations of leaves are getting applied
![broken-decoration mov](https://user-images.githubusercontent.com/18670101/41453739-38c12850-70ba-11e8-82b7-e2d99b2de9a8.gif)

#### What's the new behavior?
All decorations of leaves are getting applied properly
![fix-decoration mov](https://user-images.githubusercontent.com/18670101/41453761-4f23e09c-70ba-11e8-88cc-935fd824226d.gif)

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Previously `getLeaves` of text only applied the last decoration of each leaves as on every single loop it reapplied decorations to the original leaves instead of the updated leaves

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @zhujinxuan @ianstormtaylor 
