### PR TITLE
Added onKeyUp event suppor to slate-simulator and updated docs.

### DIFF
--- a/docs/reference/slate-simulator/index.md
+++ b/docs/reference/slate-simulator/index.md
@@ -83,6 +83,12 @@ Simulator a `focus` event with an `event` object.
 
 Simulator a `keyDown` event with an `event` object.
 
+### `keyUp`
+
+`keyUp(event: Object) => Simulator`
+
+Simulator a `keyUp` event with an `event` object.
+
 ### `paste`
 
 `paste(event: Object) => Simulator`

--- a/packages/slate-simulator/src/index.js
+++ b/packages/slate-simulator/src/index.js
@@ -14,6 +14,7 @@ const EVENT_HANDLERS = [
   'onDrop',
   'onFocus',
   'onKeyDown',
+  'onKeyUp',
   'onPaste',
   'onSelect',
 ]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a new feature.

#### What's the new behavior?

Now `slate-simulator` supports `onKeyUp` event.
