### PR TITLE
Remove resolvePlugins and some small refactors

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -3,7 +3,6 @@ import React from 'react'
 import SlateTypes from 'slate-prop-types'
 import Types from 'prop-types'
 import invariant from 'tiny-invariant'
-import memoizeOne from 'memoize-one'
 import warning from 'tiny-warning'
 import { Editor as Controller } from 'slate'
 
@@ -69,23 +68,13 @@ class Editor extends React.Component {
     spellCheck: true,
   }
 
-  /**
-   * Constructor.
-   *
-   * @param {Object} props
-   */
+  state = {}
 
-  constructor(props) {
-    super(props)
-    this.resolvePlugins = memoizeOne(this.resolvePlugins)
-    this.state = {}
-
-    this.tmp = {
-      mounted: false,
-      change: null,
-      resolves: 0,
-      updates: 0,
-    }
+  tmp = {
+    mounted: false,
+    change: null,
+    resolves: 0,
+    updates: 0,
   }
 
   /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Refactor

#### What's the new behavior?

Because `component.resolvePlugins` are not used and is not bound with exact function.  This PR removes it and refactor the constructor.

#### How does this change work?

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
