### PR TITLE
Remove return true on key down function

### DIFF
--- a/docs/walkthroughs/adding-event-handlers.md
+++ b/docs/walkthroughs/adding-event-handlers.md
@@ -83,7 +83,6 @@ class App extends React.Component {
 
     // Change the value by inserting 'and' at the cursor's position.
     editor.insertText('and')
-    return true
   }
 
   render() {


### PR DESCRIPTION
Correct me if I am wrong, but I believe that this `return true` is a no-op. I removed it and everything kept working as usual. And, when I was following the tutorial, that particular line created an interrogation mark in my brain. So, my suggestion is to remove that line to avoid creating entropy for no reason.

#### Is this adding or improving a _feature_ or fixing a _bug_?
No.
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Just updating the docs.
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Correct me if I am wrong, but I believe that this `return true` is a no-op. I removed it and everything kept working as usual. And, when I was following the tutorial, that particular line created an interrogation mark in my brain. So, my suggestion is to remove that line to avoid creating entropy for no reason.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Nope.
