### PR TITLE
use fragment instead of node transfer type on drag

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -266,9 +266,11 @@ function AfterPlugin() {
     isDraggingInternally = true
 
     const { value } = change
-    const { document } = value
+    const { document, schema } = value
     const node = findNode(event.target, value)
-    const isVoid = node && (node.isVoid || document.hasVoidParent(node.key))
+    const ancestors = document.getAncestors(node.key)
+    const isVoid =
+      node && (schema.isVoid(node) || ancestors.some(a => schema.isVoid(a)))
     const selectionIncludesNode = value.blocks.some(
       block => block.key === node.key
     )

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -4,7 +4,7 @@ import Plain from 'slate-plain-serializer'
 import { IS_IOS } from 'slate-dev-environment'
 import React from 'react'
 import getWindow from 'get-window'
-import { Block, Inline, Text } from 'slate'
+import { Text } from 'slate'
 import Hotkeys from 'slate-hotkeys'
 
 import Content from '../components/content'
@@ -273,6 +273,7 @@ function AfterPlugin() {
       block => block.key === node.key
     )
 
+    // If a void block is dragged and is not selected, select it (necessary for local drags).
     if (isVoid && !selectionIncludesNode) {
       change.moveToRangeOfNode(node)
     }
@@ -300,7 +301,7 @@ function AfterPlugin() {
     if (!target) return
 
     const transfer = getEventTransfer(event)
-    const { type, fragment, node, text } = transfer
+    const { type, fragment, text } = transfer
 
     change.focus()
 
@@ -350,16 +351,6 @@ function AfterPlugin() {
 
     if (type == 'fragment') {
       change.insertFragment(fragment)
-    }
-
-    // todo: this never gets called anymore because we just work with fragments
-    if (type == 'node' && Block.isBlock(node)) {
-      change.insertBlock(node.regenerateKey())
-    }
-
-    // todo: this never gets called anymore because we just work with fragments
-    if (type == 'node' && Inline.isInline(node)) {
-      change.insertInline(node.regenerateKey())
     }
 
     // COMPAT: React's onSelect event breaks after an onDrop event

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -266,20 +266,9 @@ function AfterPlugin() {
     isDraggingInternally = true
 
     const { value } = change
-    const { document, schema } = value
-    const node = findNode(event.target, value)
-    const ancestors = document.getAncestors(node.key)
-    const isVoid =
-      node && (schema.isVoid(node) || ancestors.some(a => schema.isVoid(a)))
-
-    if (isVoid) {
-      const encoded = Base64.serializeNode(node, { preserveKeys: true })
-      setEventTransfer(event, 'node', encoded)
-    } else {
-      const { fragment } = value
-      const encoded = Base64.serializeNode(fragment)
-      setEventTransfer(event, 'fragment', encoded)
-    }
+    const { fragment } = value
+    const encoded = Base64.serializeNode(fragment)
+    setEventTransfer(event, 'fragment', encoded)
   }
 
   /**
@@ -352,12 +341,14 @@ function AfterPlugin() {
       change.insertFragment(fragment)
     }
 
+    // todo: this never gets called anymore because we just work with fragments
     if (type == 'node' && Block.isBlock(node)) {
-      change.insertBlock(node.regenerateKey()).removeNodeByKey(node.key)
+      change.insertBlock(node.regenerateKey())
     }
 
+    // todo: this never gets called anymore because we just work with fragments
     if (type == 'node' && Inline.isInline(node)) {
-      change.insertInline(node.regenerateKey()).removeNodeByKey(node.key)
+      change.insertInline(node.regenerateKey())
     }
 
     // COMPAT: React's onSelect event breaks after an onDrop event

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -266,7 +266,16 @@ function AfterPlugin() {
     isDraggingInternally = true
 
     const { value } = change
-    const { fragment } = value
+    const { selection, document } = value
+    const node = findNode(event.target, value)
+    const isVoid = node && (node.isVoid || document.hasVoidParent(node.key))
+    const selectionIncludesNode = value.blocks.some(block => block.key === node.key)
+
+    if (isVoid && !selectionIncludesNode) {
+      change.moveToRangeOfNode(node)
+    }
+
+    const fragment = change.value.fragment;
     const encoded = Base64.serializeNode(fragment)
     setEventTransfer(event, 'fragment', encoded)
   }

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -266,16 +266,18 @@ function AfterPlugin() {
     isDraggingInternally = true
 
     const { value } = change
-    const { selection, document } = value
+    const { document } = value
     const node = findNode(event.target, value)
     const isVoid = node && (node.isVoid || document.hasVoidParent(node.key))
-    const selectionIncludesNode = value.blocks.some(block => block.key === node.key)
+    const selectionIncludesNode = value.blocks.some(
+      block => block.key === node.key
+    )
 
     if (isVoid && !selectionIncludesNode) {
       change.moveToRangeOfNode(node)
     }
 
-    const fragment = change.value.fragment;
+    const fragment = change.value.fragment
     const encoded = Base64.serializeNode(fragment)
     setEventTransfer(event, 'fragment', encoded)
   }

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -70,7 +70,6 @@ Changes.addMarksAtRange = (change, range, marks, options = {}) => {
  */
 
 Changes.deleteAtRange = (change, range, options = {}) => {
-
   // Snapshot the selection, which creates an extra undo save point, so that
   // when you undo a delete, the expanded selection will be retained.
   change.snapshotSelection()

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -70,7 +70,6 @@ Changes.addMarksAtRange = (change, range, marks, options = {}) => {
  */
 
 Changes.deleteAtRange = (change, range, options = {}) => {
-  if (range.isCollapsed) return
 
   // Snapshot the selection, which creates an extra undo save point, so that
   // when you undo a delete, the expanded selection will be retained.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### What's the new behavior?
Creates a fragment EventTransfer instead of a node EventTransfer object. 

#### How does this change work?
Previously only the direct node that was dragged was stored in the EventTransfer, now the complete fragment is, allowing for dragging of a selection with multiple blocks.

#### Does this fix any issues or need any specific reviewers?

Fixes: #1850
Reviewers: @
