### PR TITLE
rebuild selection from anchorPath and focusPath if keys were dropped

### DIFF
--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -100,6 +100,18 @@ class Value extends Record(DEFAULTS) {
     let data = new Map()
 
     document = Document.fromJSON(document)
+
+    // rebuild selection from anchorPath and focusPath if keys were dropped
+    const { anchorPath, focusPath, anchorKey, focusKey } = selection
+
+    if (anchorPath !== undefined && anchorKey === undefined) {
+      selection.anchorKey = document.assertPath(anchorPath).key
+    }
+
+    if (focusPath !== undefined && focusKey === undefined) {
+      selection.focusKey = document.assertPath(focusPath).key
+    }
+
     selection = Range.fromJSON(selection)
     schema = Schema.fromJSON(schema)
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Arguably adding a feature

#### What's the new behavior?

`Value.fromJSON` can rebuild the selection `anchorKey` and `focusKey` from `anchorPath` and `focusPath` respectively if they were dropped at `Value.toJSON`

#### How does this change work?

Uses existing code from https://github.com/ianstormtaylor/slate/blob/e4ff1972d79911baf8a6aed683765b66107b09a4/packages/slate/src/operations/apply.js#L446-L454

#### Have you checked that...?

* [*] The new code matches the existing patterns and styles.
* [*] The tests pass with `yarn test`.
* [*] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [*] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1978 
