### PR TITLE
Update ‘Submitting Pull Requests’ to refer to an active label

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -37,7 +37,7 @@ Please use the Slack instead of asking questions in issues, since we want to res
 
 ## Submitting Pull Requests
 
-All pull requests are super welcomed and greatly appreciated! Easy issues are marked with an [`easy-one`](https://github.com/ianstormtaylor/slate/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy-one) label if you're looking for a simple place to get familiar with the code base.
+All pull requests are super welcomed and greatly appreciated! Issues in need of a solution are marked with a [`♥ help please`](https://github.com/ianstormtaylor/slate/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%99%A5+help+please%22) label if you're looking for somewhere to start.
 
 Please include tests and docs with every pull request!
 


### PR DESCRIPTION
I’m hoping to start making a few contributions myself and was checking this guide out, but noticed that the `✓ easy one` label hasn’t been used in a while and has no open issues.

Instead, we now recommend the `♥ help please` label as a source of issues to fix for potential contributors.