### PR TITLE
Speed improvements for Input Example

### DIFF
--- a/examples/input-tester/index.js
+++ b/examples/input-tester/index.js
@@ -210,6 +210,19 @@ class InputTester extends React.Component {
     window.document.addEventListener('selectionchange', this.onEvent)
   }
 
+  componentWillUnmount() {
+    const editor = this.el.querySelector('[contenteditable="true"]')
+    editor.removeEventListener('keydown', this.onEvent)
+    editor.removeEventListener('keyup', this.onEvent)
+    editor.removeEventListener('keypress', this.onEvent)
+    editor.removeEventListener('input', this.onEvent)
+    editor.removeEventListener('beforeinput', this.onEvent)
+    editor.removeEventListener('compositionstart', this.onEvent)
+    editor.removeEventListener('compositionupdate', this.onEvent)
+    editor.removeEventListener('compositionend', this.onEvent)
+    window.document.removeEventListener('selectionchange', this.onEvent)
+  }
+
   ref = editor => {
     this.editor = editor
   }

--- a/examples/input-tester/index.js
+++ b/examples/input-tester/index.js
@@ -8,6 +8,7 @@ import { Icon } from '../components'
 import { createArrayValue } from 'react-values'
 
 const EventsValue = createArrayValue()
+let itemCount = 0
 
 const Wrapper = styled('div')`
   position: relative;
@@ -114,7 +115,7 @@ const RangeCell = ({ value }) =>
 
 const EventsList = () => (
   <EventsValue>
-    {({ value: events }) => (
+    {({ value: eventrows }) => (
       <EventsWrapper>
         <EventsTable>
           <thead>
@@ -126,6 +127,7 @@ const EventsList = () => (
                   onMouseDown={e => {
                     e.preventDefault()
                     EventsValue.clear()
+                    itemCount = 0
                   }}
                 >
                   block
@@ -143,18 +145,16 @@ const EventsList = () => (
               <th>findSelection</th>
             </tr>
           </thead>
-          <tbody>
-            {events.map((props, i) => <Event key={i} {...props} />)}
-          </tbody>
+          <tbody>{eventrows}</tbody>
         </EventsTable>
       </EventsWrapper>
     )}
   </EventsValue>
 )
 
-const Event = ({ event, targetRange, selection }) => {
+const EventRow = ({ key, event, targetRange, selection }) => {
   return (
-    <tr>
+    <tr key={key}>
       <td />
       <td>
         <TypeCell event={event} />
@@ -299,7 +299,6 @@ class InputTester extends React.Component {
 
   recordEvent = event => {
     const { editor } = this
-    const { value } = editor
     let targetRange
 
     if (event.getTargetRanges) {
@@ -312,13 +311,16 @@ class InputTester extends React.Component {
       ? nativeSelection.getRangeAt(0)
       : undefined
     const selection = nativeRange && findRange(nativeRange, editor)
-
-    EventsValue.push({
+    const key = itemCount++
+    if (itemCount > 150) EventsValue.shift()
+    const tr = EventRow({
+      key,
       event,
-      value,
       targetRange,
       selection,
     })
+
+    EventsValue.push(tr)
   }
 
   logEvent = event => {

--- a/examples/input-tester/value.json
+++ b/examples/input-tester/value.json
@@ -12,10 +12,10 @@
                 "text": "This Slate editor records all of the "
               },
               {
-                "text": "bold",
+                "text": "keyboard",
                 "marks": [
                   {
-                    "type": "keyboard"
+                    "type": "bold"
                   }
                 ]
               },
@@ -23,10 +23,10 @@
                 "text": ", "
               },
               {
-                "text": "bold",
+                "text": "input",
                 "marks": [
                   {
-                    "type": "input"
+                    "type": "bold"
                   }
                 ]
               },
@@ -34,10 +34,10 @@
                 "text": " and "
               },
               {
-                "text": "bold",
+                "text": "selection",
                 "marks": [
                   {
-                    "type": "selection"
+                    "type": "bold"
                   }
                 ]
               },

--- a/examples/input-tester/value.json
+++ b/examples/input-tester/value.json
@@ -12,10 +12,10 @@
                 "text": "This Slate editor records all of the "
               },
               {
-                "text": "keyboard",
+                "text": "bold",
                 "marks": [
                   {
-                    "type": "bold"
+                    "type": "keyboard"
                   }
                 ]
               },
@@ -23,10 +23,10 @@
                 "text": ", "
               },
               {
-                "text": "input",
+                "text": "bold",
                 "marks": [
                   {
-                    "type": "bold"
+                    "type": "input"
                   }
                 ]
               },
@@ -34,10 +34,10 @@
                 "text": " and "
               },
               {
-                "text": "selection",
+                "text": "bold",
                 "marks": [
                   {
-                    "type": "bold"
+                    "type": "selection"
                   }
                 ]
               },


### PR DESCRIPTION
I am finding the Input Tester example very useful while diagnosing issues with composition input. However, once you type for a while things slow down to a crawl as the huge table of logged events gets re-rendered.

Optimize by:
- Store JSX row components instead of the data needed to build each row.
- Limit to showing only the 150 most recent events.

PR includes a change that removes the event listeners when the example is unmounted. While it can sometimes be handy to have input events sent to the console log while typing in other examples, it occasionally throws exceptions on selection events, so it's safer to stop listening.

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
