### PR TITLE
Move `insertBlock`s outside of void inlines

### DIFF
--- a/packages/slate/test/changes/at-current-range/insert-block/is-inline-void.js
+++ b/packages/slate/test/changes/at-current-range/insert-block/is-inline-void.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.insertBlock('quote')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji>
+          <cursor />
+        </emoji>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji />
+      </paragraph>
+      <quote>
+        <cursor />
+      </quote>
+      <paragraph />
+    </document>
+  </value>
+)


### PR DESCRIPTION
When inserting a block, we shouldn't split void inlines -- otherwise,
they're duplicated. Instead, move the insert to either before or after
the void node.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

When inserting a block while a void inline is selected, the block will be inserted before or after the block, rather than splitting the void node.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
