### PR TITLE
Fix a linter bug in a semi-colon case

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -149,6 +149,7 @@
       { "blankLine": "any", "prev": "multiline-expression", "next": "return" },
       { "blankLine": "always", "prev": "*", "next": "multiline-expression" },
       { "blankLine": "always", "prev": "*", "next": "multiline-expression" },
+      { "blankLine": "any", "prev": "empty", "next": "multiline-expression" },
       { "blankLine": "always", "prev": "multiline-block-like", "next": "*" },
       { "blankLine": "any", "prev": "multiline-block-like", "next": "return" },
       { "blankLine": "always", "prev": "*", "next": "multiline-block-like" },

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -59,7 +59,6 @@ function cloneFragment(event, value, fragment = value.fragment) {
 
   // Remove any zero-width space spans from the cloned DOM so that they don't
   // show up elsewhere when pasted.
-  // eslint-disable-next-line padding-line-between-statements
   ;[].slice.call(contents.querySelectorAll(ZERO_WIDTH_SELECTOR)).forEach(zw => {
     const isNewline = zw.getAttribute(ZERO_WIDTH_ATTRIBUTE) === 'n'
     zw.textContent = isNewline ? '\n' : ''


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?
Previously we have to disable padding-lines rule when
```
if (...) {
 ..
}

;[].forEach((x) => {
...
})
```
becuase `;` is considered an empty block.  This PR fixes that problem
#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
