### PR TITLE
Prevent default browser scroll on content focus

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -173,9 +173,10 @@ class Content extends React.Component {
     }
 
     // If the Slate selection is focused, but the DOM's active element is not
-    // the editor, we need to focus it.
+    // the editor, we need to focus it. We prevent scrolling because we handle
+    // scrolling to the correct selection.
     if (selection.isFocused && activeElement !== this.element) {
-      this.element.focus()
+      this.element.focus({ preventScroll: true })
       updated = true
     }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_? 
Fixing a bug. 

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Without this, when calling `this.element.focus`, the browser will scroll to the top of the container if the selection is not already set. Since we set the selection later in this function, we don't need the browser to handle this. 

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2517
Reviewers: @
