### PR TITLE
Fix `renderBlockButton` of rich text example

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -144,9 +144,12 @@ class RichTextExample extends React.Component {
     let isActive = this.hasBlock(type)
 
     if (['numbered-list', 'bulleted-list'].includes(type)) {
-      const { value } = this.state
-      const parent = value.document.getParent(value.blocks.first().key)
-      isActive = this.hasBlock('list-item') && parent && parent.type === type
+      const { value: { document, blocks } } = this.state
+
+      if (blocks.size > 0) {
+        const parent = document.getParent(blocks.first().key)
+        isActive = this.hasBlock('list-item') && parent && parent.type === type
+      }
     }
 
     return (


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

When refocusing (click outside editor -> click inside editor) the example will not crash.

![refocusingeditordoesnotbork](https://user-images.githubusercontent.com/1681435/48318453-92f9cb80-e601-11e8-9292-11f4ddd3016d.gif)

#### How does this change work?

Checking if there are any blocks in the selection before doing stuff with the first block in the selection.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2407 
