### PR TITLE
Filter out double-underscore keys (babel junk) from hyperscipt values

### DIFF
--- a/packages/slate-hyperscript/src/index.js
+++ b/packages/slate-hyperscript/src/index.js
@@ -77,6 +77,13 @@ function createHyperscript(options = {}) {
       .filter(child => Boolean(child))
       .reduce((memo, child) => memo.concat(child), [])
 
+    // by convention, strip attributes prefixed with double underscores
+    for (const key in attributes) {
+      if (key.lastIndexOf('__', 0) === 0) {
+        delete attributes[key]
+      }
+    }
+
     const ret = creator(tagName, attributes, children)
     return ret
   }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a quasi-bug (unexpected behavior), #1536.

#### What's the new behavior?

All hyperscript attributes prefixed with double underscores (`__foo`) will be filtered out by convention. This gets rid of the unexpected `__source` and `__self` attributes added by create-react-app's default babel configuration.

#### How does this change work?

I basically copied @jasonphillips's workaround from #1536. Iterate all the attribute keys and delete the prefixed ones from `attributes`.

I do have a small concern that mutating `attributes` like this will have some adverse effects, maybe with something babel-related. However, when I tried copying/filtering keys into a new object, other things were somehow going awry. `attributes` must be a more rich object than I realized.

#### Have you checked that...?

* [X] The new code matches the existing patterns and styles.
* [X] The tests pass with `yarn test`.
* [X] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
**^ All examples were throwing an error in local for me both before and after the change. Will try rebasing against latest to see if I can get things clean.**

#### Does this fix any issues or need any specific reviewers?

Fixes: #1536
Reviewers: @ianstormtaylor 
