### PR TITLE
Fix delete intent

### DIFF
--- a/packages/slate/src/commands/with-intent.js
+++ b/packages/slate/src/commands/with-intent.js
@@ -94,7 +94,7 @@ Commands.deleteBackward = (editor, n = 1) => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteBackwardAtRange(selection, n).moveToStart()
+    editor.deleteBackwardAtRange(selection, n)
   }
 }
 
@@ -111,7 +111,7 @@ Commands.deleteCharBackward = editor => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteCharBackwardAtRange(selection).moveToStart()
+    editor.deleteCharBackwardAtRange(selection)
   }
 }
 
@@ -128,7 +128,7 @@ Commands.deleteLineBackward = editor => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteLineBackwardAtRange(selection).moveToStart()
+    editor.deleteLineBackwardAtRange(selection)
   }
 }
 
@@ -145,7 +145,7 @@ Commands.deleteWordBackward = editor => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteWordBackwardAtRange(selection).moveToStart()
+    editor.deleteWordBackwardAtRange(selection)
   }
 }
 
@@ -163,7 +163,7 @@ Commands.deleteForward = (editor, n = 1) => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteForwardAtRange(selection, n).moveToEnd()
+    editor.deleteForwardAtRange(selection, n)
   }
 }
 
@@ -180,7 +180,7 @@ Commands.deleteCharForward = editor => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteCharForwardAtRange(selection).moveToEnd()
+    editor.deleteCharForwardAtRange(selection)
   }
 }
 
@@ -197,7 +197,7 @@ Commands.deleteLineForward = editor => {
   if (selection.isExpanded) {
     editor.delete()
   } else {
-    editor.deleteLineForwardAtRange(selection).moveToEnd()
+    editor.deleteLineForwardAtRange(selection)
   }
 }
 
@@ -212,7 +212,7 @@ Commands.deleteWordForward = editor => {
   const { selection } = value
 
   if (selection.isExpanded) {
-    editor.delete().moveToEnd()
+    editor.delete()
   } else {
     editor.deleteWordForwardAtRange(selection)
   }

--- a/packages/slate/src/plugins/core.js
+++ b/packages/slate/src/plugins/core.js
@@ -1,4 +1,3 @@
-import AtCurrentRange from '../commands/at-current-range'
 import AtRange from '../commands/at-range'
 import ByPath from '../commands/by-path'
 import Commands from './commands'
@@ -8,6 +7,7 @@ import OnValue from '../commands/on-value'
 import Queries from './queries'
 import Schema from './schema'
 import Text from '../models/text'
+import WithIntent from '../commands/with-intent'
 
 /**
  * A plugin that defines the core Slate logic.
@@ -26,12 +26,12 @@ function CorePlugin(options = {}) {
    */
 
   const commands = Commands({
-    ...AtCurrentRange,
     ...AtRange,
     ...ByPath,
     ...OnHistory,
     ...OnSelection,
     ...OnValue,
+    ...WithIntent,
   })
 
   /**

--- a/packages/slate/test/commands/at-current-range/delete/across-blocks-inlines.js
+++ b/packages/slate/test/commands/at-current-range/delete/across-blocks-inlines.js
@@ -10,14 +10,18 @@ export const input = (
   <value>
     <document>
       <paragraph>
+        <text />
         <link>
           wo<anchor />rd
         </link>
+        <text />
       </paragraph>
       <paragraph>
+        <text />
         <link>
           an<focus />other
         </link>
+        <text />
       </paragraph>
     </document>
   </value>
@@ -27,10 +31,13 @@ export const output = (
   <value>
     <document>
       <paragraph>
+        <text />
+        <link>wo</link>
+        <text />
         <link>
-          wo<cursor />
+          <cursor />other
         </link>
-        <link>other</link>
+        <text />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/split-block/with-delete-across-blocks-and-inlines.js
+++ b/packages/slate/test/commands/at-current-range/split-block/with-delete-across-blocks-and-inlines.js
@@ -10,14 +10,18 @@ export const input = (
   <value>
     <document>
       <paragraph>
+        <text />
         <link>
           wo<anchor />rd
         </link>
+        <text />
       </paragraph>
       <paragraph>
+        <text />
         <hashtag>
           an<focus />other
         </hashtag>
+        <text />
       </paragraph>
     </document>
   </value>
@@ -27,13 +31,20 @@ export const output = (
   <value>
     <document>
       <paragraph>
+        <text />
         <link>wo</link>
+        <text />
+        <hashtag>
+          <text />
+        </hashtag>
+        <text />
       </paragraph>
       <paragraph>
-        <link />
+        <text />
         <hashtag>
           <cursor />other
         </hashtag>
+        <text />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/split-block/with-delete-hanging-selection.js
+++ b/packages/slate/test/commands/at-current-range/split-block/with-delete-hanging-selection.js
@@ -24,7 +24,7 @@ export const output = (
   <value>
     <document>
       <paragraph>zero</paragraph>
-      <paragraph />
+      <quote />
       <quote>
         <cursor />cat is cute
       </quote>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug / improvement.

#### What's the new behavior?

This fixes the "user intent" with deletes, ensuring that `editor.delete()` is always channeled if the selection is expanded, preserving the ability to override the command in a single place.

It also cleans up the deleting logic to ensure that cases where missing start/end nodes after a delete are fixed consistently.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
