### PR TITLE
Pasting into a Block with only a Void Inline

### DIFF
--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -372,7 +372,6 @@ Check whether a node exists in the tree by `path` or `key`.
 
 Check whether a node is inside a `range`. This will return true for all [`Text`](./text.md) nodes inside the range and all ancestors of those [`Text`](./text.md) nodes up to this node.
 
-
 ### `isEmpty`
 
 `isEmpty() => Boolean`

--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -371,3 +371,10 @@ Check whether a node exists in the tree by `path` or `key`.
 `isNodeInRange(key: String) => Boolean`
 
 Check whether a node is inside a `range`. This will return true for all [`Text`](./text.md) nodes inside the range and all ancestors of those [`Text`](./text.md) nodes up to this node.
+
+
+### `isEmpty`
+
+`isEmpty() => Boolean`
+
+Check whether there is content inside of the node.

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -789,7 +789,7 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
 
     // If the starting block is empty, we replace it entirely with the first block
     // of the fragment, since this leads to a more expected behavior for the user.
-    if (!editor.isVoid(startBlock) && startBlock.text === '') {
+    if (!editor.isVoid(startBlock) && startBlock.isEmpty()) {
       editor.removeNodeByKey(startBlock.key)
       editor.insertNodeByKey(parent.key, index, firstBlock)
     } else {

--- a/packages/slate/src/interfaces/node.js
+++ b/packages/slate/src/interfaces/node.js
@@ -147,6 +147,16 @@ class NodeInterface {
   }
 
   /**
+   * Check if the node has content
+   *
+   * @return {Boolean}
+   */
+
+  isEmpty() {
+    return this.getText() === '' && this.nodes.length === 1
+  }
+
+  /**
    * Check if a node exists.
    *
    * @param {List|String} path
@@ -231,6 +241,7 @@ memoize(NodeInterface.prototype, [
   'getKeysToPathsTable',
   'getLastText',
   'getText',
+  'isEmpty',
   'normalize',
   'validate',
 ])

--- a/packages/slate/test/commands/at-current-range/insert-fragment/start-block-with-void-no-text.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/start-block-with-void-no-text.js
@@ -17,7 +17,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <cursor /><emoji/>
+        <cursor />
+        <emoji />
       </paragraph>
     </document>
   </value>
@@ -27,7 +28,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        onetwo<cursor /><emoji/>
+        onetwo<cursor />
+        <emoji />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/start-block-with-void-no-text.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/start-block-with-void-no-text.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.insertFragment(
+    <document>
+      <paragraph>
+        <text>one</text>
+        <text>two</text>
+      </paragraph>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor /><emoji/>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        onetwo<cursor /><emoji/>
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
 BUG  🐛 

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Nodes will count extra nodes as content during insertFragmentAtRange. So that void nodes can be counted as content.

![inlinedeleteonpastefixed](https://user-images.githubusercontent.com/25068382/51340611-a0da2b80-1a4c-11e9-924b-cb06ed3d0059.gif)


<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

Added an isEmpty method on the node interface. It seems that to check if a node is empty there is a check for text being empty. Feels like there should be an explicit check for if a node is empty. I am now using it in the InsertFragmentAtRange method in order to allow for pasting onto the same line as a void Inline without deleting it.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ x] The new code matches the existing patterns and styles.
* [ x] The tests pass with `yarn test`.
* [ x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: [2544](#https://github.com/ianstormtaylor/slate/issues/2544)
