### PR TITLE
Documentation: Add break in the Switch statement for custom formatting walkthrough

### DIFF
--- a/docs/walkthroughs/applying-custom-formatting.md
+++ b/docs/walkthroughs/applying-custom-formatting.md
@@ -72,12 +72,14 @@ class App extends React.Component {
       case 'b': {
         event.preventDefault()
         editor.addMark('bold')
+        break
       }
       // When "`" is pressed, keep our existing code block logic.
       case '`': {
         const isCode = editor.value.blocks.some(block => block.type == 'code')
         event.preventDefault()
         editor.setBlocks(isCode ? 'paragraph' : 'code')
+        break
       }
       // Otherwise, let other plugins handle it.
       default: {


### PR DESCRIPTION
**Is this adding or improving a feature or fixing a bug?**
**DOCUMENTATION CODE SNIPPET FIX**

**What's the new behavior?**

> When Ctrl + B is pressed it applies only the Bold style to the selected content. 

**How does this change work?**

> Adding a `break` will ensure that only one case is executed by the switch statement.

Fixes: #2515 