### PR TITLE
tests: remove debugger statement

### DIFF
--- a/packages/slate/src/interfaces/object.js
+++ b/packages/slate/src/interfaces/object.js
@@ -50,8 +50,6 @@ function create(type) {
  * Mix in the object interfaces.
  */
 
-debugger
-
 mixin(create('block'), [Block])
 mixin(create('change'), [Change])
 mixin(create('decoration'), [Decoration])


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->
Bug

#### What's the new behavior?
Tests should not fail because of the `debugger` statement.
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
