### PR TITLE
Unskip a test: `commands at-current-range insert-fragment start-inline`

### DIFF
--- a/packages/slate/test/commands/at-current-range/insert-fragment/start-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/start-inline.js
@@ -26,26 +26,11 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        fragment<cursor />
-        <link>word</link>
+        fragment
+        <link>
+          word<cursor />
+        </link>
       </paragraph>
     </document>
   </value>
 )
-
-// The result has an invalid selection for now:
-//
-// "selection": {
-//   "anchorOffset": 8
-//   "anchorPath": [
-//     0
-//     1
-//     0
-//   ]
-//   "focusOffset": 8
-//   "focusPath": [
-//     0
-//     1
-//     0
-//   ]
-export const skip = true


### PR DESCRIPTION
Fixes https://github.com/ianstormtaylor/slate/issues/1754

As outlined in that issue, the test was resulting in an invalid selection:
```js
// "selection": {
//   "anchorOffset": 8
//   "anchorPath": [
//     0
//     1
//     0
//   ]
//   "focusOffset": 8
//   "focusPath": [
//     0
//     1
//     0
//   ]
```
However, when running against the current codebase, a valid selection emerged:

```js
// "selection": {
//   "anchorOffset": 4
//   "anchorPath": [
//     0
//     0
//   ]
//   "focusOffset": 4
//   "focusPath": [
//     0
//     0
//   ]
```

This seems different to the initial intention of the test – which itself is a bit strange overall, see https://github.com/ianstormtaylor/slate/pull/1379#issuecomment-344587900 – but valid.

Now we adjust the expectation and reenable the test.