### PR TITLE
Add `editor.HasCommand` and `editor.HasQuery` 

### DIFF
--- a/docs/reference/slate/editor.md
+++ b/docs/reference/slate/editor.md
@@ -79,6 +79,16 @@ Synchronously flush the current changes to editor, calling `onChange`.
 
 > 🤖 In normal operation you never need to use this method! However, it can be helpful for writing tests to be able to keep the entire test synchronous.
 
+### `hasCommand`
+
+`hasCommand(type: String) => Boolean`
+
+```js
+editor.hasCommand('insertLink')
+```
+
+Checks if a command by `type` has been registered.
+
 ### `query`
 
 `query(type: String, ...args) => Any`

--- a/docs/reference/slate/editor.md
+++ b/docs/reference/slate/editor.md
@@ -89,6 +89,16 @@ editor.hasCommand('insertLink')
 
 Checks if a command by `type` has been registered.
 
+### `hasQuery`
+
+`hasQuery(type: String) => Boolean`
+
+```js
+editor.hasQuery('isLinkActive')
+```
+
+Checks if a query by `type` has been registered.
+
 ### `query`
 
 `query(type: String, ...args) => Any`

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -243,6 +243,10 @@ class Editor extends React.Component {
     return this.controller.command(...args)
   }
 
+  hasCommand(...args) {
+    return this.controller.hasCommand(...args)
+  }
+
   normalize(...args) {
     return this.controller.normalize(...args)
   }

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -247,6 +247,10 @@ class Editor extends React.Component {
     return this.controller.hasCommand(...args)
   }
 
+  hasQuery(...args) {
+    return this.controller.hasQuery(...args)
+  }
+
   normalize(...args) {
     return this.controller.normalize(...args)
   }

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -173,6 +173,20 @@ class Editor {
   }
 
   /**
+   * Checks if a query by `type` has been registered.
+   *
+   * @param {String} type
+   * @return {Boolean}
+   */
+
+  hasQuery(type) {
+    const { controller } = this
+    const has = type in controller && controller[type].__query
+
+    return has
+  }
+
+  /**
    * Normalize all of the nodes in the document from scratch.
    *
    * @return {Editor}

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -159,6 +159,20 @@ class Editor {
   }
 
   /**
+   * Checks if a command by `type` has been registered.
+   *
+   * @param {String} type
+   * @return {Boolean}
+   */
+
+  hasCommand(type) {
+    const { controller } = this
+    const has = type in controller && controller[type].__command
+
+    return has
+  }
+
+  /**
    * Normalize all of the nodes in the document from scratch.
    *
    * @return {Editor}

--- a/packages/slate/test/controllers/editor/hasCommand/existing-plugin.js
+++ b/packages/slate/test/controllers/editor/hasCommand/existing-plugin.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+const plugins = [
+  {
+    commands: {
+      customCommand: () => {},
+    },
+  },
+]
+
+export const input = new Editor({ plugins })
+
+export default function(editor) {
+  return editor.hasCommand('customCommand')
+}
+
+export const output = true

--- a/packages/slate/test/controllers/editor/hasCommand/existing-registered.js
+++ b/packages/slate/test/controllers/editor/hasCommand/existing-registered.js
@@ -1,0 +1,11 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+export const input = new Editor().registerCommand('customCommand')
+
+export default function(editor) {
+  return editor.hasCommand('customCommand')
+}
+
+export const output = true

--- a/packages/slate/test/controllers/editor/hasCommand/missing-plugin.js
+++ b/packages/slate/test/controllers/editor/hasCommand/missing-plugin.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+const plugins = [
+  {
+    commands: {
+      customCommand: () => {},
+    },
+  },
+]
+
+export const input = new Editor({ plugins })
+
+export default function(editor) {
+  return editor.hasCommand('otherCommand')
+}
+
+export const output = false

--- a/packages/slate/test/controllers/editor/hasCommand/missing-registered.js
+++ b/packages/slate/test/controllers/editor/hasCommand/missing-registered.js
@@ -1,0 +1,11 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+export const input = new Editor().registerCommand('customCommand')
+
+export default function(editor) {
+  return editor.hasCommand('otherCommand')
+}
+
+export const output = false

--- a/packages/slate/test/controllers/editor/hasQuery/existing-plugin.js
+++ b/packages/slate/test/controllers/editor/hasQuery/existing-plugin.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+const plugins = [
+  {
+    queries: {
+      customQuery: () => {},
+    },
+  },
+]
+
+export const input = new Editor({ plugins })
+
+export default function(editor) {
+  return editor.hasQuery('customQuery')
+}
+
+export const output = true

--- a/packages/slate/test/controllers/editor/hasQuery/existing-registered.js
+++ b/packages/slate/test/controllers/editor/hasQuery/existing-registered.js
@@ -1,0 +1,11 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+export const input = new Editor().registerQuery('customQuery')
+
+export default function(editor) {
+  return editor.hasQuery('customQuery')
+}
+
+export const output = true

--- a/packages/slate/test/controllers/editor/hasQuery/missing-plugin.js
+++ b/packages/slate/test/controllers/editor/hasQuery/missing-plugin.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+const plugins = [
+  {
+    queries: {
+      customquery: () => {},
+    },
+  },
+]
+
+export const input = new Editor({ plugins })
+
+export default function(editor) {
+  return editor.hasQuery('otherquery')
+}
+
+export const output = false

--- a/packages/slate/test/controllers/editor/hasQuery/missing-registered.js
+++ b/packages/slate/test/controllers/editor/hasQuery/missing-registered.js
@@ -1,0 +1,11 @@
+/** @jsx h */
+
+import { Editor } from 'slate'
+
+export const input = new Editor().registerQuery('customQuery')
+
+export default function(editor) {
+  return editor.hasQuery('otherQuery')
+}
+
+export const output = false

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -126,6 +126,15 @@ describe('slate', () => {
     assert.deepEqual(actual, expected)
   })
 
+  fixtures(__dirname, 'controllers', ({ module }) => {
+    const { input, output, default: fn } = module
+
+    const actual = fn(input)
+    const expected = output
+
+    assert.equal(actual, expected)
+  })
+
   fixtures(__dirname, 'schema', ({ module }) => {
     const { input, output, schema } = module
     const editor = new Editor({ value: input, plugins: [{ schema }] })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

`Editor` gets two new methods; `hasCommand` and `hasQuery` which checks if a command or query has been registered on the `editor`.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

Adds two new methods + tests.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2409 
