### PR TITLE
fix InputEvent global check

### DIFF
--- a/packages/slate-dev-environment/src/index.js
+++ b/packages/slate-dev-environment/src/index.js
@@ -65,7 +65,7 @@ const FEATURE_RULES = [
   [
     'inputeventslevel1',
     window => {
-      const event = window.InputEvent ? new InputEvent('input') : {}
+      const event = window.InputEvent ? new window.InputEvent('input') : {}
       const support = 'inputType' in event
       return support
     },


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

When importing slate in a JSDom environment, it won't crash

#### How does this change work?

We are importing some code from node.js that we run through JSDOM. It in turn imports slate, which thinks it's a browser (this is fine, since that's the reason for using JSDOM in the first place). There is a check in the  `slate-dev-environment` module that _checks_ for `window.InputEvent`, but tries to instantiate an event from the *global* `InputEvent`, which in this case is the node environment, not the browser.

This is a simple fix that prevents the crash from happening.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @skogsmaskin 
