### PR TITLE
Fix drag-and-drop issues in IE11

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -4,6 +4,7 @@ import { findDOMNode } from 'react-dom'
 import Hotkeys from 'slate-hotkeys'
 import {
   IS_FIREFOX,
+  IS_IE,
   IS_IOS,
   IS_ANDROID,
   SUPPORTED_EVENTS,
@@ -275,10 +276,21 @@ function BeforePlugin() {
     const node = findNode(event.target, editor.value)
     if (node.isVoid) event.preventDefault()
 
+    // COMPAT: IE won't call onDrop on contentEditables unless the
+    // default dragOver is prevented:
+    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/913982/
+    // (2018/07/11)
+    if (IS_IE) event.preventDefault()
+
     // If a drag is already in progress, don't do this again.
     if (!isDragging) {
       isDragging = true
-      event.nativeEvent.dataTransfer.dropEffect = 'move'
+
+      // COMPAT: IE will raise an `unspecified error` if dropEffect is
+      // set. (2018/07/11)
+      if (!IS_IE) {
+        event.nativeEvent.dataTransfer.dropEffect = 'move'
+      }
     }
 
     debug('onDragOver', { event })

--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -56,11 +56,23 @@ function getEventRange(event, value) {
   // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2016/07/25)
   if (window.document.caretRangeFromPoint) {
     native = window.document.caretRangeFromPoint(x, y)
-  } else {
+  } else if (window.document.caretPositionFromPoint) {
     const position = window.document.caretPositionFromPoint(x, y)
     native = window.document.createRange()
     native.setStart(position.offsetNode, position.offset)
     native.setEnd(position.offsetNode, position.offset)
+  } else if (window.document.body.createTextRange) {
+    // COMPAT: In IE, `caretRangeFromPoint` and
+    // `caretPositionFromPoint` don't exist. (2018/07/11)
+    native = window.document.body.createTextRange()
+
+    try {
+      native.moveToPoint(x, y)
+    } catch (error) {
+      // IE11 will raise an `unspecified error` if `moveToPoint` is
+      // called during a dropEvent.
+      return null
+    }
   }
 
   // Resolve a Slate range from the DOM range.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

You can now drag-and-drop files into an editor that supports it, without console errors or uncaught exceptions.

#### How does this change work?

There were three problems preventing drag-and-drop in IE:

* IE [doesn't consider contentEditables as inputs](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/913982/) when it comes to calling `onDrop`. So you have to `preventDefault` in `onDragOver`, which prevents the cursor from being displayed. Turns out _this is fine_, because:
* You can only get a cursor position from a point with `createTextRange` and `moveToPoint`. Also, `moveToPoint` raises an error if it's called during a dropEvent. So you wouldn't be able to drop into a specific point, even if you wanted to.
* Setting `dropEffect` causes an `unspecified error`.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
