### PR TITLE
Fix key duplication warning and deprecation in benchmark

### DIFF
--- a/benchmark/slate-react/rendering/decoration.js
+++ b/benchmark/slate-react/rendering/decoration.js
@@ -34,10 +34,14 @@ const decorations = texts.flatMap((t, index) => {
   if (t.length === 0) return []
   return [
     {
-      anchorKey: t.key,
-      anchorOffset: 0,
-      focusKey: t.key,
-      focusOffset: 1,
+      anchor: {
+        key: t.key,
+        offset: 0,
+      },
+      focus: {
+        key: t.key,
+        offset: 1,
+      },
       marks: [{ type: 'underline' }],
     },
   ]

--- a/benchmark/slate/changes/add-mark.js
+++ b/benchmark/slate/changes/add-mark.js
@@ -6,13 +6,13 @@ const h = require('../../helpers/h')
 module.exports.default = function(change) {
   change
     .addMark('bold')
-    .move(5)
+    .moveForward(5)
     .addMark('bold')
-    .move(5)
+    .moveForward(5)
     .addMark('bold')
-    .move(5)
+    .moveForward(5)
     .addMark('bold')
-    .move(5)
+    .moveForward(5)
     .addMark('bold')
 }
 

--- a/benchmark/slate/changes/insert-node-by-key.js
+++ b/benchmark/slate/changes/insert-node-by-key.js
@@ -5,18 +5,18 @@ const h = require('../../helpers/h')
 
 module.exports.default = function(change) {
   change
-    .insertNodeByKey('a', 0, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a', 1, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a', 2, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a', 3, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a', 4, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a0', 0, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a1', 1, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a2', 2, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a3', 3, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a4', 4, <paragraph>Hello world</paragraph>)
 }
 
 const value = (
   <value>
     <document>
       {Array.from(Array(10)).map((v, i) => (
-        <quote key="a">
+        <quote key={`a${i}`}>
           <paragraph>
             This is editable <b>rich</b> text, <i>much</i> better than a
             textarea!

--- a/benchmark/slate/changes/insert-text.js
+++ b/benchmark/slate/changes/insert-text.js
@@ -6,13 +6,13 @@ const h = require('../../helpers/h')
 module.exports.default = function(change) {
   change
     .insertText('one')
-    .move(5)
+    .moveForward(5)
     .insertText('two')
-    .move(5)
+    .moveForward(5)
     .insertText('three')
-    .move(5)
+    .moveForward(5)
     .insertText('four')
-    .move(5)
+    .moveForward(5)
     .insertText('five')
 }
 

--- a/benchmark/slate/changes/normalize.js
+++ b/benchmark/slate/changes/normalize.js
@@ -6,13 +6,13 @@ const h = require('../../helpers/h')
 module.exports.default = function(change) {
   change
     .normalize()
-    .move(5)
+    .moveForward(5)
     .normalize()
-    .move(5)
+    .moveForward(5)
     .normalize()
-    .move(5)
+    .moveForward(5)
     .normalize()
-    .move(5)
+    .moveForward(5)
     .normalize()
 }
 

--- a/benchmark/slate/changes/split-block.js
+++ b/benchmark/slate/changes/split-block.js
@@ -6,13 +6,13 @@ const h = require('../../helpers/h')
 module.exports.default = function(change) {
   change
     .splitBlock()
-    .move(5)
+    .moveForward(5)
     .splitBlock()
-    .move(5)
+    .moveForward(5)
     .splitBlock()
-    .move(5)
+    .moveForward(5)
     .splitBlock()
-    .move(5)
+    .moveForward(5)
     .splitBlock()
 }
 

--- a/benchmark/slate/models/get-active-marks-at-range.js
+++ b/benchmark/slate/models/get-active-marks-at-range.js
@@ -24,7 +24,7 @@ const value = (
   </value>
 )
   .change()
-  .selectAll().value
+  .moveToRangeOfDocument().value
 
 module.exports.input = function() {
   return value

--- a/benchmark/slate/models/get-blocks-at-range.js
+++ b/benchmark/slate/models/get-blocks-at-range.js
@@ -24,7 +24,7 @@ const value = (
   </value>
 )
   .change()
-  .selectAll().value
+  .moveToRangeOfDocument().value
 
 module.exports.input = () => {
   return value

--- a/benchmark/slate/models/get-inlines-at-range.js
+++ b/benchmark/slate/models/get-inlines-at-range.js
@@ -24,7 +24,7 @@ const value = (
   </value>
 )
   .change()
-  .selectAll().value
+  .moveToRangeOfDocument().value
 
 module.exports.input = function() {
   return value

--- a/benchmark/slate/models/get-marks-at-range.js
+++ b/benchmark/slate/models/get-marks-at-range.js
@@ -24,7 +24,7 @@ const value = (
   </value>
 )
   .change()
-  .selectAll().value
+  .moveToRangeOfDocument().value
 
 module.exports.input = function() {
   return value

--- a/benchmark/slate/models/get-texts-at-range.js
+++ b/benchmark/slate/models/get-texts-at-range.js
@@ -24,7 +24,7 @@ const value = (
   </value>
 )
   .change()
-  .selectAll().value
+  .moveToRangeOfDocument().value
 
 module.exports.input = function() {
   return value


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?

Fix key duplication warning and deprecation

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/2088 https://github.com/ianstormtaylor/slate/issues/2079
Reviewers: @
