### PR TITLE
Add `node.getNodesAtRange`

### DIFF
--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -253,6 +253,12 @@ Get the next [`Text`](./text.md) node after a descendant by `path` or `key`.
 
 Get a node in the tree by `path` or `key`.
 
+### `getNodesAtRange`
+
+`getNodesAtRange(range: Range) => List`
+
+Get all of the nodes in a `range`. This includes all of the [`Text`](./text.md) nodes inside the range and all ancestors of those [`Text`](./text.md) nodes up to this node.
+
 ### `getOffset`
 
 `getOffset(path: List|Array) => Number`

--- a/packages/slate/test/models/node/get-nodes-at-range/multiple-blocks.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/multiple-blocks.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']

--- a/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-cursor-in-first-leaf-of-first-parent.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-cursor-in-first-leaf-of-first-parent.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">
+              on<cursor />e
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="e">
+        <text key="f">two</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'b', 'c', 'd']

--- a/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-cursor-in-first-leaf-of-second-parent.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-cursor-in-first-leaf-of-second-parent.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">one</text>
+          </paragraph>
+          <paragraph key="e">
+            <text key="f">two</text>
+          </paragraph>
+        </quote>
+        <quote key="g">
+          <paragraph key="h">
+            <text key="i">
+              three
+              <cursor />
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'g', 'h', 'i']

--- a/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-cursor-in-second-leaf-of-first-parent.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-cursor-in-second-leaf-of-first-parent.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">one</text>
+          </paragraph>
+          <paragraph key="e">
+            <text key="f">
+              <cursor />
+              two
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="g">
+        <text key="h">three</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'b', 'e', 'f']

--- a/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-selection-overlapping-multiple-blocks.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-selection-overlapping-multiple-blocks.js
@@ -1,0 +1,46 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">
+          <focus />
+          one
+        </text>
+      </paragraph>
+      <quote key="c">
+        <quote key="d">
+          <paragraph key="e">
+            <text key="f">two</text>
+          </paragraph>
+        </quote>
+        <quote key="g">
+          <paragraph key="h">
+            <text key="i">three</text>
+          </paragraph>
+          <paragraph key="j">
+            <text key="k">
+              <anchor />
+              four
+            </text>
+          </paragraph>
+          <paragraph key="l">
+            <text key="m">five</text>
+          </paragraph>
+        </quote>
+      </quote>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']

--- a/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-selection-overlapping-texts-in-second-parent.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-selection-overlapping-texts-in-second-parent.js
@@ -1,0 +1,44 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">one</text>
+          </paragraph>
+        </quote>
+        <quote key="e">
+          <paragraph key="f">
+            <text key="g">
+              <anchor />two
+            </text>
+          </paragraph>
+          <paragraph key="h">
+            <text key="i">three</text>
+          </paragraph>
+          <paragraph key="j">
+            <text key="k">
+              f<focus />our
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="l">
+        <text key="m">five</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'e', 'f', 'g', 'h', 'i', 'j', 'k']

--- a/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-selection-spanning-first-text.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/nested-blocks-selection-spanning-first-text.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">
+              <anchor />one<focus />
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="e">
+        <text key="f">two</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'b', 'c', 'd']

--- a/packages/slate/test/models/node/get-nodes-at-range/single-block-cursor-beginning-of-text.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/single-block-cursor-beginning-of-text.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          <cursor />
+          two
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['c', 'd']

--- a/packages/slate/test/models/node/get-nodes-at-range/single-block-cursor-end-of-text.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/single-block-cursor-end-of-text.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          two
+          <cursor />
+        </text>
+      </paragraph>
+      <paragraph key="e">
+        <text key="f">three</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['c', 'd']

--- a/packages/slate/test/models/node/get-nodes-at-range/single-block-cursor-middle-of-text.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/single-block-cursor-middle-of-text.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">
+          on<cursor />e
+        </text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">two</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'b']

--- a/packages/slate/test/models/node/get-nodes-at-range/single-block-with-inline.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/single-block-with-inline.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+        <inline type="link" key="c">
+          <text key="d">
+            tw<cursor />o
+          </text>
+        </inline>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'c', 'd']

--- a/packages/slate/test/models/node/get-nodes-at-range/single-void-block.js
+++ b/packages/slate/test/models/node/get-nodes-at-range/single-void-block.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <image key="a" src="https://example.com/image2.png">
+        <text key="b" />
+      </image>
+    </document>
+    <selection isFocused={false}>
+      <anchor key="b" offset={0} />
+      <focus key="b" offset={0} />
+    </selection>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getNodesAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = ['a', 'b']


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### What's the new behavior?

Adds method `node.getNodesAtRange` which returns all text nodes inside the range plus all ancestors of those text nodes up to (but not including) the calling node.

#### How does this change work?

Added a method which does a depth-first stack-based search for all relevant nodes using paths.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2351 

#### Thoughts / discussion

- **Big caveat**: I'm not sure if paths are always based on the document root or if they are based relative to the callling node. I went with the calling node so let me know if I'm mistaken.
- I went for a custom and more performant implementation instead of using existing methods. This might make it more difficult to maintain so let me know if you want something else.
- I only made one method `getNodesAtRange` which returns a [`List`](https://facebook.github.io/immutable-js/docs/#/List) which is memoized, is that ok?
