### PR TITLE
add clarification for paste HTML example

### DIFF
--- a/examples/paste-html/value.json
+++ b/examples/paste-html/value.json
@@ -25,7 +25,7 @@
             "leaves": [
               {
                 "text":
-                  "Try it out for yourself! Copy and paste some rendered HTML content (not the actual syntax) from another site into this editor."
+                  "Try it out for yourself! Copy and paste some rendered HTML content (not the source code) from another site into this editor."
               }
             ]
           }

--- a/examples/paste-html/value.json
+++ b/examples/paste-html/value.json
@@ -25,7 +25,7 @@
             "leaves": [
               {
                 "text":
-                  "Try it out for yourself! Copy and paste some HTML content from another site into this editor."
+                  "Try it out for yourself! Copy and paste some rendered HTML content (not the actual syntax) from another site into this editor."
               }
             ]
           }


### PR DESCRIPTION
fixes #1392

#### Is this adding or improving a _feature_ or fixing a _bug_?
This just adds clarification to the paste HTML example that confused myself and others (as evidenced by #1392).
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
N/A
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
This only changes one line in the JSON example.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
