### PR TITLE
fix(content): attach the right `onNativeSelectionChange`.

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -91,7 +91,7 @@ class Content extends React.Component {
 
     window.document.addEventListener(
       'selectionchange',
-      this.handlers.onNativeSelectionChange
+      this.onNativeSelectionChange
     )
 
     // COMPAT: Restrict scope of `beforeinput` to clients that support the
@@ -113,7 +113,7 @@ class Content extends React.Component {
     if (window) {
       window.document.removeEventListener(
         'selectionchange',
-        this.handlers.onNativeSelectionChange
+        this.onNativeSelectionChange
       )
     }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### How does this change work?

This undoes a recent change https://github.com/ianstormtaylor/slate/pull/2131

Which hooked up `this.handlers.onNativeSelectionChange` to `'selectionchange'` as well as `this.handlers.onBeforeInput` to `'beforeinput'`.

It turns out that in order to fix the iOS issues, we only needed the change to `onBeforeInput`. The corect handler for `'selectionchange'` is the instance method `this.onNativeSelectionChange`. This broke a whole bunch of focus related issues.

I did double check that with this change, https://github.com/ianstormtaylor/slate/issues/2125 is still fixed.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2147
Reviewers: @ianstormtaylor @zhujinxuan 
