### PR TITLE
Checks for nodes in isLeafBlock & isLeafInline

### DIFF
--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1428,6 +1428,7 @@ class ElementInterface {
 
   isLeafBlock() {
     const { object, nodes } = this
+    if (!nodes.size) return true
     const first = nodes.first()
     return object === 'block' && first.object !== 'block'
   }
@@ -1440,6 +1441,7 @@ class ElementInterface {
 
   isLeafInline() {
     const { object, nodes } = this
+    if (!nodes.size) return true
     const first = nodes.first()
     return object === 'inline' && first.object !== 'inline'
   }


### PR DESCRIPTION
These functions now check for `nodes` before running `nodes.first()`

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug


#### How does this change work?

Checks for `nodes.size` before running `nodes.first()` in `isLeafInline` & `isLeafBlock`


#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2356
Reviewers: @ianstormtaylor 
