### PR TITLE
Fix insert-node-by-key benchmark, add normalize and insert-fragment benchmarks

### DIFF
--- a/benchmark/helpers/h.js
+++ b/benchmark/helpers/h.js
@@ -16,6 +16,12 @@ const h = createHyperscript({
     list: 'list',
     item: 'item',
     image: 'image',
+    table: 'table',
+    tbody: 'tbody',
+    tr: 'tr',
+    td: 'td',
+    thead: 'thead',
+    th: 'th',
   },
   inlines: {
     link: 'link',

--- a/benchmark/slate/changes/insert-fragment-deep-with-problems.js
+++ b/benchmark/slate/changes/insert-fragment-deep-with-problems.js
@@ -1,0 +1,67 @@
+/** @jsx h */
+/* eslint-disable react/jsx-key */
+
+const h = require('../../helpers/h')
+const { Editor } = require('slate')
+
+const fragment = (
+  <document>
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <paragraph>Column 1</paragraph>
+          </th>
+          <th>
+            <paragraph>Column 2</paragraph>
+          </th>
+          <th>
+            <paragraph>Column 3</paragraph>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {Array.from(10).map(n => (
+          <tr key={n}>
+            <td>
+              <paragraph>Plain text</paragraph>
+            </td>
+            <td>
+              <paragraph>
+                <b>Bolded text</b>
+              </paragraph>
+            </td>
+            <td />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    <list>
+      <item>
+        <paragraph>Plain text</paragraph>
+      </item>
+      <item>
+        <emoji />
+      </item>
+      <item />
+    </list>
+  </document>
+)
+
+module.exports.default = function(editor) {
+  editor.insertFragment(fragment)
+}
+
+const value = (
+  <value>
+    <document>
+      <paragraph>
+        Some initial text.<cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+module.exports.input = function() {
+  return new Editor({ value })
+}

--- a/benchmark/slate/changes/insert-fragment-large.js
+++ b/benchmark/slate/changes/insert-fragment-large.js
@@ -6,8 +6,8 @@ const { Editor } = require('slate')
 
 const fragment = (
   <document>
-    {Array.from(Array(10)).map((v, i) => (
-      <quote key={`a${i}`}>
+    {Array.from(Array(100)).map((v, i) => (
+      <quote>
         <paragraph>
           This is editable <b>rich</b> text, <i>much</i> better than a textarea!
           {i == 0 ? <cursor /> : ''}

--- a/benchmark/slate/changes/insert-fragment.js
+++ b/benchmark/slate/changes/insert-fragment.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+/* eslint-disable react/jsx-key */
+
+const h = require('../../helpers/h')
+const { Editor } = require('slate')
+
+const fragment = (
+  <document>
+    {Array.from(Array(10)).map((v, i) => (
+      <quote key={`a${i}`}>
+        <paragraph>
+          This is editable <b>rich</b> text, <i>much</i> better than a
+          textarea!
+          {i == 0 ? <cursor /> : ''}
+        </paragraph>
+      </quote>
+    ))}
+  </document>
+)
+
+module.exports.default = function(editor) {
+  editor.insertFragment(fragment)
+}
+
+const value = (
+  <value>
+    <document>
+      <paragraph>Some initial text.<cursor /></paragraph>
+    </document>
+  </value>
+)
+
+
+module.exports.input = function() {
+  return new Editor({ value })
+}

--- a/benchmark/slate/changes/insert-node-by-key.js
+++ b/benchmark/slate/changes/insert-node-by-key.js
@@ -8,9 +8,9 @@ module.exports.default = function(editor) {
   editor
     .insertNodeByKey('a0', 0, <paragraph>Hello world</paragraph>)
     .insertNodeByKey('a1', 1, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a2', 2, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a3', 3, <paragraph>Hello world</paragraph>)
-    .insertNodeByKey('a4', 4, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a2', 0, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a3', 1, <paragraph>Hello world</paragraph>)
+    .insertNodeByKey('a4', 0, <paragraph>Hello world</paragraph>)
 }
 
 const value = (

--- a/benchmark/slate/changes/normalize-with-problems.js
+++ b/benchmark/slate/changes/normalize-with-problems.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+/* eslint-disable react/jsx-key */
+
+const h = require('../../helpers/h')
+const { Editor } = require('slate')
+
+module.exports.default = function(editor) {
+  editor.normalize().normalize()
+}
+
+const value = (
+  <value>
+    <document>
+      {Array.from(Array(10)).map((v, i) => (
+        <quote>
+          <paragraph>
+            <paragraph>
+              <link>link text</link>
+            </paragraph>
+            <paragraph />
+            <paragraph>
+              <paragraph>
+                <link>link text</link>
+                <text> more text after</text>
+              </paragraph>
+            </paragraph>
+          </paragraph>
+        </quote>
+      ))}
+    </document>
+  </value>
+)
+
+module.exports.input = function() {
+  return new Editor({ value }, { normalize: false })
+}

--- a/packages/slate-plain-serializer/test/helpers/h.js
+++ b/packages/slate-plain-serializer/test/helpers/h.js
@@ -13,6 +13,12 @@ const h = createHyperscript({
     quote: 'quote',
     code: 'code',
     image: 'image',
+    table: 'table',
+    tbody: 'tbody',
+    tr: 'tr',
+    td: 'td',
+    thead: 'thead',
+    th: 'th',
   },
   inlines: {
     link: 'link',


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving _benchmarks_

#### What's the new behavior?

(See PR title)

#### How does this change work?

`insert-node-by-key` wasn't working because the index passed into all but the first couple operations were invalid.

`normalize-with-problems` should check how long it takes to normalize a Slate tree that has some problems (`block` with no `text` children, `inline` not surrounded by `text`). This could potentially be improved by adding other types of things that violate the core schema, but those are two issues that we've noticed causing a lot of issues in our own app.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
