### PR TITLE
Mutate newDirtyPaths instead of creating a new array every iteration

### DIFF
--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -100,14 +100,13 @@ class Editor {
 
     // Get the paths of the affected nodes, and mark them as dirty.
     const newDirtyPaths = getDirtyPaths(operation)
-    const dirty = this.tmp.dirty.reduce((memo, path) => {
-      path = PathUtils.create(path)
-      const transformed = PathUtils.transform(path, operation)
-      Array.prototype.push.apply(memo, transformed.toArray())
-      return memo
-    }, newDirtyPaths)
 
-    this.tmp.dirty = dirty
+    const dirty = this.tmp.dirty.map(path => {
+      path = PathUtils.create(path)
+      return PathUtils.transform(path, operation).toArray()
+    })
+
+    this.tmp.dirty = Array.prototype.concat.apply(newDirtyPaths, dirty)
 
     // If we're not already, queue the flushing process on the next tick.
     if (!this.tmp.flushing) {

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -103,7 +103,7 @@ class Editor {
     const dirty = this.tmp.dirty.reduce((memo, path) => {
       path = PathUtils.create(path)
       const transformed = PathUtils.transform(path, operation)
-      memo = memo.concat(transformed.toArray())
+      Array.prototype.push.apply(memo, transformed.toArray())
       return memo
     }, newDirtyPaths)
 

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -103,7 +103,8 @@ class Editor {
 
     const dirty = this.tmp.dirty.map(path => {
       path = PathUtils.create(path)
-      return PathUtils.transform(path, operation).toArray()
+      const transformed = PathUtils.transform(path, operation)
+      return transformed.toArray()
     })
 
     this.tmp.dirty = Array.prototype.concat.apply(newDirtyPaths, dirty)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Performance. 

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Mutate `newDirtyPaths` on each iteration instead of copying it. For my unscientific paste test, this brings a 4s paste to about 2.5s. 

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
