### PR TITLE
Update products to include Cake

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -19,6 +19,7 @@ These tools are helpful when developing with Slate:
 
 These products are built with Slate, and can give you an idea of what's possible:
 
+* [Cake](https://www.cake.co/)
 * [GitBook](https://www.gitbook.com/)
 * [Grafana](https://grafana.com/)
 * [Guru](https://www.getguru.com/)


### PR DESCRIPTION
Now that Cake is coming out of invite only mode, figured it was a good time to add it as a product using Slate. :)

Link to https://www.cake.co/