### PR TITLE
added the schema reference to the list of documents for gitbook

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,7 +3,7 @@
   "root": "./docs",
   "structure": {
     "readme": "Introduction.md",
-    "summary": "Readme.md"
+    "summary": "Summary.md"
   },
   "plugins": ["-highlight", "prism", "github"],
   "pluginsConfig": {

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -42,6 +42,7 @@
 * [Plugins](./reference/slate/plugins.md)
 * [Point](./reference/slate/point.md)
 * [Range](./reference/slate/range.md)
+* [Schema](./reference/slate/schema.md)
 * [Selection](./reference/slate/selection.md)
 * [Text](./reference/slate/text.md)
 * [Utils](./reference/slate/utils.md)


### PR DESCRIPTION
This PR adds the schema reference to the list of documents for gitbook and renames Readme.md to Summary to be consistent with conventions.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Documentation Bug

#### What's the new behavior?

Schema reference document is available, and the summary config file is renamed appropriately.

#### How does this change work?

* Adds /docs/reference/slate/schema.md to the list of documents in the summary config file.
* Renames summary config file from `Readme.md` to `Summary.md` to be consistent with gitbook conventions and alleviate confusion.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2383
Reviewers: @ianstormtaylor 
