### PR TITLE
Adds Unicode LF character to line endings for clipboard plaintext

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -1,4 +1,6 @@
 import Base64 from 'slate-base64-serializer'
+import Plain from 'slate-plain-serializer'
+import { Value } from 'slate'
 import TRANSFER_TYPES from '../constants/transfer-types'
 import getWindow from 'get-window'
 import findDOMNode from './find-dom-node'
@@ -82,16 +84,15 @@ function cloneFragment(event, value, fragment = value.fragment) {
 
   attach.setAttribute('data-slate-fragment', encoded)
   
-  //  Builds plaintext object for clipboard line by line using top-level nodes.
-  //  Adds '\u000A' (unicode LF) to end of each line except the last.
-  //  This prevents line breaks from being lost when pasting to targets
-  //  which don't support html input.
-  let plainText = ''
-
-  for (let i = 0; i < contents.childNodes.length; i++) {
-    plainText += contents.childNodes[i].innerText
-    if (i < contents.childNodes.length - 1) plainText += '\u000A'
-  }
+  //  Creates value from only the selected blocks
+  //  Then gets plaintext for clipboard with proper linebreaks for BLOCK elements
+  //  Via Plain serializer
+  const valFromSelection = Value.create({
+    document: {
+      nodes: value.blocks,
+    },
+  })
+  const plainText = Plain.serialize(valFromSelection)
 
   // Add the phony content to a div element. This is needed to copy the
   // contents into the html clipboard register.

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -87,11 +87,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   //  Creates value from only the selected blocks
   //  Then gets plaintext for clipboard with proper linebreaks for BLOCK elements
   //  Via Plain serializer
-  const valFromSelection = Value.create({
-    document: {
-      nodes: value.blocks,
-    },
-  })
+  const valFromSelection = Value.create({ document: fragment })
   const plainText = Plain.serialize(valFromSelection)
 
   // Add the phony content to a div element. This is needed to copy the

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -83,7 +83,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   }
 
   attach.setAttribute('data-slate-fragment', encoded)
-  
+
   //  Creates value from only the selected blocks
   //  Then gets plaintext for clipboard with proper linebreaks for BLOCK elements
   //  Via Plain serializer

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -81,6 +81,17 @@ function cloneFragment(event, value, fragment = value.fragment) {
   }
 
   attach.setAttribute('data-slate-fragment', encoded)
+  
+  //  Builds plaintext object for clipboard line by line using top-level nodes.
+  //  Adds '\u000A' (unicode LF) to end of each line except the last.
+  //  This prevents line breaks from being lost when pasting to targets
+  //  which don't support html input.
+  let plainText = ''
+
+  for (let i = 0; i < contents.childNodes.length; i++) {
+    plainText += contents.childNodes[i].innerText
+    if (i < contents.childNodes.length - 1) plainText += '\u000A'
+  }
 
   // Add the phony content to a div element. This is needed to copy the
   // contents into the html clipboard register.
@@ -95,7 +106,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
   // (mapped to 'text/url-list'); so, we should only enter block if !IS_IE
   if (event.clipboardData && event.clipboardData.setData && !IS_IE) {
     event.preventDefault()
-    event.clipboardData.setData(TEXT, div.textContent)
+    event.clipboardData.setData(TEXT, plainText)
     event.clipboardData.setData(FRAGMENT, encoded)
     event.clipboardData.setData(HTML, div.innerHTML)
     return


### PR DESCRIPTION
This addresses https://github.com/ianstormtaylor/slate/issues/1932

I do not believe this will break any existing functionality. In my testing I could not find any issues with this solution so far.