### PR TITLE
Enable event logging in development mode

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -6,7 +6,7 @@ import React from 'react'
 import getWindow from 'get-window'
 import { Text } from 'slate'
 import Hotkeys from 'slate-hotkeys'
-
+import eventLogger from './event-logger'
 import Content from '../components/content'
 import cloneFragment from '../utils/clone-fragment'
 import findDOMNode from '../utils/find-dom-node'
@@ -23,7 +23,7 @@ import setEventTransfer from '../utils/set-event-transfer'
  * @type {Function}
  */
 
-const debug = Debug('slate:after')
+const debug = eventLogger(Debug('slate:after'))
 
 /**
  * The after plugin.

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -6,7 +6,6 @@ import React from 'react'
 import getWindow from 'get-window'
 import { Text } from 'slate'
 import Hotkeys from 'slate-hotkeys'
-import eventLogger from './event-logger'
 import Content from '../components/content'
 import cloneFragment from '../utils/clone-fragment'
 import findDOMNode from '../utils/find-dom-node'
@@ -23,7 +22,7 @@ import setEventTransfer from '../utils/set-event-transfer'
  * @type {Function}
  */
 
-const debug = eventLogger(Debug('slate:after'))
+const debug = Debug('slate:after')
 
 /**
  * The after plugin.

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -8,8 +8,8 @@ import {
   IS_IOS,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
-import eventLogger from './event-logger'
 
+import eventLogger from './event-logger'
 import findNode from '../utils/find-node'
 
 /**

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -8,6 +8,7 @@ import {
   IS_IOS,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
+import eventLogger from './event-logger'
 
 import findNode from '../utils/find-node'
 
@@ -17,7 +18,7 @@ import findNode from '../utils/find-node'
  * @type {Function}
  */
 
-const debug = Debug('slate:before')
+const debug = eventLogger(Debug('slate:before'))
 
 /**
  * The core before plugin.

--- a/packages/slate-react/src/plugins/event-logger.js
+++ b/packages/slate-react/src/plugins/event-logger.js
@@ -2,7 +2,8 @@
  * event log is enabled by localStorage
 */
 
-const IS_EVENT_LOG_ENABLED = window && window.localStorage.ENABLE_EVENT_LOG
+const IS_EVENT_LOG_ENABLED =
+  global.window && global.window.localStorage.ENABLE_EVENT_LOG
 
 /*
  * Call event.persist() to view event property in devtool

--- a/packages/slate-react/src/plugins/event-logger.js
+++ b/packages/slate-react/src/plugins/event-logger.js
@@ -1,0 +1,20 @@
+const isEventLoggerEnabled = window && window.localStorage.ENABLE_EVENT_LOG
+
+function eventLogger(debug) {
+  if (!isEventLoggerEnabled) return debug
+
+  return function(handlerType, message) {
+    if (!message || !debug.enabled) {
+      return debug(handlerType, message)
+    }
+
+    const { event } = message
+
+    if (event && event.persist) {
+      event.persist()
+    }
+    return debug(handlerType, message)
+  }
+}
+
+export default eventLogger

--- a/packages/slate-react/src/plugins/event-logger.js
+++ b/packages/slate-react/src/plugins/event-logger.js
@@ -1,9 +1,13 @@
-/*
- * event log is enabled by localStorage
-*/
+/**
+ * Is in development?
+ *
+ * @type {Boolean}
+ */
 
-const IS_EVENT_LOG_ENABLED =
-  global.window && global.window.localStorage.ENABLE_EVENT_LOG
+const IS_DEV =
+  typeof process !== 'undefined' &&
+  process.env &&
+  process.env.NODE_ENV !== 'production'
 
 /*
  * Call event.persist() to view event property in devtool
@@ -12,7 +16,7 @@ const IS_EVENT_LOG_ENABLED =
 */
 
 function eventLogger(debug) {
-  if (!IS_EVENT_LOG_ENABLED) return debug
+  if (!IS_DEV) return debug
 
   return function(handlerType, message) {
     if (!message || !debug.enabled) {

--- a/packages/slate-react/src/plugins/event-logger.js
+++ b/packages/slate-react/src/plugins/event-logger.js
@@ -1,7 +1,17 @@
-const isEventLoggerEnabled = window && window.localStorage.ENABLE_EVENT_LOG
+/*
+ * event log is enabled by localStorage
+*/
+
+const IS_EVENT_LOG_ENABLED = window && window.localStorage.ENABLE_EVENT_LOG
+
+/*
+ * Call event.persist() to view event property in devtool
+ * @param {Debug} debug
+ * @return {Debug}
+*/
 
 function eventLogger(debug) {
-  if (!isEventLoggerEnabled) return debug
+  if (!IS_EVENT_LOG_ENABLED) return debug
 
   return function(handlerType, message) {
     if (!message || !debug.enabled) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

featrue

#### What's the new behavior?
When localestorage.ENABLE_EVENT_LOG is true, `event.persist()` will be called to understand {event} in `debug('onEvent', {event})`

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
