### PR TITLE
fix(DragAndDrop): isDraggingInternally should not be reset by the onDragOver handler

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -163,8 +163,6 @@ function AfterPlugin() {
 
   function onDragOver(event, change, editor) {
     debug('onDragOver', { event })
-
-    isDraggingInternally = false
   }
 
   /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Drag and drop works again.
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
This bug exists since : [Removed early return in onDragOver](https://github.com/ianstormtaylor/slate/commit/4712e64c308e68895f2601b5572b367aec2c4001). This commit removed the _return true_ that was stopping the call of `onDragOver` for the plugins stack. Since now the after plugin `onDragOver` is called, the internal dragging flag (`isInternallyDragging`) is reset to null which prevents the `onDrop` handler to remove the selection when it's an internal drag operation.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1871 
