### PR TITLE
Fixes the worst schema failures in 0.42.x

### DIFF
--- a/packages/slate/src/controllers/change.js
+++ b/packages/slate/src/controllers/change.js
@@ -327,7 +327,7 @@ function getDirtyPaths(operation) {
     case 'set_mark': {
       return [path]
     }
-    
+
     case 'set_node':
     case 'insert_node': {
       const table = node.getKeysToPathsTable()

--- a/packages/slate/src/controllers/change.js
+++ b/packages/slate/src/controllers/change.js
@@ -324,11 +324,11 @@ function getDirtyPaths(operation) {
     case 'insert_text':
     case 'remove_mark':
     case 'remove_text':
-    case 'set_mark':
-    case 'set_node': {
+    case 'set_mark': {
       return [path]
     }
-
+    
+    case 'set_node':
     case 'insert_node': {
       const table = node.getKeysToPathsTable()
       const paths = Object.values(table).map(p => path.concat(p))


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug fix

#### What's the new behavior?

Parent nodes are normalized on `set_node` operations

#### How does this change work?

`set_node` operations normalize using the same logic as `insert_node` operations. This fixes `block` nesting issues, ~~include the `first` and `last` rules~~ _(It seems to fix some of these, but not all)_. This does not fix issues with `marks` (or with `insert_text`, though I'm not aware of any bugs related to that)

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

(Partially) Fixes: #2312
Reviewers: @ianstormtaylor @zhujinxuan @thesunny 

**To be clear, things are still pretty broken, but this is a definite improvement in my testing**