### PR TITLE
Add View Source link on examples page

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -291,7 +291,14 @@ export default class App extends React.Component {
         <Switch>
           {EXAMPLES.map(([name, Component, path]) => (
             <Route key={path} exact path={path}>
-              <ExampleTitle>{name}</ExampleTitle>
+              <ExampleTitle>
+                {name}
+                <Link
+                  href={`https://github.com/ianstormtaylor/slate/blob/master/examples${path}`}
+                >
+                  (View Source)
+                </Link>
+              </ExampleTitle>
             </Route>
           ))}
         </Switch>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a new feature requested in #2576.

#### What's the new behavior?

A new "View Source" button on the examples page next to the example title. 

![](https://cl.ly/b9311a33581b/download/Image%2525202019-02-16%252520at%25252010.55.35%252520PM.png)

#### How does this change work?

The link points to `https://github.com/ianstormtaylor/slate/blob/master/examples/{example-name}`, for example, https://github.com/ianstormtaylor/slate/tree/master/examples/rich-text.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2576
Reviewers: 