### PR TITLE
add null-guard for insertTextAtRange when marks is undefined

### DIFF
--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -875,7 +875,7 @@ Changes.insertTextAtRange = (change, range, text, marks, options = {}) => {
 
   // PERF: Unless specified, don't normalize if only inserting text.
   if (normalize === undefined) {
-    normalize = range.isExpanded && marks.size !== 0
+    normalize = range.isExpanded && marks && marks.size !== 0
   }
 
   change.insertTextByKey(key, offset, text, marks, { normalize: false })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a recent bug that slipped in during #1875 

#### What's the new behavior?

No error is thrown.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
