### PR TITLE
Docs: Fix typo in guides/rendering

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -120,7 +120,7 @@ function renderPlaceholder(props) {
 />
 ```
 
-That will render a simple placeholder element inside all of the your `caption` blocks until someone decides to write in a caption.
+That will render a simple placeholder element inside all of your `caption` blocks until someone decides to write in a caption.
 
 ## The Editor Itself
 


### PR DESCRIPTION
@ianstormtaylor found another typo, see below.
~If you want you can keep this PR open (in case I find another typo) and I'll ping you(/whoever else) when I am done reading the docs?~ **edit** nvm think I read all articles

Really loving the docs so far and looking forward to working with Slate! 👏 👍 ⚡️ 

---

In [guides/rendering#Placeholders](https://docs.slatejs.org/guides/rendering#placeholders):
> That will render a simple placeholder element inside all of **~the~ your** caption blocks until someone decides to write in a caption.

---



#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug/typo in the docs.

#### What's the new behavior?
This fixes a typo in the docs.

#### How does this change work?
See above.

#### Have you checked that...?
No.

* [X] ~The new code matches the existing patterns and styles.~
* [X] ~The tests pass with `yarn test`.~
* [X] ~The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)~
* [X] ~The relevant examples still work. (Run examples with `yarn watch`.)~

#### Does this fix any issues or need any specific reviewers?
No, I don't think so.