### PR TITLE
fix(Safari): Set a text value in dataTransfer to have the cursor on Safari when dragging a text node

### DIFF
--- a/packages/slate-react/src/utils/set-event-transfer.js
+++ b/packages/slate-react/src/utils/set-event-transfer.js
@@ -34,6 +34,9 @@ function setEventTransfer(event, type, content) {
 
   try {
     transfer.setData(mime, content)
+    // COMPAT: Safari needs to have the 'text' (and not 'text/plain') value in dataTransfer
+    // to display the cursor while dragging internally.
+    transfer.setData('text', transfer.getData('text'))
   } catch (err) {
     const prefix = 'SLATE-DATA-EMBED::'
     const text = transfer.getData(TEXT)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
While dragging some text or a node, it displays the caret where the drop will happen.

#### How to test it ?
1. Go to the rich text example
2. Select words/sentences and move your selection somewhere else in the same slate editor
3. While dragging it, you'll see the "drop point" thanks to a caret
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
I suppose that Safari does not like to have a value for _application/x-slate-fragment_ in _dataTransfer_ and no _text_ value
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: no issues found
