### PR TITLE
fix: make to have a path when comparing decoration paths.

### DIFF
--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -119,10 +119,12 @@ class Text extends React.Component {
 
       // If the node's path is before the start path, ignore it.
       const path = document.assertPath(key)
-      if (PathUtils.compare(path, start.path) === -1) return false
+      const startPath = start.path || document.assertPath(start.key)
+      if (PathUtils.compare(path, startPath) === -1) return false
 
       // If the node's path is after the end path, ignore it.
-      if (PathUtils.compare(path, end.path) === 1) return false
+      const endPath = end.path || document.assertPath(end.key)
+      if (PathUtils.compare(path, endPath) === 1) return false
 
       // Otherwise, include it.
       return true


### PR DESCRIPTION
If no path, use a key to get a path.

#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### How does this change work?

This example is specifying decorations with keys rather than paths (which is valid). When rendering, the Text nodes were trying to reference and compare the paths of the nodes which did not exist.

This change makes it so if there is no path when trying to compare paths, get the path from the key.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2319
Reviewers: @
