### PR TITLE
Use <br /> inside empty block so those appear selected

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -142,7 +142,7 @@ class Leaf extends React.Component {
       parent.text === '' &&
       parent.nodes.last() === node
     ) {
-      return <span data-slate-zero-width="n">{'\uFEFF'}</span>
+      return <br />
     }
 
     // COMPAT: If the text is empty, it's because it's on the edge of an inline

--- a/packages/slate-react/test/rendering/fixtures/custom-block-blurred.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-blurred.js
@@ -63,7 +63,7 @@ export const output = `
    <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>
@@ -82,7 +82,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-block-focused.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-focused.js
@@ -59,7 +59,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>
@@ -78,7 +78,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-block-selected.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-selected.js
@@ -59,7 +59,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>
@@ -78,7 +78,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -63,7 +63,7 @@ export const output = `
     </span>
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/empty-block.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block.js
@@ -19,7 +19,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">\uFEFF</span>
+        <br />
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/readonly-custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/readonly-custom-inline-void.js
@@ -55,7 +55,7 @@ export const output = `
     </span>
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <br />
       </span>
     </span>
   </div>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing more or less. 

#### What's the new behavior?

Selected empty blocks now look selected as well
![image](https://user-images.githubusercontent.com/289053/47320466-1afa4000-d617-11e8-8d6a-861c3c8b4185.png)

#### How does this change work?

Instead of rendering a zero-width no-break space in an empty block, render a `<br />` instead

This is what other editors do (I checked quill and prosemirror specifically). It didn't appear to break any expectations, but I did only test in Chrome. I tried the old zero-width whitespace, as well as no-break space and neither would appear selected. I went through old PRs etc to make sure I had the back story, and tested copying the block and pasting it back in and that worked as well.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2275
Reviewers: @
