### PR TITLE
fix unwrapBlockAtRange disorder

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -1110,7 +1110,7 @@ Commands.unwrapBlockAtRange = (editor, range, properties) => {
     wrappers.forEach(block => {
       const first = block.nodes.first()
       const last = block.nodes.last()
-      const parent = document.getParent(block.key)
+      const parent = editor.value.document.getParent(block.key)
       const index = parent.nodes.indexOf(block)
 
       const children = block.nodes.filter(child => {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a _bug_

#### What's the new behavior?

Blocks behave right  after unwrap.

#### How does this change work?

As `document` variable is assigned before `forEach` and there are serval operations in each loop, it's not equal to `editor.value.document`. This causes `index` variable inaccurate and blocks disorder after unwrap.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
