### PR TITLE
Refactor duplicate code in mixin

### DIFF
--- a/packages/slate/src/interfaces/object.js
+++ b/packages/slate/src/interfaces/object.js
@@ -48,8 +48,6 @@ function create(type) {
  * Mix in the object interfaces.
  */
 
-debugger
-
 Object.entries({
   Block,
   Change,

--- a/packages/slate/src/interfaces/object.js
+++ b/packages/slate/src/interfaces/object.js
@@ -48,18 +48,22 @@ function create(type) {
  * Mix in the object interfaces.
  */
 
-mixin(create('block'), [Block])
-mixin(create('change'), [Change])
-mixin(create('decoration'), [Decoration])
-mixin(create('document'), [Document])
-mixin(create('editor'), [Editor])
-mixin(create('inline'), [Inline])
-mixin(create('leaf'), [Leaf])
-mixin(create('mark'), [Mark])
-mixin(create('node'), [Node])
-mixin(create('operation'), [Operation])
-mixin(create('point'), [Point])
-mixin(create('range'), [Range])
-mixin(create('selection'), [Selection])
-mixin(create('text'), [Text])
-mixin(create('value'), [Value])
+debugger
+
+Object.entries({
+  Block,
+  Change,
+  Decoration,
+  Document,
+  Editor,
+  Inline,
+  Leaf,
+  Mark,
+  Node,
+  Operation,
+  Point,
+  Range,
+  Selection,
+  Text,
+  Value,
+}).forEach(([camel, obj]) => mixin(create(camel.toLowerCase()), [obj]))


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Refactor

#### What's the new behavior?
Eliminate some duplication of `mixin(create())`

#### How does this change work?

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
