### PR TITLE
Fix delete undo

### DIFF
--- a/packages/slate/src/changes/on-selection.js
+++ b/packages/slate/src/changes/on-selection.js
@@ -607,7 +607,7 @@ Changes.setStart = (change, ...args) => {
 
 Changes.snapshotSelection = change => {
   change.withoutMerging(c =>
-    change.select(change.value.selection, { snapshot: true })
+    c.select(change.value.selection, { snapshot: true })
   )
 }
 

--- a/packages/slate/src/changes/on-selection.js
+++ b/packages/slate/src/changes/on-selection.js
@@ -606,7 +606,9 @@ Changes.setStart = (change, ...args) => {
 }
 
 Changes.snapshotSelection = change => {
-  change.select(change.value.selection, { snapshot: true })
+  change.withoutMerging(c =>
+    change.select(change.value.selection, { snapshot: true })
+  )
 }
 
 /**

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -47,11 +47,10 @@ class Change {
    * history if needed.
    *
    * @param {Operation|Object} operation
-   * @param {Object} options
    * @return {Change}
    */
 
-  applyOperation(operation, options = {}) {
+  applyOperation(operation) {
     const { operations } = this
     let { value } = this
     let { history } = value

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -65,7 +65,7 @@ class Change {
 
     // Default options to the change-level flags, this allows for setting
     // specific options for all of the operations of a given change.
-    let { merge, save } = this.tmp
+    let { merge, save } = { ...this.tmp, ...options }
 
     // If `merge` is non-commital, and this is not the first operation in a new change
     // then we should merge.

--- a/packages/slate/src/models/change.js
+++ b/packages/slate/src/models/change.js
@@ -65,7 +65,7 @@ class Change {
 
     // Default options to the change-level flags, this allows for setting
     // specific options for all of the operations of a given change.
-    let { merge, save } = { ...this.tmp, ...options }
+    let { merge, save } = this.tmp
 
     // If `merge` is non-commital, and this is not the first operation in a new change
     // then we should merge.

--- a/packages/slate/test/history/undo/remove-text.js
+++ b/packages/slate/test/history/undo/remove-text.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function(value) {
+  return value
+    .change()
+    .moveAnchorForward(4)
+    .moveFocusForward(7)
+    .delete()
+    .value.change()
+    .undo().value
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />one two
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>one <anchor />two<focus /></paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/history/undo/remove-text.js
+++ b/packages/slate/test/history/undo/remove-text.js
@@ -25,7 +25,9 @@ export const input = (
 export const output = (
   <value>
     <document>
-      <paragraph>one <anchor />two<focus /></paragraph>
+      <paragraph>
+        one <anchor />two<focus />
+      </paragraph>
     </document>
   </value>
 )


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- The `change.snapshotSelection` calls the `change.applyOperation ` tithe the flag {merge: false}
 but the actual applyOperation dose not use it and therefore the selection snapshot is getting merged with the previous batch of undos.

- when we delete something right after the `applyOperation` will then merge the delete operation because then change contains some other operations in it's internal state 
`
    // If `merge` is non-commital, and this is not the first operation in a new change
    // then we should merge.
    if (merge == null && operations.size !== 0) {
      merge = true
    }`

This cause every delete operations to be merge with the last history batch.  

- when we undo this change it will revert all the way through the previous batch



If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

by using the options sent to the applyOperation method 

`change.applyOperation(
    {
      type: 'set_selection',
      value,
      properties: props,
      selection: selection.toJSON(),
    },
    snapshot ? **{ skip: false, merge: false }** : {}
  )`


`applyOperation(operation, options = {}) {
    const { operations } = this
    let { value } = this
    let { history } = value

    // Add in the current `value` in case the operation was serialized.
    if (isPlainObject(operation)) {
      operation = { ...operation, value }
    }

    operation = Operation.create(operation)

    // Default options to the change-level flags, this allows for setting
    // specific options for all of the operations of a given change.
    let { merge, save } = **{ ...this.tmp, ...options }**
`
#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ x] The new code matches the existing patterns and styles.
* [x ] The tests pass with `yarn test`.
* [ x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?


Fixes: https://github.com/ianstormtaylor/slate/issues/2201
Reviewers: @zhujinxuan
