### PR TITLE
Do not show placeholder when document contains multiple text nodes

### DIFF
--- a/packages/slate-react/src/plugins/react.js
+++ b/packages/slate-react/src/plugins/react.js
@@ -120,7 +120,8 @@ function ReactPlugin(options = {}) {
         when: (editor, node) =>
           node.object === 'document' &&
           node.text === '' &&
-          node.nodes.size === 1,
+          node.nodes.size === 1 &&
+          node.getTexts().size === 1,
       })
     )
   }

--- a/packages/slate-react/test/rendering/fixtures/placeholder/multiple-blocks-with-single-empty-text.js
+++ b/packages/slate-react/test/rendering/fixtures/placeholder/multiple-blocks-with-single-empty-text.js
@@ -1,0 +1,46 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const props = {
+  placeholder: 'placeholder text',
+}
+
+export const value = (
+  <value>
+    <document>
+      <paragraph>
+        <text />
+      </paragraph>
+      <paragraph>
+        <text />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = `
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+    <div style="position:relative">
+        <span>
+            <span data-slate-leaf="true">
+                <span data-slate-zero-width="n" data-slate-length="0">
+                    <br>
+                </span>
+            </span>
+        </span>
+    </div>
+    <div style="position:relative">
+        <span>
+            <span data-slate-leaf="true">
+                <span data-slate-zero-width="n" data-slate-length="0">
+                    <br>
+                </span>
+            </span>
+        </span>
+    </div>
+</div>
+`
+  .split('\n')
+  .map(l => l.trim())
+  .join('')

--- a/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-inline.js
+++ b/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-inline.js
@@ -1,0 +1,49 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const props = {
+  placeholder: 'placeholder text',
+}
+
+export const value = (
+  <value>
+    <document>
+      <paragraph>
+        <inline type="link">
+          <text />
+        </inline>
+        <text />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = `
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+    <div style="position:relative">
+        <span>
+            <span data-slate-leaf="true">
+                <span data-slate-zero-width="z" data-slate-length="0"></span>
+            </span>
+        </span>
+        <span style="position:relative">
+            <span>
+                <span data-slate-leaf="true">
+                    <span data-slate-zero-width="z" data-slate-length="0"></span>
+                </span>
+            </span>
+        </span>
+        <span>
+            <span data-slate-leaf="true">
+                <span data-slate-zero-width="n" data-slate-length="0">
+                    <br>
+                </span>
+            </span>
+        </span>
+    </div>
+</div>
+`
+  .split('\n')
+  .map(l => l.trim())
+  .join('')

--- a/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-single-empty-text.js
+++ b/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-single-empty-text.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const props = {
+  placeholder: 'placeholder text',
+}
+
+export const value = (
+  <value>
+    <document>
+      <paragraph>
+        <text />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = `
+<div data-slate-editor="true" contenteditable="true" role="textbox">
+  <div style="position:relative">
+    <span>
+      <span data-slate-leaf="true">
+        <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333">
+            placeholder text
+        </span>
+        <span data-slate-zero-width="n" data-slate-length="0">
+            <br>
+        </span>
+      </span>
+    </span>
+  </div>
+</div>
+`
+  .split('\n')
+  .map(l => l.trim())
+  .join('')


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Placeholder are not shown when document contains multiple text nodes.

#### How does this change work?

We check for `node.getTexts().size === 1`.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2397 
