### PR TITLE
Fix insertTextAtRange selection

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -794,7 +794,8 @@ Commands.insertTextAtRange = (change, range, text, marks) => {
   const { document } = value
   const { start } = range
   let key = start.key
-  let offset = start.offset
+  const offset = start.offset
+  const path = start.path
   const parent = document.getParent(start.key)
 
   if (change.isVoid(parent)) {
@@ -805,10 +806,11 @@ Commands.insertTextAtRange = (change, range, text, marks) => {
     if (range.isExpanded) {
       change.deleteAtRange(range)
 
+      const startText = change.value.document.getNode(path)
+
       // Update range start after delete
-      if (change.value.selection.start.key !== key) {
-        key = change.value.selection.start.key
-        offset = change.value.selection.start.offset
+      if (startText && startText.key !== key) {
+        key = startText.key
       }
     }
 

--- a/packages/slate/test/changes/at-range/insert-text-at-range/non-matching-section-and-range.js
+++ b/packages/slate/test/changes/at-range/insert-text-at-range/non-matching-section-and-range.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+
+import { Point, Range } from 'slate'
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  const { key } = change.value.document.getFirstText()
+  const range = new Range({
+    anchor: new Point({ key, offset: 0 }),
+    focus: new Point({ key, offset: 3 }),
+  })
+  change.insertTextAtRange(range, 'That')
+}
+
+export const input = (
+  <value>
+    <document>
+      <line>The change will be here.</line>
+      <line>
+        The cursor is <cursor />over here.
+      </line>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <line>That change will be here.</line>
+      <line>
+        The cursor is <cursor />over here.
+      </line>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

The issue is describe in detail in #2209 and demonstrated by the test included here. But, basically, this makes `insertTextAtRange` insert text at the range specified instead of the current selection when the selection is elsewhere. Here was the original issue in action:

![ouch](https://user-images.githubusercontent.com/273453/46079578-20ba4e00-c15d-11e8-802e-910d71fc81c1.gif)

#### How does this change work?

Instead of referencing the current selection to determine the key to use for text insertion, `insertTextAtRange` now preserves the path of the original block that may be deleted during the replacement of the range. If the block is deleted and keys change, the path should remain consistent. So, this change gets the key from the new block at that path, regardless of where the current selection is. (Previously, it tried to get the range start block from the current selection, which isn't always the same).

#### Have you checked that...?

* [X] The new code matches the existing patterns and styles.
* [X] The tests pass with `yarn test`.
* [X] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [X] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2209 
Reviewers: @ianstormtaylor, @ericedem, @czechdave, @echenley, @blakeembrey 
