### PR TITLE
Add possibility to specify a custom delimiter to slate-plain-serializer

### DIFF
--- a/packages/slate-plain-serializer/src/index.js
+++ b/packages/slate-plain-serializer/src/index.js
@@ -13,7 +13,12 @@ import { Set } from 'immutable'
  */
 
 function deserialize(string, options = {}) {
-  let { defaultBlock = 'line', defaultMarks = [], delimiter = "\n", toJSON = false } = options
+  let {
+    defaultBlock = 'line',
+    defaultMarks = [],
+    delimiter = '\n',
+    toJSON = false,
+  } = options
 
   if (Set.isSet(defaultMarks)) {
     defaultMarks = defaultMarks.toArray()
@@ -60,8 +65,8 @@ function deserialize(string, options = {}) {
  * @return {String}
  */
 
-function serialize(value) {
-  return serializeNode(value.document)
+function serialize(value, options = {}) {
+  return serializeNode(value.document, options)
 }
 
 /**
@@ -71,12 +76,14 @@ function serialize(value) {
  * @return {String}
  */
 
-function serializeNode(node) {
+function serializeNode(node, options = {}) {
+  let { delimiter = '\n' } = options
+
   if (
     node.object == 'document' ||
     (node.object == 'block' && Block.isBlockList(node.nodes))
   ) {
-    return node.nodes.map(serializeNode).join('\n')
+    return node.nodes.map(serializeNode).join(delimiter)
   } else {
     return node.text
   }

--- a/packages/slate-plain-serializer/src/index.js
+++ b/packages/slate-plain-serializer/src/index.js
@@ -13,7 +13,7 @@ import { Set } from 'immutable'
  */
 
 function deserialize(string, options = {}) {
-  let { defaultBlock = 'line', defaultMarks = [], toJSON = false } = options
+  let { defaultBlock = 'line', defaultMarks = [], delimiter = "\n", toJSON = false } = options
 
   if (Set.isSet(defaultMarks)) {
     defaultMarks = defaultMarks.toArray()
@@ -27,7 +27,7 @@ function deserialize(string, options = {}) {
     document: {
       object: 'document',
       data: {},
-      nodes: string.split('\n').map(line => {
+      nodes: string.split(delimiter).map(line => {
         return {
           ...defaultBlock,
           object: 'block',

--- a/packages/slate-plain-serializer/src/index.js
+++ b/packages/slate-plain-serializer/src/index.js
@@ -77,7 +77,7 @@ function serialize(value, options = {}) {
  */
 
 function serializeNode(node, options = {}) {
-  let { delimiter = '\n' } = options
+  const { delimiter = '\n' } = options
 
   if (
     node.object == 'document' ||

--- a/packages/slate-plain-serializer/test/deserialize/custom-delimiter.js
+++ b/packages/slate-plain-serializer/test/deserialize/custom-delimiter.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = `
+one
+same paragraph
+
+two
+`.trim()
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>one{'\n'}same paragraph</paragraph>
+      <paragraph>two</paragraph>
+    </document>
+  </value>
+)
+
+export const options = {
+  defaultBlock: 'paragraph',
+  delimiter: '\n\n',
+}

--- a/packages/slate-plain-serializer/test/serialize/custom-delimiter.js
+++ b/packages/slate-plain-serializer/test/serialize/custom-delimiter.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one{'\n'}same paragraph</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>three</paragraph>
+    </document>
+  </value>
+)
+
+export const output = `
+one
+same paragraph
+
+two
+
+three
+`.trim()
+
+export const options = {
+  delimiter: '\n\n',
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

#### What's the new behavior?

It adds the option to specify a custom delimiter to the plain deserializer for more complex scenarios.

eg:
- A paragraph the accepts single new lines and every paragraph is delimited by two new line "\n"
- Support regexp(split) as a delimiter for more flexibility

#### How does this change work?

Simply add a delimiter to the options passed to the slate-plain-serializer

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 

This is a quick fix I did for my project, and I thought it would be a good addition to the project
