### PR TITLE
Use weakmap to prevent memory leak and remove indirect __cache__key

### DIFF
--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -74,7 +74,7 @@ function memoize(object, properties) {
       if (!memoizeStore.has(this)) {
         memoizeStore.set(this, {
           noArgs: {},
-          hasArgs: {}, // eslint-disable-line no-restricted-globals
+          hasArgs: {},
         })
       }
 

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -25,7 +25,7 @@ const LEAF = Symbol('LEAF')
  */
 
 const UNDEFINED = Symbol('undefined')
-const NULL = Symbol('NULL')
+const NULL = Symbol('null')
 
 /**
  * Default value for unset keys in native Maps
@@ -102,7 +102,7 @@ function memoize(object, properties) {
   }
 }
 
-const STOREKEY = Symbol('STOREKEY')
+const STORE_KEY = Symbol('STORE_KEY')
 
 /**
  * Get a value at a key path in a tree of Map.
@@ -124,7 +124,7 @@ function getIn(map, keys) {
     }
 
     if (typeof key === 'object') {
-      map = map[STOREKEY] && map[STOREKEY].get(key)
+      map = map[STORE_KEY] && map[STORE_KEY].get(key)
     } else {
       map = map[key]
     }
@@ -163,18 +163,18 @@ function setIn(map, keys, value) {
       continue
     }
 
-    if (!child[STOREKEY]) {
-      child[STOREKEY] = new WeakMap()
+    if (!child[STORE_KEY]) {
+      child[STORE_KEY] = new WeakMap()
     }
 
-    if (!child[STOREKEY].has(key)) {
+    if (!child[STORE_KEY].has(key)) {
       const newChild = {}
-      child[STOREKEY].set(key, newChild)
+      child[STORE_KEY].set(key, newChild)
       child = newChild
       continue
     }
 
-    child = child[STOREKEY].get(key)
+    child = child[STORE_KEY].get(key)
   }
 
   // The whole path has been created, so set the value to the bottom most map.

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -26,7 +26,7 @@ const LEAF = Symbol('LEAF')
 const STORE_KEY = Symbol('STORE_KEY')
 
 /**
- * A value to represent a memoized undefined and null value. Allows efficient value
+ * Values to represent a memoized undefined and null value. Allows efficient value
  * retrieval using Map.get only.
  *
  * @type {Symbol}

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -78,7 +78,7 @@ function memoize(object, properties) {
         keys = [property, ...args]
         cachedValue = getIn(hasArgs, keys)
       } else {
-        cachedValue = noArgs[property] === undefined ? UNSET : noArgs[property]
+        cachedValue = noArgs[property]
       }
 
       // If we've got a result already, return it.

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -12,16 +12,24 @@ let ENABLED = true
  * The leaf node of a cache tree. Used to support variable argument length. A
  * unique object, so that native Maps will key it by reference.
  *
- * @type {Object}
+ * @type {Symbol}
  */
 
 const LEAF = Symbol('LEAF')
 
 /**
- * A value to represent a memoized undefined value. Allows efficient value
+ * The node of a cache tree for a WeakMap to store cache visited by objects
+ *
+ * @type {Symbol}
+ */
+
+const STORE_KEY = Symbol('STORE_KEY')
+
+/**
+ * A value to represent a memoized undefined and null value. Allows efficient value
  * retrieval using Map.get only.
  *
- * @type {Object}
+ * @type {Symbol}
  */
 
 const UNDEFINED = Symbol('undefined')
@@ -101,8 +109,6 @@ function memoize(object, properties) {
     }
   }
 }
-
-const STORE_KEY = Symbol('STORE_KEY')
 
 /**
  * Get a value at a key path in a tree of Map.

--- a/packages/slate/src/utils/memoize.js
+++ b/packages/slate/src/utils/memoize.js
@@ -45,6 +45,8 @@ const UNSET = undefined
 
 /**
  * Global Store for all cached values
+ *
+ * @type {WeakMap}
  */
 
 let memoizeStore = new WeakMap()


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix potential bug and Refactor code

#### What's the new behavior?

Instead of this.__cache and __cache_key; the cache will be stored in WeakMap.  

Then we can:
1. We have some one-time range in memorized `getXXXAtRange(range)`. After this PR, the memoized one-time range results will be removed.
2. clear cache will be localized in one place, rather than `__cache_key` logic scattering everywhere.
3. clean the object stucture.  We will not see `this.__cache` in logging out the object.  Perhaps it makes moving to immer with cache easier.
4. Use symbol instead of object for some readability.

#### How does this change work?

For normal arguments, the cache tree will visit directly as a property of dictionary.  If an object is passed, it will visit a WeakMap store to ensure no memory leak.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
