### PR TITLE
Checking to make sure there is only text in the node before removing the whole node on deleteBackward

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -312,7 +312,7 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
 
   // PERF: If the closest block is empty, remove it. This is just a shortcut,
   // since merging it would result in the same outcome.
-  if (document.nodes.size !== 1 && block && block.text === '') {
+  if (document.nodes.size !== 1 && block && block.text === '' && block.nodes.size === 1) {
     editor.removeNodeByKey(block.key)
     return
   }

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -312,7 +312,12 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
 
   // PERF: If the closest block is empty, remove it. This is just a shortcut,
   // since merging it would result in the same outcome.
-  if (document.nodes.size !== 1 && block && block.text === '' && block.nodes.size === 1) {
+  if (
+    document.nodes.size !== 1 &&
+    block &&
+    block.text === '' &&
+    block.nodes.size === 1
+  ) {
     editor.removeNodeByKey(block.key)
     return
   }

--- a/packages/slate/test/commands/at-current-range/delete-backward/empty-after-multiple-void-blocks.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/empty-after-multiple-void-blocks.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.deleteBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji />
+        <emoji />
+        <cursor />
+      </paragraph>
+      <paragraph>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji />
+        <cursor />
+      </paragraph>
+      <paragraph>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/delete-backward/empty-after-multiple-void-blocks.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/empty-after-multiple-void-blocks.js
@@ -14,8 +14,7 @@ export const input = (
         <emoji />
         <cursor />
       </paragraph>
-      <paragraph>
-      </paragraph>
+      <paragraph />
     </document>
   </value>
 )
@@ -27,8 +26,7 @@ export const output = (
         <emoji />
         <cursor />
       </paragraph>
-      <paragraph>
-      </paragraph>
+      <paragraph />
     </document>
   </value>
 )


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a Bug

#### What's the new behavior?

Old Behavior 
![inlinedeletebug2](https://user-images.githubusercontent.com/25068382/49409151-8bb77080-f71c-11e8-9354-abb532007f55.gif)

New Behavior
![inlinedeletebugfixed](https://user-images.githubusercontent.com/25068382/49409165-9f62d700-f71c-11e8-9e2b-5976f2a43509.gif)


<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
  Checking to see that there is only one node in the block before using the PERF case of removing the whole node. to see if there are other nodes besides text.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
   I am getting a lot of unable to resolve path to module 'slate'. No other errors. Not sure what I did to invalidate the linter setup.
* [x] The relevant examples still work. (Run examples with `yarn watch`.)


Fixes: #2475 

![](https://media.giphy.com/media/5UtbrBfjmaYq4kfvAW/giphy.gif)