### PR TITLE
Refactor Editor Memoize interface

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -81,6 +81,7 @@ class Editor extends React.Component {
 
   tmp = {
     isChanging: false,
+    isResolvingValue: false,
     operationsSize: null,
     plugins: null,
     resolves: 0,
@@ -119,7 +120,7 @@ class Editor extends React.Component {
 
     const { autoFocus } = this.props
     this.resolveMemoize()
-    const change = this.memoized.change
+    const { change } = this.memoized
 
     if (autoFocus) {
       if (change) {
@@ -233,7 +234,7 @@ class Editor extends React.Component {
     }
 
     this.resolveMemoize()
-    const change = this.memoized.change
+    const { change } = this.memoized
 
     try {
       this.tmp.isChanging = true

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -85,7 +85,6 @@ class Editor extends React.Component {
     plugins: null,
     resolves: 0,
     updates: 0,
-    cycles: 0,
     value: null,
     propsValue: null,
   }

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -377,9 +377,7 @@ class Editor extends React.Component {
    * Resolve a change from the current `plugins`, a potential `change` and its
    * current operations `size`.
    *
-   * @param {Array} plugins
-   * @param {Change} change
-   * @param {Number} size
+   * @return {Change}
    */
 
   resolveChange = () => {
@@ -388,14 +386,13 @@ class Editor extends React.Component {
   }
 
   /**
-   * Resolve a value from the current `plugins` and a potential `value`.
+   * Resolve value and change in each lifecycle, and store them in this.memoized
    *
-   * @param {Array} plugins
-   * @param {Value} value
-   * @return {Change}
+   * @return {}
    */
 
   resolveMemoize = () => {
+    // Flush the memoize when props changes
     if (this.tmp.propsValue !== this.props.value) {
       this.tmp.propsValue = this.props.value
       this.memoized = {}

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -278,7 +278,7 @@ class Editor extends React.Component {
     debug('onChange', { change })
 
     if (change.operations.size > this.tmp.operationsSize) {
-      this.resolveChange(this.plugins, change)
+      this.resolveChange(change)
     }
 
     // Store a reference to the last `value` and `plugins` that were seen by the
@@ -317,7 +317,7 @@ class Editor extends React.Component {
    * @param {Number} size
    */
 
-  resolveChange = (plugins, change) => {
+  resolveChange = change => {
     const { stack } = this
     stack.run('onChange', change, this)
     return change
@@ -428,7 +428,7 @@ class Editor extends React.Component {
     try {
       this.tmp.isResolvingValue = true
       debug('resolveValue', { plugins, value })
-      this.resolveChange(plugins, change)
+      this.resolveChange(change)
 
       // Store the change and it's operations count so that it can be flushed once
       // the component next updates.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### How does this change work?

I think memoize is fine, but the problem is that we are using `memoize-one` as the only memoize method.  `memoize-one` is good for `plugins`, `stack` and `schema`.  But for `value` and `change`, the result depends on how the context/process to generate value or change, it cannot be easily processed by `memoizeOne(...props)`, but more easier to be implement by `memoizeOne(updates)`.

Here we isolate the `value` and `change` in a different memoize process.  I set a cache `editor.memoized` and clear/reset the memoize cache for each update (by resetting at props change, componentDidUpdate, componentDidMount, `editor.onChange`)



#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor @ericedem 
