### PR TITLE
Fix dirty path normalization on move_node

### DIFF
--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -351,9 +351,17 @@ function transform(path, operation) {
     const npAbove = isAbove(np, path)
 
     if (pAbove) {
-      path = np.concat(path.slice(p.size))
+      if (isAfter(np, p)) {
+        path = decrement(np, 1, min(np, p) - 1).concat(path.slice(p.size))
+      } else {
+        path = np.concat(path.slice(p.size))
+      }
     } else if (pEqual) {
-      path = np
+      if (isAfter(np, p)) {
+        path = decrement(np, 1, min(np, p) - 1)
+      } else {
+        path = np
+      }
     } else {
       if (pYounger) {
         path = decrement(path, 1, pIndex)

--- a/packages/slate/test/commands/at-current-range/delete-backward/join-nested-blocks-different-depth.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/join-nested-blocks-different-depth.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.deleteBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>Hello</paragraph>
+      <list>
+        <item>
+          <cursor />world!
+        </item>
+      </list>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        Hello<cursor />world!
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/history/undo/delete-backward-nested-blocks.js
+++ b/packages/slate/test/history/undo/delete-backward-nested-blocks.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function(editor) {
+  editor.deleteBackward().undo()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>Hello</paragraph>
+      <list>
+        <item>
+          <cursor />world!
+        </item>
+      </list>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>Hello</paragraph>
+      <list>
+        <item>
+          <cursor />world!
+        </item>
+      </list>
+    </document>
+  </value>
+)

--- a/packages/slate/test/history/undo/delete-backward.js
+++ b/packages/slate/test/history/undo/delete-backward.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function(editor) {
+  editor.deleteBackward().undo()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>Hello</paragraph>
+      <paragraph>
+        <cursor />world!
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>Hello</paragraph>
+      <paragraph>
+        <cursor />world!
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

`PathUtils.transform` now returns correct updated path after a `move_node` operation

#### How does this change work?

In this particular example:
```xml
<document>
  <block key="A" path=[0] />
  <block key="B" path=[1] />
  <block key="C" path=[2] />
</document>
```

If I move the node `B` to the path `[2, 0]` so it becomes this:
```xml
<document>
  <block key="A" path=[0] />
  <block key="C" path=[1]>
    <block key="B" path=[1, 0] />
  </block>
</document>
```

If in the same `withoutNormalization` batch, I have a `tmp.dirty` that contains `[1, 0]`, the current `PathUtils.tranform` will transform our dirty path according to the `move_node` operation's `newPath`. Here it will be `[2,0]`. The new dirty path will eventually become `[2, 0, 0]` refering to a non-existing block, that will fail during the next normalization.

A very simple test to show the issue in real life:

0. Open the `console`
1. Go to [Slatejs.org `rich-text` example](https://www.slatejs.org/#/rich-text)
2. Insert a list after the very first paragraph
3. Create a selection from somewhere in the paragraph, and the list item below, like this:  <details>
    <summary>Screenshot of a selection example</summary>
    <img width="503" alt="screen shot 2019-01-14 at 19 05 53" src="https://user-images.githubusercontent.com/3692274/51141119-76f7ed80-182f-11e9-9cb6-8bf8c6cdf246.png">
  </details>

4. Press backspace then undo
6. You should now have an error in your console:
  ```
  element.js:1991 Uncaught Error: `Node.assertNode` could not find node with path or key: List [ 2, 0, 0 ]
    at a.ct.(/anonymous function) [as assertNode] (https://www.slatejs.org/main-cf7fba3ac17904d8ae2c.js:1:144119)
    at it (editor.js:597)
    at editor.js:580
    at e.value (editor.js:398)
    at rt (editor.js:578)
    at e.value (editor.js:400)
    at a.value (editor.js:275)
    at on-history.js:116
    at La.withoutSaving (on-history.js:168)
    at e.value (editor.js:148)
  ```

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2528 
Reviewers: @ianstormtaylor 
