### PR TITLE
Added missing paste event handler in slate-simulator docs

### DIFF
--- a/docs/reference/slate-simulator/index.md
+++ b/docs/reference/slate-simulator/index.md
@@ -83,6 +83,12 @@ Simulator a `focus` event with an `event` object.
 
 Simulator a `keyDown` event with an `event` object.
 
+### `paste`
+
+`paste(event: Object) => Simulator`
+
+Simulator a `paste` event with an `event` object.
+
 ### `select`
 
 `select(event: Object) => Simulator`


### PR DESCRIPTION
Acording to https://github.com/ianstormtaylor/slate/blob/master/packages/slate-simulator/src/index.js onPaste event is suported by slate-simulator. Tested locally and the onPaste function of plugins gets called if simulator.paste() is called.