### PR TITLE
When trying to move a node from a path to an equal path, ignore it

### DIFF
--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -194,6 +194,12 @@ Commands.mergeNodeByPath = (change, path) => {
 Commands.moveNodeByPath = (change, path, newPath, newIndex) => {
   const { value } = change
 
+  // If the operation path and newPath are the same,
+  // this should be considered a NOOP
+  if (PathUtils.isEqual(path, newPath)) {
+    return change
+  }
+
   change.applyOperation({
     type: 'move_node',
     value,

--- a/packages/slate/src/controllers/change.js
+++ b/packages/slate/src/controllers/change.js
@@ -353,6 +353,10 @@ function getDirtyPaths(operation) {
       let parentPath = PathUtils.lift(path)
       let newParentPath = PathUtils.lift(newPath)
 
+      if (PathUtils.isEqual(path, newPath)) {
+        return []
+      }
+
       // HACK: this clause only exists because the `move_path` logic isn't
       // consistent when it deals with siblings.
       if (!PathUtils.isSibling(path, newPath)) {

--- a/packages/slate/src/operations/apply.js
+++ b/packages/slate/src/operations/apply.js
@@ -1,6 +1,7 @@
 import Debug from 'debug'
 
 import Operation from '../models/operation'
+import PathUtils from '../utils/path-utils'
 
 /**
  * Debug.
@@ -50,6 +51,11 @@ function applyOperation(value, op) {
 
     case 'move_node': {
       const { path, newPath } = op
+
+      if (PathUtils.isEqual(path, newPath)) {
+        return value
+      }
+
       const next = value.moveNode(path, newPath)
       return next
     }

--- a/packages/slate/src/operations/invert.js
+++ b/packages/slate/src/operations/invert.js
@@ -37,6 +37,11 @@ function invertOperation(op) {
 
     case 'move_node': {
       const { newPath, path } = op
+
+      if (PathUtils.isEqual(newPath, path)) {
+        return op
+      }
+
       let inversePath = newPath
       let inverseNewPath = path
 

--- a/packages/slate/test/commands/by-path/move-node-by-path/path-equals-new-path.js
+++ b/packages/slate/test/commands/by-path/move-node-by-path/path-equals-new-path.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import PathUtils from '../../../../src/utils/path-utils'
+import assert from 'assert'
+
+const pathA = PathUtils.create([0])
+const pathB = PathUtils.create([1])
+
+export default function(change) {
+  change.moveNodeByPath(pathA, pathA, 0)
+  change.moveNodeByPath(pathA, pathA, 1)
+  change.moveNodeByPath(pathB, pathB, 0)
+  change.moveNodeByPath(pathB, pathB, 1)
+  assert(change.operations.size === 0)
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>1</paragraph>
+      <paragraph>2</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>1</paragraph>
+      <paragraph>2</paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/operations/apply/move-node/path-equals-new-path.js
+++ b/packages/slate/test/operations/apply/move-node/path-equals-new-path.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default [
+  {
+    type: 'move_node',
+    path: [0],
+    newPath: [0],
+  },
+]
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>1</paragraph>
+      <paragraph>2</paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>1</paragraph>
+      <paragraph>2</paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing potential bugs and improving performance.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Commands or operations trying to move a node from one path to a equal path should be ignored throughout the code.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

By simply ignoring those operations, or not returning anything (like for marking dirty paths).

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: Issues where ``slate-react`` will regenerate keys for nodes when it's really not necessary. Improving performance. 
Reviewers: @ianstormtaylor
