### PR TITLE
Docs: Remove leading semicolon in code snippet

### DIFF
--- a/docs/guides/changes.md
+++ b/docs/guides/changes.md
@@ -112,7 +112,7 @@ class Image extends React.Component {
   }
 
   render() {
-    ;<img {...this.props.attributes} onClick={this.onClick} />
+    <img {...this.props.attributes} onClick={this.onClick} />
   }
 }
 ```

--- a/docs/guides/changes.md
+++ b/docs/guides/changes.md
@@ -112,7 +112,7 @@ class Image extends React.Component {
   }
 
   render() {
-    <img {...this.props.attributes} onClick={this.onClick} />
+    return <img {...this.props.attributes} onClick={this.onClick} />
   }
 }
 ```


### PR DESCRIPTION
Hey,
just started working with Slate.js, so far it looks pretty amazing! 🎉 ❤️ 

I think I found a bug in the docs.
In the [guides/changes](https://docs.slatejs.org/guides/changes) it says:
```jsx
render() {
    ;<img {...this.props.attributes} onClick={this.onClick} />
}
```
I suppose that the leading `;` is not intended so I attached a fix where I removed it.
Hope that's alright.

Thanks!

---

#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixes a bug.

#### What's the new behavior?
Doesn't change the behaviour, just fixes a typo in the docs.

#### How does this change work?
See above.

#### Have you checked that...?
I did not change the code.

* [ ] ~The new code matches the existing patterns and styles.~
* [ ] ~The tests pass with `yarn test`.~
* [ ] ~The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)~
* [ ] ~The relevant examples still work. (Run examples with `yarn watch`.)~

#### Does this fix any issues or need any specific reviewers?
Hm I don't think so, no.
