### PR TITLE
Fix bolded text in input-tester initial value

### DIFF
--- a/examples/input-tester/value.json
+++ b/examples/input-tester/value.json
@@ -12,10 +12,10 @@
                 "text": "This Slate editor records all of the "
               },
               {
-                "text": "bold",
+                "text": "keyboard",
                 "marks": [
                   {
-                    "type": "keyboard"
+                    "type": "bold"
                   }
                 ]
               },
@@ -23,10 +23,10 @@
                 "text": ", "
               },
               {
-                "text": "bold",
+                "text": "input",
                 "marks": [
                   {
-                    "type": "input"
+                    "type": "bold"
                   }
                 ]
               },
@@ -34,10 +34,10 @@
                 "text": " and "
               },
               {
-                "text": "bold",
+                "text": "selection",
                 "marks": [
                   {
-                    "type": "selection"
+                    "type": "bold"
                   }
                 ]
               },


### PR DESCRIPTION
Initial value in the input-tester example renders the bolded items as "bold".

This fixes the initial value so it reads correctly.

Current initial value:
![screenshot](https://user-images.githubusercontent.com/139918/47104661-cad64480-d1f6-11e8-849e-42bf5a5c0a26.png)

Fixed:
![screenshot](https://user-images.githubusercontent.com/139918/47104676-d32e7f80-d1f6-11e8-83f2-a89725a695fe.png)
