### PR TITLE
Allow onContextMenu event handler

### DIFF
--- a/packages/slate-react/src/constants/event-handlers.js
+++ b/packages/slate-react/src/constants/event-handlers.js
@@ -8,6 +8,7 @@ const EVENT_HANDLERS = [
   'onBeforeInput',
   'onBlur',
   'onClick',
+  'onContextMenu',
   'onCompositionEnd',
   'onCompositionStart',
   'onCopy',


### PR DESCRIPTION
Right clicks aren't handled by onClick in a content-editable component. So we need access to a onContextMenu handler to handle these events properly.

My use case is to be able to open a context menu with actions when the user right-clicks a specific inline node.

Let me know if you think we need tests for this, but I made the change in GitHub since it was so small.