### PR TITLE
improvement(slate-react): optimise cursors in inline placeholders

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -174,7 +174,7 @@ class Node extends React.Component {
         key: `${node.key}-placeholder`,
       })
 
-      children = [...children, placeholder, ]
+      children = [...children, placeholder]
     }
 
     const element = stack.find('renderNode', {

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -174,7 +174,7 @@ class Node extends React.Component {
         key: `${node.key}-placeholder`,
       })
 
-      children = [placeholder, ...children]
+      children = [...children, placeholder, ]
     }
 
     const element = stack.find('renderNode', {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This improves cursor positioning in empty nodes with an inline (not absolutely positioned) placeholder.

#### What's the new behavior?

Cursor is positioned *before* the placeholder instead of after. 
It's basically `[...children, placeholder]` instead of `[placeholder, ...children]` 

#### How does this change work?

Out of the box. No adjustments to existing code needed. 

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1678
Reviewers: @vilic @ianstormtaylor 
