### PR TITLE
fix insert fragment with void children

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -789,7 +789,11 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
 
     // If the starting block is empty, we replace it entirely with the first block
     // of the fragment, since this leads to a more expected behavior for the user.
-    if (!editor.isVoid(startBlock) && startBlock.text === '') {
+    if (
+      !editor.isVoid(startBlock) &&
+      startBlock.text === '' &&
+      !startBlock.findDescendant(n => editor.isVoid(n))
+    ) {
       editor.removeNodeByKey(startBlock.key)
       editor.insertNodeByKey(parent.key, index, firstBlock)
     } else {

--- a/packages/slate/test/commands/at-current-range/insert-fragment/start-block-with-void-no-text.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/start-block-with-void-no-text.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.insertFragment(
+    <document>
+      <paragraph>
+        <text>one</text>
+        <text>two</text>
+      </paragraph>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji />
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <emoji />
+        <text>
+          onetwo<cursor />
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a _bug_.

When inserting a fragment into a range where `startBlock` has void children but no text, `startBlock` would be removed.

#### What's the new behavior?

`startBlock` is not removed.

#### How does this change work?

Check for void children before removing a node.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2545
Reviewers: @ianstormtaylor @ldavidpace 
