### PR TITLE
Improve/fix index property of child_min_invalid validation error

### DIFF
--- a/docs/reference/slate/schema.md
+++ b/docs/reference/slate/schema.md
@@ -317,10 +317,15 @@ Raised when the `object` property of a child node is invalid.
 
 Raised when a child node repeats less than required by a rule's `min` property.
 
+* `index`: index of the last matching node, or where the first matching would be, if there are no matching nodes
+* `count`: number of matching nodes
+* `limit`: value of rule's `min` property
+
 ### `child_max_invalid`
 
 ```js
 {
+  child: Node,
   index: Number,
   count: Number,
   limit: Number,
@@ -331,6 +336,10 @@ Raised when a child node repeats less than required by a rule's `min` property.
 
 Raised when a child node repeats more than permitted by a rule's `max`
 property.
+
+* `index`: index of the last matching node
+* `count`: number of matching nodes
+* `limit`: value of rule's `max` property
 
 ### `'child_type_invalid'`
 

--- a/packages/slate/src/plugins/schema.js
+++ b/packages/slate/src/plugins/schema.js
@@ -517,7 +517,7 @@ function validateNodes(node, rule, rules = []) {
         return fail('child_min_invalid', {
           rule,
           node,
-          index,
+          index: count === 0 ? index : index - 1,
           count,
           limit: min,
         })

--- a/packages/slate/test/schema/custom/child-max-properties.js
+++ b/packages/slate/test/schema/custom/child-max-properties.js
@@ -1,0 +1,55 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ type: 'paragraph' }],
+          max: 1,
+        },
+      ],
+      normalize: (editor, { code, node, child, index, count, limit }) => {
+        if (code === 'child_max_invalid') {
+          editor.removeNodeByKey(child.key)
+
+          editor.setNodeByKey(node.key, {
+            data: node.data.merge({
+              max: { index, count, limit },
+            }),
+          })
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          <text />
+        </paragraph>
+        <paragraph>
+          <text />
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote max={{ index: 1, count: 2, limit: 1 }}>
+        <paragraph>
+          <text />
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/child-min-invalid-empty.js
+++ b/packages/slate/test/schema/custom/child-min-invalid-empty.js
@@ -1,0 +1,60 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    title: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ type: 'title' }],
+          min: 1,
+          max: 1,
+        },
+        {
+          match: [{ type: 'paragraph' }],
+          min: 1,
+        },
+      ],
+      normalize: (editor, { code, node, index, count }) => {
+        if (code == 'child_min_invalid') {
+          const type = index === 0 ? 'title' : 'paragraph'
+
+          editor.insertNodeByKey(node.key, index, {
+            object: 'block',
+            type,
+          })
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <block type="title">
+          <text />
+        </block>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <block type="title">
+          <text />
+        </block>
+        <paragraph>
+          <text />
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/child-min-last-group-properties.js
+++ b/packages/slate/test/schema/custom/child-min-last-group-properties.js
@@ -1,0 +1,62 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    title: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ type: 'title' }],
+        },
+        {
+          match: [{ type: 'paragraph' }],
+          min: 2,
+        },
+      ],
+      normalize: (editor, { code, node, index, count, limit }) => {
+        if (code == 'child_min_invalid') {
+          editor.insertNodeByKey(node.key, index, {
+            object: 'block',
+            type: 'paragraph',
+          })
+
+          editor.setNodeByKey(node.key, {
+            data: {
+              min: { index, count, limit },
+            },
+          })
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          <text />
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote min={{ index: 0, count: 1, limit: 2 }}>
+        <paragraph>
+          <text />
+        </paragraph>
+        <paragraph>
+          <text />
+        </paragraph>
+      </quote>
+    </document>
+  </value>
+)

--- a/packages/slate/test/schema/custom/child-min-properties.js
+++ b/packages/slate/test/schema/custom/child-min-properties.js
@@ -1,0 +1,68 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export const schema = {
+  blocks: {
+    paragraph: {},
+    title: {},
+    quote: {
+      nodes: [
+        {
+          match: [{ type: 'paragraph' }],
+          min: 2,
+        },
+        {
+          match: [{ type: 'title' }],
+        },
+      ],
+      normalize: (editor, { code, node, index, count, limit }) => {
+        if (code == 'child_min_invalid') {
+          editor.insertNodeByKey(node.key, index, {
+            object: 'block',
+            type: 'paragraph',
+          })
+
+          editor.setNodeByKey(node.key, {
+            data: {
+              min: { index, count, limit },
+            },
+          })
+        }
+      },
+    },
+  },
+}
+
+export const input = (
+  <value>
+    <document>
+      <quote>
+        <paragraph>
+          <text />
+        </paragraph>
+        <block type="title">
+          <text />
+        </block>
+      </quote>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote min={{ index: 0, count: 1, limit: 2 }}>
+        <paragraph>
+          <text />
+        </paragraph>
+        <paragraph>
+          <text />
+        </paragraph>
+        <block type="title">
+          <text />
+        </block>
+      </quote>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Unsure, but seems more like a bug to me (would've been part of #2388 had I noticed it before submitting that PR).

#### What's the new behavior?

My intent in #2388 for the `index` property of `child_min_invalid` was that it pointed at the last matching node. Unfortunately there were two problems with implementation:

1. when `min` was violated in the last group, `index` would point one past the last matching node
2. when the group was empty, `index` would point at the previous index. This, when the first group required exactly one element (such as the _Forced Layout_ example), made it impossible to distinguish violation of `min` for the first and second group, as both would report `index` as 0.

This PR changes `index` to always point at the last matching node, unless there are none (`count == 0`), in which case it will point at where the first matching node would be had it existed. It also updates documentation to include description for properties of `child_min_invalid` and `child_max_invalid`.

#### How does this change work?

- Adjust `index` where relevant
- Add tests for this and other properties of `child_min_invalid` and `child_max_invalid` (as I should have in the original PR)

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes:
Reviewers:
