### PR TITLE
Fix deprecated function calls in slate-react

### DIFF
--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -40,12 +40,12 @@ function getEventRange(event, value) {
       const previousText = document.getPreviousText(text.key)
 
       if (previousText) {
-        return range.moveToEndOf(previousText)
+        return range.moveToEndOfNode(previousText)
       }
     }
 
     const nextText = document.getNextText(text.key)
-    return nextText ? range.moveToStartOf(nextText) : null
+    return nextText ? range.moveToStartOfNode(nextText) : null
   }
 
   // Else resolve a range from the caret position where the drop occured.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing deprecated function calls in ``slate-react`` (get-event-range.js).

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
