### PR TITLE
serialize path as well in Operation.toJSON

### DIFF
--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -249,6 +249,10 @@ class Operation extends Record(DEFAULTS) {
       if (key == 'value') continue
       if (key == 'node' && type != 'insert_node') continue
 
+      if (key === 'path' || key === 'newPath') {
+        value = value.toJSON()
+      }
+
       if (key == 'mark' || key == 'marks' || key == 'node') {
         value = value.toJSON()
       }

--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -249,11 +249,13 @@ class Operation extends Record(DEFAULTS) {
       if (key == 'value') continue
       if (key == 'node' && type != 'insert_node') continue
 
-      if (key === 'path' || key === 'newPath') {
-        value = value.toJSON()
-      }
-
-      if (key == 'mark' || key == 'marks' || key == 'node') {
+      if (
+        key == 'mark' ||
+        key == 'marks' ||
+        key == 'node' ||
+        key == 'path' ||
+        key == 'newPath'
+      ) {
         value = value.toJSON()
       }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
serializes the path for operations that have one instead of returning the immutable instance
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
