### PR TITLE
Do not use requestAnimation if DataTransfer is available

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -6,8 +6,8 @@ import React from 'react'
 import getWindow from 'get-window'
 import { Block, Inline, Text } from 'slate'
 import Hotkeys from 'slate-hotkeys'
-import EVENT_HANDLERS from '../constants/event-handlers'
 
+import EVENT_HANDLERS from '../constants/event-handlers'
 import Content from '../components/content'
 import cloneFragment from '../utils/clone-fragment'
 import findDOMNode from '../utils/find-dom-node'
@@ -598,7 +598,6 @@ function AfterPlugin() {
 
   function renderEditor(props, editor) {
     const handlers = EVENT_HANDLERS.reduce((obj, handler) => {
-      const { handlers } = editor
       obj[handler] = editor[handler]
       return obj
     }, {})

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -116,11 +116,9 @@ function AfterPlugin() {
   function onCut(event, change, editor) {
     debug('onCut', { event })
 
-    const callback = cloneFragment(event, change.value)
-
     // Once the fake cut content has successfully been added to the clipboard,
     // delete the content in the current selection.
-    callback(() => {
+    cloneFragment(event, change.value, change.value.fragment, () => {
       // If user cuts a void block node or a void inline node,
       // manually removes it since selection is collapsed in this case.
       const { value } = change

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -7,7 +7,6 @@ import getWindow from 'get-window'
 import { Block, Inline, Text } from 'slate'
 import Hotkeys from 'slate-hotkeys'
 
-import EVENT_HANDLERS from '../constants/event-handlers'
 import Content from '../components/content'
 import cloneFragment from '../utils/clone-fragment'
 import findDOMNode from '../utils/find-dom-node'
@@ -116,12 +115,11 @@ function AfterPlugin() {
   function onCut(event, change, editor) {
     debug('onCut', { event })
 
-    cloneFragment(event, change.value)
-    const window = getWindow(event.target)
+    const callback = cloneFragment(event, change.value)
 
     // Once the fake cut content has successfully been added to the clipboard,
     // delete the content in the current selection.
-    window.requestAnimationFrame(() => {
+    callback(() => {
       // If user cuts a void block node or a void inline node,
       // manually removes it since selection is collapsed in this case.
       const { value } = change
@@ -598,10 +596,7 @@ function AfterPlugin() {
    */
 
   function renderEditor(props, editor) {
-    const handlers = EVENT_HANDLERS.reduce((obj, handler) => {
-      obj[handler] = editor[handler]
-      return obj
-    }, {})
+    const { handlers } = editor
 
     return (
       <Content

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -6,6 +6,7 @@ import React from 'react'
 import getWindow from 'get-window'
 import { Block, Inline, Text } from 'slate'
 import Hotkeys from 'slate-hotkeys'
+import EVENT_HANDLERS from '../constants/event-handlers'
 
 import Content from '../components/content'
 import cloneFragment from '../utils/clone-fragment'
@@ -596,7 +597,11 @@ function AfterPlugin() {
    */
 
   function renderEditor(props, editor) {
-    const { handlers } = editor
+    const handlers = EVENT_HANDLERS.reduce((obj, handler) => {
+      const { handlers } = editor
+      obj[handler] = editor[handler]
+      return obj
+    }, {})
 
     return (
       <Content

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -2,6 +2,7 @@ import Debug from 'debug'
 import getWindow from 'get-window'
 import { findDOMNode } from 'react-dom'
 import Hotkeys from 'slate-hotkeys'
+import EVENT_HANDLERS from '../constants/event-handlers'
 import {
   IS_FIREFOX,
   IS_IE,

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -2,7 +2,6 @@ import Debug from 'debug'
 import getWindow from 'get-window'
 import { findDOMNode } from 'react-dom'
 import Hotkeys from 'slate-hotkeys'
-import EVENT_HANDLERS from '../constants/event-handlers'
 import {
   IS_FIREFOX,
   IS_IE,

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -106,7 +106,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
     event.clipboardData.setData(TEXT, plainText)
     event.clipboardData.setData(FRAGMENT, encoded)
     event.clipboardData.setData(HTML, div.innerHTML)
-    return
+    return callback => callback()
   }
 
   // COMPAT: For browser that don't support the Clipboard API's setData method,
@@ -120,11 +120,14 @@ function cloneFragment(event, value, fragment = value.fragment) {
   native.selectAllChildren(div)
 
   // Revert to the previous selection right after copying.
-  window.requestAnimationFrame(() => {
-    editor.removeChild(div)
-    removeAllRanges(native)
-    native.addRange(range)
-  })
+  return callback => {
+    window.requestAnimationFrame(() => {
+      editor.removeChild(div)
+      removeAllRanges(native)
+      native.addRange(range)
+      callback()
+    })
+  }
 }
 
 export default cloneFragment

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -18,7 +18,12 @@ const { FRAGMENT, HTML, TEXT } = TRANSFER_TYPES
  * @param {Document} [fragment]
  */
 
-function cloneFragment(event, value, fragment = value.fragment) {
+function cloneFragment(
+  event,
+  value,
+  fragment = value.fragment,
+  callback = () => undefined
+) {
   const window = getWindow(event.target)
   const native = window.getSelection()
   const { start, end } = value.selection
@@ -106,7 +111,7 @@ function cloneFragment(event, value, fragment = value.fragment) {
     event.clipboardData.setData(TEXT, plainText)
     event.clipboardData.setData(FRAGMENT, encoded)
     event.clipboardData.setData(HTML, div.innerHTML)
-    return callback => callback()
+    callback()
   }
 
   // COMPAT: For browser that don't support the Clipboard API's setData method,
@@ -120,14 +125,12 @@ function cloneFragment(event, value, fragment = value.fragment) {
   native.selectAllChildren(div)
 
   // Revert to the previous selection right after copying.
-  return callback => {
-    window.requestAnimationFrame(() => {
-      editor.removeChild(div)
-      removeAllRanges(native)
-      native.addRange(range)
-      callback()
-    })
-  }
+  window.requestAnimationFrame(() => {
+    editor.removeChild(div)
+    removeAllRanges(native)
+    native.addRange(range)
+    callback()
+  })
 }
 
 export default cloneFragment


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

We are using dataTransfer for chrome, firefox and other modern browsers in clone-fragment.  Therefore, for these browsers, we do not need to call editor.change with `window.requestAnimation`.  

Calling `window.requestAnimation` sometimes makes the code hard to debug, and we cannot ensure there is no another React state change between `window.requestAnimation` in React v16 (as React.requestIdleCallback + queue are very unpredictable)

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
