### PR TITLE
fix(content): use handlers that actually exist in event listeners

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -113,12 +113,15 @@ class Content extends React.Component {
     if (window) {
       window.document.removeEventListener(
         'selectionchange',
-        this.onNativeSelectionChange
+        this.handlers.onNativeSelectionChange
       )
     }
 
     if (HAS_INPUT_EVENTS_LEVEL_2) {
-      this.element.removeEventListener('beforeinput', this.onBeforeInput)
+      this.element.removeEventListener(
+        'beforeinput',
+        this.handlers.onBeforeInput
+      )
     }
   }
 

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -91,13 +91,13 @@ class Content extends React.Component {
 
     window.document.addEventListener(
       'selectionchange',
-      this.onNativeSelectionChange
+      this.handlers.onNativeSelectionChange
     )
 
     // COMPAT: Restrict scope of `beforeinput` to clients that support the
     // Input Events Level 2 spec, since they are preventable events.
     if (HAS_INPUT_EVENTS_LEVEL_2) {
-      this.element.addEventListener('beforeinput', this.onBeforeInput)
+      this.element.addEventListener('beforeinput', this.handlers.onBeforeInput)
     }
 
     this.updateSelection()


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a _bug_

#### How does this change work?

In a recent change, handlers now only exist in `Content#handlers` and not directly on the instance itself. There were still a couple of places where they were being accessed directly from the instance for event listeners. This was causing some side effects in iOS.

More details in #2125 

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2125 #2129 
Reviewers: @zhujinxuan @ianstormtaylor 
