### PR TITLE
Pass path to decoration in code highlight example

### DIFF
--- a/examples/code-highlighting/index.js
+++ b/examples/code-highlighting/index.js
@@ -226,18 +226,10 @@ class CodeHighlighting extends React.Component {
 
       if (typeof token != 'string') {
         const dec = {
-          anchor: {
-            key: startText.key,
-            offset: startOffset,
-          },
-          focus: {
-            key: endText.key,
-            offset: endOffset,
-          },
-          mark: {
-            type: token.type,
-          },
-        }
+            anchor: { key: startText.key, offset: startOffset, path: node.getPath(startText.key) },
+            focus: { key: endText.key, offset: endOffset, path: node.getPath(endText.key) },
+            mark: { type: token.type }
+          }
 
         decorations.push(dec)
       }


### PR DESCRIPTION
Decoration accepts a point for it's anchor and focus values. A point requires a key, offset and a path. Without the path this will crash when comparing the point's paths.
https://github.com/ianstormtaylor/slate/issues/2154

#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug outlined in the issue above.

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2154
Reviewers: @An0nymous0
