### PR TITLE
Pretends that we have fixed the zero-width selection problem

### DIFF
--- a/examples/index.css
+++ b/examples/index.css
@@ -83,6 +83,3 @@ span[data-slate-zero-width='n']:before {
   user-select: all;
 }
 
-span[data-slate-zero-width='n']::selection {
-  background-color: #aed5d7;
-}

--- a/examples/index.css
+++ b/examples/index.css
@@ -76,8 +76,6 @@ input:focus {
 
 span[data-slate-zero-width='n'] {
   user-select: all;
-  display: inline-block;
-  min-width: 1em;
 }
 
 span[data-slate-zero-width='n']:before {

--- a/examples/index.css
+++ b/examples/index.css
@@ -74,19 +74,17 @@ input:focus {
   margin-top: 1em;
 }
 
-
-span[data-slate-zero-width="n"] {
+span[data-slate-zero-width='n'] {
   user-select: all;
   display: inline-block;
   min-width: 1em;
 }
 
-span[data-slate-zero-width="n"]:before {
-  content:' ';
+span[data-slate-zero-width='n']:before {
+  content: ' ';
   user-select: all;
 }
 
-span[data-slate-zero-width="n"]::selection {
+span[data-slate-zero-width='n']::selection {
   background-color: cyan;
 }
-

--- a/examples/index.css
+++ b/examples/index.css
@@ -82,4 +82,3 @@ span[data-slate-zero-width='n']:before {
   content: ' ';
   user-select: all;
 }
-

--- a/examples/index.css
+++ b/examples/index.css
@@ -86,5 +86,5 @@ span[data-slate-zero-width='n']:before {
 }
 
 span[data-slate-zero-width='n']::selection {
-  background-color: cyan;
+  background-color: #aed5d7;
 }

--- a/examples/index.css
+++ b/examples/index.css
@@ -73,3 +73,20 @@ input:focus {
 [data-slate-editor] > * + * {
   margin-top: 1em;
 }
+
+
+span[data-slate-zero-width="n"] {
+  user-select: all;
+  display: inline-block;
+  min-width: 1em;
+}
+
+span[data-slate-zero-width="n"]:before {
+  content:' ';
+  user-select: all;
+}
+
+span[data-slate-zero-width="n"]::selection {
+  background-color: cyan;
+}
+

--- a/examples/index.css
+++ b/examples/index.css
@@ -81,4 +81,8 @@ span[data-slate-zero-width='n'] {
 span[data-slate-zero-width='n']:before {
   content: ' ';
   user-select: all;
+  display: inline-block;
+  width: 4px;
+  padding: 2px 0px;
+  margin: -2px -4px -2px 0px;
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature


Trying to work around with https://github.com/ianstormtaylor/slate/issues/1971.  Use ::before and user-select to pretend that we solves the zero-width selection problem.


* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
