### PR TITLE
Fix marks being cleared on selection events

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -677,6 +677,10 @@ function AfterPlugin() {
       if (next) range = range.moveFocusTo(next.key, 0)
     }
 
+    // Preserve active marks from the current selection.
+    // They will be cleared by `change.select` if the selection actually moved.
+    range = range.set('marks', value.selection.marks)
+
     let selection = document.createSelection(range)
     selection = selection.setIsFocused(true)
     change.select(selection)


### PR DESCRIPTION
This is a bug fix.

#### Bug example

https://jsfiddle.net/fj9dvhom/2040/

Here is a JSFiddle with a button that inserts some bold text, and then remove the bold from active marks. The bug is that the bold stays active:

![marks](https://user-images.githubusercontent.com/5644953/45228754-5b4e6a80-b2c4-11e8-8fe1-ff53dc52e917.gif)


#### What's the new behavior?

The bug come from the fact that any `onSelect` event will clear the active marks from the selection. And in this case, an `onSelect` event is happening after the operation. Though the selection has not changed, this is something that can happen [as stated here](https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/src/components/content.js#L290-L294). The fix happens in the `onSelect` handling by the `AfterPlugin`, that was currently ignoring active marks.

---

I have checked that:

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @uipoptart because it could be related to https://github.com/ianstormtaylor/slate/issues/1962

