### PR TITLE
Use height:0 on placeholder styles to better support text alignment

### DIFF
--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -74,20 +74,19 @@ function SlateReactPlaceholder(options = {}) {
     if (mark.type === 'placeholder' && mark.data.get('key') === instanceId) {
       const style = {
         pointerEvents: 'none',
-        display: 'inline-block',
-        width: '0',
+        height: 0,
         maxWidth: '100%',
         whiteSpace: 'nowrap',
         opacity: '0.333',
       }
 
       return (
-        <span>
-          <span contentEditable={false} style={style}>
+        <div>
+          <div contentEditable={false} style={style}>
             {placeholder}
-          </span>
+          </div>
           {children}
-        </span>
+        </div>
       )
     }
 

--- a/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-single-empty-text.js
+++ b/packages/slate-react/test/rendering/fixtures/placeholder/single-block-with-single-empty-text.js
@@ -21,14 +21,14 @@ export const output = `
   <div style="position:relative">
     <span>
       <span data-slate-leaf="true">
-        <span>
-            <span contenteditable="false" style="pointer-events:none;display:inline-block;width:0;max-width:100%;white-space:nowrap;opacity:0.333">
+        <div>
+            <div contenteditable="false" style="pointer-events:none;height:0;max-width:100%;white-space:nowrap;opacity:0.333">
                 placeholder text
-            </span>
-            <span data-slate-zero-width="n" data-slate-length="0">
+            </div>
+            <div data-slate-zero-width="n" data-slate-length="0">
                 <br>
-            </span>
-        </span>
+            </div>
+        </div>
       </span>
     </span>
   </div>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improves placeholder styles. By using `height: 0` and keeping the default `width`, we can support centered placeholders. 

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

![Screen Shot 2019-03-25 at 6 30 49 PM](https://user-images.githubusercontent.com/2984336/54960805-318d2600-4f2c-11e9-81ba-9d791ca3ab63.png)


<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2608
Reviewers: @
