### PR TITLE
RFC: Fix for Android devices

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -129,8 +129,32 @@ class Content extends React.Component {
    * On update, update the selection.
    */
 
-  componentDidUpdate = () => {
-    this.updateSelection()
+  getSnapshotBeforeUpdate() {
+    // Android changes are debounced and the range needs to be cached
+    if (!IS_ANDROID) return null
+    const selection = window.getSelection()
+    if (selection.rangeCount !== 1) return null
+    const range = selection.getRangeAt(0)
+    return {
+      startOffset: range.startOffset,
+      endOffset: range.endOffset,
+      startContainer: range.startContainer,
+      endContainer: range.endContainer,
+    }
+  }
+
+  componentDidUpdate = (prevProps, prevState, snapshot) => {
+    if (snapshot) {
+      const selection = window.getSelection()
+      if (selection.rangeCount === 1) {
+        const range = selection.getRangeAt(0)
+        const { startContainer, endContainer, startOffset, endOffset } = snapshot
+        range.setStart(startContainer, startOffset)
+        range.setEnd(endContainer, endOffset)
+      }
+    } else {
+      this.updateSelection()
+    }
   }
 
   /**

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -146,9 +146,15 @@ class Content extends React.Component {
   componentDidUpdate = (prevProps, prevState, snapshot) => {
     if (snapshot) {
       const selection = window.getSelection()
+
       if (selection.rangeCount === 1) {
         const range = selection.getRangeAt(0)
-        const { startContainer, endContainer, startOffset, endOffset } = snapshot
+        const {
+          startContainer,
+          endContainer,
+          startOffset,
+          endOffset,
+        } = snapshot
         range.setStart(startContainer, startOffset)
         range.setEnd(endContainer, endOffset)
       }

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -1,7 +1,7 @@
 import Base64 from 'slate-base64-serializer'
 import Debug from 'debug'
 import Plain from 'slate-plain-serializer'
-import { IS_IOS } from 'slate-dev-environment'
+import { IS_IOS, IS_ANDROID } from 'slate-dev-environment'
 import React from 'react'
 import getWindow from 'get-window'
 import { Block, Inline, Text } from 'slate'
@@ -25,6 +25,7 @@ import setEventTransfer from '../utils/set-event-transfer'
  */
 
 const debug = Debug('slate:after')
+const ANDROID_KEYSTROKE_DEBOUNCE = 300
 
 /**
  * The after plugin.
@@ -34,7 +35,7 @@ const debug = Debug('slate:after')
 
 function AfterPlugin() {
   let isDraggingInternally = null
-
+  let stagedChange = null
   /**
    * On before input, correct any browser inconsistencies.
    *
@@ -45,7 +46,9 @@ function AfterPlugin() {
 
   function onBeforeInput(event, change, editor) {
     debug('onBeforeInput', { event })
-
+    // onBeforeInput is used as a cheaper insert
+    // Android events are debounced and a full diff is required
+    if (IS_ANDROID) return
     event.preventDefault()
     change.insertText(event.data)
   }
@@ -349,7 +352,22 @@ function AfterPlugin() {
       .moveFocusTo(point.key, end)
 
     // Change the current value to have the leaf's text replaced.
-    change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)
+
+    if (IS_ANDROID) {
+      // Controlled contentEditables lose their selection range every render
+      // and must be updated manually (see Content#componentDidUpdate)
+      // Updating the selection causes the IME auto-suggest to recompute
+      // synchronously, causing lost input events during that recompute
+      // If device turns off IME auto-suggest, this is not needed
+      clearTimeout(stagedChange)
+
+      stagedChange = setTimeout(() => {
+        change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)
+        editor.onChange(change)
+      }, ANDROID_KEYSTROKE_DEBOUNCE)
+    } else {
+      change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)
+    }
   }
 
   /**

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -36,6 +36,7 @@ const ANDROID_KEYSTROKE_DEBOUNCE = 300
 function AfterPlugin() {
   let isDraggingInternally = null
   let stagedChange = null
+
   /**
    * On before input, correct any browser inconsistencies.
    *
@@ -362,11 +363,16 @@ function AfterPlugin() {
       clearTimeout(stagedChange)
 
       stagedChange = setTimeout(() => {
-        change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)
+        change
+          .insertTextAtRange(entire, textContent, leaf.marks)
+          .select(corrected)
+
         editor.onChange(change)
       }, ANDROID_KEYSTROKE_DEBOUNCE)
     } else {
-      change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)
+      change
+        .insertTextAtRange(entire, textContent, leaf.marks)
+        .select(corrected)
     }
   }
 

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -131,6 +131,8 @@ function BeforePlugin() {
    */
 
   function onCompositionEnd(event, change, editor) {
+    // triggering a forced update here will close the Android IME
+    if (IS_ANDROID) return
     const n = compositionCount
 
     // The `count` check here ensures that if another composition starts
@@ -161,6 +163,8 @@ function BeforePlugin() {
    */
 
   function onCompositionStart(event, change, editor) {
+    // Overriding Android native composition logic results in errors
+    if (IS_ANDROID) return
     isComposing = true
     compositionCount++
 
@@ -370,6 +374,14 @@ function BeforePlugin() {
 
   function onKeyDown(event, change, editor) {
     if (editor.props.readOnly) return true
+
+    // ignore garbage 229 events sent during composition
+    // event.isComposing doesn't exist in react pseudo events
+    // https://github.com/facebook/react/issues/13104
+    if (event.key === 'Unidentified') {
+      event.preventDefault()
+      return true
+    }
 
     // When composing, we need to prevent all hotkeys from executing while
     // typing. However, certain characters also move the selection before


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

It works

Proof: https://photos.google.com/share/AF1QipO2uaYQFgq8PuYPq2ojGLokBHhqPaLoFQif8fQFyq220giwtcfz6x1FFdl8HWp7XQ/photo/AF1QipMrSTxFBM5GeXc98E_2gh7p9SKveXRmphrDQfJ1?key=Q19FaENxc01ka3VKZnZINXgzNGxfZThhSG1XYXhn

Device is an OG Pixel, using GBoard on Android 8.1.0. YMMV. PLEASE TEST ON YOUR DEVICES!

#### How does this change work?

1. It doesn't hijack events. it just lets android do its thing
2. it debounces updates to slate so the IME auto-suggest isn't constantly refreshing when the selection gets reset every render. Without a debounce, you can't type faster than ~3 keys per second and holding the backspace doesn't work. 

NOTE: 
- I use snapshotting, so react version is pinned at 16.3, making this a breaking change. you can use cWU if you want, but the package will need to be made react 17-ready soon anyways...
- Before merging, please consider using snapshotting to replace `updateSelection` for all devices, not just android.

#### Does this fix any issues or need any specific reviewers?

fix #725 fix #1857 

Reviewers: @Slapbox @ianstormtaylor 
