### PR TITLE
Alter cursor placement in `insertFragment` tests to reflect reality

### DIFF
--- a/packages/slate/test/commands/at-current-range/insert-fragment/end-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/end-inline.js
@@ -14,9 +14,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          word<cursor />
-        </link>
+        <link>word</link>
+        <cursor />
       </paragraph>
     </document>
   </value>
@@ -27,10 +26,7 @@ export const output = (
     <document>
       <paragraph>
         <link>word</link>
-        fragment
-        <link>
-          <cursor />
-        </link>
+        fragment<cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/middle-inline-fragment-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/middle-inline-fragment-inline.js
@@ -24,7 +24,6 @@ export const input = (
   </value>
 )
 
-// TODO: the cursor placement needs to be fixed
 export const output = (
   <value>
     <document>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/start-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/start-inline.js
@@ -14,9 +14,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          <cursor />word
-        </link>
+        <cursor />
+        <link>word</link>
       </paragraph>
     </document>
   </value>
@@ -32,20 +31,3 @@ export const output = (
     </document>
   </value>
 )
-
-// The result has an invalid selection for now:
-//
-// "selection": {
-//   "anchorOffset": 8
-//   "anchorPath": [
-//     0
-//     1
-//     0
-//   ]
-//   "focusOffset": 8
-//   "focusPath": [
-//     0
-//     1
-//     0
-//   ]
-export const skip = true


### PR DESCRIPTION
Previously, `start-inline` and `end-inline` included the cursor at the end of an inline, i.e.
```js
<paragraph>
  <link>example<cursor /></link>
</paragraph>
```

Using Slate in a browser, it doesn’t seem possible to me to actually achieve this state: i.e. whenever the cursor is on either side of an inline such as a link, typing will not add text to that inline. (This is consistent with other editors, for example Google Docs).

Now, these tests are updated to have a cursor just outside the inline. This leads to more sensible outputs.

(Finally, I removed a TODO comment indicating that `middle-inline-fragment-inline`’s cursor output was incorrect. I believe this is a sensible expectation, which matches behavior in editors including Google Docs.)

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes https://github.com/ianstormtaylor/slate/issues/1754