### PR TITLE
Gracefully handle permission denied error in FF when checking for element.nodeType

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -14,6 +14,8 @@ import getChildrenDecorations from '../utils/get-children-decorations'
 import scrollToSelection from '../utils/scroll-to-selection'
 import removeAllRanges from '../utils/remove-all-ranges'
 
+const FIREFOX_NODE_TYPE_ACCESS_ERROR = /Permission denied to access property "nodeType"/
+
 /**
  * Debug.
  *
@@ -259,9 +261,24 @@ class Content extends React.Component {
 
   isInEditor = target => {
     const { element } = this
-    // COMPAT: Text nodes don't have `isContentEditable` property. So, when
-    // `target` is a text node use its parent node for check.
-    const el = target.nodeType === 3 ? target.parentNode : target
+
+    let el
+
+    try {
+      // COMPAT: Text nodes don't have `isContentEditable` property. So, when
+      // `target` is a text node use its parent node for check.
+      el = target.nodeType === 3 ? target.parentNode : target
+    } catch (err) {
+      // COMPAT: In Firefox, `target.nodeType` will throw an error if target is
+      // originating from an internal "restricted" element (e.g. a stepper
+      // arrow on a number input)
+      // see github.com/ianstormtaylor/slate/issues/1819
+      if (IS_FIREFOX && FIREFOX_NODE_TYPE_ACCESS_ERROR.test(err.message)) {
+        return false
+      }
+
+      throw err
+    }
     return (
       el.isContentEditable &&
       (el === element || el.closest('[data-slate-editor]') === element)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### What's the new behavior?
Not crashing in Firefox when clicking stepper arrows on number inputs (even outside of Slate itself) (#1819) and not crashing in embeds example (#843), and possibly providing a workaround for #1744.

#### How does this change work?
This is a workaround for an issue with Firefox that causes `Restricted` nodes to throw on property access (e.g. `.nodeType`). I've tried to narrow the test to identify the particular situation as much as possible to avoid accidentally catching other errors that may happen here.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
