### PR TITLE
Only insert fragment of same schema on paste and drop

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -352,7 +352,13 @@ function AfterPlugin(options = {}) {
       }
     }
 
-    if (type == 'fragment') {
+    const schemaHashCodeChecksOut =
+      fragment &&
+      fragment.data.has('schemaHashCode') &&
+      editor.getSchemaHashCode &&
+      fragment.data.get('schemaHashCode') === editor.getSchemaHashCode()
+
+    if (type == 'fragment' && schemaHashCodeChecksOut) {
       editor.insertFragment(fragment)
     }
 
@@ -648,11 +654,21 @@ function AfterPlugin(options = {}) {
     const transfer = getEventTransfer(event)
     const { type, fragment, text } = transfer
 
-    if (type == 'fragment') {
+    const schemaHashCodeChecksOut =
+      fragment &&
+      fragment.data.has('schemaHashCode') &&
+      editor.getSchemaHashCode &&
+      fragment.data.get('schemaHashCode') === editor.getSchemaHashCode()
+
+    if (type == 'fragment' && schemaHashCodeChecksOut) {
       editor.insertFragment(fragment)
     }
 
-    if (type == 'text' || type == 'html') {
+    if (
+      type == 'text' ||
+      type == 'html' ||
+      (type == 'fragment' && !schemaHashCodeChecksOut)
+    ) {
       if (!text) return next()
       const { document, selection, startBlock } = value
       if (editor.isVoid(startBlock)) return next()

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -32,12 +32,23 @@ function cloneFragment(event, editor, callback = () => undefined) {
   const startVoid = document.getClosestVoid(start.key, editor)
   const endVoid = document.getClosestVoid(end.key, editor)
 
+  let fragmentToSerialize = fragment
+
+  if (editor.getSchemaHashCode) {
+    const schemaHashCode = editor.getSchemaHashCode()
+    const newData = fragmentToSerialize
+      .get('data')
+      .set('schemaHashCode', schemaHashCode)
+
+    fragmentToSerialize = fragmentToSerialize.set('data', newData)
+  }
+
   // If the selection is collapsed, and it isn't inside a void node, abort.
   if (native.isCollapsed && !startVoid) return
 
   // Create a fake selection so that we can add a Base64-encoded copy of the
   // fragment to the HTML, to decode on future pastes.
-  const encoded = Base64.serializeNode(fragment)
+  const encoded = Base64.serializeNode(fragmentToSerialize)
   const range = native.getRangeAt(0)
   let contents = range.cloneContents()
   let attach = contents.childNodes[0]
@@ -94,7 +105,7 @@ function cloneFragment(event, editor, callback = () => undefined) {
   //  Creates value from only the selected blocks
   //  Then gets plaintext for clipboard with proper linebreaks for BLOCK elements
   //  Via Plain serializer
-  const valFromSelection = Value.create({ document: fragment })
+  const valFromSelection = Value.create({ document: fragmentToSerialize })
   const plainText = Plain.serialize(valFromSelection)
 
   // Add the phony content to a div element. This is needed to copy the

--- a/packages/slate/src/plugins/schema.js
+++ b/packages/slate/src/plugins/schema.js
@@ -1,3 +1,5 @@
+import { List } from 'immutable'
+
 import SlateError from '../utils/slate-error'
 import Queries from './queries'
 
@@ -50,6 +52,8 @@ function SchemaPlugin(schema) {
     }
   }
 
+  const schemaHashCode = List(schemaRules).hashCode()
+
   /**
    * Check if a `mark` is void based on the schema rules.
    *
@@ -80,6 +84,16 @@ function SchemaPlugin(schema) {
     )
 
     return rule && rule.isVoid
+  }
+
+  /**
+   * Get hash code of this schema.
+   *
+   * @return {Number}
+   */
+
+  function getSchemaHashCode() {
+    return schemaHashCode
   }
 
   /**
@@ -138,7 +152,7 @@ function SchemaPlugin(schema) {
    * @param {Function} next
    */
 
-  const queries = Queries({ isAtomic, isVoid })
+  const queries = Queries({ isAtomic, isVoid, getSchemaHashCode })
 
   /**
    * Return the plugins.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

When user pastes or drops something into an editor it will only insert an attached fragment if it has the same schema (hash code) as the target editor.

#### How does this change work?

Computes a schema hash code of the schema rules inside the `SchemaPlugin`. `SchemaPlugin` then exposes this hash code with a query that `cloneFragment`, `onPaste`  and `onDrop` uses.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2065 
