### PR TITLE
Add slate-slt1-serializer

### DIFF
--- a/packages/slate-slt1-serializer/Changelog.md
+++ b/packages/slate-slt1-serializer/Changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This document maintains a list of changes to the `slate-slt1-serializer` package with each new version. Until `1.0.0` is released, breaking changes will be added as minor version bumps, and smaller changes won't be accounted for since the library is moving quickly.
+
+---
+
+### `0.1.0` — September 17, 2017
+
+:tada:

--- a/packages/slate-slt1-serializer/Readme.md
+++ b/packages/slate-slt1-serializer/Readme.md
@@ -1,0 +1,70 @@
+# slate-slt1-serializer
+
+This package contains the slt1 serializer for Slate documents.
+
+The Slate Data Model is good for editing, but not so good for storing. Furthermore, it might change in the future.
+
+This serializer is meant to provide a stable and compact format for storing Slate documents in a lossless manner.
+
+As an example example, these are equivalent:
+
+slt1:
+
+```json
+["slt1", 1, [2, "line", [["bold", ["italic", { "very": true }], "one"]]]]
+```
+
+slate-hyperscript:
+
+```html
+  <value>
+    <document>
+      <line><b><i very>one</i></b></line>
+    </document>
+  </value>
+```
+
+slate data model - JSON version:
+
+```json
+{
+  "object": "value",
+  "document": {
+    "object": "document",
+    "data": {},
+    "nodes": [
+      {
+        "object": "block",
+        "data": {},
+        "isVoid": false,
+        "type": "line",
+        "nodes": [
+          {
+            "object": "text",
+            "leaves": [
+              {
+                "marks": [
+                  {
+                    "data": {},
+                    "object": "mark",
+                    "type": "bold"
+                  },
+                  {
+                    "data": {
+                      "very": true
+                    },
+                    "object": "mark",
+                    "type": "italic"
+                  }
+                ],
+                "object": "leaf",
+                "text": "one"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/packages/slate-slt1-serializer/benchmark/index.js
+++ b/packages/slate-slt1-serializer/benchmark/index.js
@@ -1,0 +1,46 @@
+/* global suite, set, bench */
+
+import fs from 'fs'
+import { basename, extname, resolve } from 'path'
+import { resetMemoization } from 'slate'
+
+/**
+ * Benchmarks.
+ */
+
+const categoryDir = resolve(__dirname)
+const categories = fs
+  .readdirSync(categoryDir)
+  .filter(c => c[0] != '.' && c != 'index.js')
+
+categories.forEach(category => {
+  suite(category, () => {
+    set('iterations', 50)
+    set('mintime', 1000)
+
+    if (category == 'models') {
+      after(() => {
+        resetMemoization()
+      })
+    }
+
+    const benchmarkDir = resolve(categoryDir, category)
+    const benchmarks = fs
+      .readdirSync(benchmarkDir)
+      .filter(b => b[0] != '.' && !!~b.indexOf('.js'))
+      .map(b => basename(b, extname(b)))
+
+    benchmarks.forEach(benchmark => {
+      const dir = resolve(benchmarkDir, benchmark)
+      const module = require(dir)
+      const fn = module.default
+      let { input, before, after } = module
+      if (before) input = before(input)
+
+      bench(benchmark, () => {
+        fn(input)
+        if (after) after()
+      })
+    })
+  })
+})

--- a/packages/slate-slt1-serializer/benchmark/slt1-serializer/deserialize.js
+++ b/packages/slate-slt1-serializer/benchmark/slt1-serializer/deserialize.js
@@ -1,0 +1,23 @@
+/** @jsx h */
+/* eslint-disable react/jsx-key */
+
+import slt1 from '../..'
+
+export default function(slt) {
+  slt1.deserialize(slt)
+}
+
+export const input = [
+  'slt1',
+  1,
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+]

--- a/packages/slate-slt1-serializer/benchmark/slt1-serializer/serialize.js
+++ b/packages/slate-slt1-serializer/benchmark/slt1-serializer/serialize.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+/* eslint-disable react/jsx-key */
+
+import slt1 from '../..'
+import h from '../../test/helpers/h'
+
+export default function(state) {
+  slt1.serialize(state)
+}
+
+export const input = (
+  <value>
+    <document>
+      {Array.from(Array(10)).map(() => (
+        <quote>
+          <paragraph>
+            <paragraph>
+              This is editable <b>rich</b> text, <i>much</i> better than a
+              textarea!
+            </paragraph>
+          </paragraph>
+        </quote>
+      ))}
+    </document>
+  </value>
+)

--- a/packages/slate-slt1-serializer/package.json
+++ b/packages/slate-slt1-serializer/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "slate-slt1-serializer",
+  "description": "A slt1 serializer for Slate editors.",
+  "version": "0.1.0",
+  "license": "MIT",
+  "repository": "git://github.com/ianstormtaylor/slate.git",
+  "main": "lib/slate-slt1-serializer.js",
+  "module": "lib/slate-slt1-serializer.es.js",
+  "umd": "dist/slate-slt1-serializer.js",
+  "umdMin": "dist/slate-slt1-serializer.min.js",
+  "files": [
+    "dist/",
+    "lib/"
+  ],
+  "dependencies": {
+    "slate-dev-logger": "^0.1.39"
+  },
+  "peerDependencies": {
+    "slate": ">=0.32.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.5.3",
+    "slate": "^0.34.5",
+    "slate-hyperscript": "^0.5.20"
+  },
+  "scripts": {
+    "clean": "rm -rf ./dist ./lib ./node_modules"
+  },
+  "umdGlobals": {
+    "slate": "Slate"
+  },
+  "keywords": [
+    "deserialize",
+    "editor",
+    "slt1",
+    "serialize",
+    "serializer",
+    "slate",
+    "string",
+    "text",
+    "xml"
+  ]
+}

--- a/packages/slate-slt1-serializer/shrinkwrap.yaml
+++ b/packages/slate-slt1-serializer/shrinkwrap.yaml
@@ -1,0 +1,208 @@
+dependencies:
+  slate-dev-logger: 0.1.39
+devDependencies:
+  mocha: 2.5.3
+  slate: 0.34.5
+  slate-hyperscript: 0.5.20
+packages:
+  /commander/0.6.1:
+    dev: true
+    engines:
+      node: '>= 0.4.x'
+    resolution:
+      integrity: sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
+  /commander/2.3.0:
+    dev: true
+    engines:
+      node: '>= 0.6.x'
+    resolution:
+      integrity: sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=
+  /debug/2.2.0:
+    dependencies:
+      ms: 0.7.1
+    dev: true
+    resolution:
+      integrity: sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
+  /debug/3.1.0:
+    dependencies:
+      ms: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  /diff/1.4.0:
+    dev: true
+    engines:
+      node: '>=0.3.1'
+    resolution:
+      integrity: sha1-fyjS657nsVqX79ic5j3P2qPMur8=
+  /direction/0.1.5:
+    dev: true
+    resolution:
+      integrity: sha1-zl15f5fib4vnvv9T99xA4cGp7Ew=
+  /escape-string-regexp/1.0.2:
+    dev: true
+    engines:
+      node: '>=0.8.0'
+    resolution:
+      integrity: sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=
+  /esrever/0.2.0:
+    dev: true
+    resolution:
+      integrity: sha1-lunSj08bGnZ4TNXUkOquAQ50B7g=
+  /glob/3.2.11:
+    dependencies:
+      inherits: 2.0.3
+      minimatch: 0.3.0
+    dev: true
+    resolution:
+      integrity: sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
+  /growl/1.9.2:
+    dev: true
+    resolution:
+      integrity: sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
+  /inherits/2.0.3:
+    dev: true
+    resolution:
+      integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+  /is-empty/1.2.0:
+    dev: true
+    resolution:
+      integrity: sha1-3pu1snhzigWgsJpX4ftNSjQan2s=
+  /is-plain-object/2.0.4:
+    dependencies:
+      isobject: 3.0.1
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  /isobject/3.0.1:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+  /jade/0.26.3:
+    dependencies:
+      commander: 0.6.1
+      mkdirp: 0.3.0
+    deprecated: 'Jade has been renamed to pug, please install the latest version of pug instead of jade'
+    dev: true
+    resolution:
+      integrity: sha1-jxDXl32NefL2/4YqgbBRPMslaGw=
+  /lodash/4.17.10:
+    dev: true
+    resolution:
+      integrity: sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+  /lru-cache/2.7.3:
+    dev: true
+    resolution:
+      integrity: sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
+  /minimatch/0.3.0:
+    dependencies:
+      lru-cache: 2.7.3
+      sigmund: 1.0.1
+    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+    dev: true
+    resolution:
+      integrity: sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=
+  /minimist/0.0.8:
+    dev: true
+    resolution:
+      integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+  /mkdirp/0.3.0:
+    dev: true
+    resolution:
+      integrity: sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
+  /mkdirp/0.5.1:
+    dependencies:
+      minimist: 0.0.8
+    dev: true
+    resolution:
+      integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  /mocha/2.5.3:
+    dependencies:
+      commander: 2.3.0
+      debug: 2.2.0
+      diff: 1.4.0
+      escape-string-regexp: 1.0.2
+      glob: 3.2.11
+      growl: 1.9.2
+      jade: 0.26.3
+      mkdirp: 0.5.1
+      supports-color: 1.2.0
+      to-iso-string: 0.0.2
+    dev: true
+    engines:
+      node: '>= 0.8.x'
+    resolution:
+      integrity: sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=
+  /ms/0.7.1:
+    dev: true
+    resolution:
+      integrity: sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
+  /ms/2.0.0:
+    dev: true
+    resolution:
+      integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+  /sigmund/1.0.1:
+    dev: true
+    resolution:
+      integrity: sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
+  /slate-dev-logger/0.1.39:
+    resolution:
+      integrity: sha1-dEppuFA0JEcT5t5RSDr1cTw0WvQ=
+  /slate-hyperscript/0.5.20:
+    dependencies:
+      is-empty: 1.2.0
+      is-plain-object: 2.0.4
+      slate-dev-logger: 0.1.39
+    dev: true
+    peerDependencies:
+      slate: '>=0.32.0'
+    resolution:
+      integrity: sha1-gzVJBKV+4behILEzUVTsapB9tkk=
+  /slate-schema-violations/0.1.18:
+    dev: true
+    resolution:
+      integrity: sha1-vHYOF9q4WmE82aU5m5jL+GfbDrc=
+  /slate/0.34.5:
+    dependencies:
+      debug: 3.1.0
+      direction: 0.1.5
+      esrever: 0.2.0
+      is-empty: 1.2.0
+      is-plain-object: 2.0.4
+      lodash: 4.17.10
+      slate-dev-logger: 0.1.39
+      slate-schema-violations: 0.1.18
+      type-of: 2.0.1
+    dev: true
+    peerDependencies:
+      immutable: '>=3.8.1'
+      react: '>=0.14.0'
+    resolution:
+      integrity: sha1-S8MNwwDJJBk9QjcaevzBaGdvJ5g=
+  /supports-color/1.2.0:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=
+  /to-iso-string/0.0.2:
+    deprecated: 'to-iso-string has been deprecated, use @segment/to-iso-string instead.'
+    dev: true
+    resolution:
+      integrity: sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=
+  /type-of/2.0.1:
+    dev: true
+    resolution:
+      integrity: sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI=
+registry: 'https://registry.npmjs.org/'
+shrinkwrapMinorVersion: 7
+shrinkwrapVersion: 3
+specifiers:
+  mocha: ^2.5.3
+  slate: ^0.34.5
+  slate-dev-logger: ^0.1.39
+  slate-hyperscript: ^0.5.20

--- a/packages/slate-slt1-serializer/src/index.js
+++ b/packages/slate-slt1-serializer/src/index.js
@@ -1,0 +1,215 @@
+import { Value } from 'slate'
+
+const isArray = Array.isArray
+const isString = o => typeof o === 'string'
+const isObj = o => typeof o === 'object' && !isArray(o)
+
+const assert = (b, msg) => {
+  if (!b) throw new Error('assertion failed')
+  return true
+}
+
+/**
+ * Deserialize a slt value to a Slate value.
+ *
+ * @param {String} string
+ * @param {Object} options
+ *   @property {Boolean} toJSON
+ *   @property {String|Object|Block} defaultBlock
+ *   @property {Array|Set} defaultMarks
+ * @return {Value}
+ */
+
+function deserialize(slt, options = {}) {
+  const { toJSON } = options
+
+  if (!slt) return new Value()
+
+  // Allow passing raw JSON, to assist in DB upgrades
+  if (isObj(slt) && slt.object === 'value') return Value.fromJSON(slt)
+
+  if (slt[0] !== 'slt1') throw new Error('Not an slt1 value')
+
+  const json = {
+    object: 'value',
+    document: deserializeDocument(slt.slice(1)),
+  }
+
+  const ret = toJSON ? json : Value.fromJSON(json)
+  return ret
+}
+
+function deserializeData(obj) {
+  if (obj && isObj(obj)) return obj
+}
+
+function deserializeDocument(arr) {
+  let i = 1
+
+  const data = deserializeData(arr[i])
+  if (data) i++
+
+  const nodes = arr.slice(i).map(deserializeBlock)
+
+  return { object: 'document', data: data || {}, nodes }
+}
+
+function deserializeNode(obj) {
+  // Single-leaf text without marks
+  if (isString(obj)) return deserializeText([obj])
+
+  const t = obj[0]
+  // Texts are array of string or array
+  if (isString(t) || isArray(t)) return deserializeText(obj)
+  if (t === 2 || t === 3) return deserializeBlock(obj)
+
+  throw new Error(`cannot handle ${JSON.stringify(obj)}`)
+}
+
+function deserializeBlock(arr) {
+  const object =
+    arr[0] === 2
+      ? 'block'
+      : arr[0] === 3
+        ? 'inline'
+        : assert(0, `unknown block type ${arr[0]}`)
+  const type = arr[1]
+
+  let i = 2
+  const data = deserializeData(arr[i])
+  if (data) i++
+
+  let isVoid, nodes
+
+  if (arr[i] === 5) {
+    isVoid = true
+    nodes = []
+  } else {
+    isVoid = false
+    nodes = arr.slice(i).map(deserializeNode)
+  }
+
+  return {
+    object,
+    type,
+    data: data || {},
+    isVoid,
+    nodes,
+  }
+}
+
+function deserializeText(obj) {
+  return { object: 'text', leaves: obj.map(deserializeLeaf) }
+}
+
+function deserializeLeaf(obj) {
+  const str = isString(obj)
+  const marks = str ? [] : obj.slice(0, -1).map(deserializeMark)
+
+  return { object: 'leaf', marks, text: str ? obj : obj[obj.length - 1] }
+}
+
+function deserializeMark(obj) {
+  const str = isString(obj)
+  const type = str ? obj : obj[0]
+  const data = str ? {} : obj[1]
+  return { object: 'mark', data, type }
+}
+
+/**
+ * Serialize a Slate `value` to a plain object string.
+ *
+ * @param {Value} value
+ * @return {String}
+ */
+
+function serialize(value) {
+  return ['slt1', ...serializeNode(value.document)]
+}
+
+/**
+ * Serialize a `node` to plain text.
+ *
+ * @param {Node} node
+ * @return {String}
+ */
+
+function serializeNode(node) {
+  switch (node.object) {
+    case 'document':
+      return serializeDocument(node)
+    case 'block':
+      return serializeBlock(node)
+    case 'text':
+      return serializeText(node)
+    case 'inline':
+      return serializeBlock(node)
+  }
+  return []
+}
+
+function serializeData(data) {
+  if (data.size) return data.toJS()
+}
+
+function serializeDocument(node) {
+  const out = [1]
+
+  const data = serializeData(node.data)
+  if (data) out.push(data)
+
+  const children = [...node.nodes].map(serializeNode)
+  out.push(...children)
+
+  return out
+}
+
+function serializeBlock(node) {
+  const out = [node.object === 'block' ? 2 : 3, node.type]
+
+  const data = serializeData(node.data)
+  if (data) out.push(data)
+
+  if (node.isVoid) {
+    out.push(5)
+    return out
+  }
+
+  const children = [...node.nodes].map(serializeNode)
+  // remove empty text nodes, Slate will auto-add them back
+  if (children[0] === '') children.splice(0, 1)
+
+  const l = children.length
+  if (l && children[l - 1] === '') children.splice(l - 1, 1)
+  out.push(...children)
+
+  return out
+}
+
+function serializeText(node) {
+  const leaves = [...node.leaves].map(serializeLeaf)
+  if (leaves.length === 1 && typeof leaves[0] === 'string') return leaves[0]
+  return leaves
+}
+
+function serializeLeaf(node) {
+  if (!node.marks.size) return node.text
+  return [...[...node.marks].map(serializeMark), node.text]
+}
+
+function serializeMark(node) {
+  const data = serializeData(node.data)
+  if (data) return [node.type, data]
+  return node.type
+}
+
+/**
+ * Export.
+ *
+ * @type {Object}
+ */
+
+export default {
+  deserialize,
+  serialize,
+}

--- a/packages/slate-slt1-serializer/test/deserialize/line-multiple.js
+++ b/packages/slate-slt1-serializer/test/deserialize/line-multiple.js
@@ -1,0 +1,14 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = ['slt1', 1, [2, 'line', 'one'], [2, 'line', 'two']]
+
+export const output = (
+  <value>
+    <document>
+      <line>one</line>
+      <line>two</line>
+    </document>
+  </value>
+)

--- a/packages/slate-slt1-serializer/test/deserialize/line.js
+++ b/packages/slate-slt1-serializer/test/deserialize/line.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = ['slt1', 1, [2, 'line', 'one']]
+
+export const output = (
+  <value>
+    <document>
+      <line>one</line>
+    </document>
+  </value>
+)

--- a/packages/slate-slt1-serializer/test/deserialize/to-json.js
+++ b/packages/slate-slt1-serializer/test/deserialize/to-json.js
@@ -1,0 +1,50 @@
+export const input = [
+  'slt1',
+  1,
+  [2, 'line', [['bold', ['italic', { very: true }], 'one']]],
+]
+
+export const output = {
+  object: 'value',
+  document: {
+    object: 'document',
+    data: {},
+    nodes: [
+      {
+        object: 'block',
+        data: {},
+        isVoid: false,
+        type: 'line',
+        nodes: [
+          {
+            object: 'text',
+            leaves: [
+              {
+                marks: [
+                  {
+                    data: {},
+                    object: 'mark',
+                    type: 'bold',
+                  },
+                  {
+                    data: {
+                      very: true,
+                    },
+                    object: 'mark',
+                    type: 'italic',
+                  },
+                ],
+                object: 'leaf',
+                text: 'one',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export const options = {
+  toJSON: true,
+}

--- a/packages/slate-slt1-serializer/test/helpers/h.js
+++ b/packages/slate-slt1-serializer/test/helpers/h.js
@@ -1,0 +1,42 @@
+import { createHyperscript } from 'slate-hyperscript'
+
+/**
+ * Define a hyperscript.
+ *
+ * @type {Function}
+ */
+
+const h = createHyperscript({
+  blocks: {
+    line: 'line',
+    paragraph: 'paragraph',
+    quote: 'quote',
+    code: 'code',
+    image: {
+      type: 'image',
+      isVoid: true,
+    },
+  },
+  inlines: {
+    link: 'link',
+    hashtag: 'hashtag',
+    comment: 'comment',
+    emoji: {
+      type: 'emoji',
+      isVoid: true,
+    },
+  },
+  marks: {
+    b: 'bold',
+    i: 'italic',
+    u: 'underline',
+  },
+})
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default h

--- a/packages/slate-slt1-serializer/test/index.js
+++ b/packages/slate-slt1-serializer/test/index.js
@@ -1,0 +1,75 @@
+/**
+ * Dependencies.
+ */
+
+import slt1 from '../src'
+import assert from 'assert'
+import fs from 'fs'
+import { Value, resetKeyGenerator } from 'slate'
+import { basename, extname, resolve } from 'path'
+
+/**
+ * Reset Slate's internal key generator state before each text.
+ */
+
+beforeEach(() => {
+  resetKeyGenerator()
+})
+
+/**
+ * Tests.
+ */
+
+describe('slate-slt1-serializer', () => {
+  describe('deserialize(falsy)', () => {
+    assert(Value.isValue(slt1.deserialize(null)))
+  })
+
+  describe('deserialize(JSON)', () => {
+    const toJson = require('./deserialize/to-json')
+    const value = slt1.deserialize(toJson.output)
+    assert(Value.isValue(value))
+    const reserialized = slt1.serialize(value)
+    assert.deepEqual(reserialized, toJson.input)
+  })
+
+  describe('deserialize(slt)', () => {
+    const dir = resolve(__dirname, './deserialize')
+    const tests = fs
+      .readdirSync(dir)
+      .filter(t => t[0] != '.')
+      .map(t => basename(t, extname(t)))
+
+    for (const test of tests) {
+      it(test, async () => {
+        const module = require(resolve(dir, test))
+        const { input, output, options } = module
+        const value = slt1.deserialize(input, options)
+        const actual = Value.isValue(value) ? value.toJSON() : value
+        const expected = Value.isValue(output) ? output.toJSON() : output
+        assert.deepEqual(actual, expected)
+      })
+    }
+  })
+
+  describe('serialize(value)', () => {
+    const dir = resolve(__dirname, './serialize')
+    const tests = fs
+      .readdirSync(dir)
+      .filter(t => t[0] != '.')
+      .map(t => basename(t, extname(t)))
+
+    for (const test of tests) {
+      it(test, async () => {
+        const module = require(resolve(dir, test))
+        const { input, output, options } = module
+        const string = slt1.serialize(input, options)
+        const actual = string
+        const expected = output
+        assert.deepEqual(actual, expected)
+        const reserialized = slt1.deserialize(actual)
+        assert.deepEqual(input.toJSON(), reserialized.toJSON())
+      })
+    }
+  })
+})

--- a/packages/slate-slt1-serializer/test/serialize/block-multiple-empty.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-multiple-empty.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph />
+      <paragraph>three</paragraph>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'paragraph', 'one'],
+  [2, 'paragraph'],
+  [2, 'paragraph', 'three'],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-multiple.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-multiple.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>three</paragraph>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'paragraph', 'one'],
+  [2, 'paragraph', 'two'],
+  [2, 'paragraph', 'three'],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-nested-multiple-empty.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-nested-multiple-empty.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>one</paragraph>
+        <paragraph>two</paragraph>
+      </quote>
+      <quote>
+        <paragraph />
+        <paragraph>four</paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'quote', [2, 'paragraph', 'one'], [2, 'paragraph', 'two']],
+  [2, 'quote', [2, 'paragraph'], [2, 'paragraph', 'four']],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-nested-multiple.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-nested-multiple.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>one</paragraph>
+        <paragraph>two</paragraph>
+      </quote>
+      <quote>
+        <paragraph>three</paragraph>
+        <paragraph>four</paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'quote', [2, 'paragraph', 'one'], [2, 'paragraph', 'two']],
+  [2, 'quote', [2, 'paragraph', 'three'], [2, 'paragraph', 'four']],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-nested-nested-multiple.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-nested-nested-multiple.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <quote>
+          <paragraph>one</paragraph>
+          <paragraph>two</paragraph>
+        </quote>
+        <quote>
+          <paragraph>three</paragraph>
+          <paragraph>four</paragraph>
+        </quote>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [
+    2,
+    'quote',
+    [2, 'quote', [2, 'paragraph', 'one'], [2, 'paragraph', 'two']],
+    [2, 'quote', [2, 'paragraph', 'three'], [2, 'paragraph', 'four']],
+  ],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-nested-with-inline-nested.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-nested-with-inline-nested.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>one</paragraph>
+        <paragraph>
+          <link>
+            <hashtag>two</hashtag>
+          </link>
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [
+    2,
+    'quote',
+    [2, 'paragraph', 'one'],
+    [2, 'paragraph', [3, 'link', [3, 'hashtag', 'two']]],
+  ],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-nested-with-inlines.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-nested-with-inlines.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          <link>one</link>
+        </paragraph>
+        <paragraph>
+          <link>two</link>
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [
+    2,
+    'quote',
+    [2, 'paragraph', [3, 'link', 'one']],
+    [2, 'paragraph', [3, 'link', 'two']],
+  ],
+]

--- a/packages/slate-slt1-serializer/test/serialize/block-with-data.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-with-data.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph thing="value">one</paragraph>
+    </document>
+  </value>
+)
+
+export const output = ['slt1', 1, [2, 'paragraph', { thing: 'value' }, 'one']]

--- a/packages/slate-slt1-serializer/test/serialize/block-with-is-void.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-with-is-void.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <image />
+    </document>
+  </value>
+)
+
+export const output = ['slt1', 1, [2, 'image', 5]]

--- a/packages/slate-slt1-serializer/test/serialize/block-with-mark.js
+++ b/packages/slate-slt1-serializer/test/serialize/block-with-mark.js
@@ -1,0 +1,15 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        on<b>e</b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = ['slt1', 1, [2, 'paragraph', ['on', ['bold', 'e']]]]

--- a/packages/slate-slt1-serializer/test/serialize/block.js
+++ b/packages/slate-slt1-serializer/test/serialize/block.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+    </document>
+  </value>
+)
+
+export const output = ['slt1', 1, [2, 'paragraph', 'one']]

--- a/packages/slate-slt1-serializer/test/serialize/inline-nested.js
+++ b/packages/slate-slt1-serializer/test/serialize/inline-nested.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          <hashtag>one</hashtag>
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'paragraph', [3, 'link', [3, 'hashtag', 'one']]],
+]

--- a/packages/slate-slt1-serializer/test/serialize/inline-with-data.js
+++ b/packages/slate-slt1-serializer/test/serialize/inline-with-data.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link thing="value">one</link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'paragraph', [3, 'link', { thing: 'value' }, 'one']],
+]

--- a/packages/slate-slt1-serializer/test/serialize/inline-with-is-void.js
+++ b/packages/slate-slt1-serializer/test/serialize/inline-with-is-void.js
@@ -1,0 +1,15 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = ['slt1', 1, [2, 'paragraph', [3, 'emoji', 5]]]

--- a/packages/slate-slt1-serializer/test/serialize/inline-with-mark.js
+++ b/packages/slate-slt1-serializer/test/serialize/inline-with-mark.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          on<b>e</b>
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = [
+  'slt1',
+  1,
+  [2, 'paragraph', [3, 'link', ['on', ['bold', 'e']]]],
+]

--- a/packages/slate-slt1-serializer/test/serialize/inline.js
+++ b/packages/slate-slt1-serializer/test/serialize/inline.js
@@ -1,0 +1,14 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>one</link>
+      </paragraph>
+    </document>
+  </value>
+)
+export const output = ['slt1', 1, [2, 'paragraph', [3, 'link', 'one']]]

--- a/packages/slate-slt1-serializer/test/serialize/tutti-frutti.js
+++ b/packages/slate-slt1-serializer/test/serialize/tutti-frutti.js
@@ -1,0 +1,49 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document order={[3, 2, 1]} article>
+      <quote big>
+        <paragraph>
+          <i very>hi</i>
+          <link src="over there">
+            <i>
+              <b>o</b>n
+            </i>e
+          </link>
+        </paragraph>
+        <paragraph>
+          <link>two</link>
+        </paragraph>
+        <paragraph>
+          <emoji nice />
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+// console.log(JSON.stringify(input.toJS(), null, 2))
+export const output = [
+  'slt1',
+  1,
+  [
+    2,
+    'quote',
+    { big: true },
+    [
+      2,
+      'paragraph',
+      [[['italic', { very: true }], 'hi']],
+      [
+        3,
+        'link',
+        { src: 'over there' },
+        [['bold', 'italic', 'o'], ['italic', 'n'], 'e'],
+      ],
+    ],
+    [2, 'paragraph', [3, 'link', 'two']],
+    [2, 'paragraph', [3, 'emoji', { nice: true }, 5]],
+  ],
+]

--- a/support/rollup/config.js
+++ b/support/rollup/config.js
@@ -11,6 +11,7 @@ import slatePropTypes from '../../packages/slate-prop-types/package.json'
 import slateReact from '../../packages/slate-react/package.json'
 import slateSchemaViolations from '../../packages/slate-schema-violations/package.json'
 import slateSimulator from '../../packages/slate-simulator/package.json'
+import slateSlt1Serializer from '../../packages/slate-slt1-serializer/package.json'
 
 const configurations = [
   ...factory(slate),
@@ -25,6 +26,7 @@ const configurations = [
   ...factory(slateReact),
   ...factory(slateSchemaViolations),
   ...factory(slateSimulator),
+  ...factory(slateSlt1Serializer),
 ]
 
 export default configurations


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

Provide a serialization format that is hopefully future-proof. See #1959 

#### How does this change work?

It provides a simple, compact, and easily extensible format to store documents. It seems to be 7-10x faster than the html (de)serializer.

The format is explained in [the Readme](https://github.com/wmertens/slate/blob/a082765d64f66367d4968cc81bf8ec324c279de0/packages/slate-slt1-serializer/Readme.md).

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [?] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1959 
Reviewers: @ianstormtaylor 


## Questions

* Currently, the format includes a tag for the document, so that other things from the value can be serialized. Will that ever be useful?
* I noticed that the `<document>` hyperscript tag doesn't accept attributes to pass to `data`. Intended?
* Would it be more useful to serialize to a string using jsurl2? Maybe add a `.toJSON` method on the result that stringifies it?