### PR TITLE
fix(IME): cursor is placed at start of uncommitted string while compo…

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -69,6 +69,7 @@ class Content extends React.Component {
 
   tmp = {
     isUpdatingSelection: false,
+    isComposing: false,
   }
 
   /**
@@ -325,6 +326,14 @@ class Content extends React.Component {
   onEvent(handler, event) {
     debug('onEvent', handler)
 
+    if (handler == 'onCompositionStart') {
+      this.tmp.isComposing = true
+    }
+
+    if (handler == 'onCompositionEnd') {
+      window.requestAnimationFrame(() => (this.tmp.isComposing = false))
+    }
+
     // Ignore `onBlur`, `onFocus` and `onSelect` events generated
     // programmatically while updating selection.
     if (
@@ -339,7 +348,7 @@ class Content extends React.Component {
     // cases we don't need to trigger any changes, since our internal model is
     // already up to date, but we do want to update the native selection again
     // to make sure it is in sync. (2017/10/16)
-    if (handler == 'onSelect') {
+    if (handler == 'onSelect' && !this.tmp.isComposing) {
       const { editor } = this.props
       const { value } = editor
       const { selection } = value


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a bug

#### What's the new behavior?

The cursor is placed at the end of the composition string.

#### How does this change work?

Ignore updating the native selection from `editor.value.selection` while composing. Because `onSelect` returns early in before plugin, without updating editor selection from native.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
