### PR TITLE
fix soft-break at the end of the leaf

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -175,7 +175,8 @@ class Leaf extends React.Component {
     const lastChar = text.charAt(text.length - 1)
     const isLastText = node === lastText
     const isLastLeaf = index === leaves.size - 1
-    if (isLastText && isLastLeaf && lastChar === '\n') return `${text}\n`
+    if (isLastText && isLastLeaf && lastChar === '\n')
+      return <span data-slate-content>{`${text}\n`}</span>
 
     // Otherwise, just return the content.
     return <span data-slate-content>{text}</span>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a bug #2382
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Fix selection behaviour on soft-break as the last character of a leaf

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

With the new addition of having data-slate-content span that was introduced recently,
the last  new line character of the leaf hack that used to work was broken since it's not wrapped with the same `<span data-slate-content>`. This added the span to make sure that it works the same way when finding the domRange

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2382
Reviewers: @mehdikazi, @ianstormtaylor 
