### PR TITLE
Add API version and Input Events Level 2 for Android

### DIFF
--- a/packages/slate-dev-environment/src/index.js
+++ b/packages/slate-dev-environment/src/index.js
@@ -92,6 +92,43 @@ if (isBrowser) {
 }
 
 /**
+ * Array of regular expression matchers and their API version
+ *
+ * @type {Array}
+ */
+
+const ANDROID_API_VERSIONS = [
+  [/^9([.]0|)/, 28],
+  [/^8[.]1/, 27],
+  [/^8([.]0|)/, 26],
+  [/^7[.]1/, 25],
+  [/^7([.]0|)/, 24],
+  [/^6([.]0|)/, 23],
+  [/^5[.]1/, 22],
+  [/^5([.]0|)/, 21],
+  [/^4[.]4/, 20],
+]
+
+/**
+ * get the Android API version from the userAgent
+ *
+ * @return {number} version
+ */
+
+function getAndroidApiVersion() {
+  if (os !== 'android') return null
+  const { userAgent } = window.navigator
+  const matchData = userAgent.match(/Android\s([0-9\.]+)/)
+  if (matchData == null) return null
+  const versionString = matchData[1]
+
+  for (const [regex, version] of ANDROID_API_VERSIONS) {
+    if (versionString.match(regex)) return version
+  }
+  return null
+}
+
+/**
  * Export.
  *
  * @type {Boolean}
@@ -109,5 +146,8 @@ export const IS_IOS = os === 'ios'
 export const IS_MAC = os === 'macos'
 export const IS_WINDOWS = os === 'windows'
 
+export const ANDROID_API_VERSION = getAndroidApiVersion()
+
 export const HAS_INPUT_EVENTS_LEVEL_1 = features.includes('inputeventslevel1')
-export const HAS_INPUT_EVENTS_LEVEL_2 = features.includes('inputeventslevel2')
+export const HAS_INPUT_EVENTS_LEVEL_2 =
+  features.includes('inputeventslevel2') || ANDROID_API_VERSION === 28

--- a/packages/slate-dev-environment/src/index.js
+++ b/packages/slate-dev-environment/src/index.js
@@ -150,4 +150,5 @@ export const ANDROID_API_VERSION = getAndroidApiVersion()
 
 export const HAS_INPUT_EVENTS_LEVEL_1 = features.includes('inputeventslevel1')
 export const HAS_INPUT_EVENTS_LEVEL_2 =
-  features.includes('inputeventslevel2') || ANDROID_API_VERSION === 28
+  features.includes('inputeventslevel2') ||
+  (IS_ANDROID && (ANDROID_API_VERSION === 28 || ANDROID_API_VERSION === null))


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature and fixing a bug. The feature is the export of `ANDROID_API_VERSION` from `slate-dev-environment`. The bug is that `HAS_INPUT_EVENTS_LEVEL_2` returns false for Android 9 but should return true.

#### What's the new behavior?

Returns true for `HAS_INPUT_EVENTS_LEVEL_2` which results in Slate using the real `beforeinput` event instead of React's synthetic version.

#### How does this change work?

Queries the browser's `window.navigator.userAgent` to derive the API version. When setting `HAS_INPUT_EVENTS_LEVEL_2` sets it to true if the `ANDROID_API_VERSION` is 28 even though it otherwise is not identified as supporting the feature.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)