### PR TITLE
Update schema rule's marks property documentation

### DIFF
--- a/docs/reference/slate/schema.md
+++ b/docs/reference/slate/schema.md
@@ -155,11 +155,11 @@ Will validate a node's children. The `nodes` definitions can declare the `object
 
 ```js
 {
-  marks: ['italic']
+  marks: [{ type: 'bold' }, { type: 'italic' }]
 }
 ```
 
-Will validate a node's marks. The `marks` definitions can declare a list of mark types to be allowed. If declared, any marks that are not in the list will be removed.
+Will validate a node's marks. The `marks` definitions can declare the `type` property, providing a list of mark types to be allowed. If declared, any marks that are not in the list will be removed.
 
 ### `normalize`
 


### PR DESCRIPTION
Hey, firstly thanks for creating and maintaining Slate! Love the concepts behind it as they make creating non-standard editors a breeze.

When working with Schema I found a part where docs do not reflect the actual code. Schema rule's property `marks` does not validate when provided with list of types, but needs list of objects with `type` property as it is apparent [from the code](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/models/schema.js#L306) and [tests](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/test/schema/custom/node-mark-valid-default.js#L8)