### PR TITLE
Fix error when pasting an image into Slate image example.

### DIFF
--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -29,7 +29,7 @@ const Image = styled('img')`
   box-shadow: ${props => (props.selected ? '0 0 0 2px blue;' : 'none')};
 `
 
-/*
+/**
  * A function to determine whether a URL has an image extension.
  *
  * @param {String} url
@@ -37,14 +37,18 @@ const Image = styled('img')`
  */
 
 function isImage(url) {
-  return !!imageExtensions.find(
-    element =>
-      element ===
-      url
-        .split('?')[0]
-        .split('.')
-        .pop()
-  )
+  return imageExtensions.includes(getExtension(url))
+}
+
+/**
+ * Get the extension of the URL, using the URL API.
+ *
+ * @param {String} url
+ * @return {String}
+ */
+
+function getExtension(url) {
+  return new URL(url).pathname.split('.').pop()
 }
 
 /**

--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -37,7 +37,14 @@ const Image = styled('img')`
  */
 
 function isImage(url) {
-  return !!imageExtensions.find(url.endsWith)
+  return !!imageExtensions.find(
+    element =>
+      element ===
+      url
+        .split('?')[0]
+        .split('.')
+        .pop()
+  )
 }
 
 /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
This pull request is to fix a bug in the Slate image example code.

The following error occurs on https://www.slatejs.org/#/images when attempting to paste an image URL and the image isn't actually added due to the function not returning properly:
`Uncaught TypeError: String.prototype.endsWith called on null or undefined`

I'm aware that there is a separate image pasting plugin, however. Feel free to kill this PR if it makes more sense to use that instead.

#### What's the new behavior?
This patch re-enables the pasting of images into the editor without using the previously mentioned plugin.

#### How does this change work?
It strips query tags from the end of the URL, then grabs the URL extension and compares it to the given image extension list.

#### Have you checked that...?
* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

I couldn't find a bug that was reported for this.
Reviewers: @ianstormtaylor 