### PR TITLE
fix selection operations being duplicated

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -102,14 +102,14 @@ const TabList = styled('div')`
   }
 `
 
-const Tab = styled(RouterLink)`
+const Tab = styled(({ active, ...props }) => <RouterLink {...props} />)`
   display: inline-block;
   margin-bottom: 0.2em;
   padding: 0.2em 0.5em;
   border-radius: 0.2em;
   text-decoration: none;
-  color: ${props => (props.active ? 'white' : '#777')};
-  background: ${props => (props.active ? '#333' : 'transparent')};
+  color: ${p => (p.active ? 'white' : '#777')};
+  background: ${p => (p.active ? '#333' : 'transparent')};
 
   &:hover {
     background: #333;

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -347,6 +347,7 @@ function AfterPlugin() {
     const entire = selection
       .moveAnchorTo(point.key, start)
       .moveFocusTo(point.key, end)
+      .normalize(document)
 
     // Change the current value to have the leaf's text replaced.
     change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -60,7 +60,7 @@ function findRange(native, value) {
     }
   }
 
-  const range = Range.create({
+  let range = Range.create({
     anchorKey: anchor.key,
     anchorOffset: anchor.offset,
     focusKey: focus.key,
@@ -69,6 +69,7 @@ function findRange(native, value) {
     isFocused: true,
   })
 
+  range = range.normalize(value.document)
   return range
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug.

#### What's the new behavior?

Fixes selection operations from being duplicated.

#### How does this change work?

Previously the selection properties were compared by reference, but paths are immutable `List` objects, which always show up as having changed, resulting in extra selection operations that without any real changes. We now use `Immutable.is` to remove those duplicates, fixing the undo history stack.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2006

