### PR TITLE
Prevent crash when handling composition when selection is not collapsed

### DIFF
--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -173,6 +173,20 @@ function BeforePlugin() {
       editor.setState({ isComposing: true })
     }
 
+    const { value } = change
+    const { selection } = value
+
+    if (!selection.isCollapsed) {
+      // https://github.com/ianstormtaylor/slate/issues/1879
+      // When composition starts and the current selection is not collapsed, the
+      // second composition key-down would drop the text wrapping <spans> which
+      // resulted on crash in content.updateSelection after composition ends
+      // (because it cannot find <span> nodes in DOM). This is a workaround that
+      // erases selection as soon as composition starts and preventing <spans>
+      // to be dropped.
+      change.delete()
+    }
+
     debug('onCompositionStart', { event })
   }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix 

#### What's the new behavior?

Doesn't crash when compositions starts on expanded selection.

#### How does this change work?

When composition starts and the current selection is not collapsed, the
second composition key-down would drop the text wrapping <spans> which
resulted on crash in content.updateSelection after composition ends
(because it cannot find <span> nodes in DOM). This is a workaround that
erases selection as soon as composition starts and preventing <spans>
to be dropped.

Note that composition is still not handled quite right in Slate - when composing, the caret should be at the end of composition rather that at start. I might look into that later.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/1879

