### PR TITLE
Actually fix marks being cleared on selection events

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -677,6 +677,10 @@ function AfterPlugin() {
       if (next) range = range.moveFocusTo(next.key, 0)
     }
 
+    // Preserve active marks from the current selection.
+    // They will be cleared by `change.select` if the selection actually moved.
+    range = range.set('marks', value.selection.marks)
+
     let selection = document.createSelection(range)
     selection = selection.setIsFocused(true)
     change.select(selection)

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -677,12 +677,13 @@ function AfterPlugin() {
       if (next) range = range.moveFocusTo(next.key, 0)
     }
 
-    // Preserve active marks from the current selection.
-    // They will be cleared by `change.select` if the selection actually moved.
-    range = range.set('marks', value.selection.marks)
-
     let selection = document.createSelection(range)
     selection = selection.setIsFocused(true)
+
+    // Preserve active marks from the current selection.
+    // They will be cleared by `change.select` if the selection actually moved.
+    selection = selection.set('marks', value.selection.marks)
+
     change.select(selection)
   }
 


### PR DESCRIPTION
I improperly rebased my fix in https://github.com/ianstormtaylor/slate/pull/2158 and was setting `marks` on the old `Range` objects instead of the new `Selection` object.