### PR TITLE
Include current node in iterator of `node.getClosest`

### DIFF
--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -85,28 +85,28 @@ Get a child by `path` or `key`.
 `getClosest(path: List|Array, match: Function) => Node|Void`
 `getClosest(key: String, match: Function) => Node|Void`
 
-Get the closest parent node of a descendant node by `path` or `key` that matches a `match` function.
+Get the closest ancestor to a descendant node (by `path` or `key`) OR the descendant node itself which matches a `match` function.
 
 ### `getClosestBlock`
 
 `getClosestBlock(path: List|Array) => Node|Void`
 `getClosestBlock(key: String) => Node|Void`
 
-Get the closest [`Block`](./block.md) node to a descendant node by `path` or `key`.
+Get the closest [`Block`](./block.md) node to a descendant node (by `path` or `key`) OR the descendant node itself if it is a [`Block`](./block.md) node.
 
 ### `getClosestInline`
 
 `getClosestInline(path: List|Array) => Node|Void`
 `getClosestInline(key: String) => Node|Void`
 
-Get the closest [`Inline`](./inline.md) node to a descendant node by `path` or `key`.
+Get the closest [`Inline`](./inline.md) node to a descendant node (by `path` or `key`) OR the descendant node itself if it is a [`Inline`](./inline.md) node.
 
 ### `getClosestVoid`
 
 `getClosestVoid(path: List|Array) => Node|Void`
 `getClosestVoid(key: String) => Node|Void`
 
-Get the closest void parent of a descendant node by `path` or `key`.
+Get the closest void parent of a descendant node (by `path` or `key`) OR the descendant node itself if it is a void node.
 
 ### `getCommonAncestor`
 

--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -82,10 +82,10 @@ Get a child by `path` or `key`.
 
 ### `getClosest`
 
-`getClosest(path: List|Array, match: Function) => Node|Void`
-`getClosest(key: String, match: Function) => Node|Void`
+`getClosest(path: List|Array, predicate: Function) => Node|Void`
+`getClosest(key: String, predicate: Function) => Node|Void`
 
-Get the closest ancestor to a descendant node (by `path` or `key`) OR the descendant node itself which matches a `match` function.
+Get the closest ancestor to a descendant node (by `path` or `key`) OR the descendant node itself which matches a `predicate` function.
 
 ### `getClosestBlock`
 

