### PR TITLE
fix activeMarks for intersecting marks text

### DIFF
--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -307,7 +307,7 @@ class Text extends Record(DEFAULTS) {
     const result = this.leaves.first().marks
     if (result.size === 0) return result
 
-    return result.withMutations(x => {
+    return result.toOrderedSet().withMutations(x => {
       this.leaves.forEach(c => {
         x.intersect(c.marks)
         if (x.size === 0) return false

--- a/packages/slate/test/models/text/marks/get-active-marks/intersecting-marks-text.js
+++ b/packages/slate/test/models/text/marks/get-active-marks/intersecting-marks-text.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../../../helpers/h'
+import { Set } from 'immutable'
+import Mark from '../../../../../src/models/mark'
+
+export const input = (
+  <text>
+    <u>
+      <i>
+        <b>b</b>
+      </i>
+    </u>
+    <u>
+      <i>u</i>
+    </u>
+    <i>g</i>
+  </text>
+)[0]
+
+export default function(t) {
+  return t.getActiveMarks()
+}
+
+export const output = Set.of(Mark.create('italic'))


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixes bug

#### How does this change work?

Immutable OrderedSet is used instead of Set
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2223 
