### PR TITLE
update placeholder

### DIFF
--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -41,7 +41,7 @@ function SlateReactPlaceholder(options = {}) {
     const decoration = {
       anchor: { key: first.key, offset: 0 },
       focus: { key: last.key, offset: last.text.length },
-      mark: { type: 'placeholder' },
+      mark: { type: 'placeholder', data: { placeholder } },
     }
 
     return [...others, decoration]
@@ -68,6 +68,8 @@ function SlateReactPlaceholder(options = {}) {
         whiteSpace: 'nowrap',
         opacity: '0.333',
       }
+
+      const placeholder = mark.data.get('placeholder')
 
       return (
         <React.Fragment>

--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -69,12 +69,12 @@ function SlateReactPlaceholder(options = {}) {
         opacity: '0.333',
       }
 
-      const placeholder = mark.data.get('placeholder')
+      const content = mark.data.get('placeholder')
 
       return (
         <React.Fragment>
           <span contentEditable={false} style={style}>
-            {placeholder}
+            {content}
           </span>
           {children}
         </React.Fragment>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?

After (#2370) we can use only one placeholder text multiple times, because first placeholder plugin render self placeholder each time.

#### How does this change work?

Now we pass placeholder to mark data and get it from that.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
