### PR TITLE
docs(change.md): correct `setOperationFlag()` signature

### DIFF
--- a/docs/reference/slate/change.md
+++ b/docs/reference/slate/change.md
@@ -99,7 +99,7 @@ Set the entire `value` using either a `properties` object or a `Value` object. C
 
 Warning: Calling `setValue` with a `Value` object has unpredictable behavior including the loss of the edit history. Only use with a `Value` object if you know what you are doing. For most use cases, we recommend passing `properties` as an `Object` (e.g. `change.setValue({data: myNewDataObject})`.
 
-Hint: Wrapping the call to `setValue` as follows can be helpful if you want to update a value, like in the value's `data` but do not want to have another save point in the undo history: `change.setOperationFlag({save: false}).setValue({data: myNewDataObject}).setOperationFlag({save: true}).
+Hint: Wrapping the call to `setValue` as follows can be helpful if you want to update a value, like in the value's `data` but do not want to have another save point in the undo history: `change.setOperationFlag('save', false).setValue({data: myNewDataObject}).setOperationFlag('save', true).
 
 ## Current Selection Changes
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing docs

`setOperationFlag()` actually accepts a `key` and a `value`.

https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/models/change.js#L161