### PR TITLE
Fix missing break in last example

### DIFF
--- a/docs/walkthroughs/applying-custom-formatting.md
+++ b/docs/walkthroughs/applying-custom-formatting.md
@@ -146,11 +146,13 @@ class App extends React.Component {
       case 'b': {
         event.preventDefault()
         editor.toggleMark('bold')
+        break
       }
       case '`': {
         const isCode = editor.value.blocks.some(block => block.type == 'code')
         event.preventDefault()
         editor.setBlocks(isCode ? 'paragraph' : 'code')
+        break
       }
       default: {
         return next()


### PR DESCRIPTION
In the last chunk of code, it was missing the `break` (or `return`). So, if used as is, the bold key will toggle the `code` feature as well.

#### Is this adding or improving a _feature_ or fixing a _bug_?
A bug in the implementation example in the documentation
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
The `b` key should only toggle the `bold` behavior. That was fixed.
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
Nope :)
