### PR TITLE
[Fix] Copy-paste error "object.nodes is undefined"

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -794,7 +794,8 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
 }
 
 const findInsertionNode = (fragment, document, startKey) => {
-  const hasSingleNode = object => object && object.nodes && object.nodes.size === 1
+  const hasSingleNode = object =>
+    object && object.nodes && object.nodes.size === 1
   const firstNode = object => object && object.nodes && object.nodes.first()
   let node = fragment
 

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -794,8 +794,8 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
 }
 
 const findInsertionNode = (fragment, document, startKey) => {
-  const hasSingleNode = object => object && object.nodes.size === 1
-  const firstNode = object => object && object.nodes.first()
+  const hasSingleNode = object => object && object.nodes && object.nodes.size === 1
+  const firstNode = object => object && object.nodes && object.nodes.first()
   let node = fragment
 
   if (hasSingleNode(fragment)) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### What's the new behavior?
I simply added a "undefined" check in "findInsertionNode", which seems to fix the bug where it was not possible to Paste content in an empty block.
Honestly I'm not sure if this is a fix or simply hiding the real problem. It does however fixes the behavior in my project: pasting now works as expected. Plus there was already part of the check in place so I guess this is OK.

#### How does this change work?
Just checking if "object.nodes" is not undefined before getting "object.nodes.size"

#### Have you checked that...?


* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
No
