### PR TITLE
Convert remaining `Node.get*` methods to use paths

### DIFF
--- a/benchmark/slate/changes/normalize.js
+++ b/benchmark/slate/changes/normalize.js
@@ -4,8 +4,8 @@
 const h = require('../../helpers/h')
 const { Editor } = require('slate')
 
-module.exports.default = function(change) {
-  change
+module.exports.default = function(editor) {
+  editor
     .normalize()
     .moveForward(5)
     .normalize()

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -461,9 +461,17 @@ class Content extends React.Component {
     const childrenDecorations = getChildrenDecorations(document, decs)
 
     const children = document.nodes.toArray().map((child, i) => {
-      const isSelected = !!indexes && indexes.start <= i && i < indexes.end
+      const containedInSelection =
+        !!indexes && indexes.start < i && i < indexes.end - 1
+      const onEdgeOfSelection =
+        !!indexes && (i === indexes.start || i === indexes.end - 1)
 
-      return this.renderNode(child, isSelected, childrenDecorations[i])
+      return this.renderNode(
+        child,
+        { onEdgeOfSelection, containedInSelection },
+        childrenDecorations[i],
+        i
+      )
     })
 
     const style = {
@@ -522,11 +530,17 @@ class Content extends React.Component {
    * @return {Element}
    */
 
-  renderNode = (child, isSelected, decorations) => {
+  renderNode = (
+    child,
+    { onEdgeOfSelection, containedInSelection },
+    decorations,
+    index
+  ) => {
     const { editor, readOnly } = this.props
     const { value } = editor
     const { document, selection } = value
     const { isFocused } = selection
+    const isSelected = onEdgeOfSelection || containedInSelection
 
     return (
       <Node
@@ -534,6 +548,9 @@ class Content extends React.Component {
         editor={editor}
         decorations={decorations}
         isSelected={isSelected}
+        onEdgeOfSelection={onEdgeOfSelection}
+        containedInSelection={containedInSelection}
+        path={onEdgeOfSelection && [index]}
         isFocused={isFocused && isSelected}
         key={child.key}
         node={child}

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -461,17 +461,9 @@ class Content extends React.Component {
     const childrenDecorations = getChildrenDecorations(document, decs)
 
     const children = document.nodes.toArray().map((child, i) => {
-      const containedInSelection =
-        !!indexes && indexes.start < i && i < indexes.end - 1
-      const onEdgeOfSelection =
-        !!indexes && (i === indexes.start || i === indexes.end - 1)
+      const isSelected = !!indexes && indexes.start <= i && i < indexes.end
 
-      return this.renderNode(
-        child,
-        { onEdgeOfSelection, containedInSelection },
-        childrenDecorations[i],
-        i
-      )
+      return this.renderNode(child, isSelected, childrenDecorations[i])
     })
 
     const style = {
@@ -530,17 +522,11 @@ class Content extends React.Component {
    * @return {Element}
    */
 
-  renderNode = (
-    child,
-    { onEdgeOfSelection, containedInSelection },
-    decorations,
-    index
-  ) => {
+  renderNode = (child, isSelected, decorations) => {
     const { editor, readOnly } = this.props
     const { value } = editor
     const { document, selection } = value
     const { isFocused } = selection
-    const isSelected = onEdgeOfSelection || containedInSelection
 
     return (
       <Node
@@ -548,9 +534,6 @@ class Content extends React.Component {
         editor={editor}
         decorations={decorations}
         isSelected={isSelected}
-        onEdgeOfSelection={onEdgeOfSelection}
-        containedInSelection={containedInSelection}
-        path={onEdgeOfSelection && [index]}
         isFocused={isFocused && isSelected}
         key={child.key}
         node={child}

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -142,16 +142,15 @@ class Node extends React.Component {
     const children = []
 
     node.nodes.forEach((child, i) => {
-      const containedInSelection =
+      const contained =
         containedInSelection ||
         (!!indexes && indexes.start < i && i < indexes.end - 1)
-      const onEdgeOfSelection =
-        !!indexes && (i === indexes.start || i === indexes.end - 1)
+      const onEdge = !!indexes && (i === indexes.start || i === indexes.end - 1)
 
       children.push(
         this.renderNode(
           child,
-          { onEdgeOfSelection, containedInSelection },
+          { onEdgeOfSelection: onEdge, containedInSelection: contained },
           childrenDecorations[i],
           i
         )

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -124,9 +124,6 @@ class Node extends React.Component {
       editor,
       isSelected,
       isFocused,
-      containedInSelection,
-      onEdgeOfSelection,
-      path,
       node,
       decorations,
       parent,
@@ -134,26 +131,16 @@ class Node extends React.Component {
     } = this.props
     const { value } = editor
     const { selection } = value
-    // Only do this calculation if we need to
-    const indexes =
-      onEdgeOfSelection && node.getSelectionIndexes(selection, path)
+    const indexes = node.getSelectionIndexes(selection, isSelected)
     const decs = decorations.concat(node.getDecorations(editor))
     const childrenDecorations = getChildrenDecorations(node, decs)
     const children = []
 
     node.nodes.forEach((child, i) => {
-      const contained =
-        containedInSelection ||
-        (!!indexes && indexes.start < i && i < indexes.end - 1)
-      const onEdge = !!indexes && (i === indexes.start || i === indexes.end - 1)
+      const isChildSelected = !!indexes && indexes.start <= i && i < indexes.end
 
       children.push(
-        this.renderNode(
-          child,
-          { onEdgeOfSelection: onEdge, containedInSelection: contained },
-          childrenDecorations[i],
-          i
-        )
+        this.renderNode(child, isChildSelected, childrenDecorations[i])
       )
     })
 
@@ -210,9 +197,6 @@ class Node extends React.Component {
         decorations={decorations}
         editor={editor}
         isSelected={isSelected}
-        containedInSelection={containedInSelection}
-        onEdgeOfSelection={onEdgeOfSelection}
-        path={onEdgeOfSelection && path.concat(index)}
         isFocused={isFocused && isSelected}
         key={child.key}
         node={child}

--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -124,6 +124,9 @@ class Node extends React.Component {
       editor,
       isSelected,
       isFocused,
+      containedInSelection,
+      onEdgeOfSelection,
+      path,
       node,
       decorations,
       parent,
@@ -131,16 +134,27 @@ class Node extends React.Component {
     } = this.props
     const { value } = editor
     const { selection } = value
-    const indexes = node.getSelectionIndexes(selection, isSelected)
+    // Only do this calculation if we need to
+    const indexes =
+      onEdgeOfSelection && node.getSelectionIndexes(selection, path)
     const decs = decorations.concat(node.getDecorations(editor))
     const childrenDecorations = getChildrenDecorations(node, decs)
     const children = []
 
     node.nodes.forEach((child, i) => {
-      const isChildSelected = !!indexes && indexes.start <= i && i < indexes.end
+      const containedInSelection =
+        containedInSelection ||
+        (!!indexes && indexes.start < i && i < indexes.end - 1)
+      const onEdgeOfSelection =
+        !!indexes && (i === indexes.start || i === indexes.end - 1)
 
       children.push(
-        this.renderNode(child, isChildSelected, childrenDecorations[i])
+        this.renderNode(
+          child,
+          { onEdgeOfSelection, containedInSelection },
+          childrenDecorations[i],
+          i
+        )
       )
     })
 
@@ -197,6 +211,9 @@ class Node extends React.Component {
         decorations={decorations}
         editor={editor}
         isSelected={isSelected}
+        containedInSelection={containedInSelection}
+        onEdgeOfSelection={onEdgeOfSelection}
+        path={onEdgeOfSelection && path.concat(index)}
         isFocused={isFocused && isSelected}
         key={child.key}
         node={child}

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -219,7 +219,7 @@ class ElementInterface {
         return false
       }
 
-      if (child.object != 'text') {
+      if (child.object !== 'text') {
         ret = child.forEachDescendantWithPath(iterator, childPath, findLast)
         return ret
       }

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -452,7 +452,6 @@ class ElementInterface {
    */
 
   getClosestBlock(path) {
-    path = this.resolvePath(path)
     const closest = this.getClosest(path, n => n.object === 'block')
     return closest
   }
@@ -465,7 +464,6 @@ class ElementInterface {
    */
 
   getClosestInline(path) {
-    path = this.resolvePath(path)
     const closest = this.getClosest(path, n => n.object === 'inline')
     return closest
   }
@@ -547,7 +545,7 @@ class ElementInterface {
   /**
    * Get a descendant node.
    *
-   * @param {List|string} path
+   * @param {List|String} path
    * @return {Node|Null}
    */
 
@@ -556,12 +554,11 @@ class ElementInterface {
     if (!path || !path.size) return null
 
     let node = this
-    let i = 0
 
-    while (i < path.size && node) {
-      node = node.getIn(['nodes', path.get(i)])
-      i++
-    }
+    path.forEach(index => {
+      node = node.getIn(['nodes', index])
+      return !!node
+    })
 
     return node
   }
@@ -630,7 +627,7 @@ class ElementInterface {
   /**
    * Get the furthest ancestor of a node.
    *
-   * @param {Path|string} path
+   * @param {List|String} path
    * @return {Node|Null}
    */
 
@@ -649,7 +646,6 @@ class ElementInterface {
    */
 
   getFurthestBlock(path) {
-    path = this.resolvePath(path)
     const furthest = this.getFurthest(path, n => n.object === 'block')
     return furthest
   }
@@ -662,7 +658,6 @@ class ElementInterface {
    */
 
   getFurthestInline(path) {
-    path = this.resolvePath(path)
     const furthest = this.getFurthest(path, n => n.object === 'inline')
     return furthest
   }
@@ -670,7 +665,7 @@ class ElementInterface {
   /**
    * Get the furthest ancestor of a node, where all ancestors to that point only have one child.
    *
-   * @param {Path|string} path
+   * @param {Path} path
    * @return {Node|Null}
    */
 

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -220,9 +220,8 @@ function lift(path) {
   return parent
 }
 
-
 /**
- * Drop a `path` to make it relative to 
+ * Drop a `path`, returning the path from the first child.
  *
  * @param {List} path
  * @return {List}

--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -212,12 +212,25 @@ function isYounger(path, target) {
  * Lift a `path` to refer to its parent.
  *
  * @param {List} path
- * @return {Array}
+ * @return {List}
  */
 
 function lift(path) {
   const parent = path.slice(0, -1)
   return parent
+}
+
+
+/**
+ * Drop a `path` to make it relative to 
+ *
+ * @param {List} path
+ * @return {List}
+ */
+
+function drop(path) {
+  const relative = path.slice(1)
+  return relative
 }
 
 /**
@@ -391,6 +404,7 @@ export default {
   isSibling,
   isYounger,
   lift,
+  drop,
   max,
   min,
   relate,

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/different-marks-across-blocks.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/different-marks-across-blocks.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <mark type="a">rd</mark>
+      </paragraph>
+      <paragraph>
+        <paragraph>
+          <mark type="b">middle</mark>
+        </paragraph>
+        <paragraph />
+      </paragraph>
+      <paragraph>unmarked</paragraph>
+      <paragraph>
+        <mark type="c">
+          an<focus />other
+        </mark>
+        <mark type="d">unselected marked text</mark>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getActiveMarksAtRange(selection)
+}
+
+export const output = Set()

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/mixed-marks-across-range.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/mixed-marks-across-range.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import { Mark } from 'slate'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <mark type="a">rd</mark>
+      </paragraph>
+      <paragraph>
+        <paragraph>
+          <mark type="b">
+            <mark type="a">middle</mark>
+          </mark>
+        </paragraph>
+        <paragraph />
+      </paragraph>
+      <paragraph>
+        <mark type="b">
+          <mark type="a">
+            an<focus />other
+          </mark>
+        </mark>
+        <mark type="c">unselected marked text</mark>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getActiveMarksAtRange(selection)
+}
+
+export const output = Set.of(Mark.create('a'))

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/same-mark-across-blocks.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/same-mark-across-blocks.js
@@ -1,0 +1,34 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import { Mark } from 'slate'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <mark type="a">rd</mark>
+      </paragraph>
+      <paragraph>
+        <paragraph>
+          <mark type="a">middle</mark>
+        </paragraph>
+        <paragraph />
+      </paragraph>
+      <paragraph>
+        <mark type="a">
+          an<focus />other
+        </mark>
+        <mark type="b">unselected marked text</mark>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getActiveMarksAtRange(selection)
+}
+
+export const output = Set.of(Mark.create('a'))

--- a/packages/slate/test/models/node/get-closest/by-key.js
+++ b/packages/slate/test/models/node/get-closest/by-key.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getClosestBlock(selection.end.key)
+}
+
+export const output = (
+  <paragraph>
+    <anchor />two<focus />
+  </paragraph>
+)

--- a/packages/slate/test/models/node/get-closest/get-block-parent-inline.js
+++ b/packages/slate/test/models/node/get-closest/get-block-parent-inline.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <inline type="inline_type">
+          <anchor />two<focus />
+        </inline>
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getClosestBlock(selection.end.path)
+}
+
+export const output = (
+  <paragraph>
+    <inline type="inline_type">
+      <anchor />two<focus />
+    </inline>
+  </paragraph>
+)

--- a/packages/slate/test/models/node/get-closest/top-level.js
+++ b/packages/slate/test/models/node/get-closest/top-level.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { PathUtils } from 'slate'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getClosestBlock(PathUtils.create([1]))
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-fragment-at-range/across-block-with-marks.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/across-block-with-marks.js
@@ -1,0 +1,40 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <b>rd</b>
+      </paragraph>
+      <paragraph>
+        <b>middle</b>
+      </paragraph>
+      <paragraph>
+        <b>
+          an<focus />other
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getFragmentAtRange(selection)
+}
+
+export const output = (
+  <document>
+    <paragraph>
+      <b>rd</b>
+    </paragraph>
+    <paragraph>
+      <b>middle</b>
+    </paragraph>
+    <paragraph>
+      <b>an</b>
+    </paragraph>
+  </document>
+)

--- a/packages/slate/test/models/node/get-furthest-only-child/multiple-nodes-in-nested-block.js
+++ b/packages/slate/test/models/node/get-furthest-only-child/multiple-nodes-in-nested-block.js
@@ -1,0 +1,23 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <paragraph>
+          <inline type="test">one</inline>
+          <text key="a">two</text>
+        </paragraph>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function(value) {
+  const { document } = value
+  return document.getFurthestOnlyChildAncestor('a')
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-furthest-only-child/multiple-nodes.js
+++ b/packages/slate/test/models/node/get-furthest-only-child/multiple-nodes.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <inline type="test">one</inline>
+        <text key="a">two</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function(value) {
+  const { document } = value
+  return document.getFurthestOnlyChildAncestor('a')
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-next-block/by-key.js
+++ b/packages/slate/test/models/node/get-next-block/by-key.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.key)
+}
+
+export const output = <paragraph>three</paragraph>

--- a/packages/slate/test/models/node/get-next-block/multiple-siblings-to-bypass.js
+++ b/packages/slate/test/models/node/get-next-block/multiple-siblings-to-bypass.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+        <inline type="inline_type" />
+        <inline type="inline_type" />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.path)
+}
+
+export const output = <paragraph>three</paragraph>

--- a/packages/slate/test/models/node/get-next-block/next-block-is-ancestor-sibling.js
+++ b/packages/slate/test/models/node/get-next-block/next-block-is-ancestor-sibling.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.path)
+}
+
+export const output = <paragraph>three</paragraph>

--- a/packages/slate/test/models/node/get-next-block/next-block-is-in-sibling-with-deeper-blocks.js
+++ b/packages/slate/test/models/node/get-next-block/next-block-is-in-sibling-with-deeper-blocks.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>1</paragraph>
+      <paragraph>
+        <anchor />2<focus />
+      </paragraph>
+      <paragraph>
+        <paragraph>3</paragraph>
+        <paragraph>
+          <paragraph>3.1</paragraph>
+        </paragraph>
+      </paragraph>
+      <paragraph>4</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.path)
+}
+
+export const output = <paragraph>3</paragraph>

--- a/packages/slate/test/models/node/get-next-block/next-block-is-sibling-descendent.js
+++ b/packages/slate/test/models/node/get-next-block/next-block-is-sibling-descendent.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>
+        <paragraph>three</paragraph>
+      </paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.path)
+}
+
+export const output = <paragraph>three</paragraph>

--- a/packages/slate/test/models/node/get-next-block/next-block-is-sibling.js
+++ b/packages/slate/test/models/node/get-next-block/next-block-is-sibling.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import PathUtils from '../../../../src/utils/path-utils'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document }) {
+  return document.getNextBlock(PathUtils.create([1]))
+}
+
+export const output = <paragraph>three</paragraph>

--- a/packages/slate/test/models/node/get-next-block/no-next-block.js
+++ b/packages/slate/test/models/node/get-next-block/no-next-block.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>
+        <paragraph>three</paragraph>
+      </paragraph>
+      <paragraph>
+        <anchor />four<focus />
+        <inline type="inline_type">five</inline>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.path)
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-next-block/no-next-node.js
+++ b/packages/slate/test/models/node/get-next-block/no-next-node.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>
+        <paragraph>three</paragraph>
+      </paragraph>
+      <paragraph>
+        <anchor />four<focus />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextBlock(selection.end.path)
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-next-node/next-node-is-ancestor-sibling-with-nested-blocks.js
+++ b/packages/slate/test/models/node/get-next-node/next-node-is-ancestor-sibling-with-nested-blocks.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>
+        <paragraph>three</paragraph>
+      </paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextNode(selection.end.path)
+}
+
+export const output = (
+  <paragraph>
+    <paragraph>three</paragraph>
+  </paragraph>
+)

--- a/packages/slate/test/models/node/get-next-node/next-node-is-ancestor-sibling.js
+++ b/packages/slate/test/models/node/get-next-node/next-node-is-ancestor-sibling.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getNextNode(selection.end.path)
+}
+
+export const output = <paragraph>three</paragraph>

--- a/packages/slate/test/models/node/get-previous-block/by-key.js
+++ b/packages/slate/test/models/node/get-previous-block/by-key.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.key)
+}
+
+export const output = <paragraph>one</paragraph>

--- a/packages/slate/test/models/node/get-previous-block/multiple-siblings-to-bypass.js
+++ b/packages/slate/test/models/node/get-previous-block/multiple-siblings-to-bypass.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <inline type="inline_type" />
+        <inline type="inline_type" />
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.path)
+}
+
+export const output = <paragraph>one</paragraph>

--- a/packages/slate/test/models/node/get-previous-block/no-prev-block.js
+++ b/packages/slate/test/models/node/get-previous-block/no-prev-block.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <inline type="inline_type">zer</inline>
+        <anchor />one<focus />
+      </paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>
+        <paragraph>four</paragraph>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.path)
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-previous-block/no-prev-node.js
+++ b/packages/slate/test/models/node/get-previous-block/no-prev-node.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <anchor />one<focus />
+      </paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>
+        <paragraph>three</paragraph>
+      </paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.path)
+}
+
+export const output = null

--- a/packages/slate/test/models/node/get-previous-block/prev-block-is-ancestor-sibling.js
+++ b/packages/slate/test/models/node/get-previous-block/prev-block-is-ancestor-sibling.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>
+        <anchor />three<focus />
+      </paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.path)
+}
+
+export const output = <paragraph>two</paragraph>

--- a/packages/slate/test/models/node/get-previous-block/prev-block-is-in-sibling-with-deeper-blocks.js
+++ b/packages/slate/test/models/node/get-previous-block/prev-block-is-in-sibling-with-deeper-blocks.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>1</paragraph>
+      <paragraph>
+        <paragraph>2</paragraph>
+        <paragraph>
+          <paragraph>2.1</paragraph>
+        </paragraph>
+      </paragraph>
+      <paragraph>
+        <paragraph>
+          <paragraph>3.1</paragraph>
+        </paragraph>
+        <paragraph>3.2</paragraph>
+      </paragraph>
+      <paragraph>
+        <anchor />4><focus />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.path)
+}
+
+export const output = <paragraph>3.2</paragraph>

--- a/packages/slate/test/models/node/get-previous-block/prev-block-is-sibling-descendent.js
+++ b/packages/slate/test/models/node/get-previous-block/prev-block-is-sibling-descendent.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>
+        <anchor />two<focus />
+      </paragraph>
+      <paragraph>
+        <paragraph>three</paragraph>
+      </paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getPreviousBlock(selection.end.path)
+}
+
+export const output = <paragraph>one</paragraph>

--- a/packages/slate/test/models/node/get-previous-block/prev-block-is-sibling.js
+++ b/packages/slate/test/models/node/get-previous-block/prev-block-is-sibling.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import PathUtils from '../../../../src/utils/path-utils'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>one</paragraph>
+      <paragraph>two</paragraph>
+      <paragraph>three</paragraph>
+      <paragraph>four</paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document }) {
+  return document.getPreviousBlock(PathUtils.create([2]))
+}
+
+export const output = <paragraph>two</paragraph>

--- a/packages/slate/test/models/node/get-selection-indexes/across-blocks-from-nested-node.js
+++ b/packages/slate/test/models/node/get-selection-indexes/across-blocks-from-nested-node.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import PathUtils from '../../../../src/utils/path-utils'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <mark type="a">rd</mark>
+      </paragraph>
+      <paragraph>
+        <paragraph>
+          <mark type="b">middle</mark>
+        </paragraph>
+        <paragraph />
+      </paragraph>
+      <paragraph>unmarked</paragraph>
+      <paragraph>
+        <mark type="c">
+          an<focus />other
+        </mark>
+        <mark type="d">unselected marked text</mark>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  const node = document.getDescendant(PathUtils.create([1]))
+  return node.getSelectionIndexes(selection, [1])
+}
+
+export const output = { start: 0, end: 2 }

--- a/packages/slate/test/models/node/get-selection-indexes/across-blocks.js
+++ b/packages/slate/test/models/node/get-selection-indexes/across-blocks.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        wo<anchor />
+        <mark type="a">rd</mark>
+      </paragraph>
+      <paragraph>
+        <paragraph>
+          <mark type="b">middle</mark>
+        </paragraph>
+        <paragraph />
+      </paragraph>
+      <paragraph>unmarked</paragraph>
+      <paragraph>
+        <mark type="c">
+          an<focus />other
+        </mark>
+        <mark type="d">unselected marked text</mark>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getSelectionIndexes(selection)
+}
+
+export const output = { start: 0, end: 4 }

--- a/packages/slate/test/models/node/get-selection-indexes/in-single-block-from-middle-nested-node.js
+++ b/packages/slate/test/models/node/get-selection-indexes/in-single-block-from-middle-nested-node.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import PathUtils from '../../../../src/utils/path-utils'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        before
+        <anchor />start
+        <inline type="inline_type" />
+        <inline type="inline_with_text">inline text</inline>
+        end<focus />
+        after
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  const node = document.getDescendant(PathUtils.create([0, 2]))
+  return node.getSelectionIndexes(selection, [0, 2])
+}
+
+export const output = { start: 0, end: 1 }

--- a/packages/slate/test/models/node/get-selection-indexes/in-single-block-from-parent-node.js
+++ b/packages/slate/test/models/node/get-selection-indexes/in-single-block-from-parent-node.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import PathUtils from '../../../../src/utils/path-utils'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        before
+        <anchor />start
+        <inline type="inline_type" />
+        <inline type="inline_with_text">inline text</inline>
+        end<focus />
+        after
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  const node = document.getDescendant(PathUtils.create([0]))
+  return node.getSelectionIndexes(selection, [0])
+}
+
+export const output = { start: 0, end: 4 }

--- a/packages/slate/test/models/node/get-selection-indexes/in-single-block.js
+++ b/packages/slate/test/models/node/get-selection-indexes/in-single-block.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        before
+        <anchor />start
+        <inline type="inline_type" />
+        <inline type="inline_with_text">inline text</inline>
+        end<focus />
+        after
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getSelectionIndexes(selection)
+}
+
+export const output = { start: 0, end: 1 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

Opening this PR right now to get discussion on the basic approach (see below).

#### What's the new behavior?

See #2000 for background.

#### How does this change work?

The difficulty using `path` rather than `key` is that there is no `node.path` equivalent for `node.key`.

There are at least 4 potential approaches (some or all could be combined):
1. Store some sort of pointer / reference to `path` on the node itself, and update all of them whenever a change is made that might affect some paths. This would make the rest of the changes easier, just switch to use `node.path` where we use `node.key`.

2. Store some sort of pointer / reference to `path` as a prop when rendering in the editor to make `getSelectionIndexes` easier to calculate at `render` time. 

(See https://github.com/ianstormtaylor/slate/issues/2413 for related discussion).

3. Create a `getPathForKey(key)` that is more efficient than `getKeysToPathsTable` for when we just need the path for a particular node (we can bail early). This would then allow us to call `getPathForKey(node.key)` where we use `node.key`. We could cache this to some extent, but probably calling it more than once or twice is just as expensive as `getKeysToPathsTable`.

4. Create methods that are similar to current `getFirstText`, `getNextBlock` etc, but which return the node and path. This allows some of the more complex methods such as `getActiveMarksAtRange` to iterate internally and still continue to use paths to call various getters.

This PR has three parts:
1. Adds tests
2. Some work towards (4) (see e.g. `getNextTextAndPath`, which can be used to improve the perf of `getActiveMarksAtRange`)
3. A promising approach for (2)

Opening now so we can discuss the approaches / tradeoffs.

If we don't like them, I can just add the tests in a separate PR (fwiw, some of them are failing against `master`, but I'm pretty sure I've captured the expected / desired behavior, and so those might represent legitimate bugs).

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2000
Reviewers: @ianstormtaylor @alanctkc 
