### PR TITLE
Add support for validating functions inside schema's rules

### DIFF
--- a/docs/reference/slate/schema.md
+++ b/docs/reference/slate/schema.md
@@ -154,6 +154,24 @@ Will determine whether the node is treated as a "void" node or not, making its c
 
 Will validate the last child node against a [`match`](#match).
 
+### `next`
+
+`Object|Array`
+
+```js
+{
+  next: { type: 'quote' },
+}
+```
+
+```js
+{
+  next: [{ type: 'quote' }, { type: 'paragraph' }],
+}
+```
+
+Will validate the next sibling node against a [`match`](#match).
+
 ### `nodes`
 
 `Array`
@@ -230,6 +248,24 @@ For more information on the arguments passed to `normalize`, see the [Normalizin
 ```
 
 Will validate a node's parent against a [`match`](#match).
+
+### `previous`
+
+`Object|Array`
+
+```js
+{
+  previous: { type: 'quote' },
+}
+```
+
+```js
+{
+  previous: [{ type: 'quote' }, { type: 'paragraph' }],
+}
+```
+
+Will validate the previous sibling node against a [`match`](#match).
 
 ### `text`
 
@@ -380,6 +416,30 @@ Raised when the `object` property of the last child node is invalid, when a spec
 
 Raised when the `type` property of the last child node is invalid, when a specific `last` rule was defined in a schema.
 
+### `'next_sibling_object_invalid'`
+
+```js
+{
+  next: Node,
+  node: Node,
+  rule: Object,
+}
+```
+
+Raised when the `object` property of the next sibling node is invalid, when a specific `next` rule was defined in a schema.
+
+### `'next_sibling_type_invalid'`
+
+```js
+{
+  next: Node,
+  node: Node,
+  rule: Object,
+}
+```
+
+Raised when the `type` property of the next sibling node is invalid, when a specific `next` rule was defined in a schema.
+
 ### `'node_data_invalid'`
 
 ```js
@@ -451,3 +511,27 @@ Raised when the `object` property of the parent of a node is invalid, when a spe
 ```
 
 Raised when the `type` property of the parent of a node is invalid, when a specific `parent` rule was defined in a schema.
+
+### `'previous_sibling_object_invalid'`
+
+```js
+{
+  previous: Node,
+  node: Node,
+  rule: Object,
+}
+```
+
+Raised when the `object` property of the previous sibling node is invalid, when a specific `previous` rule was defined in a schema.
+
+### `'previous_sibling_type_invalid'`
+
+```js
+{
+  previous: Node,
+  node: Node,
+  rule: Object,
+}
+```
+
+Raised when the `type` property of the previous sibling node is invalid, when a specific `previous` rule was defined in a schema.

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -511,18 +511,25 @@ function validateRules(object, rule, rules, options = {}) {
 function validateObject(node, rule) {
   if (rule.object == null) return
   if (rule.object === node.object) return
+  if (typeof rule.object === 'function' && rule.object(node.object)) return
   return fail('node_object_invalid', { rule, node })
 }
 
 function validateType(node, rule) {
   if (rule.type == null) return
   if (rule.type === node.type) return
+  if (typeof rule.type === 'function' && rule.type(node.type)) return
   return fail('node_type_invalid', { rule, node })
 }
 
 function validateData(node, rule) {
   if (rule.data == null) return
   if (node.data == null) return
+
+  if (typeof rule.data === 'function') {
+    if (rule.data(node.data)) return
+    return fail('node_data_invalid', { rule, node })
+  }
 
   for (const key in rule.data) {
     const fn = rule.data[key]
@@ -538,7 +545,12 @@ function validateMarks(node, rule) {
   const marks = node.getMarks().toArray()
 
   for (const mark of marks) {
-    const valid = rule.marks.some(def => def.type === mark.type)
+    const valid = rule.marks.some(
+      def =>
+        typeof def.type === 'function'
+          ? def.type(mark.type)
+          : def.type === mark.type
+    )
     if (valid) continue
     return fail('node_mark_invalid', { rule, node, mark })
   }

--- a/packages/slate/src/models/schema.js
+++ b/packages/slate/src/models/schema.js
@@ -386,7 +386,7 @@ class Schema extends Record(DEFAULTS) {
  */
 
 function defaultNormalize(change, error) {
-  const { code, node, child, key, mark } = error
+  const { code, node, child, next, previous, key, mark } = error
 
   switch (code) {
     case 'child_object_invalid':
@@ -401,6 +401,24 @@ function defaultNormalize(change, error) {
         node.nodes.size === 1
         ? change.removeNodeByKey(node.key, { normalize: false })
         : change.removeNodeByKey(child.key, { normalize: false })
+    }
+
+    case 'previous_sibling_object_invalid':
+    case 'previous_sibling_type_invalid': {
+      return previous.object === 'text' &&
+        node.object === 'block' &&
+        node.nodes.size === 1
+        ? change.removeNodeByKey(node.key, { normalize: false })
+        : change.removeNodeByKey(previous.key, { normalize: false })
+    }
+
+    case 'next_sibling_object_invalid':
+    case 'next_sibling_type_invalid': {
+      return next.object === 'text' &&
+        node.object === 'block' &&
+        node.nodes.size === 1
+        ? change.removeNodeByKey(node.key, { normalize: false })
+        : change.removeNodeByKey(next.key, { normalize: false })
     }
 
     case 'child_required':

--- a/packages/slate/test/schema/custom/child-kind-invalid-function.js
+++ b/packages/slate/test/schema/custom/child-kind-invalid-function.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ object: o => ['inline', 'text'].includes(o) }],
+        },
+      ],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>text</paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/child-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/child-type-invalid-function.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ type: t => t === 'paragraph' }],
+        },
+      ],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <image />
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document />
+  </value>
+)

--- a/packages/slate/test/schema/custom/first-child-kind-invalid-function.js
+++ b/packages/slate/test/schema/custom/first-child-kind-invalid-function.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      first: [{ object: o => o === 'text' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph />
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/first-child-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/first-child-type-invalid-function.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      first: { type: t => t === 'paragraph' },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <image />
+        <paragraph />
+        <paragraph />
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph />
+        <paragraph />
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/last-child-kind-invalid-function.js
+++ b/packages/slate/test/schema/custom/last-child-kind-invalid-function.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      last: [{ object: o => o === 'text' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph />
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/last-child-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/last-child-type-invalid-function.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      last: { type: t => t === 'paragraph' },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph />
+        <paragraph />
+        <image />
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <paragraph />
+        <paragraph />
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/next-kind-invalid-custom.js
+++ b/packages/slate/test/schema/custom/next-kind-invalid-custom.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    image: {
+      next: [{ object: 'inline' }, { object: 'text' }],
+      normalize: (change, { code, next }) => {
+        if (code == 'next_sibling_object_invalid') {
+          change.unwrapBlockByKey(next.key, 'paragraph')
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+        <quote />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+      </paragraph>
+      <quote />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/next-kind-invalid-default.js
+++ b/packages/slate/test/schema/custom/next-kind-invalid-default.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    image: {
+      next: [{ object: 'text' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+        <quote />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/next-kind-invalid-function.js
+++ b/packages/slate/test/schema/custom/next-kind-invalid-function.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    image: {
+      next: [{ object: o => o === 'text' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+        <quote />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/next-type-invalid-custom.js
+++ b/packages/slate/test/schema/custom/next-type-invalid-custom.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      next: [{ type: 'paragraph' }],
+      normalize: (change, { code, next }) => {
+        if (code == 'next_sibling_type_invalid') {
+          change.wrapBlockByKey(next.key, 'paragraph')
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph />
+      <image />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+      <paragraph>
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/next-type-invalid-default.js
+++ b/packages/slate/test/schema/custom/next-type-invalid-default.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      next: [{ type: 'paragraph' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph />
+      <image />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/next-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/next-type-invalid-function.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      next: [{ type: t => t === 'paragraph' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph />
+      <image />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/node-data-invalid-function.js
+++ b/packages/slate/test/schema/custom/node-data-invalid-function.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      data: d => d.get('thing') === 'valid',
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph thing="valid" />
+      <paragraph thing="invalid" />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph thing="valid" />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/node-mark-invalid-function.js
+++ b/packages/slate/test/schema/custom/node-mark-invalid-function.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      marks: [{ type: t => ['bold', 'underline'].includes(t) }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        one <i>two</i> <u>three</u>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        one two <u>three</u>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/node-object-invalid-function.js
+++ b/packages/slate/test/schema/custom/node-object-invalid-function.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      object: o => o === 'inline',
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>invalid</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document />
+  </value>
+)

--- a/packages/slate/test/schema/custom/node-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/node-type-invalid-function.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      type: t => t === 'impossible',
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>invalid</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document />
+  </value>
+)

--- a/packages/slate/test/schema/custom/parent-kind-invalid-function.js
+++ b/packages/slate/test/schema/custom/parent-kind-invalid-function.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  inlines: {
+    link: {
+      parent: { object: o => o === 'block' },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          <link>one</link>
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <link />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/parent-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/parent-type-invalid-function.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    list: {},
+    item: {
+      parent: { type: t => t === 'list' },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <item />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/previous-kind-invalid-custom.js
+++ b/packages/slate/test/schema/custom/previous-kind-invalid-custom.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    image: {
+      previous: [{ object: 'inline' }, { object: 'text' }],
+      normalize: (change, { code, previous }) => {
+        if (code == 'previous_sibling_object_invalid') {
+          change.unwrapBlockByKey(previous.key, 'paragraph')
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <quote />
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote />
+      <paragraph>
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/previous-kind-invalid-default.js
+++ b/packages/slate/test/schema/custom/previous-kind-invalid-default.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    image: {
+      previous: [{ object: 'text' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <quote />
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/previous-kind-invalid-function.js
+++ b/packages/slate/test/schema/custom/previous-kind-invalid-function.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    image: {
+      previous: [{ object: o => o === 'text' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <quote />
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/previous-type-invalid-custom.js
+++ b/packages/slate/test/schema/custom/previous-type-invalid-custom.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      previous: [{ type: 'paragraph' }],
+      normalize: (change, { code, previous }) => {
+        if (code == 'previous_sibling_type_invalid') {
+          change.wrapBlockByKey(previous.key, 'paragraph')
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <image />
+      <paragraph />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <image />
+      </paragraph>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/previous-type-invalid-default.js
+++ b/packages/slate/test/schema/custom/previous-type-invalid-default.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      previous: [{ type: 'paragraph' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <image />
+      <paragraph />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/previous-type-invalid-function.js
+++ b/packages/slate/test/schema/custom/previous-type-invalid-function.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {
+      previous: [{ type: t => t === 'paragraph' }],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <image />
+      <paragraph />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behaviour?

With this change we can now use validating functions inside schema's matching properties, at least for a few keys.

A few example:
```js
{
  match: { /* something */ },
  object: kind => kind !== 'text',
  type: type => ['paragraph', 'image'].includes(type),
  data: data => data.has('thing'),
  marks: mark => mark.type === 'mention' && mark.data.has('userId'),
}
```

I also added documentation, specs, and default normalization on `next` and `previous` rules.

#### How does this change work?

A more complex one now allowed by this change:

```js
{
  // Merge two consecutives lists
  match: { type: 'list' },
  next: {
    type: type => type !== 'list'
  },
  normalize: (change, error) => {
    if (error.code === 'next_sibling_invalid_type') {
      change.mergeNodeByKey(error.next);
    }
  },
}
```

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2139