### PR TITLE
Add `node.isNodeInRange`

### DIFF
--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -364,3 +364,10 @@ Check whether the node has a descendant node by `path` or `key`.
 `hasNode(key: String) => Boolean`
 
 Check whether a node exists in the tree by `path` or `key`.
+
+### `isNodeInRange`
+
+`isNodeInRange(path: List|Array) => Boolean`
+`isNodeInRange(key: String) => Boolean`
+
+Check whether a node is inside a `range`. This will return true for all [`Text`](./text.md) nodes inside the range and all ancestors of those [`Text`](./text.md) nodes up to this node.

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1637,6 +1637,31 @@ class ElementInterface {
   }
 
   /**
+   * Check whether a descendant node is inside a range. This will return true for all
+   * text nodes inside the range and all ancestors of those text nodes up to this node.
+   *
+   * @param {List|Key} path
+   * @param {Range} range
+   * @return {Node}
+   */
+
+  isNodeInRange(path, range) {
+    this.assertDescendant(path)
+    path = this.resolvePath(path)
+    range = this.resolveRange(range)
+    if (range.isUnset) return false
+
+    const toStart = PathUtils.compare(path, range.start.path)
+    const toEnd =
+      range.start.key === range.end.key
+        ? toStart
+        : PathUtils.compare(path, range.end.path)
+
+    const is = toStart !== -1 && toEnd !== 1
+    return is
+  }
+
+  /**
    * Map all child nodes, updating them in their parents. This method is
    * optimized to not return a new node if no changes are made.
    *

--- a/packages/slate/test/models/node/is-node-in-range/block-above-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/block-above-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('a', selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/block-above.js
+++ b/packages/slate/test/models/node/is-node-in-range/block-above.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([0], selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/block-below-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/block-below-using-key.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+      <paragraph key="k">
+        <text key="l">five</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('k', selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/block-below.js
+++ b/packages/slate/test/models/node/is-node-in-range/block-below.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+      <paragraph key="k">
+        <text key="l">five</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([4], selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/first-block-inside-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/first-block-inside-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('c', selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/first-block-inside.js
+++ b/packages/slate/test/models/node/is-node-in-range/first-block-inside.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([1], selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/first-text-inside-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/first-text-inside-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('d', selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/first-text-inside.js
+++ b/packages/slate/test/models/node/is-node-in-range/first-text-inside.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([1, 0], selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/last-block-inside-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/last-block-inside-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('g', selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/last-block-inside.js
+++ b/packages/slate/test/models/node/is-node-in-range/last-block-inside.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([3], selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/last-text-inside-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/last-text-inside-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('j', selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/last-text-inside.js
+++ b/packages/slate/test/models/node/is-node-in-range/last-text-inside.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([3, 1], selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/text-above-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/text-above-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('b', selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/text-above.js
+++ b/packages/slate/test/models/node/is-node-in-range/text-above.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([0, 0], selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/text-below-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/text-below-using-key.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+      <paragraph key="k">
+        <text key="l">five</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('l', selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/text-below.js
+++ b/packages/slate/test/models/node/is-node-in-range/text-below.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+      <paragraph key="k">
+        <text key="l">five</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([4, 0], selection)
+}
+
+export const output = false

--- a/packages/slate/test/models/node/is-node-in-range/text-in-middle-inside-using-key.js
+++ b/packages/slate/test/models/node/is-node-in-range/text-in-middle-inside-using-key.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange('f', selection)
+}
+
+export const output = true

--- a/packages/slate/test/models/node/is-node-in-range/text-in-middle-inside.js
+++ b/packages/slate/test/models/node/is-node-in-range/text-in-middle-inside.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.isNodeInRange([2, 0], selection)
+}
+
+export const output = true


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

Adds `node.isNodeInRange` method which can be used to check whether a descendant node is inside a range. This will return true for all text nodes inside the range and all ancestors of those text nodes up to this node.

#### How does this change work?

Using `PathUtils.compare` method against the start and end paths of the range.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2103 
