### PR TITLE
Very nearly fixes undo/redo batching

### DIFF
--- a/packages/slate/src/commands/on-history.js
+++ b/packages/slate/src/commands/on-history.js
@@ -1,6 +1,5 @@
 import omit from 'lodash/omit'
 import { List } from 'immutable'
-import Selection from '../models/selection'
 import Operation from '../models/operation'
 
 /**


### PR DESCRIPTION
This change makes Slate picky about which `set_selection` operations to save to history, and manually creates selection operations prior to changes to content to enable predictable undo/redo

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

Undo/redo behavior more or less matches the standard behavior of all text editors (there is always some very minor variation between different editors, but selections by themselves are no longer an operation that gets its own undo/redo

#### How does this change work?

1. Only commit `set_selection` operations with an `isFocused` property - These are the only ones that actually need to be committed
2. Manually build a `set_selection` operation and sandwich changes of any type besides `set_selection` and `insert_text` with that manually built selection.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2098 - Almost
Reviewers: @ianstormtaylor @ericedem 

#### Does this commit have any issues itself?

Yes.

1. The `insert_text_not_contiguous` test fails - https://github.com/ianstormtaylor/slate/blob/master/packages/slate/test/history/undo/insert-text-not-contiguous.js - **I'm not sure that this is a real issue. The test might need to be updated, but I'm unclear on how** When I try to recreate this on my own I can't, I assume because the test uses `editor.flush()` - The actual behavior in practice appears to be 100% correct

#### Are there enhancements that could still be implemented?

Yes. These are issues that exist with or without this PR.

1. BUG - For `insert_text`, we don't sandwich it with a manually built `set_selection` and this works fine, but `remove_text` sets its new selection prior to removing text, which means excluding it from being saved isn't as simple as `insert_text` - **Currently each deleted character is its own undo, which is obviously not good at all** (Apparently this is not caused by my PR, I was surprised to find - I'm unsure of the origin of this issue)

2. BUG - Refocusing the editor clears the redo stack. Previously blurring the editor, or even changing the selection did this, so it's a step in the right direction, but still broken in that regard.

3. BUG - Selecting parts of multiple nodes, pressing `enter` and then undoing leads to the replaced text being restored one line down from where it should be (in its own new node) as a result of a `split_node` operation I assume

4. FEATURE - We may want to create checkpoints to undo to either every `x` number of `text_insert`/`text_remove` operations, or when the text inserted is a `space`

Additionally, the code could use some cleaning up. Since it's only 99% functional at the moment, I figured it was a bit early to go refactoring.