### PR TITLE
deprecate isVoid and related properties/methods

### DIFF
--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -93,21 +93,16 @@ When you define a `normalizeNode` function, you either return nothing if the nod
 
 ```js
 function normalizeNode(node) {
-  if (node.object != 'block') return
-  if (node.isVoid) return
-
   const { nodes } = node
-  if (nodes.size != 3) return
-  if (nodes.first().object != 'text') return
-  if (nodes.last().object != 'text') return
-
-  return change => {
-    change.removeNodeByKey(node.key)
-  }
+  if (node.object !== 'block') return
+  if (nodes.size !== 3) return
+  if (nodes.first().object !== 'text') return
+  if (nodes.last().object !== 'text') return
+  return change => change.removeNodeByKey(node.key)
 }
 ```
 
-This validation defines a very specific (honestly, useless) behavior, where if a node is block, non-void and has three children, the first and last of which are text nodes, it is removed. I don't know why you'd ever do that, but the point is that you can get very specific with your validations this way. Any property of the node can be examined.
+This validation defines a very specific (honestly, useless) behavior, where if a node is a block and has three children, the first and last of which are text nodes, it is removed. I don't know why you'd ever do that, but the point is that you can get very specific with your validations this way. Any property of the node can be examined.
 
 When you need this level of specificity, using the `normalizeNode` property of the editor or plugins is handy.
 

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -131,7 +131,7 @@ class HoveringMenu extends React.Component {
     const { value } = this.state
     const { fragment, selection } = value
 
-    if (select.isBlurred || selection.isCollapsed || fragment.text === '') {
+    if (selection.isBlurred || selection.isCollapsed || fragment.text === '') {
       menu.removeAttribute('style')
       return
     }

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -125,17 +125,19 @@ class HoveringMenu extends React.Component {
    */
 
   updateMenu = () => {
-    const { value } = this.state
     const menu = this.menu
     if (!menu) return
 
-    if (value.isBlurred || value.isEmpty) {
+    const { value } = this.state
+    const { fragment, selection } = value
+
+    if (select.isBlurred || selection.isCollapsed || fragment.text === '') {
       menu.removeAttribute('style')
       return
     }
 
-    const selection = window.getSelection()
-    const range = selection.getRangeAt(0)
+    const native = window.getSelection()
+    const range = native.getRangeAt(0)
     const rect = range.getBoundingClientRect()
     menu.style.opacity = 1
     menu.style.top = `${rect.top + window.pageYOffset - menu.offsetHeight}px`

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "release": "yarn build:production && yarn test && yarn lint && lerna publish && yarn gh-pages",
     "server": "webpack-dev-server --config ./support/webpack/config.js",
     "start": "npm-run-all --parallel --print-label watch server",
-    "test": "cross-env BABEL_ENV=test FORBID_DEPRECATIONS=true FORBID_WARNINGS=true mocha --require babel-core/register ./packages/*/test/index.js",
+    "test": "cross-env BABEL_ENV=test FORBID_WARNINGS=true mocha --require babel-core/register ./packages/*/test/index.js",
     "test:coverage": "cross-env NODE_ENV=test nyc yarn test",
     "watch": "rollup --config ./support/rollup/config.js --watch"
   }

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -126,11 +126,13 @@ class Leaf extends React.Component {
    */
 
   renderText() {
-    const { block, node, parent, text, index, leaves } = this.props
+    const { block, node, editor, parent, text, index, leaves } = this.props
+    const { value } = editor
+    const { schema } = value
 
     // COMPAT: Render text inside void nodes with a zero-width space.
     // So the node can contain selection but the text is not visible.
-    if (parent.isVoid) {
+    if (schema.isVoid(parent)) {
       return <span data-slate-zero-width="z">{'\u200B'}</span>
     }
 

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -131,7 +131,7 @@ class Node extends React.Component {
       readOnly,
     } = this.props
     const { value } = editor
-    const { selection } = value
+    const { selection, schema } = value
     const { stack } = editor
     const indexes = node.getSelectionIndexes(selection, isSelected)
     const decs = decorations.concat(node.getDecorations(stack))
@@ -184,7 +184,11 @@ class Node extends React.Component {
       children,
     })
 
-    return node.isVoid ? <Void {...this.props}>{element}</Void> : element
+    return schema.isVoid(node) ? (
+      <Void {...this.props}>{element}</Void>
+    ) : (
+      element
+    )
   }
 
   /**

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -66,6 +66,7 @@ function BeforePlugin() {
     if (editor.props.readOnly) return true
 
     const { value } = change
+    const { schema } = value
     const { relatedTarget, target } = event
     const window = getWindow(target)
 
@@ -93,7 +94,8 @@ function BeforePlugin() {
       // editable section of an element that isn't a void node (eg. a list item
       // of the check list example).
       const node = findNode(relatedTarget, value)
-      if (el.contains(relatedTarget) && node && !node.isVoid) return true
+      if (el.contains(relatedTarget) && node && !schema.isVoid(node))
+        return true
     }
 
     debug('onBlur', { event })
@@ -269,8 +271,10 @@ function BeforePlugin() {
     // call `preventDefault` to signal that drops are allowed.
     // When the target is editable, dropping is already allowed by
     // default, and calling `preventDefault` hides the cursor.
+    const { value } = editor
+    const { schema } = value
     const node = findNode(event.target, editor.value)
-    if (node.isVoid) event.preventDefault()
+    if (schema.isVoid(node)) event.preventDefault()
 
     // COMPAT: IE won't call onDrop on contentEditables unless the
     // default dragOver is prevented:

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -26,9 +26,10 @@ function cloneFragment(
 ) {
   const window = getWindow(event.target)
   const native = window.getSelection()
+  const { schema } = value
   const { start, end } = value.selection
-  const startVoid = value.document.getClosestVoid(start.key)
-  const endVoid = value.document.getClosestVoid(end.key)
+  const startVoid = value.document.getClosestVoid(start.key, schema)
+  const endVoid = value.document.getClosestVoid(end.key, schema)
 
   // If the selection is collapsed, and it isn't inside a void node, abort.
   if (native.isCollapsed && !startVoid) return

--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -19,14 +19,14 @@ function getEventRange(event, value) {
   const { x, y, target } = event
   if (x == null || y == null) return null
 
-  const { document } = value
+  const { document, schema } = value
   const node = findNode(target, value)
   if (!node) return null
 
   // If the drop target is inside a void node, move it into either the next or
   // previous node, depending on which side the `x` and `y` coordinates are
   // closest to.
-  if (node.isVoid) {
+  if (schema.isVoid(node)) {
     const rect = target.getBoundingClientRect()
     const isPrevious =
       node.object == 'inline'

--- a/packages/slate/src/changes/at-range.js
+++ b/packages/slate/src/changes/at-range.js
@@ -626,8 +626,6 @@ Changes.insertBlockAtRange = (change, range, block, options = {}) => {
   const parent = document.getParent(startBlock.key)
   const index = parent.nodes.indexOf(startBlock)
 
-  debugger
-
   if (schema.isVoid(startBlock)) {
     const extra = start.isAtEndOfNode(startBlock) ? 1 : 0
     change.insertNodeByKey(parent.key, index + extra, block, { normalize })

--- a/packages/slate/src/changes/on-selection.js
+++ b/packages/slate/src/changes/on-selection.js
@@ -658,9 +658,9 @@ function pointBackward(change, point, n = 1) {
 
   const Point = point.slice(0, 1).toUpperCase() + point.slice(1)
   const { value } = change
-  const { document, selection } = value
+  const { document, selection, schema } = value
   const p = selection[point]
-  const isInVoid = document.hasVoidParent(p.path)
+  const isInVoid = document.hasVoidParent(p.path, schema)
 
   // what is this?
   if (!isInVoid && p.offset - n >= 0) {
@@ -674,7 +674,8 @@ function pointBackward(change, point, n = 1) {
 
   const block = document.getClosestBlock(p.path)
   const isInBlock = block.hasNode(previous.key)
-  const isPreviousInVoid = previous && document.hasVoidParent(previous.key)
+  const isPreviousInVoid =
+    previous && document.hasVoidParent(previous.key, schema)
   change[`move${Point}ToEndOfNode`](previous)
 
   // when is this called?
@@ -690,10 +691,10 @@ function pointForward(change, point, n = 1) {
 
   const Point = point.slice(0, 1).toUpperCase() + point.slice(1)
   const { value } = change
-  const { document, selection } = value
+  const { document, selection, schema } = value
   const p = selection[point]
   const text = document.getNode(p.path)
-  const isInVoid = document.hasVoidParent(p.path)
+  const isInVoid = document.hasVoidParent(p.path, schema)
 
   // what is this?
   if (!isInVoid && p.offset + n <= text.text.length) {
@@ -707,7 +708,7 @@ function pointForward(change, point, n = 1) {
 
   const block = document.getClosestBlock(p.path)
   const isInBlock = block.hasNode(next.key)
-  const isNextInVoid = document.hasVoidParent(next.key)
+  const isNextInVoid = document.hasVoidParent(next.key, schema)
   change[`move${Point}ToStartOfNode`](next)
 
   // when is this called?

--- a/packages/slate/src/models/block.js
+++ b/packages/slate/src/models/block.js
@@ -152,6 +152,16 @@ class Block extends Record(DEFAULTS) {
     return this.object
   }
 
+  get isVoid() {
+    logger.deprecate(
+      '0.38.0',
+      'The `Node.isVoid` property is deprecated, please use the `Schema.isVoid()` checking method instead.'
+    )
+
+    debugger
+    return this.get('isVoid')
+  }
+
   /**
    * Check if the block is empty.
    * Returns true if block is not void and all it's children nodes are empty.
@@ -161,7 +171,9 @@ class Block extends Record(DEFAULTS) {
    */
 
   get isEmpty() {
-    return !this.isVoid && !this.nodes.some(child => !child.isEmpty)
+    logger.deprecate('0.38.0', 'The `Node.isEmpty` property is deprecated.')
+
+    return !this.get('isVoid') && !this.nodes.some(child => !child.isEmpty)
   }
 
   /**
@@ -185,7 +197,7 @@ class Block extends Record(DEFAULTS) {
     const object = {
       object: this.object,
       type: this.type,
-      isVoid: this.isVoid,
+      isVoid: this.get('isVoid'),
       data: this.data.toJSON(),
       nodes: this.nodes.toArray().map(n => n.toJSON(options)),
     }

--- a/packages/slate/src/models/block.js
+++ b/packages/slate/src/models/block.js
@@ -158,7 +158,6 @@ class Block extends Record(DEFAULTS) {
       'The `Node.isVoid` property is deprecated, please use the `Schema.isVoid()` checking method instead.'
     )
 
-    debugger
     return this.get('isVoid')
   }
 

--- a/packages/slate/src/models/document.js
+++ b/packages/slate/src/models/document.js
@@ -105,6 +105,16 @@ class Document extends Record(DEFAULTS) {
     return this.object
   }
 
+  get isVoid() {
+    logger.deprecate(
+      '0.38.0',
+      'The `Node.isVoid` property is deprecated, please use the `Schema.isVoid()` checking method instead.'
+    )
+
+    debugger
+    return this.get('isVoid')
+  }
+
   /**
    * Check if the document is empty.
    * Returns true if all it's children nodes are empty.
@@ -113,6 +123,7 @@ class Document extends Record(DEFAULTS) {
    */
 
   get isEmpty() {
+    logger.deprecate('0.38.0', 'The `Node.isEmpty` property is deprecated.')
     return !this.nodes.some(child => !child.isEmpty)
   }
 

--- a/packages/slate/src/models/document.js
+++ b/packages/slate/src/models/document.js
@@ -111,7 +111,6 @@ class Document extends Record(DEFAULTS) {
       'The `Node.isVoid` property is deprecated, please use the `Schema.isVoid()` checking method instead.'
     )
 
-    debugger
     return this.get('isVoid')
   }
 

--- a/packages/slate/src/models/inline.js
+++ b/packages/slate/src/models/inline.js
@@ -158,7 +158,6 @@ class Inline extends Record(DEFAULTS) {
       'The `Node.isVoid` property is deprecated, please use the `Schema.isVoid()` checking method instead.'
     )
 
-    debugger
     return this.get('isVoid')
   }
 

--- a/packages/slate/src/models/inline.js
+++ b/packages/slate/src/models/inline.js
@@ -152,6 +152,16 @@ class Inline extends Record(DEFAULTS) {
     return this.object
   }
 
+  get isVoid() {
+    logger.deprecate(
+      '0.38.0',
+      'The `Node.isVoid` property is deprecated, please use the `Schema.isVoid()` checking method instead.'
+    )
+
+    debugger
+    return this.get('isVoid')
+  }
+
   /**
    * Check if the inline is empty.
    * Returns true if inline is not void and all it's children nodes are empty.
@@ -161,7 +171,8 @@ class Inline extends Record(DEFAULTS) {
    */
 
   get isEmpty() {
-    return !this.isVoid && !this.nodes.some(child => !child.isEmpty)
+    logger.deprecate('0.38.0', 'The `Node.isEmpty` property is deprecated.')
+    return !this.get('isVoid') && !this.nodes.some(child => !child.isEmpty)
   }
 
   /**
@@ -185,7 +196,7 @@ class Inline extends Record(DEFAULTS) {
     const object = {
       object: this.object,
       type: this.type,
-      isVoid: this.isVoid,
+      isVoid: this.get('isVoid'),
       data: this.data.toJSON(),
       nodes: this.nodes.toArray().map(n => n.toJSON(options)),
     }

--- a/packages/slate/src/models/node.js
+++ b/packages/slate/src/models/node.js
@@ -540,12 +540,24 @@ class Node {
    * Get the closest void parent of a node by `path`.
    *
    * @param {List|String} path
+   * @param {Schema} schema
    * @return {Node|Null}
    */
 
-  getClosestVoid(path) {
-    const closest = this.getClosest(path, p => p.isVoid)
-    return closest
+  getClosestVoid(path, schema) {
+    if (!schema) {
+      logger.deprecate(
+        '0.38.0',
+        'Calling the `Node.getClosestVoid` method without passing a second `schema` argument is deprecated.'
+      )
+
+      const closest = this.getClosest(path, p => p.get('isVoid'))
+      return closest
+    }
+
+    const ancestors = this.getAncestors(path)
+    const ancestor = ancestors.findLast(a => schema.isVoid(a))
+    return ancestor
   }
 
   /**
@@ -1636,11 +1648,22 @@ class Node {
    * Check if a node has a void parent.
    *
    * @param {List|String} path
+   * @param {Schema} schema
    * @return {Boolean}
    */
 
-  hasVoidParent(path) {
-    const closest = this.getClosestVoid(path)
+  hasVoidParent(path, schema) {
+    if (!schema) {
+      logger.deprecate(
+        '0.38.0',
+        'Calling the `Node.hasVoidParent` method without the second `schema` argument is deprecated.'
+      )
+
+      const closest = this.getClosestVoid(path)
+      return !!closest
+    }
+
+    const closest = this.getClosestVoid(path, schema)
     return !!closest
   }
 

--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -282,7 +282,7 @@ class Operation extends Record(DEFAULTS) {
       if (key == 'properties' && type == 'set_node') {
         const v = {}
         if ('data' in value) v.data = value.data.toJS()
-        if ('isVoid' in value) v.isVoid = value.isVoid
+        if ('isVoid' in value) v.isVoid = value.get('isVoid')
         if ('type' in value) v.type = value.type
         value = v
       }

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -360,6 +360,19 @@ class Schema extends Record(DEFAULTS) {
   }
 
   /**
+   * Check if a node is void.
+   *
+   * @param {Node}
+   * @return {Boolean}
+   */
+
+  isVoid(node) {
+    // COMPAT: Right now this just provides a way to get around the
+    // deprecation warnings, but in the future it will check the rules.
+    return node.get('isVoid')
+  }
+
+  /**
    * Return a JSON representation of the schema.
    *
    * @return {Object}
@@ -432,7 +445,7 @@ function defaultNormalize(change, error) {
     case NODE_IS_VOID_INVALID: {
       return change.setNodeByKey(
         node.key,
-        { isVoid: !node.isVoid },
+        { isVoid: !node.get('isVoid') },
         { normalize: false }
       )
     }
@@ -530,7 +543,7 @@ function validateType(node, rule) {
 
 function validateIsVoid(node, rule) {
   if (rule.isVoid == null) return
-  if (rule.isVoid === node.isVoid) return
+  if (rule.isVoid === node.get('isVoid')) return
   return fail(NODE_IS_VOID_INVALID, { rule, node })
 }
 

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -528,6 +528,7 @@ class Value extends Record(DEFAULTS) {
    */
 
   get isEmpty() {
+    logger.deprecate('0.38.0', 'The `Value.isEmpty` property is deprecated.')
     if (this.selection.isCollapsed) return true
     if (this.selection.end.offset != 0 && this.selection.start.offset != 0)
       return false
@@ -541,8 +542,9 @@ class Value extends Record(DEFAULTS) {
    */
 
   get isInVoid() {
+    logger.deprecate('0.38.0', 'The `Value.isInVoid` property is deprecated.')
     if (this.selection.isExpanded) return false
-    return this.document.hasVoidParent(this.selection.start.key)
+    return this.document.hasVoidParent(this.selection.start.key, this.schema)
   }
 
   /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

#### What's the new behavior?

This deprecates the `node.isVoid` property in favor of using `schema.isVoid(node)`, which will allow us to remove the hardcoded "void" concept from the data model, and have it depend on the schema instead. 

This allows you to build different kinds of editors, with different void semantics, depending on your use case, without having this information hardcoded in the data itself. Even switching the `isVoid` semantics on the fly based on a user toggling a setting for example.

#### How does this change work?

This is the first step, which just deprecates `node.isVoid`, and provides the new alternative of `schema.isVoid(node)`, while still using the `isVoid` value of nodes under the covers.

The next step is to change the logic to search the schema for real, and completely remove the `isVoid` value from nodes.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

