### PR TITLE
Fixed KeyDown handler signature in code snippet

### DIFF
--- a/docs/guides/commands-and-queries.md
+++ b/docs/guides/commands-and-queries.md
@@ -88,7 +88,7 @@ When you decide you want to make a change to the Slate value, you're almost alwa
 The first place, is inside a Slate-controlled event handler, like `onKeyDown` or `onPaste`. These handlers take a signature of `event, change, next`. That `change` argument is a [`Change`](../reference/slate/change.md) object that you can manipulate. For example...
 
 ```js
-function onKeyDown(event, change, editor) {
+function onKeyDown(event, change, next) {
   if (event.key == 'Enter') {
     change.splitBlock()
   }


### PR DESCRIPTION
The paragraph mentioned handle signature being `event, change, next` but the snippet had a signature with `event, change, editor`

#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
