### PR TITLE
Codecov: Only test slate, slate-html-serializer and slate-plain-serializer

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -4,7 +4,7 @@
   "all": true,
   "extension" : ["js"],
   "cache": false,
-  "include": ["packages/slate/src/**"],
+  "include": ["packages/slate/src/**", "packages/slate-html-serializer/src/**",  "packages/slate-plain-serializer/src/**"],
   "reporter": [
     "html",
     "lcov",

--- a/.nycrc
+++ b/.nycrc
@@ -4,7 +4,7 @@
   "all": true,
   "extension" : ["js"],
   "cache": false,
-  "include": ["**/src/**"],
+  "include": ["packages/slate/src/**"],
   "reporter": [
     "html",
     "lcov",

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache: yarn
 env:
   # Do two runs, one for testing and one for linting.
   matrix:
+    - TEST_TYPE=test:coverage	
     - TEST_TYPE=lint:eslint
     - TEST_TYPE=lint:prettier
 
@@ -27,4 +28,5 @@ script:
   - |
     set -e
     yarn $TEST_TYPE
+    if [[ $TEST_TYPE == 'test:coverage' ]]; then yarn codecov; fi	
     set +e


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

slate-react cannot be tested currently, so this PR limits the codecov covers the testable parts to avoid false failings.

#### What's the new behavior?

Coverage only reports three packages. 

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2106
Reviewers: @ianstormtaylor , @ericedem 
