### PR TITLE
Changing the selection when input by ime sometimes will break the ime.

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -151,7 +151,7 @@ class Content extends React.Component {
 
     // COMPAT: In Firefox, there's a but where `getSelection` can return `null`.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=827585 (2018/11/07)
-    if (!native) {
+    if (!native || editor.isComposing()) {
       return
     }
 

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -32,7 +32,6 @@ function BeforePlugin() {
   let isCopying = false
   let isDragging = false
 
-
   /**
    * The before plugin queries.
    *

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -32,6 +32,17 @@ function BeforePlugin() {
   let isCopying = false
   let isDragging = false
 
+
+  /**
+   * The before plugin queries.
+   *
+   * @type {Object}
+   */
+
+  const queries = {
+    isComposing: () => isComposing,
+  }
+
   /**
    * On before input.
    *
@@ -480,6 +491,7 @@ function BeforePlugin() {
     onKeyDown,
     onPaste,
     onSelect,
+    queries,
   }
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?
Changing the selection when input by ime sometimes will break the ime.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2376 

