### PR TITLE
Fix memory leak in undo stack implementation (#2456)

### DIFF
--- a/packages/slate/src/commands/on-history.js
+++ b/packages/slate/src/commands/on-history.js
@@ -22,6 +22,17 @@ Commands.save = (editor, operation) => {
   let { save, merge } = editor.tmp
   if (save === false) return
 
+  // Remove the undo/redo history from the operation's Value. This prevents
+  // us from recursively retaining the entire history of all Value objects.
+  operation = operation.withMutations(op => {
+    op.set(
+      'value',
+      op.value.withMutations(v => {
+        v.set('data', op.value.data.remove('undos').remove('redos'))
+      })
+    )
+  })
+
   let undos = data.get('undos') || List()
   const lastBatch = undos.last()
   const lastOperation = lastBatch && lastBatch.last()


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

This change strips Operation's values of their undo/redo stacks before placing them on the undo/redo stack. This avoids recursively retaining previous undo stacks containing previous values which are more than 100 elements deep. This had significant memory use implications documented in #2456.

#### How does this change work?

Discussed in #2456!

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [X] The new code matches the existing patterns and styles.
* [X] The tests pass with `yarn test`.
* [X] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [X] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2456
Reviewers: @ianstormtaylor 
