### PR TITLE
Clarify children access in renderEditor in docs

### DIFF
--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -109,14 +109,18 @@ This handler is called whenever the native DOM selection changes.
 
 `Function renderEditor(props: Object, next: Function) => ReactNode|Void`
 
-The `renderEditor` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `children`, which you can access as `next()`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. This can be useful for rendering toolbars, styling the editor, rendering validation, etc. Remember that the `renderEditor` function has to render `children` for editor's content to render. For example:
+The `renderEditor` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `children`, which you can access as `next()`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. Note, that multiple plugins can define `renderEditor` and each one can add a specific behaviour to the editor, as `next()` refers to `children` from another plugin in the stack. This can be useful for rendering toolbars, styling the editor, rendering validation, etc, and each plugin can be responsible for a given functionality only, keeping your code dry and well organized. Just remember that the `renderEditor` function has to render `children` for editor's content to render. For example:
 ```js
-renderEditor: ({ editor }, next) => (
-  <div>
-    <MyToolbarComponent editor={editor} />
-    <MyEditorComponent editor={editor}>{next()}</MyEditorComponent>
-  </div>
-)
+renderEditor: (props, next) => {
+  const children = next();
+
+  return (
+    <div>
+      <MyToolbarComponent editor={props.editor} />
+      <MyEditorComponent editor={props.editor}>{children}</MyEditorComponent>
+    </div>
+  );
+}
 ```
 
 ### `renderMark`

--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -109,7 +109,15 @@ This handler is called whenever the native DOM selection changes.
 
 `Function renderEditor(props: Object, next: Function) => ReactNode|Void`
 
-The `renderEditor` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `props.children`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. This can be useful for rendering toolbars, styling the editor, rendering validation, etc. Remember that the `renderEditor` function has to render `props.children` for editor's content to render.
+The `renderEditor` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `children`, which you can access as `next()`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. This can be useful for rendering toolbars, styling the editor, rendering validation, etc. Remember that the `renderEditor` function has to render `children` for editor's content to render. For example:
+```js
+renderEditor: ({ editor }, next) => (
+  <div>
+    <MyToolbarComponent editor={editor} />
+    <MyEditorComponent editor={editor}>{next()}</MyEditorComponent>
+  </div>
+)
+```
 
 ### `renderMark`
 

--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -111,13 +111,13 @@ This handler is called whenever the native DOM selection changes.
 
 The `renderEditor` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `children`, which you can access as `next()`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. Note, that multiple plugins can define `renderEditor` and each one can add a specific behaviour to the editor, as `next()` refers to `children` from another plugin in the stack. This can be useful for rendering toolbars, styling the editor, rendering validation, etc, and each plugin can be responsible for a given functionality only, keeping your code dry and well organized. Just remember that the `renderEditor` function has to render `children` for editor's content to render. For example:
 ```js
-renderEditor: (props, next) => {
+renderEditor: (props, editor, next) => {
   const children = next();
 
   return (
     <div>
-      <MyToolbarComponent editor={props.editor} />
-      <MyEditorComponent editor={props.editor}>{children}</MyEditorComponent>
+      <MyToolbarComponent editor={editor} />
+      <MyEditorComponent editor={editor}>{children}</MyEditorComponent>
     </div>
   );
 }

--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -110,16 +110,17 @@ This handler is called whenever the native DOM selection changes.
 `Function renderEditor(props: Object, next: Function) => ReactNode|Void`
 
 The `renderEditor` property allows you to define higher-order-component-like behavior. It is passed all of the properties of the editor, including `children`, which you can access as `next()`. You can then choose to wrap the existing `children` in any custom elements or proxy the properties however you choose. Note, that multiple plugins can define `renderEditor` and each one can add a specific behaviour to the editor, as `next()` refers to `children` from another plugin in the stack. This can be useful for rendering toolbars, styling the editor, rendering validation, etc, and each plugin can be responsible for a given functionality only, keeping your code dry and well organized. Just remember that the `renderEditor` function has to render `children` for editor's content to render. For example:
+
 ```js
 renderEditor: (props, editor, next) => {
-  const children = next();
+  const children = next()
 
   return (
     <div>
       <MyToolbarComponent editor={editor} />
       <MyEditorComponent editor={editor}>{children}</MyEditorComponent>
     </div>
-  );
+  )
 }
 ```
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Docs improvement related to #2259 
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
