### PR TITLE
fix(IME): can not input when use IME in Safari

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -115,6 +115,7 @@ function AfterPlugin(options = {}) {
       }
 
       case 'insertFromYank':
+      case 'insertFromComposition':
       case 'insertReplacementText':
       case 'insertText': {
         // COMPAT: `data` should have the text for the `insertText` input type


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a bug

#### What's the new behavior?

Can input when use IME in Safari.

#### How does this change work?

In input events level 2, when a part or the entire composition string is to be committed to the DOM, a beforeinput event with the inputType `insertFromComposition` is dispatched with the data attribute set to the part of the final composition string that is to be committed to the DOM.

Thus I suppose `insertFromComposition` should be handled in after plugin.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor
