### PR TITLE
[hyperscript] rename decorators option in params to decorations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,12 +9,12 @@
 <br/>
 
 <p align="center">
-  <a href="#why"><strong>Why?</strong></a> · 
-  <a href="#principles"><strong>Principles</strong></a> · 
-  <a href="http://slatejs.org"><strong>Demo</strong></a> · 
-  <a href="#examples"><strong>Examples</strong></a> · 
-  <a href="./docs/general/plugins.md"><strong>Plugins</strong></a> · 
-  <a href="http://docs.slatejs.org"><strong>Documentation</strong></a> · 
+  <a href="#why"><strong>Why?</strong></a> ·
+  <a href="#principles"><strong>Principles</strong></a> ·
+  <a href="http://slatejs.org"><strong>Demo</strong></a> ·
+  <a href="#examples"><strong>Examples</strong></a> ·
+  <a href="./docs/general/plugins.md"><strong>Plugins</strong></a> ·
+  <a href="http://docs.slatejs.org"><strong>Documentation</strong></a> ·
   <a href="./Contributing.md"><strong>Contributing!</strong></a>
 </p>
 <br/>
@@ -26,7 +26,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/slate">
     <img src="https://img.shields.io/npm/dt/localeval.svg?maxAge=3600">
-  </a> 
+  </a>
   <a href="https://unpkg.com/slate/dist/slate.min.js">
     <img src="http://img.badgesize.io/https://unpkg.com/slate/dist/slate.min.js?compression=gzip&amp;label=slate">
   </a>
@@ -35,19 +35,19 @@
   </a>
   <a href="https://travis-ci.org/ianstormtaylor/slate">
     <img src="https://travis-ci.org/ianstormtaylor/slate.svg?branch=master">
-  </a> 
+  </a>
   <a href="https://slate-slack.herokuapp.com">
     <img src="https://slate-slack.herokuapp.com/badge.svg">
-  <a/> 
+  </a>
   <a href="./packages/slate/package.json">
     <img src="https://img.shields.io/npm/v/slate.svg?maxAge=3600&label=slate&colorB=007ec6">
-  </a> 
+  </a>
   <a href="./packages/slate-react/package.json">
     <img src="https://img.shields.io/npm/v/slate-react.svg?maxAge=3600&label=slate-react&colorB=007ec6">
-  </a> 
+  </a>
   <a href="./License.md">
     <img src="https://img.shields.io/npm/l/slate.svg?maxAge=3600">
-  </a> 
+  </a>
 </p>
 <br/>
 
@@ -127,7 +127,7 @@ To get a sense for how you might use Slate, check out a few of the examples:
 * [**Hovering menu**](./examples/hovering-menu) — showing how a contextual hovering menu can be implemented.
 * [**Tables**](./examples/tables) — showing how to nest blocks to render more advanced components.
 * [**Paste HTML**](./examples/paste-html) — showing how to use an HTML serializer to handle pasted HTML.
