### PR TITLE
Docs: Add info on how to use schema object

### DIFF
--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -8,6 +8,8 @@ That said, just because Slate is agnostic doesn't mean you aren't going to need 
 
 To that end, Slate provides a `Schema` model, which allows you to easily define validations for the structure of your documents, and to fix them if the document ever becomes invalid. This guide will show you how they work.
 
+> ❗️To tell Slate about your custom schema add it to the editor as a prop [like this](https://github.com/ianstormtaylor/slate/blob/405cef0225c314b4162d587c74cfce6b65a7b257/examples/forced-layout/index.js#L62).
+
 ## Basic Schemas
 
 Slate schemas are defined as Javascript objects, with properties that describe the document, block nodes, and inline nodes in your editor. Here's a simple schema:


### PR DESCRIPTION
Extend the documentation to more obviously show where to reference the created schema object.

In light of a couple of questions on Slack recently [[1]](https://slate-js.slack.com/archives/C1RH7AXSS/p1535275266000100) [[2]](https://slate-js.slack.com/archives/C1RH7AXSS/p1534953134000100?thread_ts=1534952365.000100&cid=C1RH7AXSS) regarding how to tell the editor about the schema object one created, I propose an extension to the current docs.
I am by no means a Slate expert (actually pretty much the opposite) but I think that this extension would eliminate some confusion around schemas.
I am very open to changes/comments/whatever regarding this proposal.

---
#### How does this change work?
Extends the documentation.

#### Have you checked that...?
I have.

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
