### PR TITLE
Fix exception in Input Tester example

### DIFF
--- a/examples/input-tester/index.js
+++ b/examples/input-tester/index.js
@@ -176,7 +176,7 @@ const Event = ({ event, targetRange, selection }) => {
       </td>
       <td>
         <StringCell
-          value={event.dataTransfer && event.dataTransfer.get('text/plain')}
+          value={event.dataTransfer && event.dataTransfer.getData('text/plain')}
         />
       </td>
       <td>

--- a/examples/input-tester/value.json
+++ b/examples/input-tester/value.json
@@ -12,10 +12,10 @@
                 "text": "This Slate editor records all of the "
               },
               {
-                "text": "bold",
+                "text": "keyboard",
                 "marks": [
                   {
-                    "type": "keyboard"
+                    "type": "bold"
                   }
                 ]
               },
@@ -23,10 +23,10 @@
                 "text": ", "
               },
               {
-                "text": "bold",
+                "text": "input",
                 "marks": [
                   {
-                    "type": "input"
+                    "type": "bold"
                   }
                 ]
               },
@@ -34,10 +34,10 @@
                 "text": " and "
               },
               {
-                "text": "bold",
+                "text": "selection",
                 "marks": [
                   {
-                    "type": "selection"
+                    "type": "bold"
                   }
                 ]
               },

--- a/examples/input-tester/value.json
+++ b/examples/input-tester/value.json
@@ -12,10 +12,10 @@
                 "text": "This Slate editor records all of the "
               },
               {
-                "text": "keyboard",
+                "text": "bold",
                 "marks": [
                   {
-                    "type": "bold"
+                    "type": "keyboard"
                   }
                 ]
               },
@@ -23,10 +23,10 @@
                 "text": ", "
               },
               {
-                "text": "input",
+                "text": "bold",
                 "marks": [
                   {
-                    "type": "bold"
+                    "type": "input"
                   }
                 ]
               },
@@ -34,10 +34,10 @@
                 "text": " and "
               },
               {
-                "text": "selection",
+                "text": "bold",
                 "marks": [
                   {
-                    "type": "bold"
+                    "type": "selection"
                   }
                 ]
               },


### PR DESCRIPTION
If an Input event with inputType `"insertReplacementText"` is received, the example crashes because `event.dataTransfer.get is not a function`

The correct API is `getData()`, not `get()`. Ref: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/getData

You can cause the exception by mis-spelling a word in the Input Tester with Safari, then using control-click (or right-click on a 2-button mouse) to correct the spelling.
