### PR TITLE
fix(at-range): correct `findInsertionNode` method throw a type error …

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -808,7 +808,11 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
 }
 
 const findInsertionNode = (fragment, document, startKey) => {
-  const hasSingleNode = object => object && object.nodes.size === 1
+  const hasSingleNode = object => {
+    if (!object || object.object === 'text') return
+    return object.nodes.size === 1
+  }
+
   const firstNode = object => object && object.nodes.first()
   let node = fragment
 

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-single-child-block.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-single-child-block.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.insertFragment(
+    <document>
+      <code>
+        <paragraph>2</paragraph>
+      </code>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <code>
+        <paragraph>
+          1<cursor />
+        </paragraph>
+      </code>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <code>
+        <paragraph>
+          12<cursor />
+        </paragraph>
+      </code>
+    </document>
+  </value>
+)


### PR DESCRIPTION
…when there arg is a Text node

#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
