### PR TITLE
allow fromJSON to restore history

### DIFF
--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -54,6 +54,24 @@ class History extends Record(DEFAULTS) {
   }
 
   /**
+   * Create a list of `Operations` from `operations`.
+   *
+   * @param {Array<Object>|List<Object>} operations
+   * @return {List<Object>}
+   */
+
+  static createList(operations = []) {
+    if (List.isList(operations) || Array.isArray(operations)) {
+      const list = new List(operations)
+      return list
+    }
+
+    throw new Error(
+      `\`History.createList\` only accepts arrays or lists, but you passed it: ${operations}`
+    )
+  }
+
+  /**
    * Create a `History` from a JSON `object`.
    *
    * @param {Object} object
@@ -64,8 +82,8 @@ class History extends Record(DEFAULTS) {
     const { redos = [], undos = [] } = object
 
     const history = new History({
-      redos: new Stack(redos),
-      undos: new Stack(undos),
+      redos: new Stack(redos.map(this.createList)),
+      undos: new Stack(undos.map(this.createList)),
     })
 
     return history

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -60,7 +60,7 @@ class History extends Record(DEFAULTS) {
    * @return {List<Object>}
    */
 
-  static createList(operations = []) {
+  static createOperationsList(operations = []) {
     if (List.isList(operations)) {
       return operations
     }
@@ -85,8 +85,8 @@ class History extends Record(DEFAULTS) {
     const { redos = [], undos = [] } = object
 
     const history = new History({
-      redos: new Stack(redos.map(this.createList)),
-      undos: new Stack(undos.map(this.createList)),
+      redos: new Stack(redos.map(this.createOperationsList)),
+      undos: new Stack(undos.map(this.createOperationsList)),
     })
 
     return history

--- a/packages/slate/src/models/history.js
+++ b/packages/slate/src/models/history.js
@@ -61,9 +61,12 @@ class History extends Record(DEFAULTS) {
    */
 
   static createList(operations = []) {
-    if (List.isList(operations) || Array.isArray(operations)) {
-      const list = new List(operations)
-      return list
+    if (List.isList(operations)) {
+      return operations
+    }
+
+    if (Array.isArray(operations)) {
+      return new List(operations)
     }
 
     throw new Error(

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -95,13 +95,14 @@ class Value extends Record(DEFAULTS) {
    */
 
   static fromJSON(object, options = {}) {
-    let { document = {}, selection = {}, schema = {} } = object
+    let { document = {}, selection = {}, schema = {}, history = {} } = object
 
     let data = new Map()
 
     document = Document.fromJSON(document)
     selection = Range.fromJSON(selection)
     schema = Schema.fromJSON(schema)
+    history = History.fromJSON(history)
 
     // Allow plugins to set a default value for `data`.
     if (options.plugins) {
@@ -125,6 +126,7 @@ class Value extends Record(DEFAULTS) {
       document,
       selection,
       schema,
+      history,
     })
 
     if (options.normalize !== false) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Arguably adding a feature

#### What's the new behavior?

`Value.fromJSON` can now restore `history` from the given object

#### How does this change work?

Trivial

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1977 
