### PR TITLE
Add onSetValue plugin hook

### DIFF
--- a/docs/reference/slate/plugins.md
+++ b/docs/reference/slate/plugins.md
@@ -14,6 +14,7 @@ Plugins are plain JavaScript objects, containing a set of middleware functions t
   onChange: Function,
   onCommand: Function,
   onConstruct: Function,
+  onSetValue: Function,
   onQuery: Function,
   validateNode: Function,
 }
@@ -87,6 +88,12 @@ The `onQuery` hook is a low-level way to have access to all of the queries passi
 The `onConstruct` hook is called when a new instance of `Editor` is created. This is where you can call `editor.registerCommand` or `editor.registerQuery`.
 
 > 🤖 This is always called with the low-level `Editor` instance, and not the React `<Editor>` component. And it is called before the React editor has its `value` set based on its props. It is purely used for editor-related configuration setup, and not for any schema-related or value-related purposes.
+
+### `onSetValue`
+
+`onSetValue(editor: Editor, next: Function) => Void`
+
+The `onSetValue` hook is called when current value changes without an operation being applied, e.g. when the `Editor` is first created or as a result of `Editor.setValue()`.
 
 ### `onQuery`
 

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -381,6 +381,8 @@ class Editor {
       this.normalize()
     }
 
+    this.run('onSetValue')
+
     return this
   }
 

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -377,11 +377,11 @@ class Editor {
     const { normalize = value !== this.value } = options
     this.value = value
 
+    this.run('onSetValue')
+
     if (normalize) {
       this.normalize()
     }
-
-    this.run('onSetValue')
 
     return this
   }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

Currently plugins can only observe changes in value via the `onChange` hook. This presents two problems for plugins which derive their state from value:

- If they use that state to influence rendering (e.g. in `renderEditor`), the editor will render incorrectly until it's first focused, which is the first time `onChange` is run, and the first time the plugin can derive state

- If value is changed via `setValue` they have no way of detecting this change and updating their state.

This PR adds a new plugin hook, `onSetValue(editor, next)`, which is invoked with the new value when it is changed via `setValue`. This addresses both points:

- Since `Editor`'s constructor uses `setValue`, plugins will receive `onSetValue` right after `onConstruct`, allowing them to inspect value before editor is first rendered;

- Since the only ways to set value are `setValue` and `applyOperation` (I'm assuming setting `editor.value` manually is not a supported use case), plugins can now observe all changes to value.

#### How does this change work?

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test` — all existing tests pass, but I probably should add some and I'm not sure how to test this.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
