### PR TITLE
[WIP] Add onMouseMove method; Fix incorrect selection when click and drag move

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -273,7 +273,9 @@ class Content extends React.Component {
    */
 
   onEvent(handler, event) {
-    debug('onEvent', handler)
+    if (handler !== 'onMouseMove') {
+      debug('onEvent', handler)
+    }
 
     // Ignore `onBlur`, `onFocus` and `onSelect` events generated
     // programmatically while updating selection.

--- a/packages/slate-react/src/constants/event-handlers.js
+++ b/packages/slate-react/src/constants/event-handlers.js
@@ -22,6 +22,7 @@ const EVENT_HANDLERS = [
   'onDrop',
   'onInput',
   'onFocus',
+  'onMouseMove',
   'onKeyDown',
   'onKeyUp',
   'onPaste',

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -453,10 +453,9 @@ function AfterPlugin() {
   */
 
   function onMouseMove(event, change, editor) {
-    debug('onMouseMove', { event })
-
     // It means the left key of mouse is pressed
     if (event.buttons % 2 === 1) {
+      debug('onMouseMove', { event })
       lastMouseMovingTimeStamp = event.timeStamp
     }
   }

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -33,7 +33,7 @@ const debug = Debug('slate:after')
 
 function AfterPlugin() {
   let isDraggingInternally = null
-  let lastMouseMovingTimeStamp
+  let lastMousePressedMovingTimeStamp
 
   /**
    * On before input.
@@ -456,10 +456,23 @@ function AfterPlugin() {
     // It means the left key of mouse is pressed
     if (event.buttons % 2 === 1) {
       debug('onMouseMove', { event })
-      lastMouseMovingTimeStamp = event.timeStamp
+      lastMousePressedMovingTimeStamp = event.timeStamp
     } else {
-      lastMouseMovingTimeStamp = NaN
+      lastMousePressedMovingTimeStamp = NaN
     }
+  }
+
+  /*
+   * On mouse up
+   *
+   * @param {Event} event
+   * @param {Change} change
+   * @param {Editor} editor
+  */
+
+  function onMouseUp(event) {
+    debug('onMouseUp', { event })
+    if (event.buttons % 2 !== 1) lastMousePressedMovingTimeStamp = NaN
   }
 
   /**
@@ -659,7 +672,7 @@ function AfterPlugin() {
     // collapsed, and the new selection is also collapsed start; Then extend the
     // selection rather than move the selection;
     if (
-      event.timeStamp - lastMouseMovingTimeStamp < 24 &&
+      event.timeStamp - lastMousePressedMovingTimeStamp < 24 &&
       range.isCollapsed &&
       value.selection.isCollapsed
     ) {
@@ -807,6 +820,7 @@ function AfterPlugin() {
     onDrop,
     onInput,
     onMouseMove,
+    onMouseUp,
     onKeyDown,
     onPaste,
     onSelect,

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -33,6 +33,8 @@ const debug = Debug('slate:after')
 
 function AfterPlugin() {
   let isDraggingInternally = null
+  let isMouseMovingInternally = false
+  let mouseMoveCallbackId
 
   /**
    * On before input.
@@ -443,6 +445,27 @@ function AfterPlugin() {
     change.insertTextAtRange(entire, textContent, leaf.marks).select(corrected)
   }
 
+  /*
+   * On mouse move
+   *
+   * @param {Event} event
+   * @param {Change} change
+   * @param {Editor} editor
+  */
+
+  function onMouseMove(event, change, editor) {
+    debug('onMouseMove', { event })
+    window.clearTimeout(mouseMoveCallbackId)
+
+    isMouseMovingInternally = event.buttons % 2 === 1
+
+    if (isMouseMovingInternally) {
+      mouseMoveCallbackId = window.setTimeout(() => {
+        isMouseMovingInternally = false
+      }, 24)
+    }
+  }
+
   /**
    * On key down.
    *
@@ -776,6 +799,7 @@ function AfterPlugin() {
     onDragStart,
     onDrop,
     onInput,
+    onMouseMove,
     onKeyDown,
     onPaste,
     onSelect,

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -457,6 +457,8 @@ function AfterPlugin() {
     if (event.buttons % 2 === 1) {
       debug('onMouseMove', { event })
       lastMouseMovingTimeStamp = event.timeStamp
+    } else {
+      lastMouseMovingTimeStamp = NaN
     }
   }
 

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -457,6 +457,7 @@ function AfterPlugin() {
     debug('onMouseMove', { event })
     window.clearTimeout(mouseMoveCallbackId)
 
+    // It means the left key of mouse is pressed
     isMouseMovingInternally = event.buttons % 2 === 1
 
     if (isMouseMovingInternally) {
@@ -658,6 +659,17 @@ function AfterPlugin() {
     const focusInline = document.getClosestInline(focus.key)
     const focusBlock = document.getClosestBlock(focus.key)
     const anchorBlock = document.getClosestBlock(anchor.key)
+
+    // COMPAT: If the mouse is moving with major down, and the previous selection is
+    // collapsed, and the new selection is also collapsed start; Then extend the
+    // selection rather than move the selection;
+    if (
+      isMouseMovingInternally &&
+      range.isCollapsed &&
+      value.selection.isCollapsed
+    ) {
+      range = range.setAnchor(value.selection.anchor)
+    }
 
     // COMPAT: If the anchor point is at the start of a non-void, and the
     // focus point is inside a void node with an offset that isn't `0`, set

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -672,7 +672,7 @@ function AfterPlugin() {
     // collapsed, and the new selection is also collapsed start; Then extend the
     // selection rather than move the selection;
     if (
-      event.timeStamp - lastMousePressedMovingTimeStamp < 24 &&
+      event.timeStamp - lastMousePressedMovingTimeStamp < 0 &&
       range.isCollapsed &&
       value.selection.isCollapsed
     ) {

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -33,8 +33,7 @@ const debug = Debug('slate:after')
 
 function AfterPlugin() {
   let isDraggingInternally = null
-  let isMouseMovingInternally = false
-  let mouseMoveCallbackId
+  let lastMouseMovingTimeStamp
 
   /**
    * On before input.
@@ -455,15 +454,10 @@ function AfterPlugin() {
 
   function onMouseMove(event, change, editor) {
     debug('onMouseMove', { event })
-    window.clearTimeout(mouseMoveCallbackId)
 
     // It means the left key of mouse is pressed
-    isMouseMovingInternally = event.buttons % 2 === 1
-
-    if (isMouseMovingInternally) {
-      mouseMoveCallbackId = window.setTimeout(() => {
-        isMouseMovingInternally = false
-      }, 24)
+    if (event.buttons % 2 === 1) {
+      lastMouseMovingTimeStamp = event.timeStamp
     }
   }
 
@@ -664,7 +658,7 @@ function AfterPlugin() {
     // collapsed, and the new selection is also collapsed start; Then extend the
     // selection rather than move the selection;
     if (
-      isMouseMovingInternally &&
+      event.timeStamp - lastMouseMovingTimeStamp < 24 &&
       range.isCollapsed &&
       value.selection.isCollapsed
     ) {

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -373,18 +373,6 @@ function BeforePlugin() {
   }
 
   /**
-   * On mouse move.
-   *
-   * @param {Event} event
-   * @param {Change} change
-   * @param {Editor} editor
-   */
-
-  function onMouseMove(event) {
-    debug('onMouseMove', { event })
-  }
-
-  /**
    * On key down.
    *
    * @param {Event} event
@@ -487,7 +475,6 @@ function BeforePlugin() {
     onDrop,
     onFocus,
     onInput,
-    onMouseMove,
     onKeyDown,
     onPaste,
     onSelect,

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -373,6 +373,18 @@ function BeforePlugin() {
   }
 
   /**
+   * On mouse move.
+   *
+   * @param {Event} event
+   * @param {Change} change
+   * @param {Editor} editor
+   */
+
+  function onMouseMove(event) {
+    debug('onMouseMove', { event })
+  }
+
+  /**
    * On key down.
    *
    * @param {Event} event
@@ -475,6 +487,7 @@ function BeforePlugin() {
     onDrop,
     onFocus,
     onInput,
+    onMouseMove,
     onKeyDown,
     onPaste,
     onSelect,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?

If user click and drag, and an selection event is fired during dragging.  Then we shall expect an extended range instead of an collapsed range.  When the browser accidentally causes an collapsed range, then we shall extend it to the new selection instead of select.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/1969
Reviewers: @
