### PR TITLE
Fix invalid transform path in move_node operation

### DIFF
--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -343,7 +343,7 @@ function transform(path, operation) {
     const npIndex = np.size - 1
     const npEqual = isEqual(np, path)
 
-    if (npEqual) {
+    if (isEqual(p, np)) {
       return List([path])
     }
 

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -342,6 +342,11 @@ function transform(path, operation) {
     const { newPath: np } = operation
     const npIndex = np.size - 1
     const npEqual = isEqual(np, path)
+
+    if (npEqual) {
+      return List([path])
+    }
+
     const npYounger = isYounger(np, path)
     const npAbove = isAbove(np, path)
 

--- a/packages/slate/test/commands/at-current-range/delete/non-void-triple.js
+++ b/packages/slate/test/commands/at-current-range/delete/non-void-triple.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.delete()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />1
+      </paragraph>
+      <paragraph>2</paragraph>
+      <paragraph>
+        3<focus />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/delete/void-inline-as-last-with-non-void-previous-siblings.js
+++ b/packages/slate/test/commands/at-current-range/delete/void-inline-as-last-with-non-void-previous-siblings.js
@@ -9,13 +9,14 @@ export default function(change) {
 export const input = (
   <value>
     <document>
-      <anchor />
-      <paragraph>Hi</paragraph>
+      <paragraph>
+        <anchor />Hi
+      </paragraph>
       <paragraph>there</paragraph>
       <paragraph>
-        <emoji>😊</emoji>
+        <emoji />
+        <focus />
       </paragraph>
-      <focus />
     </document>
   </value>
 )

--- a/packages/slate/test/commands/at-current-range/delete/void-inline-as-last-with-non-void-previous-siblings.js
+++ b/packages/slate/test/commands/at-current-range/delete/void-inline-as-last-with-non-void-previous-siblings.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(change) {
+  change.delete()
+}
+
+export const input = (
+  <value>
+    <document>
+      <anchor />
+      <paragraph>Hi</paragraph>
+      <paragraph>there</paragraph>
+      <paragraph>
+        <emoji>😊</emoji>
+      </paragraph>
+      <focus />
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug. 

Moving a node from ``path`` to an equal ``newPath`` would increment the returned path when it shouldn't.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2291
Reviewers: @ericedem @ianstormtaylor @Slapbox 
