### PR TITLE
Check if inline ancestor exists before using it in wrapInlineAtRange

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -1268,6 +1268,10 @@ Commands.wrapInlineAtRange = (editor, range, inline) => {
     // Wrapping an inline void
     const inlineParent = document.getClosestInline(start.key)
 
+    if (!inlineParent) {
+      return
+    }
+
     if (!editor.isVoid(inlineParent)) {
       return
     }

--- a/packages/slate/test/commands/at-current-range/wrap-inline/collapsed-range-without-parent-void-inline.js
+++ b/packages/slate/test/commands/at-current-range/wrap-inline/collapsed-range-without-parent-void-inline.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.wrapInline('hashtag')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        w<cursor />d
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        w<cursor />d
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### How does this change work?

Check if inline ancestor exists before using it in wrapInlineAtRange when selection is collapsed.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2366 
