### PR TITLE
Introduce Range.updatePoints

### DIFF
--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -276,33 +276,6 @@ class Point extends Record(DEFAULTS) {
     return point
   }
 
-  /*
-   * After node change, refind the new Path with the information of old Path
-   * @param {Node} node
-   * @return {Point}
-  */
-
-  refindPath(node) {
-    const { path, key } = this
-    const newPath = node.refindPath(path, key)
-
-    if (!newPath) {
-      logger.warn("A point's `key` invalid and was reset:", this)
-      const text = node.getFirstText()
-      if (!text) return Point.create()
-
-      const point = this.merge({
-        key: text.key,
-        offset: 0,
-        path: node.getPath(text.key),
-      })
-
-      return point
-    }
-
-    return this.set('path', newPath)
-  }
-
   /**
    * Normalize the point relative to a `node`, ensuring that its key and path
    * reference a text node, or that it gets unset.

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -276,6 +276,33 @@ class Point extends Record(DEFAULTS) {
     return point
   }
 
+  /*
+   * After node change, refind the new Path with the information of old Path
+   * @param {Node} node
+   * @return {Point}
+  */
+
+  refindPath(node) {
+    const { path, key } = this
+    const newPath = node.refindPath(path, key)
+
+    if (!newPath) {
+      logger.warn("A point's `key` invalid and was reset:", this)
+      const text = node.getFirstText()
+      if (!text) return Point.create()
+
+      const point = this.merge({
+        key: text.key,
+        offset: 0,
+        path: node.getPath(text.key),
+      })
+
+      return point
+    }
+
+    return this.set('path', newPath)
+  }
+
   /**
    * Normalize the point relative to a `node`, ensuring that its key and path
    * reference a text node, or that it gets unset.

--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -212,8 +212,9 @@ class Range extends Record(DEFAULTS) {
 
   get isCollapsed() {
     return (
-      this.anchor.key === this.focus.key &&
-      this.anchor.offset === this.focus.offset
+      this.anchor === this.focus ||
+      (this.anchor.key === this.focus.key &&
+        this.anchor.offset === this.focus.offset)
     )
   }
 
@@ -321,12 +322,7 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveForward(n) {
-    const range = this.setPoints([
-      this.anchor.moveForward(n),
-      this.focus.moveForward(n),
-    ])
-
-    return range
+    return this.updatePoints(point => point.moveForward(n))
   }
 
   /**
@@ -337,12 +333,7 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveBackward(n) {
-    const range = this.setPoints([
-      this.anchor.moveBackward(n),
-      this.focus.moveBackward(n),
-    ])
-
-    return range
+    return this.updatePoints(point => point.moveBackward(n))
   }
 
   /**
@@ -609,12 +600,7 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveTo(path, offset) {
-    const range = this.setPoints([
-      this.anchor.moveTo(path, offset),
-      this.focus.moveTo(path, offset),
-    ])
-
-    return range
+    return this.updatePoints(point => point.moveTo(path, offset))
   }
 
   /**
@@ -647,12 +633,7 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveToEndOfNode(node) {
-    const range = this.setPoints([
-      this.anchor.moveToEndOfNode(node),
-      this.focus.moveToEndOfNode(node),
-    ])
-
-    return range
+    return this.updatePoints(point => point.moveToEndOfNode(node))
   }
 
   /**
@@ -702,12 +683,7 @@ class Range extends Record(DEFAULTS) {
    */
 
   moveToStartOfNode(node) {
-    const range = this.setPoints([
-      this.anchor.moveToStartOfNode(node),
-      this.focus.moveToStartOfNode(node),
-    ])
-
-    return range
+    return this.updatePoints(point => point.moveToStartOfNode(node))
   }
 
   /**
@@ -719,12 +695,7 @@ class Range extends Record(DEFAULTS) {
    */
 
   normalize(node) {
-    const range = this.setPoints([
-      this.anchor.normalize(node),
-      this.focus.normalize(node),
-    ])
-
-    return range
+    return this.updatePoints(point => point.normalize(node))
   }
 
   /**
@@ -811,6 +782,13 @@ class Range extends Record(DEFAULTS) {
     const range = this.set('anchor', anchor).set('focus', focus)
     return range
   }
+
+  /**
+   * Set the anchor and focus points with `updator` callback
+   *
+   * @param {Function} updator
+   * @return {Range}
+   */
 
   updatePoints(updator) {
     let { anchor, focus } = this

--- a/packages/slate/src/models/range.js
+++ b/packages/slate/src/models/range.js
@@ -812,6 +812,13 @@ class Range extends Record(DEFAULTS) {
     return range
   }
 
+  updatePoints(updator) {
+    let { anchor, focus } = this
+    anchor = updator(anchor)
+    focus = updator(focus)
+    return this.merge({ anchor, focus })
+  }
+
   /**
    * Set the start point to a new `point`.
    *

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -588,9 +588,9 @@ class Value extends Record(DEFAULTS) {
     document = document.insertNode(path, node)
     value = value.set('document', document)
 
-    value = value.mapRanges(range => {
-      return range.updatePoints(point => point.refindPath(document))
-    })
+    value = value.mapRanges(range =>
+      range.updatePoints(point => point.setPath(null))
+    )
 
     return value
   }
@@ -696,12 +696,9 @@ class Value extends Record(DEFAULTS) {
     document = document.moveNode(path, newPath, newIndex)
     value = value.set('document', document)
 
-    value = value.mapRanges(range => {
-      return range.setPoints([
-        range.anchor.setPath(null),
-        range.focus.setPath(null),
-      ])
-    })
+    value = value.mapRanges(range =>
+      range.updatePoints(point => point.setPath(null))
+    )
 
     return value
   }
@@ -758,12 +755,7 @@ class Value extends Record(DEFAULTS) {
           : next ? range.moveEndTo(next.key, 0) : Range.create()
       }
 
-      range = range.setPoints(
-        [range.anchor, range.focus].map(
-          point =>
-            point.key ? point.refindPath(document) : point.setPath(null)
-        )
-      )
+      range = range.updatePoints(point => point.setPath(null))
 
       return range
     })

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -913,7 +913,7 @@ class Value extends Record(DEFAULTS) {
     const { document, selection, decorations } = value
 
     if (selection) {
-      let next = selection.isSet ? iterator(selection, document) : selection
+      let next = selection.isSet ? iterator(selection) : selection
       if (!next) next = Range.create()
       if (next !== selection) next = document.createRange(next)
       value = value.set('selection', next)
@@ -921,7 +921,7 @@ class Value extends Record(DEFAULTS) {
 
     if (decorations) {
       let next = decorations.map(decoration => {
-        let n = decoration.isSet ? iterator(decoration, document) : decoration
+        let n = decoration.isSet ? iterator(decoration) : decoration
         if (n && n !== decoration) n = document.createRange(n)
         return n
       })

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -909,28 +909,28 @@ class Value extends Record(DEFAULTS) {
    */
 
   mapRanges(iterator) {
-    return this.withMutations(value => {
-      const { document, selection, decorations } = value
+    let value = this
+    const { document, selection, decorations } = value
 
-      if (selection) {
-        let next = selection.isSet ? iterator(selection, document) : selection
-        if (!next) next = Range.create()
-        if (next !== selection) next = document.createRange(next)
-        value.set('selection', next)
-      }
+    if (selection) {
+      let next = selection.isSet ? iterator(selection, document) : selection
+      if (!next) next = Range.create()
+      if (next !== selection) next = document.createRange(next)
+      value = value.set('selection', next)
+    }
 
-      if (decorations) {
-        let next = decorations.map(decoration => {
-          let n = decoration.isSet ? iterator(decoration, document) : decoration
-          if (n && n !== decoration) n = document.createRange(n)
-          return n
-        })
+    if (decorations) {
+      let next = decorations.map(decoration => {
+        let n = decoration.isSet ? iterator(decoration, document) : decoration
+        if (n && n !== decoration) n = document.createRange(n)
+        return n
+      })
 
-        next = next.filter(decoration => !!decoration)
-        next = next.size ? next : null
-        value.set('decorations', next)
-      }
-    })
+      next = next.filter(decoration => !!decoration)
+      next = next.size ? next : null
+      value = value.set('decorations', next)
+    }
+    return value
   }
 
   /**

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -930,6 +930,7 @@ class Value extends Record(DEFAULTS) {
       next = next.size ? next : null
       value = value.set('decorations', next)
     }
+
     return value
   }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

Introduce `Range.updatePoints(Point => Point)` to make the code simpler.

#### How does this change work?

We used to have `range.setPoints([anchor.doSomething, focus.doSomething])` that same point operation duplicated in setPoint.  This function mimics Immutable's update to reduce duplicated code.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
