### PR TITLE
Use <s> for strikethrough example

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -87,7 +87,7 @@ function renderMark(props, editor, next) {
     case 'underline':
       return <u {...{ attributes }}>{children}</u>
     case 'strikethrough':
-      return <strike {...{ attributes }}>{children}</strike>
+      return <s {...{ attributes }}>{children}</s>
     default:
       return next()
   }


### PR DESCRIPTION
`<strike>` is obsolete and discouraged https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strike

`<s>` is better alternative https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s