### PR TITLE
Fix crash when normalizing documents with multiple siblings.

### DIFF
--- a/packages/slate-hyperscript/test/fixtures/cursor-across-blocks-and-inlines.js
+++ b/packages/slate-hyperscript/test/fixtures/cursor-across-blocks-and-inlines.js
@@ -39,7 +39,7 @@ export const output = {
         nodes: [
           {
             object: 'text',
-            key: '11',
+            key: '13',
             leaves: [
               {
                 object: 'leaf',
@@ -69,7 +69,7 @@ export const output = {
           },
           {
             object: 'text',
-            key: '12',
+            key: '14',
             leaves: [
               {
                 object: 'leaf',
@@ -88,7 +88,7 @@ export const output = {
         nodes: [
           {
             object: 'text',
-            key: '13',
+            key: '11',
             leaves: [
               {
                 object: 'leaf',
@@ -118,7 +118,7 @@ export const output = {
           },
           {
             object: 'text',
-            key: '14',
+            key: '12',
             leaves: [
               {
                 object: 'leaf',

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 import isPlainObject from 'is-plain-object'
 import warning from 'slate-dev-warning'
-import { List, Map } from 'immutable'
+import { List } from 'immutable'
 
 import MODEL_TYPES, { isType } from '../constants/model-types'
 import Changes from '../changes'
@@ -181,44 +181,23 @@ class Change {
     const { value } = this
     const { document } = value
 
-    // TODO: if we had an `Operations.tranform` method, we could optimize this
-    // to not use keys, and instead used transformed operation paths.
-    const table = document.getKeysToPathsTable()
-    let map = Map()
+    const keysToVisit = {}
+    keys.forEach(key => (keysToVisit[key] = true))
+    const pathsToVisit = []
 
-    // TODO: this could be optimized to not need the nested map, and instead use
-    // clever sorting to arrive at the proper depth-first normalizing.
-    keys.forEach(key => {
-      const path = table[key]
-      if (!path) return
-      if (!path.length) return
-      if (!map.hasIn(path)) map = map.setIn(path, Map())
+    document.visitNodesReverseDFS((node, path) => {
+      // If this key is included, also visit the parents.
+      if (keysToVisit[node.key]) {
+        document.getNodesInPath(path).forEach(n => (keysToVisit[n.key] = true))
+
+        pathsToVisit.push(path)
+      }
     })
 
-    // To avoid infinite loops, we need to defer normalization until the end.
     this.withoutNormalizing(() => {
-      this.normalizeMapAndPath(map)
+      pathsToVisit.forEach(path => this.normalizePath(path))
     })
 
-    return this
-  }
-
-  /**
-   * Normalize all of the nodes in a normalization `map`, depth-first. An
-   * additional `path` argument specifics the current depth/location.
-   *
-   * @param {Map} map
-   * @param {Array} path (optional)
-   * @return {Change}
-   */
-
-  normalizeMapAndPath(map, path = []) {
-    map.forEach((m, k) => {
-      const p = [...path, k]
-      this.normalizeMapAndPath(m, p)
-    })
-
-    this.normalizePath(path)
     return this
   }
 

--- a/packages/slate/test/schema/custom/child-type-invalid-with-valid-sibling.js
+++ b/packages/slate/test/schema/custom/child-type-invalid-with-valid-sibling.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ type: 'paragraph' }],
+        },
+      ],
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <image />
+      </quote>
+      <paragraph />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug.

#### What's the new behavior?
Currently normalization crashes in documents like this:

```
<document>
  <invalid_node />
  <valid_node />
</document>
```

This is because <invalid_node /> will get deleted when it is normalized, which means that the original path to valid_node, [1], changes to [0]. However the current algorithm for normalization tries to access it at its original path, causing a crash.

#### How does this change work?
Without this change normalization effectively works by creating a list of the paths of all the nodes that need to be normalized and then calls Node.normalizePath() on each one in turn, which causes problems when nodes disappear during normalization as those paths can become invalid.

This change fixes the problem by reversing the order in which sibling nodes are visited during the normalization process. This way nodes that get removed during normalization will not invalidate the paths of nodes yet to be normalized. Of course it's still fairly easy to write custom normalizers that thwart this process and cause crashes, but this change is intended to handle this edge case without changing the overall approach (the motivations for which I am not familiar with).

Note that this will cause any tests that assume a certain order of normalization to break (as you can see in the updated test case).

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
