### PR TITLE
Fix deleteBackwardAtRange removing extra character when called at start of Inline

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -322,7 +322,16 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
   const text = document.getDescendant(start.key)
 
   if (start.isAtStartOfNode(text)) {
-    const prev = document.getPreviousText(text.key)
+    let prev = document.getPreviousText(text.key)
+    const inline = document.getClosestInline(text.key)
+
+    // If the range is at the start of the inline node, and previous text node
+    // is empty, take the text node before that, or "prevBlock" would be the
+    // same node as "block"
+    if (inline && prev.text === '') {
+      prev = document.getPreviousText(prev.key)
+    }
+
     const prevBlock = document.getClosestBlock(prev.key)
     const prevVoid = document.getClosestVoid(prev.key, editor)
 

--- a/packages/slate/test/commands/at-current-range/delete-backward/join-blocks-from-inline.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/join-blocks-from-inline.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.deleteBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        one<link>two</link>
+      </paragraph>
+      <paragraph>
+        <link>
+          <cursor />three
+        </link>four
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        one<link>two</link>
+        <link>
+          <cursor />three
+        </link>four
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?
![ice_video_20181111-021728](https://user-images.githubusercontent.com/1475852/48307569-971dde80-e558-11e8-9c46-acafdbb3255e.gif)

#### How does this change work?

The bug was that `deleteBackwardAtRange` grabbed the previous Text node, but it was in the same Block as Inline and merging Blocks was not triggered correctly; then it tried to remove previous character and did so in the previous block.

#### Have you checked that...?

* [ ] The new code matches the existing patterns and styles. _(not checking because who am I to judge?)_
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2391
Reviewers: @ianstormtaylor 
