### PR TITLE
fix(markdown-shortcuts): moveFocusToStartOf -> moveFocusToStartOfNode

### DIFF
--- a/examples/markdown-shortcuts/index.js
+++ b/examples/markdown-shortcuts/index.js
@@ -160,7 +160,7 @@ class MarkdownShortcuts extends React.Component {
       change.wrapBlock('bulleted-list')
     }
 
-    change.moveFocusToStartOf(startBlock).delete()
+    change.moveFocusToStartOfNode(startBlock).delete()
     return true
   }
 


### PR DESCRIPTION
This got a bit mangled during find and replace in https://github.com/ericedem/slate/commit/08f270dc1b69074c876cd2022d7addb8ef5b5836

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Markdown Shortcuts no longer throws an error

#### How does this change work?

Fixes a misspelled method name.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2145 
Reviewers: @
