### PR TITLE
Allow the dev server to work for non localhost host

### DIFF
--- a/support/webpack/config.js
+++ b/support/webpack/config.js
@@ -23,6 +23,7 @@ const config = {
     contentBase: './examples',
     publicPath: '/',
     hot: true,
+    host: '0.0.0.0',
   },
   module: {
     rules: [


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

Enable the webpack-dev-server from running at a host other than localhost. This is useful for debugging mobile devices for example where we need to specify the host by an IP address.

#### How does this change work?

Just adds a simple configuration change to the webpack `config.js` file under `devServer` to set `host` to `0.0.0.0`

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Nope. Need for working on mobile IME issues.