### PR TITLE
Exempts remove_text operation from traversing ancestors

### DIFF
--- a/packages/slate/src/controllers/change.js
+++ b/packages/slate/src/controllers/change.js
@@ -320,10 +320,13 @@ function getDirtyPaths(operation) {
   const { type, node, path, newPath } = operation
 
   switch (type) {
+    case 'remove_text': {
+      return [path]
+    }
+
     case 'add_mark':
     case 'insert_text':
     case 'remove_mark':
-    case 'remove_text':
     case 'set_mark':
     case 'set_node': {
       const ancestors = PathUtils.getAncestors(path).toArray()


### PR DESCRIPTION
**_This is not necessarily good to go_ - I've submitted it to make reviewing the change easier - It may be worth merging or it may not**

## [Test it here](https://deploy-preview-2322--slatejs.netlify.com/#/rich-text)

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug fix

#### What's the new behavior?

Exempt

#### How does this change work?

Exempts remove_text operation from traversing ancestors

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

(Partially) Fixes: #2291 - Restores functionality prior to merging of #2316
Reviewers: @ianstormtaylor @ericedem @skogsmaskin 
