### PR TITLE
Improve slate-react-placeholder component.

### DIFF
--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -4,6 +4,7 @@ import React from 'react'
 /*
  * Instance counter to enable unique marks for multiple Placeholder instances.
  */
+
 let instanceCounter = 0
 
 /**

--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -15,7 +15,11 @@ let instanceCounter = 0
  */
 
 function SlateReactPlaceholder(options = {}) {
-  const placeholderMark = `placeholder${instanceCounter++}`
+  const instanceId = instanceCounter++
+  const placeholderMark = {
+    type: 'placeholder',
+    data: { key: instanceId },
+  }
 
   const { placeholder, when } = options
 
@@ -49,7 +53,7 @@ function SlateReactPlaceholder(options = {}) {
     const decoration = {
       anchor: { key: first.key, offset: 0 },
       focus: { key: last.key, offset: last.text.length },
-      mark: { type: placeholderMark },
+      mark: placeholderMark,
     }
 
     return [...others, decoration]
@@ -67,7 +71,7 @@ function SlateReactPlaceholder(options = {}) {
   function renderMark(props, editor, next) {
     const { children, mark } = props
 
-    if (mark.type === placeholderMark) {
+    if (mark.type === 'placeholder' && mark.data.get('key') === instanceId) {
       const style = {
         pointerEvents: 'none',
         display: 'inline-block',

--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -1,6 +1,11 @@
 import invariant from 'tiny-invariant'
 import React from 'react'
 
+/*
+ * Instance counter to enable unique marks for multiple Placeholder instances.
+ */
+let instanceCounter = 0
+
 /**
  * A plugin that renders a React placeholder for a given Slate node.
  *
@@ -9,6 +14,8 @@ import React from 'react'
  */
 
 function SlateReactPlaceholder(options = {}) {
+  const placeholderMark = `placeholder${instanceCounter++}`
+
   const { placeholder, when } = options
 
   invariant(
@@ -41,7 +48,7 @@ function SlateReactPlaceholder(options = {}) {
     const decoration = {
       anchor: { key: first.key, offset: 0 },
       focus: { key: last.key, offset: last.text.length },
-      mark: { type: 'placeholder' },
+      mark: { type: placeholderMark },
     }
 
     return [...others, decoration]
@@ -59,7 +66,7 @@ function SlateReactPlaceholder(options = {}) {
   function renderMark(props, editor, next) {
     const { children, mark } = props
 
-    if (mark.type === 'placeholder') {
+    if (mark.type === placeholderMark) {
       const style = {
         pointerEvents: 'none',
         display: 'inline-block',


### PR DESCRIPTION
Now there can be multiple placeholders that do not interfere with each other.
No developer facing changes.

#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

Multiple placeholder components do not interfere.
A sample use-case with code sample is in #2459.

#### How does this change work?

The placeholder component has an instance auto-counter.
Marks thus become 'placholder0', 'placeholder1', etc. and multiple placeholder components do not interfere.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)

  `yarn lint` looked broken, ran prettier instead (would you welcome a PR with auto-prettier on commit?)

* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

 They should, haven't figured out the port number they'd run on.

#### Does this fix any issues or need any specific reviewers?

Fixes: #2459 
Reviewers: I only know @ianstormtaylor here sorry.
