### PR TITLE
fix: update mentions example to slate 0.43

### DIFF
--- a/examples/mentions/index.js
+++ b/examples/mentions/index.js
@@ -168,38 +168,33 @@ class MentionsExample extends React.Component {
   insertMention = user => {
     const value = this.state.value
     const inputValue = getInput(value)
+    const editor = this.editorRef.current
 
     // Delete the captured value, including the `@` symbol
-    this.editorRef.current.change(change => {
-      change = change.deleteBackward(inputValue.length + 1)
+    editor.deleteBackward(inputValue.length + 1)
 
-      const selectedRange = change.value.selection
+    const selectedRange = editor.value.selection
 
-      change
-        .insertText(' ')
-        .insertInlineAtRange(selectedRange, {
-          data: {
-            userId: user.id,
-            username: user.username,
+    editor
+      .insertText(' ')
+      .insertInlineAtRange(selectedRange, {
+        data: {
+          userId: user.id,
+          username: user.username,
+        },
+        nodes: [
+          {
+            object: 'text',
+            leaves: [
+              {
+                text: `@${user.username}`,
+              },
+            ],
           },
-          nodes: [
-            {
-              object: 'text',
-              leaves: [
-                {
-                  text: `@${user.username}`,
-                },
-              ],
-            },
-          ],
-          type: USER_MENTION_NODE_TYPE,
-        })
-        .focus()
-
-      this.setState({
-        value: change.value,
+        ],
+        type: USER_MENTION_NODE_TYPE,
       })
-    })
+      .focus()
   }
 
   /**
@@ -240,7 +235,11 @@ class MentionsExample extends React.Component {
         })
       }
 
-      return change.withoutSaving(() => change.setDecorations(decorations))
+      this.setState({ value: change.value }, () => {
+        // We need to set decorations after the value flushes into the editor.
+        this.editorRef.current.setDecorations(decorations)
+      })
+      return
     }
 
     this.setState({ value: change.value })


### PR DESCRIPTION
It also works in Safari now :)

#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### How does this change work?

Convert to using the editor directly instead of a change object.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2360
Reviewers: @ianstormtaylor 


#### Caveat

I'm not super excited about how I had to fix the `onChange()` handling, by wrapping it in a `setState()` callback. It seems to work ok, but it feels a bit off. If anyone has a similar issue or recommendations please let me know!