### PR TITLE
Remove stale docs for shouldNodeComponentUpdate

### DIFF
--- a/docs/reference/slate-react/custom-nodes.md
+++ b/docs/reference/slate-react/custom-nodes.md
@@ -92,17 +92,3 @@ A reference to the parent of the current [`Node`](../slate/node.md) being render
 `Boolean`
 
 Whether the editor is in "read-only" mode, where all of the rendering is the same, but the user is prevented from editing the editor's content.
-
-## `shouldNodeComponentUpdate`
-
-By default, Slate implements a `shouldComponentUpdate` preventing useless re-renders for node components. While the default implementation covers most use cases, you can customize the logic to fit your needs. For example:
-
-```js
-class CustomNode extends React.Component {
-  static shouldNodeComponentUpdate(previousProps, nextProps) {
-    // return true here to trigger a re-render
-  }
-}
-```
-
-If `shouldNodeComponentUpdate` returns false, Slate will still figure out whether a re-render is needed or not.


### PR DESCRIPTION
Almost a year ago, the implementation for `shouldNodeComponentUpdate` changed from referring to a method on the node's react component itself to referring to a general plugin hook:

https://github.com/ianstormtaylor/slate/commit/509d3d50fc8cc68afa9c0ab6e88506457da564ba#diff-87db911e8d9f44ff72402a1b833bf894R70

However, Custom Nodes docs never caught up. Small fix. :+1: 