### PR TITLE
fix: support mobile devices in examples

### DIFF
--- a/support/webpack/config.js
+++ b/support/webpack/config.js
@@ -68,6 +68,16 @@ const config = {
       title: 'Slate',
       template: HtmlWebpackTemplate,
       inject: false,
+      // Note: this is not the correct format meta for HtmlWebpackPlugin, which
+      // accepts a single object of key=name and value=content. We need to
+      // format it this way for HtmlWebpackTemplate which expects an array of
+      // objects instead.
+      meta: [
+        {
+          name: 'viewport',
+          content: 'width=device-width, initial-scale=1',
+        },
+      ],
       scripts: ['https://cdn.polyfill.io/v2/polyfill.min.js'],
       links: [
         'https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i&subset=latin-ext',


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?

Go from this:

![image](https://user-images.githubusercontent.com/1060669/48026366-b5b84b80-e0fa-11e8-96f2-d47fe44c39d6.png)

To this:

![image](https://user-images.githubusercontent.com/1060669/48026387-c7015800-e0fa-11e8-9a0b-88a1a89c04b5.png)

#### How does this change work?

This change adds the standard meta tag for supporting mobile devices. Now when viewing on mobile the viewport width will adapt to the device.

https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag#Viewport_basics

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 