### PR TITLE
Avoid crash in updateSelection() in editor when getSelection() is null

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -144,6 +144,11 @@ class Content extends React.Component {
     const { isBackward } = selection
     const window = getWindow(this.element)
     const native = window.getSelection()
+
+    // .getSelection() can return null in some cases
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=827585
+    if (!native) return
+
     const { rangeCount, anchorNode } = native
 
     // If both selections are blurred, do nothing.


### PR DESCRIPTION


#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug 

#### What's the new behavior?

Content in slate-react will not crash if on componentDidMount if `window.getSelection()` returns null

#### How does this change work?

`window.getSelection()` can sometimes return null (see https://bugzilla.mozilla.org/show_bug.cgi?id=827585). This change checks the return value of `window.getSelection()` before trying to use it.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2162
Reviewers: @
