### PR TITLE
fix(schema): previous and child variable may be exactly the same

### DIFF
--- a/packages/slate/src/plugins/schema.js
+++ b/packages/slate/src/plugins/schema.js
@@ -382,7 +382,7 @@ function validateNodes(node, rule, rules = []) {
 
   function nextChild() {
     index += 1
-    previous = child
+    previous = index ? children.get(index - 1) : null
     child = children.get(index)
     next = children.get(index + 1)
     if (!child) return false


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

 fixing a _bug_

#### What's the new behavior?

In `validateNodes` function, the `index` variable may decrease by code `index -= 1` in some specific occasion.

Thus the old code `previous = child` and `child = children.get(index)` will make child and previous variable exactly the same, and eventually lead to error of `previous_sibling_type_invalid`.

#### How does this change work?

The new way can make sure the `previous` variable is the real previous node of child.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
