### PR TITLE
fix getFragmentAtRange to use paths properly

### DIFF
--- a/packages/slate/test/models/node/get-fragment-at-range.js
+++ b/packages/slate/test/models/node/get-fragment-at-range.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+import assert from 'assert'
+
+export default function() {
+  const value = (
+    <value>
+      <document>
+        <paragraph>
+          one <anchor />two<focus /> three
+        </paragraph>
+      </document>
+    </value>
+  )
+
+  const { document, selection } = value
+  const actual = document.getFragmentAtRange(selection)
+  const expected = (
+    <document>
+      <paragraph>two</paragraph>
+    </document>
+  )
+
+  const a = actual.toJSON()
+  const e = expected.toJSON()
+  assert.deepEqual(a, e)
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug.

#### What's the new behavior?

Fixes `Node.getFragmentAtRange` to use the proper argument signature when calling `Node.splitNode`, and refactors it to use paths for all of its logic.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2009
