### PR TITLE
Fix queries documentation to show editor argument

### DIFF
--- a/docs/guides/commands-and-queries.md
+++ b/docs/guides/commands-and-queries.md
@@ -207,7 +207,7 @@ The same thing goes for queries, which can be defined in plugins and re-used acr
 ```js
 const yourPlugin = {
   queries: {
-    getActiveListItem(value) {
+    getActiveListItem(editor) {
       ...
     }
   }
@@ -217,7 +217,7 @@ const yourPlugin = {
 And then you can use them:
 
 ```js
-change.getActiveListItem(change.value)
+change.getActiveListItem()
 ```
 
 This reusability is key to being able to organize your commands and queries, and compose them together to create more advanced behaviors.

--- a/docs/reference/slate/plugins.md
+++ b/docs/reference/slate/plugins.md
@@ -160,7 +160,7 @@ Each command has a signature of `(change, ...args)`.
 ```js
 {
   queries: {
-    getActiveList(value) {
+    getActiveList(editor) {
       ...
     }
   }
@@ -169,7 +169,7 @@ Each command has a signature of `(change, ...args)`.
 
 The `queries` shorthand defines a set of custom queries that are made available in the editor, and as first-class methods on the `change` objects created by the editor.
 
-Each query has a signature of `(...args)`.
+Each query has a signature of `(editor, ...args)`.
 
 ### `schema`
 

--- a/packages/slate/Changelog.md
+++ b/packages/slate/Changelog.md
@@ -65,7 +65,7 @@ For example, you might define an `getActiveList` query:
 ```js
 const plugin = {
   queries: {
-    getActiveList(value) {},
+    getActiveList(editor) {},
   },
 }
 ```
@@ -73,8 +73,7 @@ const plugin = {
 And then be able to re-use that logic easily in different places in your codebase, or pass in the query name to a plugin that can use your custom logic itself:
 
 ```js
-const { value } = change
-const list = change.getActiveList(value)
+const list = change.getActiveList()
 
 if (list) {
   ...


### PR DESCRIPTION
This is just a documentation fix. After https://github.com/ianstormtaylor/slate/commit/bd24739411f4b5d7d6341d0e3aaa43e2e78df3a7 hit, docs weren't updated to show that queries take an `editor` object as the first argument.

eg:

```javascript
  queries: {
    getActiveListItem(editor) {
      ...
    }
  }
```

cc @ianstormtaylor for review