### PR TITLE
fix get marks from previous text on method getMarksAtPosition

### DIFF
--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -973,7 +973,7 @@ class ElementInterface {
     const [previousText, previousPath] = previous
 
     if (closestBlock.hasDescendant(previousPath)) {
-      return previous.getMarksAtIndex(previousText.text.length)
+      return previousText.getMarksAtIndex(previousText.text.length)
     }
 
     return currentMarks

--- a/packages/slate/test/models/node/get-marks-at-position/marked-text-with-zero-offset-with-no-previous-text.js
+++ b/packages/slate/test/models/node/get-marks-at-position/marked-text-with-zero-offset-with-no-previous-text.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import PathUtils from '../../../../src/utils/path-utils'
+
+const path = PathUtils.create([0, 0])
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <text>
+          <b>Cat is Cute</b>
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getMarksAtPosition(path, 0)
+}
+
+export const output = Set.of()

--- a/packages/slate/test/models/node/get-marks-at-position/marked-text-with-zero-offset-with-previous-text-not-in-the-same-block.js
+++ b/packages/slate/test/models/node/get-marks-at-position/marked-text-with-zero-offset-with-previous-text-not-in-the-same-block.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import { Mark } from 'slate'
+import PathUtils from '../../../../src/utils/path-utils'
+
+const path = PathUtils.create([1, 0])
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <text>Cat is Cute</text>
+      </paragraph>
+      <paragraph>
+        <text>
+          <b>Dog is Delightful</b>
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getMarksAtPosition(path, 0)
+}
+
+export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-position/marked-text.js
+++ b/packages/slate/test/models/node/get-marks-at-position/marked-text.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import { Mark } from 'slate'
+import PathUtils from '../../../../src/utils/path-utils'
+
+const path = PathUtils.create([0, 0])
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <text>
+          <i>Cat </i>
+          is
+          <b> Cute</b>
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getMarksAtPosition(path, 1)
+}
+
+export const output = Set.of(Mark.create('italic'))

--- a/packages/slate/test/models/node/get-marks-at-position/text-with-zero-offset.js
+++ b/packages/slate/test/models/node/get-marks-at-position/text-with-zero-offset.js
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import { Mark } from 'slate'
+import PathUtils from '../../../../src/utils/path-utils'
+
+const path = PathUtils.create([1, 1, 0])
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <text>Cat is Cute</text>
+      </paragraph>
+      <paragraph>
+        <text>
+          <b>Dog is</b>
+        </text>
+        <link>
+          <text>Delightful</text>
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getMarksAtPosition(path, 0)
+}
+
+export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-position/unmarked-text.js
+++ b/packages/slate/test/models/node/get-marks-at-position/unmarked-text.js
@@ -1,0 +1,23 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+import { Set } from 'immutable'
+import PathUtils from '../../../../src/utils/path-utils'
+
+const path = PathUtils.create([0, 0])
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <text>Cat is Cute</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getMarksAtPosition(path, 1)
+}
+
+export const output = Set.of()


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug when calling `getMarksAtPosition` with offset 0 throws an error.
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Nothing
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
There is a typo calling `getMarksAtIndex` method on `previous` which is a tuple, it should be `previousText`.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Unable to connect to `http://localhost:8080/`)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2679
Reviewers: @ianstormtaylor @jtadmor 
