### PR TITLE
IE11 html serializer parser fix

### DIFF
--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -79,7 +79,7 @@ function defaultParseHtml(html) {
   const parsed = new DOMParser().parseFromString(html, 'text/html')
   const { body } = parsed
   // COMPAT: in IE 11 body is null if html is an empty string
-  return body || document.createElement('body')
+  return body || window.document.createElement('body')
 }
 
 /**

--- a/packages/slate-html-serializer/src/index.js
+++ b/packages/slate-html-serializer/src/index.js
@@ -78,7 +78,8 @@ function defaultParseHtml(html) {
 
   const parsed = new DOMParser().parseFromString(html, 'text/html')
   const { body } = parsed
-  return body
+  // COMPAT: in IE 11 body is null if html is an empty string
+  return body || document.createElement('body')
 }
 
 /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This should fix `Unable to get property 'childNodes' of undefined or null reference` error in IE11 when using slate-html-serializer and deserializing an empty string (#1757, #1756).

#### What's the new behavior?

The `defaultParseHtml` now returns an empty body element if the parsed body is null. 

I tested this in the latest Chrome, Firefox and Safari, and they all seemed to work similarly. If the html param was an empty string, `parseFromString` returned a document element, which had a body property which was an empty body element. In IE11 though the body property was null, which caused the undefined or null reference later.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)