### PR TITLE
Remove wasted space in header for small devices by enabling horizonta…

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -106,6 +106,13 @@ const TabList = styled('div')`
   & > * + * {
     margin-left: 0.5em;
   }
+
+  @media only screen and (max-width: 768px) {
+    box-sizing: border-box;
+    width: 100%;
+    overflow-x: scroll;
+    white-space: nowrap;
+  }
 `
 
 const MaskedRouterLink = ({ active, ...props }) => <RouterLink {...props} />


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

The slate examples list of editors is getting long. When viewing the demo on small devices, most of the screen is taken up by the list of editor types. This makes the list scroll horizontally on mobile devices so it doesn't take all the screen space from the editor itself.

#### How does this change work?

Added a media-query for max-width: 768px and below and added overflow-x: scroll to it along with a few other things to make it work.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)