### PR TITLE
Avoid async commands causing rerenders after unmount.

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -125,6 +125,7 @@ class Editor extends React.Component {
   /**
    * When the component unmounts, make sure async commands don't trigger react updates.
    */
+
   componentWillUnmount() {
     this.tmp.mounted = false
   }

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -123,6 +123,13 @@ class Editor extends React.Component {
   }
 
   /**
+   * When the component unmounts, make sure async commands don't trigger react updates.
+   */
+  componentWillUnmount() {
+    this.tmp.mounted = false
+  }
+
+  /**
    * Render the editor.
    *
    * @return {Element}


### PR DESCRIPTION
SLACK CONVERSATION ↓

gersom [4:26 PM]
If a plugin has a command that makes an async change, how do you make sure this change is only applied if the editor component is still mounted in React? Currently, I get the well-known `Can't call setState (or forceUpdate) on an unmounted component.` when I navigate away from the editor page before async commands are finished running.


gersom [4:33 PM]
And if there would be a user work-around for this, I was wondering if it wouldn’t be better to make all the async editor commands safe in a way that slate-react knows not to update state or call onChange anymore?

gersom [5:18 PM]
I have come up with one workaround, that involves doing this:
```
    componentWillUnmount() {
        if (this.editor.current) {
            this.editor.current.change(change => {
                const document = change.value.document;
                change.setNodeByKey(document.key, { data: { unmounted: true } });
            });
        }
    }
```
Then you can check for this value in the command that you know is invoked async. But obviously document data is not meant for this stuff, since you also need to filter it out again when sending to the server.

ianstormtaylor [5:18 PM]
SGTM to guard against unmounting in `Slate-react` if you want to make a PR

gersom [5:19 PM]
Seems like something I should be capable of. I’ll create an issue and work on it tonight/tomorrow!
Or no issue needed when I go straight to PR?

cameron_ackerman_sel [5:25 PM]
Arent we going to get isMounted check eslint warnings?
https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
generally recommends cancelling the callbacks instead

gersom [5:42 PM]
I’m aware of that warning. Trying to do it without isMounted, but I’m seeing now that the source code already has a mounted boolean anyway. It’s just not being set back to false on unmount
Checking if that would already solve it
Yes, fixes it. Now PR’ing :confetti_ball: