### PR TITLE
Add range comparison methods to `Point`

### DIFF
--- a/docs/reference/slate/point.md
+++ b/docs/reference/slate/point.md
@@ -90,6 +90,36 @@ Return a JSON representation of the point.
 
 ## Checking Methods
 
+### `isAfterRange`
+
+`isAfterRange(range: Range) => Boolean`
+
+Determine whether the point is after a `range`.
+
+### `isAtEndOfRange`
+
+`isAtEndOfRange(range: Range) => Boolean`
+
+Determine whether the point is at the end of a `range`.
+
+### `isAtStartOfRange`
+
+`isAtStartOfRange(range: Range) => Boolean`
+
+Determine whether the point is at the start of a `range`.
+
+### `isBeforeRange`
+
+`isBeforeRange(range: Range) => Boolean`
+
+Determine whether the point is before a `range`.
+
+### `isInRange`
+
+`isInRange(range: Range) => Boolean`
+
+Determine whether the point is inside a `range`.
+
 ### `isAtEndOfNode`
 
 `isAtEndOfNode(node: Node) => Boolean`

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -119,10 +119,10 @@ class Text extends React.Component {
 
       // If the node's path is before the start path, ignore it.
       const path = document.assertPath(key)
-      if (PathUtils.compareOfSameSize(path, start.path) === -1) return false
+      if (PathUtils.compare(path, start.path) === -1) return false
 
       // If the node's path is after the end path, ignore it.
-      if (PathUtils.compareOfSameSize(path, end.path) === 1) return false
+      if (PathUtils.compare(path, end.path) === 1) return false
 
       // Otherwise, include it.
       return true

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -119,10 +119,10 @@ class Text extends React.Component {
 
       // If the node's path is before the start path, ignore it.
       const path = document.assertPath(key)
-      if (PathUtils.compare(path, start.path) === -1) return false
+      if (PathUtils.compareOfSameSize(path, start.path) === -1) return false
 
       // If the node's path is after the end path, ignore it.
-      if (PathUtils.compare(path, end.path) === 1) return false
+      if (PathUtils.compareOfSameSize(path, end.path) === 1) return false
 
       // Otherwise, include it.
       return true

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1547,7 +1547,7 @@ class ElementInterface {
     this.assertNode(newParentPath)
 
     const [p, np] = PathUtils.crop(path, newPath)
-    const position = PathUtils.compareOfSameSize(p, np)
+    const position = PathUtils.compare(p, np)
 
     // If the old path ends above and before a node in the new path, then
     // removing it will alter the target, so we need to adjust the new path.

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1547,7 +1547,7 @@ class ElementInterface {
     this.assertNode(newParentPath)
 
     const [p, np] = PathUtils.crop(path, newPath)
-    const position = PathUtils.compare(p, np)
+    const position = PathUtils.compareOfSameSize(p, np)
 
     // If the old path ends above and before a node in the new path, then
     // removing it will alter the target, so we need to adjust the new path.

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -135,6 +135,19 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is at the start of a `range`.
+   *
+   * @return {Boolean}
+   */
+
+  isAtStartOfRange(range) {
+    if (this.isUnset) return false
+    const is =
+      this.key === range.start.key && this.offset === range.start.offset
+    return is
+  }
+
+  /**
    * Check whether the point is before a `range`.
    *
    * @return {Boolean}

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -135,6 +135,20 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is before a `range`.
+   *
+   * @return {Boolean}
+   */
+
+  isBeforeRange(range) {
+    if (this.isUnset) return false
+    const is =
+      (this.key === range.start.key && this.offset < range.start.offset) ||
+      PathUtils.compare(this.path, range.start.path) === -1
+    return is
+  }
+
+  /**
    * Check whether the point is at the end of a `node`.
    *
    * @param {Node} node

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -135,6 +135,18 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is at the end of a `range`.
+   *
+   * @return {Boolean}
+   */
+
+  isAtEndOfRange(range) {
+    if (this.isUnset) return false
+    const is = this.key === range.end.key && this.offset === range.end.offset
+    return is
+  }
+
+  /**
    * Check whether the point is at the start of a `range`.
    *
    * @return {Boolean}

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -121,6 +121,20 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is after another `point`.
+   *
+   * @return {Boolean}
+   */
+
+  isAfterPoint(point) {
+    if (this.isUnset) return false
+    const is =
+      (this.key === point.key && this.offset > point.offset) ||
+      PathUtils.compare(this.path, point.path) === 1
+    return is
+  }
+
+  /**
    * Check whether the point is after a `range`.
    *
    * @return {Boolean}

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -174,6 +174,26 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is inside a `range`.
+   *
+   * @return {Boolean}
+   */
+
+  isInRange(range) {
+    if (this.isUnset) return false
+
+    const afterOrAtStart =
+      (this.key === range.start.key && this.offset >= range.start.offset) ||
+      PathUtils.compare(this.path, range.start.path) === 1
+    const beforeOrAtEnd =
+      (this.key === range.end.key && this.offset <= range.end.offset) ||
+      PathUtils.compare(this.path, range.end.path) === -1
+
+    const is = afterOrAtStart && beforeOrAtEnd
+    return is
+  }
+
+  /**
    * Check whether the point is at the end of a `node`.
    *
    * @param {Node} node

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -142,9 +142,7 @@ class Point extends Record(DEFAULTS) {
 
   isAfterRange(range) {
     if (this.isUnset) return false
-    const is =
-      (this.key === range.end.key && this.offset > range.end.offset) ||
-      PathUtils.compare(this.path, range.end.path) === 1
+    const is = this.isAfterPoint(range.end)
     return is
   }
 
@@ -156,7 +154,7 @@ class Point extends Record(DEFAULTS) {
 
   isAtEndOfRange(range) {
     if (this.isUnset) return false
-    const is = this.key === range.end.key && this.offset === range.end.offset
+    const is = this.equals(range.end)
     return is
   }
 
@@ -168,8 +166,7 @@ class Point extends Record(DEFAULTS) {
 
   isAtStartOfRange(range) {
     if (this.isUnset) return false
-    const is =
-      this.key === range.start.key && this.offset === range.start.offset
+    const is = this.equals(range.start)
     return is
   }
 
@@ -195,9 +192,7 @@ class Point extends Record(DEFAULTS) {
 
   isBeforeRange(range) {
     if (this.isUnset) return false
-    const is =
-      (this.key === range.start.key && this.offset < range.start.offset) ||
-      PathUtils.compare(this.path, range.start.path) === -1
+    const is = this.isBeforePoint(range.start)
     return is
   }
 
@@ -209,15 +204,10 @@ class Point extends Record(DEFAULTS) {
 
   isInRange(range) {
     if (this.isUnset) return false
-
-    const afterOrAtStart =
-      (this.key === range.start.key && this.offset >= range.start.offset) ||
-      PathUtils.compare(this.path, range.start.path) === 1
-    const beforeOrAtEnd =
-      (this.key === range.end.key && this.offset <= range.end.offset) ||
-      PathUtils.compare(this.path, range.end.path) === -1
-
-    const is = afterOrAtStart && beforeOrAtEnd
+    const is =
+      this.equals(range.start) ||
+      this.equals(range.end) ||
+      (this.isAfterPoint(range.start) && this.isBeforePoint(range.end))
     return is
   }
 

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -160,6 +160,20 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is before another `point`.
+   *
+   * @return {Boolean}
+   */
+
+  isBeforePoint(point) {
+    if (this.isUnset) return false
+    const is =
+      (this.key === point.key && this.offset < point.offset) ||
+      PathUtils.compare(this.path, point.path) === -1
+    return is
+  }
+
+  /**
    * Check whether the point is before a `range`.
    *
    * @return {Boolean}

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -121,6 +121,20 @@ class Point extends Record(DEFAULTS) {
   }
 
   /**
+   * Check whether the point is after a `range`.
+   *
+   * @return {Boolean}
+   */
+
+  isAfterRange(range) {
+    if (this.isUnset) return false
+    const is =
+      (this.key === range.end.key && this.offset > range.end.offset) ||
+      PathUtils.compare(this.path, range.end.path) === 1
+    return is
+  }
+
+  /**
    * Check whether the point is at the end of a `node`.
    *
    * @param {Node} node

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -5,7 +5,7 @@ import { List } from 'immutable'
  *
  * @param {List} path
  * @param {List} target
- * @return {Number}
+ * @return {Number|Null}
  */
 
 function compare(path, target) {
@@ -22,10 +22,8 @@ function compare(path, target) {
     if (pv > tv) return 1
   }
 
-  // Otherwise size decides.
-  if (path.size === target.size) return 0
-
-  return path.size < target.size ? -1 : 1
+  // Paths should now be equal, otherwise something is wrong
+  return path.size === target.size ? 0 : null
 }
 
 /**

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -29,34 +29,6 @@ function compare(path, target) {
 }
 
 /**
- * Compare paths `path` and `target` of the same size to see which is before or after.
- * Returns null if the paths are not the same size.
- *
- * @param {List} path
- * @param {List} target
- * @return {Number|Null}
- */
-
-function compareOfSameSize(path, target) {
-  // PERF: if the paths are not the same size we can exit early.
-  if (path.size !== target.size) return null
-
-  for (let i = 0; i < path.size; i++) {
-    const pv = path.get(i)
-    const tv = target.get(i)
-
-    // If the path's value is ever less than the target's, it's before.
-    if (pv < tv) return -1
-
-    // If the target's value is ever less than the path's, it's after.
-    if (pv > tv) return 1
-  }
-
-  // Otherwise they were equal the whole way, it's the same.
-  return 0
-}
-
-/**
  * Create a path from `attrs`.
  *
  * @param {Array|List} attrs
@@ -131,7 +103,7 @@ function increment(path, n = 1, index = path.size - 1) {
 
 function isAbove(path, target) {
   const [p, t] = crop(path, target)
-  return path.size < target.size && compareOfSameSize(p, t) === 0
+  return path.size < target.size && compare(p, t) === 0
 }
 
 /**
@@ -144,7 +116,7 @@ function isAbove(path, target) {
 
 function isAfter(path, target) {
   const [p, t] = crop(path, target)
-  return compareOfSameSize(p, t) === 1
+  return compare(p, t) === 1
 }
 
 /**
@@ -157,7 +129,7 @@ function isAfter(path, target) {
 
 function isBefore(path, target) {
   const [p, t] = crop(path, target)
-  return compareOfSameSize(p, t) === -1
+  return compare(p, t) === -1
 }
 
 /**
@@ -385,7 +357,6 @@ function transform(path, operation) {
 
 export default {
   compare,
-  compareOfSameSize,
   create,
   crop,
   decrement,

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -1,6 +1,34 @@
 import { List } from 'immutable'
 
 /**
+ * Compare paths `path` and `target` to see which is before or after.
+ *
+ * @param {List} path
+ * @param {List} target
+ * @return {Number}
+ */
+
+function compare(path, target) {
+  const m = min(path, target)
+
+  for (let i = 0; i < m; i++) {
+    const pv = path.get(i)
+    const tv = target.get(i)
+
+    // If the path's value is ever less than the target's, it's before.
+    if (pv < tv) return -1
+
+    // If the target's value is ever less than the path's, it's after.
+    if (pv > tv) return 1
+  }
+
+  // Otherwise size decides.
+  if (path.size === target.size) return 0
+
+  return path.size < target.size ? -1 : 1
+}
+
+/**
  * Compare paths `path` and `target` of the same size to see which is before or after.
  * Returns null if the paths are not the same size.
  *
@@ -356,6 +384,7 @@ function transform(path, operation) {
  */
 
 export default {
+  compare,
   compareOfSameSize,
   create,
   crop,

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -1,14 +1,15 @@
 import { List } from 'immutable'
 
 /**
- * Compare paths `path` and `b` to see which is before or after.
+ * Compare paths `path` and `target` of the same size to see which is before or after.
+ * Returns null if the paths are not the same size.
  *
  * @param {List} path
- * @param {List} b
+ * @param {List} target
  * @return {Number|Null}
  */
 
-function compare(path, target) {
+function compareOfSameSize(path, target) {
   // PERF: if the paths are not the same size we can exit early.
   if (path.size !== target.size) return null
 
@@ -102,7 +103,7 @@ function increment(path, n = 1, index = path.size - 1) {
 
 function isAbove(path, target) {
   const [p, t] = crop(path, target)
-  return path.size < target.size && compare(p, t) === 0
+  return path.size < target.size && compareOfSameSize(p, t) === 0
 }
 
 /**
@@ -115,7 +116,7 @@ function isAbove(path, target) {
 
 function isAfter(path, target) {
   const [p, t] = crop(path, target)
-  return compare(p, t) === 1
+  return compareOfSameSize(p, t) === 1
 }
 
 /**
@@ -128,7 +129,7 @@ function isAfter(path, target) {
 
 function isBefore(path, target) {
   const [p, t] = crop(path, target)
-  return compare(p, t) === -1
+  return compareOfSameSize(p, t) === -1
 }
 
 /**
@@ -355,7 +356,7 @@ function transform(path, operation) {
  */
 
 export default {
-  compare,
+  compareOfSameSize,
   create,
   crop,
   decrement,

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -33,6 +33,14 @@ describe('slate', () => {
     assert.deepEqual(actual, expected)
   })
 
+  fixtures(__dirname, 'models/point', ({ module }) => {
+    const { input, output } = module
+    const fn = module.default
+    const actual = fn(input)
+    const expected = output
+    assert.equal(actual, expected)
+  })
+
   fixtures(__dirname, 'models/text', ({ module }) => {
     const { input, output } = module
     const fn = module.default

--- a/packages/slate/test/models/point/is-after-point/after-target-path.js
+++ b/packages/slate/test/models/point/is-after-point/after-target-path.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [2],
+    offset: 2,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-after-point/before-target-path.js
+++ b/packages/slate/test/models/point/is-after-point/before-target-path.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [0, 2],
+    offset: 2,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-point/same-node-after-target-offset.js
+++ b/packages/slate/test/models/point/is-after-point/same-node-after-target-offset.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+  target: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 3,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-after-point/same-node-before-target-offset.js
+++ b/packages/slate/test/models/point/is-after-point/same-node-before-target-offset.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 1,
+  }),
+  target: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 2,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-point/same-node-same-offset.js
+++ b/packages/slate/test/models/point/is-after-point/same-node-same-offset.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+  target: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-point/target-is-ancestor.js
+++ b/packages/slate/test/models/point/is-after-point/target-is-ancestor.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [1, 2],
+    offset: 1,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-point/target-is-descendant.js
+++ b/packages/slate/test/models/point/is-after-point/target-is-descendant.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 0],
+    offset: 0,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [0, 0, 1],
+    offset: 0,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterPoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/after-end-node.js
+++ b/packages/slate/test/models/point/is-after-range/after-end-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-after-range/after-end-offset.js
+++ b/packages/slate/test/models/point/is-after-range/after-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 12,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-after-range/after-start-offset.js
+++ b/packages/slate/test/models/point/is-after-range/after-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/before-end-offset.js
+++ b/packages/slate/test/models/point/is-after-range/before-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/before-start-node.js
+++ b/packages/slate/test/models/point/is-after-range/before-start-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0],
+    offset: 7,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/before-start-offset.js
+++ b/packages/slate/test/models/point/is-after-range/before-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/between-nodes.js
+++ b/packages/slate/test/models/point/is-after-range/between-nodes.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [5],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/is-end.js
+++ b/packages/slate/test/models/point/is-after-range/is-end.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 3,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-after-range/is-start.js
+++ b/packages/slate/test/models/point/is-after-range/is-start.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 0,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAfterRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/after-end-node.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/after-end-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/after-end-offset.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/after-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 12,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/after-start-offset.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/after-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/before-end-offset.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/before-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/before-start-node.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/before-start-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0],
+    offset: 7,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/before-start-offset.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/before-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/between-nodes.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/between-nodes.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [5],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-end-of-range/is-end.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/is-end.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 3,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-at-end-of-range/is-start.js
+++ b/packages/slate/test/models/point/is-at-end-of-range/is-start.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 0,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtEndOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/after-end-node.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/after-end-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/after-end-offset.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/after-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 12,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/after-start-offset.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/after-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/before-end-offset.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/before-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/before-start-node.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/before-start-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0],
+    offset: 7,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/before-start-offset.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/before-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/between-nodes.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/between-nodes.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [5],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/is-end.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/is-end.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 3,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-at-start-of-range/is-start.js
+++ b/packages/slate/test/models/point/is-at-start-of-range/is-start.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 0,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isAtStartOfRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-before-point/after-target-path.js
+++ b/packages/slate/test/models/point/is-before-point/after-target-path.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [2],
+    offset: 2,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-point/before-target-path.js
+++ b/packages/slate/test/models/point/is-before-point/before-target-path.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [0, 2],
+    offset: 2,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-before-point/same-node-after-target-offset.js
+++ b/packages/slate/test/models/point/is-before-point/same-node-after-target-offset.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+  target: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 3,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-point/same-node-before-target-offset.js
+++ b/packages/slate/test/models/point/is-before-point/same-node-before-target-offset.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 1,
+  }),
+  target: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 2,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-before-point/same-node-same-offset.js
+++ b/packages/slate/test/models/point/is-before-point/same-node-same-offset.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+  target: Point.create({
+    key: 'a',
+    path: [0, 1],
+    offset: 4,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-point/target-is-ancestor.js
+++ b/packages/slate/test/models/point/is-before-point/target-is-ancestor.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [1, 2],
+    offset: 1,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-point/target-is-descendant.js
+++ b/packages/slate/test/models/point/is-before-point/target-is-descendant.js
@@ -1,0 +1,20 @@
+import Point from '../../../../src/models/point'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0, 0],
+    offset: 0,
+  }),
+  target: Point.create({
+    key: 'b',
+    path: [0, 0, 1],
+    offset: 0,
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforePoint(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/after-end-node.js
+++ b/packages/slate/test/models/point/is-before-range/after-end-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/after-end-offset.js
+++ b/packages/slate/test/models/point/is-before-range/after-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 12,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/after-start-offset.js
+++ b/packages/slate/test/models/point/is-before-range/after-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/before-end-offset.js
+++ b/packages/slate/test/models/point/is-before-range/before-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/before-start-node.js
+++ b/packages/slate/test/models/point/is-before-range/before-start-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0],
+    offset: 7,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-before-range/before-start-offset.js
+++ b/packages/slate/test/models/point/is-before-range/before-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-before-range/between-nodes.js
+++ b/packages/slate/test/models/point/is-before-range/between-nodes.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [5],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/is-end.js
+++ b/packages/slate/test/models/point/is-before-range/is-end.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 3,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-before-range/is-start.js
+++ b/packages/slate/test/models/point/is-before-range/is-start.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 0,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isBeforeRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-in-range/after-end-node.js
+++ b/packages/slate/test/models/point/is-in-range/after-end-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-in-range/after-end-offset.js
+++ b/packages/slate/test/models/point/is-in-range/after-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 12,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-in-range/after-start-offset.js
+++ b/packages/slate/test/models/point/is-in-range/after-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-in-range/before-end-offset.js
+++ b/packages/slate/test/models/point/is-in-range/before-end-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-in-range/before-start-node.js
+++ b/packages/slate/test/models/point/is-in-range/before-start-node.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [0],
+    offset: 7,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-in-range/before-start-offset.js
+++ b/packages/slate/test/models/point/is-in-range/before-start-offset.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 2,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 4,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = false

--- a/packages/slate/test/models/point/is-in-range/between-nodes.js
+++ b/packages/slate/test/models/point/is-in-range/between-nodes.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'a',
+    path: [4],
+    offset: 1,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [5],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-in-range/is-end.js
+++ b/packages/slate/test/models/point/is-in-range/is-end.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'c',
+    path: [2],
+    offset: 3,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = true

--- a/packages/slate/test/models/point/is-in-range/is-start.js
+++ b/packages/slate/test/models/point/is-in-range/is-start.js
@@ -1,0 +1,28 @@
+import Point from '../../../../src/models/point'
+import Range from '../../../../src/models/range'
+
+export const input = {
+  point: Point.create({
+    key: 'b',
+    path: [1],
+    offset: 0,
+  }),
+  target: Range.create({
+    anchor: {
+      key: 'b',
+      path: [1],
+      offset: 0,
+    },
+    focus: {
+      key: 'c',
+      path: [2],
+      offset: 3,
+    },
+  }),
+}
+
+export default function({ point, target }) {
+  return point.isInRange(target)
+}
+
+export const output = true


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving.

#### What's the new behavior?

Adds range comparison methods to `Point` as suggested in #2042 

#### How does this change work?

* Renamed the `compare` method in `path-utils.js` to `compareOfSameSize` and then added a new `compare` method that does a full comparison. The new `Point` methods uses the new `compare` method.
* Did not add any tests because I couldn't find any for neither `path-utils` nor `Point` (I could fix this if you give some pointers to how I should go about).

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2042 
