### PR TITLE
Add `isInverted` flag on inverted operations

### DIFF
--- a/docs/reference/slate/operation.md
+++ b/docs/reference/slate/operation.md
@@ -10,7 +10,7 @@ There are a handful of Slate operation types. The goal is to have the fewest pos
 
 See each operation separately below to see what they consist of.
 
-Note that all operations have a `data` property which can be used to attach arbitrary data to the operation, just like the [`Node`](./node.md) models ([`Block`](./block.md), [`Inline`](./inline.md), etc).
+Note that all operations have a `data` property which can be used to attach arbitrary data to the operation, just like the [`Node`](./node.md) models ([`Block`](./block.md), [`Inline`](./inline.md), etc), and an `isInverted` boolean.
 
 ## Text Operations
 
@@ -207,12 +207,12 @@ Set new `properties` on a value. Properties can contain `data` and `decorations`
 
 ### `apply`
 
-`apply(value: Value, operation: Object) => Value`
+`apply(value: Value) => Value`
 
 Applies an `operation` to a `value` object.
 
 ### `invert`
 
-`invert(operation: Object) => Object`
+`invert() => Operation`
 
 Create an inverse operation that will undo the changes made by the original.

--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -53,6 +53,7 @@ const DEFAULTS = {
   type: undefined,
   value: undefined,
   data: undefined,
+  isInverted: false,
 }
 
 /**

--- a/packages/slate/src/operations/invert.js
+++ b/packages/slate/src/operations/invert.js
@@ -20,7 +20,7 @@ const debug = Debug('slate:operation:invert')
  */
 
 function invertOperation(op) {
-  op = Operation.create(op)
+  op = Operation.create(op).set('isInverted', !op.get('isInverted'))
   const { type } = op
   debug(type, op)
 

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import { fixtures } from 'slate-dev-test-utils'
 import { Node, Editor, Value } from 'slate'
+import Operation from '../src/models/operation'
 
 const plugins = [
   {
@@ -36,7 +37,12 @@ describe('slate', () => {
   fixtures(__dirname, 'models/operation', ({ module }) => {
     const { input, output } = module
     const fn = module.default
-    const actual = fn(input).toJSON()
+    let actual = fn(input)
+
+    if (Operation.isOperation(actual)) {
+      actual = actual.toJSON()
+    }
+
     const expected = output
     assert.deepEqual(actual, expected)
   })

--- a/packages/slate/test/models/operation/invert/undo-move-node.js
+++ b/packages/slate/test/models/operation/invert/undo-move-node.js
@@ -1,0 +1,14 @@
+import Operation from '../../../../src/models/operation'
+
+export const input = {
+  type: 'move_node',
+  path: [1],
+  newPath: [2],
+  inverted: false,
+}
+
+export default function(op) {
+  return Operation.create(op).invert().isInverted
+}
+
+export const output = true


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

This PR adds a `isInverted` flags on operations' record.

#### How does this change work?

Every operations has a `isInverted` defaulted to `false`, and set to `true` when operation has been inverted.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

