### PR TITLE
fix: use ancestors for dirt paths

### DIFF
--- a/packages/slate/src/controllers/change.js
+++ b/packages/slate/src/controllers/change.js
@@ -332,20 +332,20 @@ function getDirtyPaths(operation) {
     case 'insert_node': {
       const table = node.getKeysToPathsTable()
       const paths = Object.values(table).map(p => path.concat(p))
-      const parentPath = PathUtils.lift(path)
-      return [parentPath, path, ...paths]
+      const ancestors = PathUtils.getAncestors(path).toArray()
+      return [...ancestors, path, ...paths]
     }
 
     case 'split_node': {
-      const parentPath = PathUtils.lift(path)
+      const ancestors = PathUtils.getAncestors(path).toArray()
       const nextPath = PathUtils.increment(path)
-      return [parentPath, path, nextPath]
+      return [...ancestors, path, nextPath]
     }
 
     case 'merge_node': {
-      const parentPath = PathUtils.lift(path)
+      const ancestors = PathUtils.getAncestors(path).toArray()
       const previousPath = PathUtils.decrement(path)
-      return [parentPath, previousPath]
+      return [...ancestors, previousPath]
     }
 
     case 'move_node': {
@@ -364,12 +364,15 @@ function getDirtyPaths(operation) {
         }
       }
 
-      return [parentPath, newParentPath]
+      const oldAncestors = PathUtils.getAncestors(parentPath).toArray()
+      const newAncestors = PathUtils.getAncestors(newParentPath).toArray()
+
+      return [...oldAncestors, parentPath, ...newAncestors, newParentPath]
     }
 
     case 'remove_node': {
-      const parentPath = PathUtils.lift(path)
-      return [parentPath]
+      const ancestors = PathUtils.getAncestors(path).toArray()
+      return [...ancestors]
     }
 
     default: {

--- a/packages/slate/src/controllers/change.js
+++ b/packages/slate/src/controllers/change.js
@@ -326,7 +326,8 @@ function getDirtyPaths(operation) {
     case 'remove_text':
     case 'set_mark':
     case 'set_node': {
-      return [path]
+      const ancestors = PathUtils.getAncestors(path).toArray()
+      return [...ancestors, path]
     }
 
     case 'insert_node': {

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -77,6 +77,23 @@ function decrement(path, n = 1, index = path.size - 1) {
 }
 
 /**
+ * Get all ancestor paths of th given path.
+ *
+ * @param {List} path
+ * @returns {List}
+ */
+
+function getAncestors(path) {
+  let ancestors = new List()
+
+  for (let i = 0; i < path.size; i++) {
+    ancestors = ancestors.push(path.slice(0, i))
+  }
+
+  return ancestors
+}
+
+/**
  * Increment a `path` by `n` at `index`, defaulting to the last index.
  *
  * @param {List} path
@@ -358,6 +375,7 @@ export default {
   create,
   crop,
   decrement,
+  getAncestors,
   increment,
   isAbove,
   isAfter,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?

Now on normalization, anywhere we were marking parent paths as dirty, we will now also mark all ancestors as dirty using the new `PathUtils.getAncestors()` function.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2312
Reviewers: @ianstormtaylor @Slapbox 