-* [**Code Highlighting**](./examples/code-highlighting) — showing how to use decorators to dynamically mark text.
+* [**Code Highlighting**](./examples/code-highlighting) — showing how to use decorations to dynamically mark text.
 * [**See all the examples...**](./examples)
 
 If you have an idea for an example that shows a common use case, pull request it!

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -70,7 +70,7 @@ To get a sense for how you might use Slate, check out a few of the examples:
 * [**Hovering menu**](https://github.com/ianstormtaylor/slate/tree/master/examples/hovering-menu) — showing how a contextual hovering menu can be implemented.
 * [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/examples/tables) — showing how to nest blocks to render more advanced components.
 * [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/examples/paste-html) — showing how to use an HTML serializer to handle pasted HTML.
-* [**Code Highlighting**](https://github.com/ianstormtaylor/slate/tree/master/examples/code-highlighting) — showing how to use decorators to dynamically mark text.
+* [**Code Highlighting**](https://github.com/ianstormtaylor/slate/tree/master/examples/code-highlighting) — showing how to use decorations to dynamically mark text.
 
 If you have an idea for an example that shows a common use case, pull request it!
 

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -13,7 +13,7 @@ This directory contains a set of examples that give you an idea for how you migh
 * [**Hovering menu**](./hovering-menu) — showing how a contextual hovering menu can be implemented.
 * [**Tables**](./tables) — showing how to nest blocks to render more advanced components.
 * [**Paste HTML**](./paste-html) — showing how to use an HTML serializer to handle pasted HTML.
-* [**Code Highlighting**](./code-highlighting) — showing how to use decorators to dynamically mark text.
+* [**Code Highlighting**](./code-highlighting) — showing how to use decorations to dynamically mark text.
 * ...and more!
 
 If you have an idea for an example that shows a common use case, pull request it!

--- a/examples/markdown-preview/index.js
+++ b/examples/markdown-preview/index.js
@@ -26,7 +26,7 @@ class MarkdownPreview extends React.Component {
 
   state = {
     value: Plain.deserialize(
-      'Slate is flexible enough to add **decorators** that can format text based on its content. For example, this editor has **Markdown** preview decorators on it, to make it _dead_ simple to make an editor with built-in Markdown previewing.\n## Try it out!\nTry it out for yourself!'
+      'Slate is flexible enough to add **decorations** that can format text based on its content. For example, this editor has **Markdown** preview decorations on it, to make it _dead_ simple to make an editor with built-in Markdown previewing.\n## Try it out!\nTry it out for yourself!'
     ),
   }
 

--- a/packages/slate-hyperscript/src/index.js
+++ b/packages/slate-hyperscript/src/index.js
@@ -445,7 +445,7 @@ function createChildren(children, options = {}) {
  */
 
 function resolveCreators(options) {
-  const { blocks = {}, inlines = {}, marks = {}, decorators = {} } = options
+  const { blocks = {}, inlines = {}, marks = {}, decorations = {} } = options
 
   const creators = {
     ...CREATORS,
@@ -464,8 +464,8 @@ function resolveCreators(options) {
     creators[key] = normalizeMark(key, marks[key])
   })
 
-  Object.keys(decorators).map(key => {
-    creators[key] = normalizeNode(key, decorators[key], 'decoration')
+  Object.keys(decorations).map(key => {
+    creators[key] = normalizeNode(key, decorations[key], 'decoration')
   })
 
   return creators

--- a/packages/slate-hyperscript/test/decorations/across-blocks.js
+++ b/packages/slate-hyperscript/test/decorations/across-blocks.js
@@ -6,7 +6,7 @@ const h = createHyperscript({
   blocks: {
     paragraph: 'paragraph',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/decorations/across-marks.js
+++ b/packages/slate-hyperscript/test/decorations/across-marks.js
@@ -9,7 +9,7 @@ const h = createHyperscript({
   marks: {
     b: 'bold',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/decorations/deep-anchors.js
+++ b/packages/slate-hyperscript/test/decorations/deep-anchors.js
@@ -7,7 +7,7 @@ const h = createHyperscript({
     ul: 'ul',
     li: 'li',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/decorations/intersecting-marks.js
+++ b/packages/slate-hyperscript/test/decorations/intersecting-marks.js
@@ -9,7 +9,7 @@ const h = createHyperscript({
   marks: {
     b: 'bold',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/decorations/multiple.js
+++ b/packages/slate-hyperscript/test/decorations/multiple.js
@@ -6,7 +6,7 @@ const h = createHyperscript({
   blocks: {
     paragraph: 'paragraph',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
     lowlight: 'lowlight',
   },

--- a/packages/slate-hyperscript/test/decorations/nested.js
+++ b/packages/slate-hyperscript/test/decorations/nested.js
@@ -6,7 +6,7 @@ const h = createHyperscript({
   blocks: {
     paragraph: 'paragraph',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/decorations/overlapping.js
+++ b/packages/slate-hyperscript/test/decorations/overlapping.js
@@ -6,7 +6,7 @@ const h = createHyperscript({
   blocks: {
     paragraph: 'paragraph',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/fixtures/decoration-across-blocks.js
+++ b/packages/slate-hyperscript/test/fixtures/decoration-across-blocks.js
@@ -6,7 +6,7 @@ const h = createHyperscript({
   blocks: {
     paragraph: 'paragraph',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate-hyperscript/test/fixtures/decoration.js
+++ b/packages/slate-hyperscript/test/fixtures/decoration.js
@@ -6,7 +6,7 @@ const h = createHyperscript({
   blocks: {
     paragraph: 'paragraph',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })

--- a/packages/slate/test/helpers/h.js
+++ b/packages/slate/test/helpers/h.js
@@ -28,7 +28,7 @@ const h = createHyperscript({
     u: 'underline',
     fontSize: 'font-size',
   },
-  decorators: {
+  decorations: {
     highlight: 'highlight',
   },
 })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Debt.

#### What's the new behavior?

`createHyperscript` takes an options object that now looks for the `decorations` property instead of the `decorators` property

#### How does this change work?

Pretty straightforward rename of an option, then all of its uses and wherever the term decorators showed up in docs

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1996
Reviewers: @ianstormtaylor 
