### PR TITLE
Use fromJS instead of Map to convert data into block data

### DIFF
--- a/packages/slate/src/models/block.js
+++ b/packages/slate/src/models/block.js
@@ -1,5 +1,5 @@
 import isPlainObject from 'is-plain-object'
-import { List, Map, Record } from 'immutable'
+import { fromJS, List, Record } from 'immutable'
 
 import KeyUtils from '../utils/key-utils'
 import Node from './node'
@@ -88,7 +88,7 @@ class Block extends Record(DEFAULTS) {
     const block = new Block({
       key,
       type,
-      data: Map(data),
+      data: fromJS(data),
       nodes: Node.createList(nodes),
     })
 


### PR DESCRIPTION
Fixes: #2603

Switched `Map` to `fromJS` in order to convert the whole js object (also nested data structures) to immutable.js when creating a block.

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
