### PR TITLE
Use <br /> inside empty block so those appear selected

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -142,7 +142,12 @@ class Leaf extends React.Component {
       parent.text === '' &&
       parent.nodes.last() === node
     ) {
-      return <span data-slate-zero-width="n">{'\uFEFF'}</span>
+      return (
+        <span data-slate-zero-width="n">
+          {'\uFEFF'}
+          <br />
+        </span>
+      )
     }
 
     // COMPAT: If the text is empty, it's because it's on the edge of an inline

--- a/packages/slate-react/test/rendering/fixtures/custom-block-blurred.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-blurred.js
@@ -63,7 +63,7 @@ export const output = `
    <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>
@@ -82,7 +82,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-block-focused.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-focused.js
@@ -59,7 +59,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>
@@ -78,7 +78,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-block-selected.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-block-selected.js
@@ -59,7 +59,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>
@@ -78,7 +78,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/custom-inline-void.js
@@ -63,7 +63,7 @@ export const output = `
     </span>
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/empty-block.js
+++ b/packages/slate-react/test/rendering/fixtures/empty-block.js
@@ -19,7 +19,7 @@ export const output = `
   <div style="position:relative">
     <span>
       <span>
-        <span data-slate-zero-width="n">\uFEFF</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>

--- a/packages/slate-react/test/rendering/fixtures/readonly-custom-inline-void.js
+++ b/packages/slate-react/test/rendering/fixtures/readonly-custom-inline-void.js
@@ -55,7 +55,7 @@ export const output = `
     </span>
     <span>
       <span>
-        <span data-slate-zero-width="n">&#xFEFF;</span>
+        <span data-slate-zero-width="n">&#xFEFF;<br /></span>
       </span>
     </span>
   </div>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing more or less. 

#### What's the new behavior?

Selected empty blocks now look selected as well
![image](https://user-images.githubusercontent.com/289053/47320466-1afa4000-d617-11e8-8d6a-861c3c8b4185.png)

#### How does this change work?

Adds a `<br />` inside the `<span data-slate-zero-width="n" />` after the zero-width no-break space

Other editors use `<br />` in those empty spaces. I had originally just replaced the `span` with the `br`, but on enter, it added the new line but the cursor didn't move. This fixes that oversight. And since that render branch is matches one specific case (when it's the last node in a block), it doesn't seem to have any additional side effects.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2275
Reviewers: @
