### PR TITLE
Fix selection being reset incorrectly after combination of events

### DIFF
--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -634,9 +634,11 @@ function AfterPlugin(options = {}) {
     const window = getWindow(event.target)
     const selection = window.getSelection()
     setSelectionFromDom(window, editor, selection)
-    // we need to reset it here in case mouseUp happens outside editor
-    // onFocus is happening before onSelect so it is safe to reset it here
+
+    // COMPAT: reset the `isMouseDown` state here in case a `mouseup` event
+    // happens outside the editor. This is needed for `onFocus` handling.
     isMouseDown = false
+
     next()
   }
 

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -634,6 +634,9 @@ function AfterPlugin(options = {}) {
     const window = getWindow(event.target)
     const selection = window.getSelection()
     setSelectionFromDom(window, editor, selection)
+    // we need to reset it here in case mouseUp happens outside editor
+    // onFocus is happening before onSelect so it is safe to reset it here
+    isMouseDown = false
     next()
   }
 


### PR DESCRIPTION
If mouseDown happens inside editor container and mouseUp outside it,
then programmatically calling editor.focus() after that will mess up
the selection

#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a _bug_

#### What's the new behavior?
to reproduce the bug do the following:
1. mouseDown inside editor, move to select content and release mouse button outside editor
2. blur the editor (click outside the editor component)
3. programmatically call editor.focus() (maybe clicking a toolbar formatting button for example)
4. see selection being collapsed instead of resetting it to the selected fragment


#### How does this change work?

the problem was is that when on mouseDown we set a closure variable isMouseDown to true and reset it on mouseUp event, but since mouseUp may happen outside the editor it was not resetting it.
The solutin is to reset it inside onSelect handler. We only need that variable in onFocus handler. 
The order of events is following:
* mouseDown
* focus (isMouseDown being used here to distinguish events created by mouse)
* select
* mouseUp

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
