### PR TITLE
fix: extend forward / backward

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "html-webpack-template": "^6.1.0",
     "image-extensions": "^1.1.0",
     "immutable": "^3.8.1",
-    "is-hotkey": "^0.1.1",
+    "is-hotkey": "^0.1.4",
     "is-url": "^1.2.2",
     "jsdom": "^11.5.1",
     "lerna": "^2.7.1",

--- a/packages/slate-hotkeys/package.json
+++ b/packages/slate-hotkeys/package.json
@@ -13,7 +13,7 @@
     "lib/"
   ],
   "dependencies": {
-    "is-hotkey": "^0.1.3",
+    "is-hotkey": "0.1.4",
     "slate-dev-environment": "^0.2.0"
   },
   "scripts": {

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -526,6 +526,33 @@ function AfterPlugin(options = {}) {
       return change.moveFocusToEndOfBlock()
     }
 
+    // Note, these need to come before `isMoveForward()` and `isMoveBackward()`
+    if (Hotkeys.isExtendBackward(event)) {
+      const { previousText, startText } = value
+      const isPreviousInVoid =
+        previousText && document.hasVoidParent(previousText.key, editor)
+
+      if (hasVoidParent || isPreviousInVoid || startText.text == '') {
+        event.preventDefault()
+        return change.moveFocusBackward()
+      }
+
+      return true
+    }
+
+    if (Hotkeys.isExtendForward(event)) {
+      const { nextText, startText } = value
+      const isNextInVoid =
+        nextText && document.hasVoidParent(nextText.key, editor)
+
+      if (hasVoidParent || isNextInVoid || startText.text == '') {
+        event.preventDefault()
+        return change.moveFocusForward()
+      }
+
+      return true
+    }
+
     // COMPAT: If a void node is selected, or a zero-width text node adjacent to
     // an inline is selected, we need to handle these hotkeys manually because
     // browsers won't know what to do.
@@ -557,28 +584,6 @@ function AfterPlugin(options = {}) {
     if (Hotkeys.isMoveWordForward(event)) {
       event.preventDefault()
       return change.moveWordForward()
-    }
-
-    if (Hotkeys.isExtendBackward(event)) {
-      const { previousText, startText } = value
-      const isPreviousInVoid =
-        previousText && document.hasVoidParent(previousText.key, editor)
-
-      if (hasVoidParent || isPreviousInVoid || startText.text == '') {
-        event.preventDefault()
-        return change.moveFocusBackward()
-      }
-    }
-
-    if (Hotkeys.isExtendForward(event)) {
-      const { nextText, startText } = value
-      const isNextInVoid =
-        nextText && document.hasVoidParent(nextText.key, editor)
-
-      if (hasVoidParent || isNextInVoid || startText.text == '') {
-        event.preventDefault()
-        return change.moveFocusForward()
-      }
     }
 
     next()

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -526,33 +526,6 @@ function AfterPlugin(options = {}) {
       return change.moveFocusToEndOfBlock()
     }
 
-    // Note, these need to come before `isMoveForward()` and `isMoveBackward()`
-    if (Hotkeys.isExtendBackward(event)) {
-      const { previousText, startText } = value
-      const isPreviousInVoid =
-        previousText && document.hasVoidParent(previousText.key, editor)
-
-      if (hasVoidParent || isPreviousInVoid || startText.text == '') {
-        event.preventDefault()
-        return change.moveFocusBackward()
-      }
-
-      return true
-    }
-
-    if (Hotkeys.isExtendForward(event)) {
-      const { nextText, startText } = value
-      const isNextInVoid =
-        nextText && document.hasVoidParent(nextText.key, editor)
-
-      if (hasVoidParent || isNextInVoid || startText.text == '') {
-        event.preventDefault()
-        return change.moveFocusForward()
-      }
-
-      return true
-    }
-
     // COMPAT: If a void node is selected, or a zero-width text node adjacent to
     // an inline is selected, we need to handle these hotkeys manually because
     // browsers won't know what to do.
@@ -584,6 +557,28 @@ function AfterPlugin(options = {}) {
     if (Hotkeys.isMoveWordForward(event)) {
       event.preventDefault()
       return change.moveWordForward()
+    }
+
+    if (Hotkeys.isExtendBackward(event)) {
+      const { previousText, startText } = value
+      const isPreviousInVoid =
+        previousText && document.hasVoidParent(previousText.key, editor)
+
+      if (hasVoidParent || isPreviousInVoid || startText.text == '') {
+        event.preventDefault()
+        return change.moveFocusBackward()
+      }
+    }
+
+    if (Hotkeys.isExtendForward(event)) {
+      const { nextText, startText } = value
+      const isNextInVoid =
+        nextText && document.hasVoidParent(nextText.key, editor)
+
+      if (hasVoidParent || isNextInVoid || startText.text == '') {
+        event.preventDefault()
+        return change.moveFocusForward()
+      }
     }
 
     next()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4500,13 +4500,9 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-hotkey@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.1.tgz#b279a2fd108391be9aa93c6cb317f50357da549a"
-
-is-hotkey@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.3.tgz#8a129eec16f3941bd4f37191e02b9c3e91950549"
+is-hotkey@0.1.4, is-hotkey@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.4.tgz#c34d2c85d6ec8d09a871dcf71931c8067a824c7d"
 
 is-in-browser@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?

Fix behavior for <kbd>shift + left</kbd> and <kbd>shift + right</kbd>. Now they will correctly move forward / backward.

#### How does this change work?

turns out that the hotkey `'left'` would also pick up with a modifier key `'shift+left'` so checking for `Hotkeys.isExtendForward()` needs to come before `Hotkeys.isMoveForward()` and it needs to short circuit with `return true`. Likewise for backward.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2307 
Reviewers: @ianstormtaylor 
