### PR TITLE
Add optional `id` prop to the `Editor` component

### DIFF
--- a/docs/reference/slate-react/editor.md
+++ b/docs/reference/slate-react/editor.md
@@ -10,6 +10,7 @@ The top-level React component that renders the Slate editor itself.
 
 ```js
 <Editor
+  id={String}
   autoCorrect={Boolean}
   autoFocus={Boolean}
   className={String}
@@ -27,6 +28,12 @@ The top-level React component that renders the Slate editor itself.
   tabIndex={Number}
 />
 ```
+
+### `id`
+
+`String`
+
+Id for the top-level rendered HTML element of the editor.
 
 ### `autoCorrect`
 

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -41,6 +41,7 @@ class Content extends React.Component {
     autoCorrect: Types.bool.isRequired,
     className: Types.string,
     editor: Types.object.isRequired,
+    id: Types.string,
     readOnly: Types.bool.isRequired,
     role: Types.string,
     spellCheck: Types.bool.isRequired,
@@ -421,6 +422,7 @@ class Content extends React.Component {
   render() {
     const { props, handlers } = this
     const {
+      id,
       className,
       readOnly,
       editor,
@@ -467,6 +469,7 @@ class Content extends React.Component {
         data-key={document.key}
         contentEditable={readOnly ? null : true}
         suppressContentEditableWarning
+        id={id}
         className={className}
         autoCorrect={props.autoCorrect ? 'on' : 'off'}
         spellCheck={spellCheck}

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -35,6 +35,7 @@ class Editor extends React.Component {
     autoCorrect: Types.bool,
     autoFocus: Types.bool,
     className: Types.string,
+    id: Types.string,
     onChange: Types.func,
     options: Types.object,
     placeholder: Types.any,

--- a/packages/slate-react/src/plugins/react.js
+++ b/packages/slate-react/src/plugins/react.js
@@ -60,6 +60,7 @@ function ReactPlugin(options = {}) {
         autoCorrect={props.autoCorrect}
         className={props.className}
         editor={editor}
+        id={props.id}
         onEvent={(handler, event) => editor.run(handler, event)}
         readOnly={props.readOnly}
         role={props.role}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

The `Editor` React component now takes an `id` prop which is put on the top-level rendered HTML element of the editor.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2184 
