### PR TITLE
fix: moving around void nodes

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -530,7 +530,7 @@ function AfterPlugin() {
       const isPreviousInVoid =
         previousText && document.hasVoidParent(previousText.key, schema)
 
-      if (hasVoidParent || isPreviousInVoid || startText.text == '') {
+      if (hasVoidParent || (isPreviousInVoid && startText.text == '')) {
         event.preventDefault()
         return change.moveBackward()
       }
@@ -541,7 +541,7 @@ function AfterPlugin() {
       const isNextInVoid =
         nextText && document.hasVoidParent(nextText.key, schema)
 
-      if (hasVoidParent || isNextInVoid || startText.text == '') {
+      if (hasVoidParent || (isNextInVoid && startText.text == '')) {
         event.preventDefault()
         return change.moveForward()
       }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Now the behavior works as expected around void nodes. The cursor jumps forward to the next word when pressing option + forward arrow, and to the previous word when pressing option + back arrow.

#### How does this change work?

The problem was that we were arbitrarily checking if the next node was a void, even though there was still text to traverse in the current node. Now we check to see if the current node contains text and if so just move as normal.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2069
