### PR TITLE
Merge decorations from multiple plugins

### DIFF
--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -439,7 +439,7 @@ class ElementInterface {
     const allDecorations = stack
       .map('decorateNode', this)
       .map(decorations => Decoration.createList(decorations))
-    const list = List(allDecorations).flatten(1)
+    const list = List(allDecorations).flatten(true)
     return list
   }
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -436,11 +436,10 @@ class ElementInterface {
    */
 
   getDecorations(stack) {
-    const list = stack
+    const allDecorations = stack
       .map('decorateNode', this)
-      .reduce((decorations, current) => (
-        decorations.concat(Decoration.createList(current))
-      ), List())
+      .map(decorations => Decoration.createList(decorations))
+    const list = List(allDecorations).flatten(1)
     return list
   }
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -440,7 +440,7 @@ class ElementInterface {
       .map('decorateNode', this)
       .reduce((decorations, current) => (
         decorations.concat(Decoration.createList(current))
-      ), new List())
+      ), List())
     return list
   }
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -436,8 +436,11 @@ class ElementInterface {
    */
 
   getDecorations(stack) {
-    const decorations = stack.find('decorateNode', this)
-    const list = Decoration.createList(decorations || [])
+    const list = stack
+      .map('decorateNode', this)
+      .reduce((decorations, current) => (
+        decorations.concat(Decoration.createList(current))
+      ), new List())
     return list
   }
 


### PR DESCRIPTION
Previously, `decorateNode` would search the plugin stack for the first `decorateNode` handler that returned a value. With this change, it will call the `decorateNode` handler on every plugin in the stack and merge their results together.

The end result is that multiple plugins can provide `decorateNode` decorations to the same node.

cc @ianstormtaylor @zhujinxuan 