### PR TITLE
Take Blocks as word break to fix word counting in example

### DIFF
--- a/examples/plugins/word-count.js
+++ b/examples/plugins/word-count.js
@@ -12,12 +12,13 @@ export default function WordCount(options) {
   return {
     renderEditor(props, next) {
       const children = next()
+      const wordCount = props.value.document
+        .getBlocks()
+        .reduce((memo, b) => memo + b.text.trim().split(/\s+/).length, 0)
       return (
         <div>
           <div>{children}</div>
-          <WordCounter>
-            Word Count: {props.value.document.text.split(' ').length}
-          </WordCounter>
+          <WordCounter>Word Count: {wordCount}</WordCounter>
         </div>
       )
     },


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

FIx two Bugs in example.
1. Block break is not considered as word break in the old example
2. Continuous spaces are considered as words

#### What's the new behavior?


#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
