### PR TITLE
fix(example/links): a few fixes for the links example

### DIFF
--- a/examples/links/index.js
+++ b/examples/links/index.js
@@ -133,16 +133,30 @@ class Links extends React.Component {
 
     if (hasLinks) {
       change.call(unwrapLink)
-    } else if (value.isExpanded) {
+    } else if (value.selection.isExpanded) {
       const href = window.prompt('Enter the URL of the link:')
+
+      if (href === null) {
+        return
+      }
+
       change.call(wrapLink, href)
     } else {
       const href = window.prompt('Enter the URL of the link:')
+
+      if (href === null) {
+        return
+      }
+
       const text = window.prompt('Enter the text for the link:')
+
+      if (text === null) {
+        return
+      }
 
       change
         .insertText(text)
-        .extend(0 - text.length)
+        .moveFocusBackward(text.length)
         .call(wrapLink, href)
     }
 


### PR DESCRIPTION
* Correctly use the selection
* check whether the user cancelled the prompt
* use `moveFocusBackward`

#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?

Make links example work again after API changes, and add cancel handling for the prompt.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

Fixes: #2164 