### PR TITLE
Fix a missing focus in test

### DIFF
--- a/packages/slate/test/changes/at-current-range/add-marks/across-marks.js
+++ b/packages/slate/test/changes/at-current-range/add-marks/across-marks.js
@@ -27,15 +27,19 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />
         Some{' '}
-        <b>
-          <u>bold</u>
-        </b>
+        <u>
+          <b>
+            <anchor />
+            bold
+          </b>
+        </u>
         <u> and some </u>
-        <i>
-          <u>ita</u>lic
-        </i>
+        <u>
+          <i>ita</i>
+        </u>
+        <focus />
+        <i>lic</i>
       </paragraph>
     </document>
   </value>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?
add-marks/across-marks.js misses a `focus` in hyperscript


#### How does this change work?
Add it back

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
