### PR TITLE
Add `defaultValue` prop to `Editor` component

### DIFF
--- a/examples/check-lists/index.js
+++ b/examples/check-lists/index.js
@@ -2,8 +2,16 @@ import { Editor } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
 import styled from 'react-emotion'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * Create a few styling components.
@@ -89,16 +97,6 @@ class CheckListItem extends React.Component {
 
 class CheckLists extends React.Component {
   /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
-  /**
    * Render.
    *
    * @return {Element}
@@ -109,8 +107,7 @@ class CheckLists extends React.Component {
       <Editor
         spellCheck
         placeholder="Get to work..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         onKeyDown={this.onKeyDown}
         renderNode={this.renderNode}
       />
@@ -131,16 +128,6 @@ class CheckLists extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change, save the new value.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/code-highlighting/index.js
+++ b/examples/code-highlighting/index.js
@@ -3,7 +3,15 @@ import { Value } from 'slate'
 
 import Prism from 'prismjs'
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * Define our code components.
@@ -68,16 +76,6 @@ function getContent(token) {
 
 class CodeHighlighting extends React.Component {
   /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
-  /**
    * Render.
    *
    * @return {Component}
@@ -87,8 +85,7 @@ class CodeHighlighting extends React.Component {
     return (
       <Editor
         placeholder="Write some code..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         onKeyDown={this.onKeyDown}
         renderNode={this.renderNode}
         renderMark={this.renderMark}
@@ -153,16 +150,6 @@ class CodeHighlighting extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change, save the new value.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/embeds/index.js
+++ b/examples/embeds/index.js
@@ -3,7 +3,15 @@ import { Value } from 'slate'
 
 import React from 'react'
 import Video from './video'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * The images example.
@@ -12,16 +20,6 @@ import initialValue from './value.json'
  */
 
 class Embeds extends React.Component {
-  /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
   /**
    * The editor's schema.
    *
@@ -46,9 +44,8 @@ class Embeds extends React.Component {
     return (
       <Editor
         placeholder="Enter some text..."
-        value={this.state.value}
+        defaultValue={initialValue}
         schema={this.schema}
-        onChange={this.onChange}
         renderNode={this.renderNode}
       />
     )
@@ -69,16 +66,6 @@ class Embeds extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 }
 

--- a/examples/emojis/index.js
+++ b/examples/emojis/index.js
@@ -2,9 +2,17 @@ import { Editor } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
 import styled from 'react-emotion'
 import { Button, Icon, Toolbar } from '../components'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * A styled emoji inline component.
@@ -58,16 +66,6 @@ const noop = e => e.preventDefault()
 
 class Emojis extends React.Component {
   /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
-  /**
    * The editor's schema.
    *
    * @type {Object}
@@ -110,9 +108,8 @@ class Emojis extends React.Component {
         <Editor
           placeholder="Write some 😍👋🎉..."
           ref={this.ref}
-          value={this.state.value}
+          defaultValue={initialValue}
           schema={this.schema}
-          onChange={this.onChange}
           renderNode={this.renderNode}
         />
       </div>
@@ -154,16 +151,6 @@ class Emojis extends React.Component {
         return next()
       }
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/forced-layout/index.js
+++ b/examples/forced-layout/index.js
@@ -2,7 +2,15 @@ import { Editor } from 'slate-react'
 import { Block, Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * A simple schema to enforce the nodes in the Slate document.
@@ -39,16 +47,6 @@ const schema = {
 
 class ForcedLayout extends React.Component {
   /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
-  /**
    * Render the editor.
    *
    * @return {Component} component
@@ -58,9 +56,8 @@ class ForcedLayout extends React.Component {
     return (
       <Editor
         placeholder="Enter a title..."
-        value={this.state.value}
+        defaultValue={initialValue}
         schema={schema}
-        onChange={this.onChange}
         renderNode={this.renderNode}
       />
     )
@@ -86,16 +83,6 @@ class ForcedLayout extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 }
 

--- a/examples/huge-document/index.js
+++ b/examples/huge-document/index.js
@@ -36,20 +36,20 @@ for (let h = 0; h < HEADINGS; h++) {
 }
 
 /**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(json, { normalize: false })
+
+/**
  * The huge document example.
  *
  * @type {Component}
  */
 
 class HugeDocument extends React.Component {
-  /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = { value: Value.fromJSON(json, { normalize: false }) }
-
   /**
    * Render the editor.
    *
@@ -61,8 +61,7 @@ class HugeDocument extends React.Component {
       <Editor
         placeholder="Enter some text..."
         spellCheck={false}
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         renderNode={this.renderNode}
         renderMark={this.renderMark}
       />
@@ -113,16 +112,6 @@ class HugeDocument extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 }
 

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -2,11 +2,19 @@ import { Editor, getEventRange, getEventTransfer } from 'slate-react'
 import { Block, Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
 import imageExtensions from 'image-extensions'
 import isUrl from 'is-url'
 import styled from 'react-emotion'
 import { Button, Icon, Toolbar } from '../components'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * A styled image block component.
@@ -84,16 +92,6 @@ const schema = {
 
 class Images extends React.Component {
   /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
-  /**
    * Store a reference to the `editor`.
    *
    * @param {Editor} editor
@@ -120,9 +118,8 @@ class Images extends React.Component {
         <Editor
           placeholder="Enter some text..."
           ref={this.ref}
-          value={this.state.value}
+          defaultValue={initialValue}
           schema={schema}
-          onChange={this.onChange}
           onDrop={this.onDropOrPaste}
           onPaste={this.onDropOrPaste}
           renderNode={this.renderNode}
@@ -151,16 +148,6 @@ class Images extends React.Component {
         return next()
       }
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/input-tester/index.js
+++ b/examples/input-tester/index.js
@@ -3,9 +3,17 @@ import { Value } from 'slate'
 
 import React from 'react'
 import styled from 'react-emotion'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
 import { Icon } from '../components'
 import { createArrayValue } from 'react-values'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 const EventsValue = createArrayValue()
 
@@ -193,10 +201,6 @@ const Event = ({ event, targetRange, selection }) => {
 }
 
 class InputTester extends React.Component {
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
   componentDidMount() {
     const editor = this.el.querySelector('[contenteditable="true"]')
     editor.addEventListener('keydown', this.onEvent)
@@ -221,7 +225,7 @@ class InputTester extends React.Component {
           spellCheck
           placeholder="Enter some text..."
           ref={this.ref}
-          value={this.state.value}
+          defaultValue={initialValue}
           onChange={this.onChange}
           renderNode={this.renderNode}
           renderMark={this.renderMark}

--- a/examples/markdown-preview/index.js
+++ b/examples/markdown-preview/index.js
@@ -12,24 +12,22 @@ import React from 'react'
 ;Prism.languages.markdown=Prism.languages.extend("markup",{}),Prism.languages.insertBefore("markdown","prolog",{blockquote:{pattern:/^>(?:[\t ]*>)*/m,alias:"punctuation"},code:[{pattern:/^(?: {4}|\t).+/m,alias:"keyword"},{pattern:/``.+?``|`[^`\n]+`/,alias:"keyword"}],title:[{pattern:/\w+.*(?:\r?\n|\r)(?:==+|--+)/,alias:"important",inside:{punctuation:/==+$|--+$/}},{pattern:/(^\s*)#+.+/m,lookbehind:!0,alias:"important",inside:{punctuation:/^#+|#+$/}}],hr:{pattern:/(^\s*)([*-])([\t ]*\2){2,}(?=\s*$)/m,lookbehind:!0,alias:"punctuation"},list:{pattern:/(^\s*)(?:[*+-]|\d+\.)(?=[\t ].)/m,lookbehind:!0,alias:"punctuation"},"url-reference":{pattern:/!?\[[^\]]+\]:[\t ]+(?:\S+|<(?:\\.|[^>\\])+>)(?:[\t ]+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\)))?/,inside:{variable:{pattern:/^(!?\[)[^\]]+/,lookbehind:!0},string:/(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/,punctuation:/^[\[\]!:]|[<>]/},alias:"url"},bold:{pattern:/(^|[^\\])(\*\*|__)(?:(?:\r?\n|\r)(?!\r?\n|\r)|.)+?\2/,lookbehind:!0,inside:{punctuation:/^\*\*|^__|\*\*$|__$/}},italic:{pattern:/(^|[^\\])([*_])(?:(?:\r?\n|\r)(?!\r?\n|\r)|.)+?\2/,lookbehind:!0,inside:{punctuation:/^[*_]|[*_]$/}},url:{pattern:/!?\[[^\]]+\](?:\([^\s)]+(?:[\t ]+"(?:\\.|[^"\\])*")?\)| ?\[[^\]\n]*\])/,inside:{variable:{pattern:/(!?\[)[^\]]+(?=\]$)/,lookbehind:!0},string:{pattern:/"(?:\\.|[^"\\])*"(?=\)$)/}}}}),Prism.languages.markdown.bold.inside.url=Prism.util.clone(Prism.languages.markdown.url),Prism.languages.markdown.italic.inside.url=Prism.util.clone(Prism.languages.markdown.url),Prism.languages.markdown.bold.inside.italic=Prism.util.clone(Prism.languages.markdown.italic),Prism.languages.markdown.italic.inside.bold=Prism.util.clone(Prism.languages.markdown.bold); // prettier-ignore
 
 /**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Plain.deserialize(
+  'Slate is flexible enough to add **decorations** that can format text based on its content. For example, this editor has **Markdown** preview decorations on it, to make it _dead_ simple to make an editor with built-in Markdown previewing.\n## Try it out!\nTry it out for yourself!'
+)
+
+/**
  * The markdown preview example.
  *
  * @type {Component}
  */
 
 class MarkdownPreview extends React.Component {
-  /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Plain.deserialize(
-      'Slate is flexible enough to add **decorations** that can format text based on its content. For example, this editor has **Markdown** preview decorations on it, to make it _dead_ simple to make an editor with built-in Markdown previewing.\n## Try it out!\nTry it out for yourself!'
-    ),
-  }
-
   /**
    *
    * Render the example.
@@ -41,8 +39,7 @@ class MarkdownPreview extends React.Component {
     return (
       <Editor
         placeholder="Write some markdown..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         renderMark={this.renderMark}
         decorateNode={this.decorateNode}
       />
@@ -132,16 +129,6 @@ class MarkdownPreview extends React.Component {
         return next()
       }
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/markdown-shortcuts/index.js
+++ b/examples/markdown-shortcuts/index.js
@@ -2,7 +2,15 @@ import { Editor } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * The auto-markdown example.
@@ -11,16 +19,6 @@ import initialValue from './value.json'
  */
 
 class MarkdownShortcuts extends React.Component {
-  /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
   /**
    * Get the block type for a series of auto-markdown shortcut `chars`.
    *
@@ -64,8 +62,7 @@ class MarkdownShortcuts extends React.Component {
     return (
       <Editor
         placeholder="Write some markdown..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         onKeyDown={this.onKeyDown}
         renderNode={this.renderNode}
       />
@@ -106,16 +103,6 @@ class MarkdownShortcuts extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -3,8 +3,16 @@ import { Editor, getEventTransfer } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
 import styled from 'react-emotion'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * Tags to blocks.
@@ -153,16 +161,6 @@ const serializer = new Html({ rules: RULES })
 
 class PasteHtml extends React.Component {
   /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
-  /**
    * The editor's schema.
    *
    * @type {Object}
@@ -186,10 +184,9 @@ class PasteHtml extends React.Component {
     return (
       <Editor
         placeholder="Paste in some HTML..."
-        value={this.state.value}
+        defaultValue={initialValue}
         schema={this.schema}
         onPaste={this.onPaste}
-        onChange={this.onChange}
         renderNode={this.renderNode}
         renderMark={this.renderMark}
       />
@@ -275,16 +272,6 @@ class PasteHtml extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change, save the new value.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/plain-text/index.js
+++ b/examples/plain-text/index.js
@@ -4,24 +4,22 @@ import { Editor } from 'slate-react'
 import React from 'react'
 
 /**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Plain.deserialize(
+  'This is editable plain text, just like a <textarea>!'
+)
+
+/**
  * The plain text example.
  *
  * @type {Component}
  */
 
 class PlainText extends React.Component {
-  /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Plain.deserialize(
-      'This is editable plain text, just like a <textarea>!'
-    ),
-  }
-
   /**
    * Render the editor.
    *
@@ -32,20 +30,9 @@ class PlainText extends React.Component {
     return (
       <Editor
         placeholder="Enter some plain text..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
       />
     )
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 }
 

--- a/examples/plugins/index.js
+++ b/examples/plugins/index.js
@@ -7,6 +7,17 @@ import SoftBreak from './soft-break'
 import WordCount from './word-count'
 
 /**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Plain.deserialize(`This example shows how you can extend Slate with plugins! It uses four fairly simple plugins, but you can use any plugins you want, or write your own!
+The first is a simple plugin to collapse the selection whenever the escape key is pressed. Try selecting some text and pressing escape.
+The second is another simple plugin that inserts a "soft" break when enter is pressed instead of creating a new block. Try pressing enter!
+The third is an example of using the plugin.render property to create a higher-order-component.`)
+
+/**
  * Plugins.
  */
 
@@ -20,19 +31,6 @@ const plugins = [CollapseOnEscape(), SoftBreak(), WordCount()]
 
 class Plugins extends React.Component {
   /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Plain.deserialize(`This example shows how you can extend Slate with plugins! It uses four fairly simple plugins, but you can use any plugins you want, or write your own!
-The first is a simple plugin to collapse the selection whenever the escape key is pressed. Try selecting some text and pressing escape.
-The second is another simple plugin that inserts a "soft" break when enter is pressed instead of creating a new block. Try pressing enter!
-The third is an example of using the plugin.render property to create a higher-order-component.`),
-  }
-
-  /**
    * Render the editor.
    *
    * @return {Component} component
@@ -43,20 +41,9 @@ The third is an example of using the plugin.render property to create a higher-o
       <Editor
         placeholder="Enter some text..."
         plugins={plugins}
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
       />
     )
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 }
 

--- a/examples/read-only/index.js
+++ b/examples/read-only/index.js
@@ -4,6 +4,16 @@ import { Editor } from 'slate-react'
 import React from 'react'
 
 /**
+ * Deserialize the read-only value.
+ *
+ * @type {Object}
+ */
+
+const value = Plain.deserialize(
+  'This is read-only text. You should not be able to edit it, which is useful for scenarios where you want to render via Slate, without giving the user editing permissions.'
+)
+
+/**
  * The read-only example.
  *
  * @type {Component}
@@ -11,42 +21,13 @@ import React from 'react'
 
 class ReadOnly extends React.Component {
   /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Plain.deserialize(
-      'This is read-only text. You should not be able to edit it, which is useful for scenarios where you want to render via Slate, without giving the user editing permissions.'
-    ),
-  }
-
-  /**
    * Render the editor.
    *
    * @return {Component} component
    */
 
   render() {
-    return (
-      <Editor
-        readOnly
-        placeholder="Enter some text..."
-        value={this.state.value}
-        onChange={this.onChange}
-      />
-    )
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
+    return <Editor defaultValue={value} readOnly />
   }
 }
 

--- a/examples/rtl/index.js
+++ b/examples/rtl/index.js
@@ -2,7 +2,15 @@ import { Editor } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * A right-to-left text example.
@@ -11,16 +19,6 @@ import initialValue from './value.json'
  */
 
 class RTL extends React.Component {
-  /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
   /**
    * Render the editor.
    *
@@ -31,8 +29,7 @@ class RTL extends React.Component {
     return (
       <Editor
         placeholder="Enter some plain text..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         onKeyDown={this.onKeyDown}
         renderNode={this.renderNode}
       />
@@ -55,16 +52,6 @@ class RTL extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/search-highlighting/index.js
+++ b/examples/search-highlighting/index.js
@@ -2,9 +2,17 @@ import { Editor } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
 import styled from 'react-emotion'
 import { Icon, Toolbar } from '../components'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * Some styled components for the search box.
@@ -35,16 +43,6 @@ const SearchInput = styled('input')`
  */
 
 class SearchHighlighting extends React.Component {
-  /**
-   * Deserialize the initial editor value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
   /**
    * The editor's schema.
    *
@@ -91,9 +89,8 @@ class SearchHighlighting extends React.Component {
         <Editor
           placeholder="Enter some rich text..."
           ref={this.ref}
-          value={this.state.value}
+          defaultValue={initialValue}
           schema={this.schema}
-          onChange={this.onChange}
           renderMark={this.renderMark}
           spellCheck
         />
@@ -121,16 +118,6 @@ class SearchHighlighting extends React.Component {
       default:
         return next()
     }
-  }
-
-  /**
-   * On change, save the new `value`.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**

--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -3,7 +3,15 @@ import { Editor, getEventTransfer } from 'slate-react'
 import { Value } from 'slate'
 
 import React from 'react'
-import initialValue from './value.json'
+import initialValueAsJson from './value.json'
+
+/**
+ * Deserialize the initial editor value.
+ *
+ * @type {Object}
+ */
+
+const initialValue = Value.fromJSON(initialValueAsJson)
 
 /**
  * The tables example.
@@ -12,16 +20,6 @@ import initialValue from './value.json'
  */
 
 class Tables extends React.Component {
-  /**
-   * Deserialize the raw initial value.
-   *
-   * @type {Object}
-   */
-
-  state = {
-    value: Value.fromJSON(initialValue),
-  }
-
   /**
    * Render the example.
    *
@@ -32,8 +30,7 @@ class Tables extends React.Component {
     return (
       <Editor
         placeholder="Enter some text..."
-        value={this.state.value}
-        onChange={this.onChange}
+        defaultValue={initialValue}
         onKeyDown={this.onKeyDown}
         onDrop={this.onDropOrPaste}
         onPaste={this.onDropOrPaste}
@@ -99,16 +96,6 @@ class Tables extends React.Component {
     const { selection } = value
     if (selection.start.offset != 0) return next()
     event.preventDefault()
-  }
-
-  /**
-   * On change.
-   *
-   * @param {Editor} editor
-   */
-
-  onChange = ({ value }) => {
-    this.setState({ value })
   }
 
   /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

The `Editor` component now takes a `defaultValue` prop which makes it behave like an uncontrolled input component.

#### How does this change work?

Adds a state inside the `Editor` component which keeps track of a `Value` if it is initially set using `defaultValue`. Examples have also been updated to use this prop.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1257
