### PR TITLE
Fix deprecated .move > .moveForward in the after plugin

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -319,7 +319,7 @@ function AfterPlugin() {
       selection.end.key == target.end.key &&
       selection.end.offset < target.end.offset
     ) {
-      target = target.move(
+      target = target.moveForward(
         selection.start.key == selection.end.key
           ? 0 - selection.end.offset + selection.start.offset
           : 0 - selection.end.offset


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug where a deprecated call to ``move`` was made in the After Plugin (onDrop). Should be ``moveForward``

#### What's the new behavior?
No new behaviour.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: (could not find any)
Reviewers: @
