### PR TITLE
Only call setValue when the value changes

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -93,6 +93,19 @@ class Editor extends React.Component {
     updates: 0,
   }
 
+  constructor(props) {
+    super(props)
+
+    const { commands, placeholder, plugins, queries, schema } = props
+    this.resolveController(plugins, schema, commands, queries, placeholder)
+
+    // Set the current props on the controller.
+    const { options, value: valueFromProps } = props
+    const { value: valueFromState } = this.state
+    const value = valueFromProps || valueFromState
+    this.controller.setValue(value, options)
+  }
+
   /**
    * When the component first mounts, flush a queued change if one exists.
    */
@@ -115,8 +128,12 @@ class Editor extends React.Component {
    * When the component updates, flush a queued change if one exists.
    */
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     this.tmp.updates++
+
+    if (prevProps.value !== this.props.value) {
+      this.controller.setValue(this.props.value, this.props.options)
+    }
 
     if (this.tmp.change) {
       this.handleChange(this.tmp.change)
@@ -147,11 +164,10 @@ class Editor extends React.Component {
     this.resolveController(plugins, schema, commands, queries, placeholder)
 
     // Set the current props on the controller.
-    const { options, readOnly, value: valueFromProps } = props
+    const { readOnly, value: valueFromProps } = props
     const { value: valueFromState } = this.state
     const value = valueFromProps || valueFromState
     this.controller.setReadOnly(readOnly)
-    this.controller.setValue(value, options)
 
     // Render the editor's children with the controller.
     const children = this.controller.run('renderEditor', {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixes #2549 

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Re-rendering a component that holds a slate `Editor` won't trigger `setValue` unless the value changes. Previously, if you called `setState` in a parent component after calling any functions on the `editor` controller, the changes would not be reflected in the editor because the re-render sets the value back to what it was. 

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

I think this editor code could use a little more work, and could benefit strongly from being refactored to hooks where some of these code paths would be much more clear. I also think treating the editor controller as a prop as suggested in #2567 could make some of this code simpler and less prone to bugs. 

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2549 
