### PR TITLE
Make use of clientX and clientY in getEventRange

### DIFF
--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -23,7 +23,7 @@ function getEventRange(event, editor) {
     event = event.nativeEvent
   }
 
-  const { x, y, target } = event
+  const { clientX: x, clientY: y, target } = event
   if (x == null || y == null) return null
 
   const { value } = editor


### PR DESCRIPTION
#### Fixes `x` and `y` missing in `event` object in some cases

#### What's the new behavior?

Instead of using `x` and `y` from `event` object, which are [experimental properties](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/x) and missing in some cases, it uses `clientX` and `clientY` which are widely supported.

#### How does this change work?

It doesn't change anything
#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2570
Reviewers: @
