### PR TITLE
Skip operations on child nodes if !node.nodes.size

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -135,25 +135,28 @@ class Node extends React.Component {
     const decs = decorations.concat(node.getDecorations(editor))
     const childrenDecorations = getChildrenDecorations(node, decs)
 
-    let children = []
-
-    node.nodes.forEach((child, i) => {
-      const isChildSelected = !!indexes && indexes.start <= i && i < indexes.end
-
-      children.push(
-        this.renderNode(child, isChildSelected, childrenDecorations[i])
-      )
-    })
-
     // Attributes that the developer must mix into the element in their
     // custom node renderer component.
     const attributes = { 'data-key': node.key }
 
-    // If it's a block node with inline children, add the proper `dir` attribute
-    // for text direction.
-    if (node.object == 'block' && node.nodes.first().object != 'block') {
-      const direction = node.getTextDirection()
-      if (direction == 'rtl') attributes.dir = 'rtl'
+    let children = []
+
+    if (node.nodes.size) {
+      node.nodes.forEach((child, i) => {
+        const isChildSelected =
+          !!indexes && indexes.start <= i && i < indexes.end
+
+        children.push(
+          this.renderNode(child, isChildSelected, childrenDecorations[i])
+        )
+      })
+
+      // If it's a block node with inline children, add the proper `dir` attribute
+      // for text direction.
+      if (node.object == 'block' && node.nodes.first().object != 'block') {
+        const direction = node.getTextDirection()
+        if (direction == 'rtl') attributes.dir = 'rtl'
+      }
     }
 
     const props = {


### PR DESCRIPTION
Avoid running decoration and text decoration related functions on child nodes that don't exist.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

Does not throw error and unfocus editor when trying to undo on an empty editor

#### How does this change work?

Checks `node.nodes.size` before running code on `node.nodes`


#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`.  (As it turns out, `yarn lint` really won't run for Slate on Windows for me - it always says it's okay - arghhh)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2260
Reviewers: @ianstormtaylor
