### PR TITLE
Update Placeholder to be compatible with older versions of React

### DIFF
--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -70,12 +70,12 @@ function SlateReactPlaceholder(options = {}) {
       }
 
       return (
-        <React.Fragment>
+        <span>
           <span contentEditable={false} style={style}>
             {placeholder}
           </span>
           {children}
-        </React.Fragment>
+        </span>
       )
     }
 

--- a/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-single-empty-text.js
+++ b/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-single-empty-text.js
@@ -21,11 +21,13 @@ export const output = `
   <div style="position:relative">
     <span>
       <span data-slate-leaf="true">
-        <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333">
-            placeholder text
-        </span>
-        <span data-slate-zero-width="n" data-slate-length="0">
-            <br>
+        <span>
+            <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333">
+                placeholder text
+            </span>
+            <span data-slate-zero-width="n" data-slate-length="0">
+                <br>
+            </span>
         </span>
       </span>
     </span>


### PR DESCRIPTION
`React.Fragment` is only available in react >= 16.2, which does not meet the dependency requirements specified by the package (react >= 0.14.0), so unfortunately needs to be replaced in order to maintain compatibility with older versions of react.

Updates from `React.Fragment` -> `<span>` to provide coverage for older versions of react.

#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a dependency bug

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
`Placeholder` component that is compatible with older versions of react

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Replaces `React.Fragment` with `<span>` wrapper because `React.Fragment` is not available in react versions before 16.2.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
