### PR TITLE
refactor native beforeinput handling

### DIFF
--- a/packages/slate-dev-environment/src/index.js
+++ b/packages/slate-dev-environment/src/index.js
@@ -73,7 +73,7 @@ const FEATURE_RULES = [
   [
     'inputeventslevel2',
     window => {
-      const element = document.createElement('div')
+      const element = window.document.createElement('div')
       element.contentEditable = true
       const support = 'onbeforeinput' in element
       return support

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -2,12 +2,7 @@ import Debug from 'debug'
 import React from 'react'
 import Types from 'prop-types'
 import getWindow from 'get-window'
-import {
-  IS_FIREFOX,
-  IS_IOS,
-  IS_ANDROID,
-  HAS_INPUT_EVENTS_LEVEL_2,
-} from 'slate-dev-environment'
+import { IS_FIREFOX, HAS_INPUT_EVENTS_LEVEL_2 } from 'slate-dev-environment'
 import logger from 'slate-dev-logger'
 import throttle from 'lodash/throttle'
 

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -6,7 +6,6 @@ import {
   IS_FIREFOX,
   IS_IE,
   IS_IOS,
-  IS_ANDROID,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
 

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -7,7 +7,7 @@ import {
   IS_IE,
   IS_IOS,
   IS_ANDROID,
-  SUPPORTED_EVENTS,
+  HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
 
 import findNode from '../utils/find-node'
@@ -44,15 +44,12 @@ function BeforePlugin() {
   function onBeforeInput(event, change, editor) {
     if (editor.props.readOnly) return true
 
-    // COMPAT: React's `onBeforeInput` synthetic event is based on the native
-    // `keypress` and `textInput` events. In browsers that support the native
-    // `beforeinput` event, we instead use that event to trigger text insertion,
-    // since it provides more useful information about the range being affected
-    // and also preserves compatibility with iOS autocorrect, which would be
-    // broken if we called `preventDefault()` on React's synthetic event here.
-    // Since native `onbeforeinput` mainly benefits autocorrect and spellcheck
-    // for mobile, on desktop it brings IME issue, limit its scope for now.
-    if ((IS_IOS || IS_ANDROID) && SUPPORTED_EVENTS.beforeinput) return true
+    const isSynthetic = !!event.nativeEvent
+
+    // COMPAT: If the browser supports Input Events Level 2, we will have
+    // attached a custom handler for the real `beforeinput` events, instead of
+    // allowing React's synthetic polyfill, so we need to ignore synthetics.
+    if (isSynthetic && HAS_INPUT_EVENTS_LEVEL_2) return true
 
     debug('onBeforeInput', { event })
   }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Debt.

#### What's the new behavior?

Moves the native `beforeinput` event handling into the `Before/AfterPlugin` and out of the `<Content>` component, so that all event handling remains in plugins.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2059
