### PR TITLE
Fix cloneFragment conditional handling of clipboardData.setData

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -114,6 +114,7 @@ function cloneFragment(event, editor, callback = () => undefined) {
     event.clipboardData.setData(FRAGMENT, encoded)
     event.clipboardData.setData(HTML, div.innerHTML)
     callback()
+    return
   }
 
   // COMPAT: For browser that don't support the Clipboard API's setData method,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Fixes the `cloneFragment` function to the intended purpose

#### How does this change work?

According to the comments in the file and the diff, the intention was for `requestAnimationFrame` to only be used when the Clipboard API's `setData` method was either not available or lackluster (IE). 

The issue was introduced accidentally here (which is how I figured out what needed to be done): https://github.com/ianstormtaylor/slate/commit/dc95ad66a522e9d5c1626e65844f160834224696#diff-dfb9fbad6106fa548b8335a644d03e49L109

This was especially problematic in the `onCut` command, since the callback was being called twice in browsers with the necessary support.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2279
Reviewers: @zhujinxuan (since you made the change above)