### PR TITLE
Normalize copying void inline nodes

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -284,8 +284,10 @@ class Content extends React.Component {
 
       throw err
     }
+
+    const allowEdit = el.isContentEditable || el.closest('[data-slate-void]')
     return (
-      el.isContentEditable &&
+      allowEdit &&
       (el === element || el.closest('[data-slate-editor]') === element)
     )
   }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a bug

#### What's the new behavior?
1. Click on a void inline node to select it
2. Copy (or cut), it will be placed on the clipboard.

The fix can be seen in the emoji demo where you can use command+c and x to copy an emoji after clicking on it. 
When a lone void inline node is selected copy and cut should behave consistently with what happens when a void inline node is selected along with other text. Prior to this commit, selecting a void node along with other text would cause it to be copied/cut. However, selecting a lone void inline would not permit copying. This change makes the behavior consistent.

#### How does this change work?
`isInEditor` would return `false` for anything marked `contenteditable=false` causing void inline nodes to always return false. This change returns `true` when the `contenteditable=false` element has a parent that is a void inline node. The event handler looks at `isInEditor` to decide if it will let the onCopy event propagate. 

#### Have you checked that...?

* [x ] The new code matches the existing patterns and styles.
* [x ] The tests pass with `yarn test`.
* [x ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2124
Reviewers: @ianstormtaylor @zhujinxuan

Also consider #2072, which calls for some changes that would allow for void inline nodes that can enable or disable copy abilities. This fix unifies the current experience, but longer term it would be rad to have the ability to explicitly decide this.