### PR TITLE
Fix: Do not use experimental array method `flat` in `Versions` example

### DIFF
--- a/examples/versions/index.js
+++ b/examples/versions/index.js
@@ -129,24 +129,13 @@ class Versions extends React.Component {
   setVersion = n => {
     const { editor } = this
     const { versions, v } = this.state
-    const isForward = n > v
     if (n === v) return
 
-    let operations
-
-    if (isForward) {
-      operations = versions
-        .slice(v + 1, n + 1)
-        .map(vers => vers.operations)
-        .flat()
-    } else {
-      operations = versions
-        .slice(n + 1, v + 1)
-        .map(vers => vers.operations)
-        .flat()
-        .reverse()
-        .map(op => op.invert())
-    }
+    const operations = versions
+      .slice(n + 1, v + 1)
+      .reduce((acc, val) => acc.concat(val.operations), []) // Make a flat array of all version operations
+      .reverse()
+      .map(op => op.invert())
 
     editor.withoutNormalizing(() => {
       editor.withoutSaving(() => {
@@ -171,13 +160,10 @@ class Versions extends React.Component {
     const { value } = this.state
     const { data } = value
     const undos = data.get('undos') || List()
+
     const version = {
       createdAt: new Date(),
-      operations: undos
-        .toArray()
-        .reverse()
-        .map(list => list.toArray())
-        .flat(),
+      operations: undos.flatten(1).toArray(),
     }
 
     this.setState(


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->
Fixing a bug.

#### What's the new behavior?

The `Versions` example will not break on (versions of) browsers that does not support the experimental array method `flat`.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

Since we are flattening a nested array that are exactly two levels, we can just use `reduce` instead.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2444 
