### PR TITLE
Ensure no deprecate exists in slate-core development

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "release": "yarn build:production && yarn test && yarn lint && lerna publish && yarn gh-pages",
     "server": "webpack-dev-server --config ./support/webpack/config.js",
     "start": "npm-run-all --parallel --print-label watch server",
-    "test": "cross-env BABEL_ENV=test mocha --require babel-core/register ./packages/*/test/index.js",
+    "test": "cross-env BABEL_ENV=test FORBID_DEPRECATIONS=true mocha --require babel-core/register ./packages/*/test/index.js",
     "watch": "rollup --config ./support/rollup/config.js --watch"
   }
 }

--- a/packages/slate-dev-logger/src/index.js
+++ b/packages/slate-dev-logger/src/index.js
@@ -6,7 +6,11 @@
  * @type {Boolean}
  */
 
-const IS_TEST = process && process.env && process.env.BABEL_ENV === 'test'
+const FORBID_DEPRECATE =
+  process &&
+  process.env &&
+  process.env.BABEL_ENV === 'test' &&
+  !process.env.ALLOW_DEPRECATE
 
 const IS_DEV =
   typeof process !== 'undefined' &&
@@ -77,7 +81,7 @@ function warn(message, ...args) {
  */
 
 function deprecate(version, message, ...args) {
-  if (IS_TEST) {
+  if (FORBID_DEPRECATE) {
     throw new Error(`Deprecation (${version}): ${message}`)
   }
 

--- a/packages/slate-dev-logger/src/index.js
+++ b/packages/slate-dev-logger/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 /**
- * Is deprecate interface forbid?
+ * Is deprecate interface forbidden?
  */
 
 const FORBID_DEPRECATE =

--- a/packages/slate-dev-logger/src/index.js
+++ b/packages/slate-dev-logger/src/index.js
@@ -6,7 +6,7 @@
  * @type {Boolean}
  */
 
-const IS_TEST = process.env && process.env.BABEL_ENV === 'test'
+const IS_TEST = process && process.env && process.env.BABEL_ENV === 'test'
 
 const IS_DEV =
   typeof process !== 'undefined' &&

--- a/packages/slate-dev-logger/src/index.js
+++ b/packages/slate-dev-logger/src/index.js
@@ -1,16 +1,17 @@
 /* eslint-disable no-console */
 
 /**
+ * Is deprecate interface forbid?
+ */
+
+const FORBID_DEPRECATE =
+  process && process.env && process.env.FORBID_DEPRECATIONS
+
+/**
  * Is in development?
  *
  * @type {Boolean}
  */
-
-const FORBID_DEPRECATE =
-  process &&
-  process.env &&
-  process.env.BABEL_ENV === 'test' &&
-  !process.env.ALLOW_DEPRECATE
 
 const IS_DEV =
   typeof process !== 'undefined' &&

--- a/packages/slate-dev-logger/src/index.js
+++ b/packages/slate-dev-logger/src/index.js
@@ -6,6 +6,8 @@
  * @type {Boolean}
  */
 
+const IS_TEST = process.env && process.env.BABEL_ENV === 'test'
+
 const IS_DEV =
   typeof process !== 'undefined' &&
   process.env &&
@@ -75,6 +77,10 @@ function warn(message, ...args) {
  */
 
 function deprecate(version, message, ...args) {
+  if (IS_TEST) {
+    throw new Error(`Deprecation (${version}): ${message}`)
+  }
+
   log('warn', `Deprecation (${version}): ${message}`, ...args)
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

Calling deprecated interface during development & test mode will throw an Error.  This ensures that, after each interface change, all tested functions  in `slate/packages` are converted from old interface to new interface.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
