### PR TITLE
debt(codecov): disable code coverage in builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache: yarn
 env:
   # Do two runs, one for testing and one for linting.
   matrix:
-    - TEST_TYPE=test:coverage
     - TEST_TYPE=lint:eslint
     - TEST_TYPE=lint:prettier
 
@@ -28,5 +27,4 @@ script:
   - |
     set -e
     yarn $TEST_TYPE
-    if [[ $TEST_TYPE == 'test:coverage' ]]; then yarn codecov; fi
     set +e


### PR DESCRIPTION
Right now code coverage results in a lot of false positives for failing builds. This makes it really difficult to tell at a glance whether PRs are passing / failing something more important like linting or tests.

Disabling for now until we can find a better approach.

#### Is this adding or improving a _feature_ or fixing a _bug_?

debt

#### What's the new behavior?

No more codecov in automated builds

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2106 
Reviewers: @ianstormtaylor @zhujinxuan 
