### PR TITLE
Fix normalizing dirty paths

### DIFF
--- a/packages/slate-hyperscript/test/fixtures/cursor-across-blocks-and-inlines.js
+++ b/packages/slate-hyperscript/test/fixtures/cursor-across-blocks-and-inlines.js
@@ -39,7 +39,7 @@ export const output = {
         nodes: [
           {
             object: 'text',
-            key: '11',
+            key: '13',
             leaves: [
               {
                 object: 'leaf',
@@ -69,7 +69,7 @@ export const output = {
           },
           {
             object: 'text',
-            key: '12',
+            key: '14',
             leaves: [
               {
                 object: 'leaf',
@@ -88,7 +88,7 @@ export const output = {
         nodes: [
           {
             object: 'text',
-            key: '13',
+            key: '11',
             leaves: [
               {
                 object: 'leaf',
@@ -118,7 +118,7 @@ export const output = {
           },
           {
             object: 'text',
-            key: '14',
+            key: '12',
             leaves: [
               {
                 object: 'leaf',

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 import isPlainObject from 'is-plain-object'
 import warning from 'slate-dev-warning'
-import { List, Map } from 'immutable'
+import { List } from 'immutable'
 
 import Changes from '../changes'
 import Operation from './operation'


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix.

#### What's the new behavior?

The dirty paths in a change are now transformed against incoming operations, such that they don't get out of sync as normalizations occur. This is a rough pass to get correctness and the bug fixed, and we can later optimize lots of the little details for performance.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2211
Fixes: #2215
Fixes: #2194