### PR TITLE
[core/models] add replaceMark method on Change, tests, docs

### DIFF
--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -192,6 +192,14 @@ Split the [`Inline`](./inline.md) node in the current selection by `depth` level
 
 Remove a [`mark`](./mark.md) from the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
+### `replaceMark`
+
+`removeMark(oldMark: Mark, newMark: Mark) => Change` <br/>
+`removeMark(oldProperties: Object, newProperties: Object) => Change` <br/>
+`removeMark(oldType: String, newType: String) => Change`
+
+Replace a [`mark`](./mark.md) in the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+
 ### `toggleMark`
 
 `toggleMark(mark: Mark) => Change` <br/>

--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -194,9 +194,9 @@ Remove a [`mark`](./mark.md) from the characters in the current selection. For c
 
 ### `replaceMark`
 
-`removeMark(oldMark: Mark, newMark: Mark) => Change` <br/>
-`removeMark(oldProperties: Object, newProperties: Object) => Change` <br/>
-`removeMark(oldType: String, newType: String) => Change`
+`replaceMark(oldMark: Mark, newMark: Mark) => Change` <br/>
+`replaceMark(oldProperties: Object, newProperties: Object) => Change` <br/>
+`replaceMark(oldType: String, newType: String) => Change`
 
 Replace a [`mark`](./mark.md) in the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 

--- a/packages/slate/src/changes/at-current-range.js
+++ b/packages/slate/src/changes/at-current-range.js
@@ -261,6 +261,19 @@ Changes.removeMark = (change, mark) => {
 }
 
 /**
+ * Replace an `oldMark` with a `newMark` in the characters in the current selection.
+ *
+ * @param {Change} change
+ * @param {Mark} oldMark
+ * @param {Mark} newMark
+ */
+
+Changes.replaceMark = (change, oldMark, newMark) => {
+  change.removeMark(oldMark)
+  change.addMark(newMark)
+}
+
+/**
  * Add or remove a `mark` from the characters in the current selection,
  * depending on whether it's already there.
  *

--- a/packages/slate/test/changes/at-current-range/replace-mark/across-blocks.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/across-blocks.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <i>rd</i>
+      </paragraph>
+      <paragraph>
+        <i>an</i>
+        <focus />other
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <b>rd</b>
+      </paragraph>
+      <paragraph>
+        <b>an</b>
+        <focus />other
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/across-inlines.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/across-inlines.js
@@ -1,0 +1,49 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          wo<anchor />
+          <i>rd</i>
+        </link>
+        <i />
+      </paragraph>
+      <paragraph>
+        <i />
+        <link>
+          <i>an</i>
+          <focus />other
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          wo<anchor />
+          <b>rd</b>
+        </link>
+        <b />
+      </paragraph>
+      <paragraph>
+        <b />
+        <link>
+          <b>an</b>
+          <focus />other
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/collapsed-selection.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/collapsed-selection.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold').insertText('a')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <i />
+        <cursor />word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>a</b>
+        <cursor />word
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/existing-marks.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/existing-marks.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <i>
+          wo<focus />rd
+        </i>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <b>wo</b>
+        <focus />
+        <i>rd</i>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/first-character.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/first-character.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <i>w</i>
+        <focus />ord
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <b>w</b>
+        <focus />ord
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/last-character.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/last-character.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wor<anchor />
+        <i>d</i>
+        <focus />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        wor<anchor />
+        <b>d</b>
+        <focus />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/middle-character.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/middle-character.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        w<anchor />
+        <i>o</i>
+        <focus />rd
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        w<anchor />
+        <b>o</b>
+        <focus />rd
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/whole-word.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/whole-word.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', 'bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <i>word</i>
+        <focus />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <b>word</b>
+        <focus />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/with-mark-object.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/with-mark-object.js
@@ -1,0 +1,39 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+import { Mark } from '../../../..'
+
+export default function(change) {
+  change.replaceMark(
+    'italic',
+    Mark.create({
+      type: 'bold',
+      data: { thing: 'value' },
+    })
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <i>w</i>
+        <focus />ord
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <b thing="value">w</b>
+        <focus />ord
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/changes/at-current-range/replace-mark/with-plain-object.js
+++ b/packages/slate/test/changes/at-current-range/replace-mark/with-plain-object.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.replaceMark('italic', {
+    type: 'bold',
+    data: { thing: 'value' },
+  })
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <i>w</i>
+        <focus />ord
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />
+        <b thing="value">w</b>
+        <focus />ord
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

Instead of having to do:

```
change.removeMark(oldMark) && change.addMark(newMark)
```

one can do:

```
change.replaceMark(oldMark, newMark)
```

#### How does this change work?

Calls the underlying removeMark && addMark instance methods

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1903
