### PR TITLE
[Refactor] Use Symbol instead of ad-hoc strings for isObject

### DIFF
--- a/packages/slate/src/utils/is-object.js
+++ b/packages/slate/src/utils/is-object.js
@@ -4,22 +4,25 @@
  * @type {Object}
  */
 
-export const TYPES = {
-  block: '@@__SLATE_BLOCK__@@',
-  change: '@@__SLATE_CHANGE__@@',
-  decoration: '@@__SLATE_DECORATION__@@',
-  document: '@@__SLATE_DOCUMENT__@@',
-  editor: '@@__SLATE_EDITOR__@@',
-  inline: '@@__SLATE_INLINE__@@',
-  leaf: '@@__SLATE_LEAF__@@',
-  mark: '@@__SLATE_MARK__@@',
-  operation: '@@__SLATE_OPERATION__@@',
-  point: '@@__SLATE_POINT__@@',
-  range: '@@__SLATE_RANGE__@@',
-  selection: '@@__SLATE_SELECTION__@@',
-  text: '@@__SLATE_TEXT__@@',
-  value: '@@__SLATE_VALUE__@@',
-}
+export const TYPES = [
+  'block',
+  'change',
+  'decoration',
+  'document',
+  'editor',
+  'inline',
+  'leaf',
+  'mark',
+  'operation',
+  'point',
+  'range',
+  'selection',
+  'text',
+  'value',
+].reduce((memo, type) => {
+  memo[type] = Symbol(`SLATE_${type.toUpperCase()}`)
+  return memo
+}, {})
 
 /**
  * Determine whether a `value` is of `type`.

--- a/packages/slate/src/utils/mixin.js
+++ b/packages/slate/src/utils/mixin.js
@@ -20,5 +20,11 @@ export default function mixin(Interface, Classes) {
       const desc = Object.getOwnPropertyDescriptor(Interface.prototype, name)
       Object.defineProperty(Class.prototype, name, desc)
     }
+
+    for (const name of Object.getOwnPropertySymbols(Interface.prototype)) {
+      if (Class.prototype.hasOwnProperty(name)) continue
+      const desc = Object.getOwnPropertyDescriptor(Interface.prototype, name)
+      Object.defineProperty(Class.prototype, name, desc)
+    }
   }
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Refactor

#### What's the new behavior?

Previously, we used a `a["@@__SLATE_....@@"]` for describing the type.  I think it is perhaps nicer to use Symbol to remove some ad-hoc `@@` chars.

#### How does this change work?

Use symbol and let the mixin supports symbols.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
