### PR TITLE
Fix Edge positioning with newlines

### DIFF
--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -51,7 +51,7 @@ function findPoint(nativeNode, nativeOffset, editor) {
     range.setStart(textNode, 0)
     range.setEnd(nearestNode, nearestOffset)
     node = textNode
-    offset = range.toString().length
+    offset = range.cloneContents().textContent.length
   } else {
     // For void nodes, the element with the offset key will be a cousin, not an
     // ancestor, so find it by going down from the nearest void parent.

--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -51,6 +51,11 @@ function findPoint(nativeNode, nativeOffset, editor) {
     range.setStart(textNode, 0)
     range.setEnd(nearestNode, nearestOffset)
     node = textNode
+
+    // COMPAT: Edge has a bug where Range.prototype.toString() will convert \n
+    // into \r\n. The bug causes a loop when slate-react attempts to reposition
+    // its cursor to match the native position. Use textContent.length instead.
+    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10291116/
     offset = range.cloneContents().textContent.length
   } else {
     // For void nodes, the element with the offset key will be a cousin, not an


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a Bug 🐛 

Edge has a [bug][1] where `Range.prototype.toString()` will convert `\n`
into `\r\n`. The bug causes a loop when slate-react attempts to
reposition its cursor to match the native position.

Example of broken behavior
![ienewlinebug](https://user-images.githubusercontent.com/57737/53515221-b77d9480-3a86-11e9-8f74-29308fb66357.gif)

Live example:
https://codesandbox.io/s/6mpnnqkpr
Open in Edge and attempt to click between `b` and `c`. Notice that the cursor will reposition to the end.

[1]: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10291116/

#### What's the new behavior?

This change avoids calling `Range.prototype.toString()` by cloning the
content nodes and measuring `textContent` on those instead.

#### How does this change work?

`textContent` doesn't add `\r` to every `\n`, so the calculated offset will be correct

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Unrelated failures)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
