### PR TITLE
fix removeText with Mark of length 1

### DIFF
--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -589,7 +589,7 @@ class Text extends Record(DEFAULTS) {
 
     // PERF: For simple backspace, we can operate directly on the leaf
     if (length === 1) {
-      const { leaf, index, startOffset } = this.searchLeafAtOffset(start)
+      const { leaf, index, startOffset } = this.searchLeafAtOffset(start + 1)
       const offset = start - startOffset
 
       if (leaf) {

--- a/packages/slate/test/models/text/delete/inside-a-leaf/delete-a-char-with-mark.js
+++ b/packages/slate/test/models/text/delete/inside-a-leaf/delete-a-char-with-mark.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+import h from '../../../../helpers/h'
+
+export const input = (
+  <text>
+    <b>Cat </b>is <i>Cute</i>
+  </text>
+)[0]
+
+export default function(t) {
+  return t.removeText(4, 1)
+}
+
+export const output = (
+  <text>
+    <b>Cat </b>s <i>Cute</i>
+  </text>
+)[0]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a _bug_
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
text with mark of length 1 get removed properly on deletion
![text with mark deleted](https://user-images.githubusercontent.com/18670101/41632372-dfc1892c-747c-11e8-8df2-2fa284ee2b38.gif)

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
previously, the `searchLeafAtOffset` got the wrong start point therefore returning previous leaves on leaves with length === 1
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/1916
Reviewers: @zhujinxuan 