--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -294,7 +294,10 @@ class RichTextExample extends React.Component {
       // Handle the extra wrapping required for list buttons.
       const isList = this.hasBlock('list-item')
       const isType = value.blocks.some(block => {
-        return !!document.getClosest(block.key, parent => parent.type == type)
+        return !!document.getClosest(
+          block.key,
+          n => n.key !== block.key && n.type == type
+        )
       })
 
       if (isList && isType) {

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -993,7 +993,7 @@ Commands.splitBlockAtRange = (editor, range, height = 1) => {
 
   while (parent && parent.object == 'block' && h < height) {
     node = parent
-    parent = document.getClosestBlock(parent.key)
+    parent = document.getParent(parent.key)
     h++
   }
 
@@ -1039,7 +1039,7 @@ Commands.splitInlineAtRange = (editor, range, height = Infinity) => {
 
   while (parent && parent.object == 'inline' && h < height) {
     node = parent
-    parent = document.getClosestInline(parent.key)
+    parent = document.getParent(parent.key)
     h++
   }
 
@@ -1089,6 +1089,7 @@ Commands.unwrapBlockAtRange = (editor, range, properties) => {
   const wrappers = blocks
     .map(block => {
       return document.getClosest(block.key, parent => {
+        if (parent.key === block.key) return false
         if (parent.object != 'block') return false
         if (properties.type != null && parent.type != properties.type)
           return false
@@ -1170,6 +1171,7 @@ Commands.unwrapInlineAtRange = (editor, range, properties) => {
   const inlines = texts
     .map(text => {
       return document.getClosest(text.key, parent => {
+        if (parent.key === text.key) return false
         if (parent.object != 'inline') return false
         if (properties.type != null && parent.type != properties.type)
           return false
@@ -1224,7 +1226,10 @@ Commands.wrapBlockAtRange = (editor, range, block) => {
   } else {
     // Determine closest shared parent to all blocks in selection.
     parent = document.getClosest(firstblock.key, p1 => {
-      return !!document.getClosest(lastblock.key, p2 => p1 == p2)
+      return (
+        p1.key !== firstblock.key &&
+        !!document.getClosest(lastblock.key, p2 => p1 == p2)
+      )
     })
   }
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -347,14 +347,14 @@ class ElementInterface {
   }
 
   /**
-   * Get closest parent of node that matches an `iterator`.
+   * Get closest parent of node OR the node itself which matches a `predicate`.
    *
    * @param {List|String} path
-   * @param {Function} iterator
+   * @param {Function} predicate
    * @return {Node|Null}
    */
 
-  getClosest(path, iterator) {
+  getClosest(path, predicate) {
     const n = this.assertNode(path)
     const ancestors = this.getAncestors(path)
     if (!ancestors) return null
@@ -362,7 +362,7 @@ class ElementInterface {
     const closest = ancestors.push(n).findLast((node, ...args) => {
       // We never want to include the top-level node.
       if (node === this) return false
-      return iterator(node, ...args)
+      return predicate(node, ...args)
     })
 
     return closest || null

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -355,10 +355,11 @@ class ElementInterface {
    */
 
   getClosest(path, iterator) {
+    const n = this.assertNode(path)
     const ancestors = this.getAncestors(path)
     if (!ancestors) return null
 
-    const closest = ancestors.findLast((node, ...args) => {
+    const closest = ancestors.push(n).findLast((node, ...args) => {
       // We never want to include the top-level node.
       if (node === this) return false
       return iterator(node, ...args)
@@ -405,11 +406,8 @@ class ElementInterface {
       'As of Slate 0.42.0, the `node.getClosestVoid` method takes an `editor` instead of a `value`.'
     )
 
-    const ancestors = this.getAncestors(path)
-    if (!ancestors) return null
-
-    const ancestor = ancestors.findLast(a => editor.query('isVoid', a))
-    return ancestor
+    const closest = this.getClosest(path, n => editor.query('isVoid', n))
+    return closest
   }
 
   /**
@@ -1569,7 +1567,11 @@ class ElementInterface {
       'As of Slate 0.42.0, the `node.hasVoidParent` method takes an `editor` instead of a `value`.'
     )
 
-    const closest = this.getClosestVoid(path, editor)
+    const node = this.assertNode(path)
+    const closest = this.getClosest(
+      path,
+      n => n.key !== node.key && editor.query('isVoid', n)
+    )
     return !!closest
   }
 

--- a/packages/slate/test/models/node/get-closest/matching-current-using-key.js
+++ b/packages/slate/test/models/node/get-closest/matching-current-using-key.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a" {...{ className: 'slate-node' }}>
+        <paragraph key="b" {...{ className: 'slate-node' }}>
+          <text key="c">one</text>
+        </paragraph>
+      </quote>
+      <paragraph key="d" {...{ className: 'slate-node' }}>
+        <text key="e">two</text>
+      </paragraph>
+      <paragraph key="f" {...{ className: 'slate-node' }}>
+        <inline type="link" key="g" {...{ className: 'slate-node' }}>
+          <text key="h">three</text>
+        </inline>
+        <text key="i">four</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document }) {
+  return document.getClosest('b', n => n.data.get('className') === 'slate-node')
+}
+
+export const output = (
+  <paragraph key="b" {...{ className: 'slate-node' }}>
+    <text key="c">one</text>
+  </paragraph>
+)

--- a/packages/slate/test/models/node/get-closest/matching-current-using-path.js
+++ b/packages/slate/test/models/node/get-closest/matching-current-using-path.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a" {...{ className: 'slate-node' }}>
+        <paragraph key="b" {...{ className: 'slate-node' }}>
+          <text key="c">one</text>
+        </paragraph>
+      </quote>
+      <paragraph key="d" {...{ className: 'slate-node' }}>
+        <text key="e">two</text>
+      </paragraph>
+      <paragraph key="f" {...{ className: 'slate-node' }}>
+        <inline type="link" key="g" {...{ className: 'slate-node' }}>
+          <text key="h">three</text>
+        </inline>
+        <text key="i">four</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document }) {
+  return document.getClosest(
+    [0, 0],
+    n => n.data.get('className') === 'slate-node'
+  )
+}
+
+export const output = (
+  <paragraph key="b" {...{ className: 'slate-node' }}>
+    <text key="c">one</text>
+  </paragraph>
+)

--- a/packages/slate/test/models/node/get-closest/matching-parent-using-key.js
+++ b/packages/slate/test/models/node/get-closest/matching-parent-using-key.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a" {...{ className: 'slate-node' }}>
+        <paragraph key="b" {...{ className: 'slate-node' }}>
+          <text key="c">one</text>
+        </paragraph>
+      </quote>
+      <paragraph key="d" {...{ className: 'slate-node' }}>
+        <text key="e">two</text>
+      </paragraph>
+      <paragraph key="f" {...{ className: 'slate-node' }}>
+        <inline type="link" key="g" {...{ className: 'slate-node' }}>
+          <text key="h">three</text>
+        </inline>
+        <text key="i">four</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document }) {
+  return document.getClosest(
+    'c',
+    n => n.data && n.data.get('className') === 'slate-node'
+  )
+}
+
+export const output = (
+  <paragraph key="b" {...{ className: 'slate-node' }}>
+    <text key="c">one</text>
+  </paragraph>
+)

--- a/packages/slate/test/models/node/get-closest/matching-parent-using-path.js
+++ b/packages/slate/test/models/node/get-closest/matching-parent-using-path.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a" {...{ className: 'slate-node' }}>
+        <paragraph key="b" {...{ className: 'slate-node' }}>
+          <text key="c">one</text>
+        </paragraph>
+      </quote>
+      <paragraph key="d" {...{ className: 'slate-node' }}>
+        <text key="e">two</text>
+      </paragraph>
+      <paragraph key="f" {...{ className: 'slate-node' }}>
+        <inline type="link" key="g" {...{ className: 'slate-node' }}>
+          <text key="h">three</text>
+        </inline>
+        <text key="i">four</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document }) {
+  return document.getClosest(
+    [0, 0],
+    n => n.data && n.data.get('className') === 'slate-node'
+  )
+}
+
+export const output = (
+  <paragraph key="b" {...{ className: 'slate-node' }}>
+    <text key="c">one</text>
+  </paragraph>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

Node methods `getClosest`, `getClosestBlock`, `getClosestInline` and `getClosestVoid` will now return the current node if it is a match (so it matches the behaviour of the DOM's native [Element.closest()](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest).

#### How does this change work?

Add the current node to the list of nodes that will be iterated over in `node.getClosest`.

Also added some tests for `node.getClosest`.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2111 
