### PR TITLE
Use run-p instead of npm-run-all --parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "prettier": "prettier --write '**/*.{js,jsx,md,json,css}'",
     "release": "yarn build:production && yarn test && yarn lint && lerna publish && yarn gh-pages",
     "server": "webpack-dev-server --config ./support/webpack/config.js",
-    "start": "npm-run-all --parallel --print-label watch server",
+    "start": "run-p --print-label watch server",
     "test": "cross-env BABEL_ENV=test FORBID_DEPRECATIONS=true mocha --require babel-core/register ./packages/*/test/index.js",
     "test:coverage": "cross-env NODE_ENV=test nyc yarn test",
     "watch": "rollup --config ./support/rollup/config.js --watch"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

`run-p` is alias of `npm-run-all --parallel` provided in `npm-run-all`.  Perhaps `run-p` is a bit better here because it is shorter


#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
