### PR TITLE
Fix deprecated editor.change in after/onCut

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -226,11 +226,11 @@ function AfterPlugin(options = {}) {
       const isVoidInline = endInline && editor.isVoid(endInline) && isCollapsed
 
       if (isVoidBlock) {
-        editor.editor(c => c.removeNodeByKey(endBlock.key))
+        editor.removeNodeByKey(endBlock.key)
       } else if (isVoidInline) {
-        editor.editor(c => c.removeNodeByKey(endInline.key))
+        editor.removeNodeByKey(endInline.key)
       } else {
-        editor.editor(c => c.delete())
+        editor.delete()
       }
     })
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a forgotten editor.change call.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
