### PR TITLE
Fix mouse refocus in IE 11

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -3,7 +3,7 @@ import Debug from 'debug'
 import Hotkeys from 'slate-hotkeys'
 import Plain from 'slate-plain-serializer'
 import getWindow from 'get-window'
-import { IS_IOS } from 'slate-dev-environment'
+import { IS_IOS, IS_IE } from 'slate-dev-environment'
 
 import cloneFragment from '../utils/clone-fragment'
 import findDOMNode from '../utils/find-dom-node'
@@ -392,7 +392,7 @@ function AfterPlugin(options = {}) {
     // followed by a `selectionchange`, so we need to deselect here to prevent
     // the old selection from being set by the `updateSelection` of `<Content>`,
     // preventing the `selectionchange` from firing. (2018/11/07)
-    if (isMouseDown) {
+    if (isMouseDown && !IS_IE) {
       editor.deselect().focus()
     } else {
       editor.focus()

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -3,7 +3,7 @@ import Debug from 'debug'
 import Hotkeys from 'slate-hotkeys'
 import Plain from 'slate-plain-serializer'
 import getWindow from 'get-window'
-import { IS_IOS, IS_IE } from 'slate-dev-environment'
+import { IS_IOS, IS_IE, IS_EDGE } from 'slate-dev-environment'
 
 import cloneFragment from '../utils/clone-fragment'
 import findDOMNode from '../utils/find-dom-node'
@@ -392,7 +392,7 @@ function AfterPlugin(options = {}) {
     // followed by a `selectionchange`, so we need to deselect here to prevent
     // the old selection from being set by the `updateSelection` of `<Content>`,
     // preventing the `selectionchange` from firing. (2018/11/07)
-    if (isMouseDown && !IS_IE) {
+    if (isMouseDown && !IS_IE && !IS_EDGE) {
       editor.deselect().focus()
     } else {
       editor.focus()


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_? 
Fixing a **bug** 🐛 

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

In IE11, refocusing by click would cause the editor to immediately lose focus because of `editor.deselect().focus()`. The original behavior was added by #2396.

Now when refocusing, IE no longer does a deselect.

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->
I've updated to skip the `deselect` in IE browsers as suggested by following @epotockly's [comment](https://github.com/ianstormtaylor/slate/issues/2364#issuecomment-443717248)

>Fixed this by running editor.focus() without deselect() inside onFocus event in MS Edge, problem definitely are in new range selection, but i don't know how to fix it without removing function

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.) *Unrelated errors*
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2364 
Reviewers: @ianstormtaylor 
