### PR TITLE
Fix examples/tables variable "previous" is null when select text and …

### DIFF
--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -163,6 +163,11 @@ class Tables extends React.Component {
 
     if (isCollapsed && start.isAtStartOfNode(startNode)) {
       const previous = document.getPreviousText(startNode.key)
+
+      if (!previous) {
+        return next()
+      }
+
       const prevBlock = document.getClosestBlock(previous.key)
 
       if (prevBlock.type === 'table-cell') {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fix a bug in `examples/tables/index.js`

#### What's the new behavior?
- When delete the choosen content in editor, the console won't print error: `Uncaught TypeError: Cannot read property 'key' of null`. (e.g.,  press `Ctrl+a` to select all and press `Backspace` to delete)
- User can key down `Ctrl + z` to recover deleted content, and no error in console

#### How does this change work?
When delete all content, the varible "previous" is `null`. So I added check for null values, and returns the default behavior when it's null.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

