### PR TITLE
Gives a warning when visiting editor.value during onChange

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -214,7 +214,7 @@ class Editor extends React.Component {
         false,
         `editor.value is initializing during onChange. Please call editor.props.value instead.`
       )
-      return this.props.onChange
+      return this.props.value
     }
 
     const value = this.resolveValue(this.plugins, this.props.value)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

perhaps a bug;  Editor run into a runaway recursion when visiting editor.value during onChange
https://github.com/ianstormtaylor/slate/issues/2152

#### What's the new behavior?

1. Allows user visit editor.value during onChange. 
2. Gives a warning when user do it.


#### How does this change work?

Adds tmp.isResolvingValue in editor

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2152
Reviewers: @ericedem 
