### PR TITLE
removed ie/edge condition that causes "node of undefined" TypeError i…

### DIFF
--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -1,10 +1,8 @@
 import getWindow from 'get-window'
 import invariant from 'tiny-invariant'
-import { IS_IE, IS_EDGE } from 'slate-dev-environment'
 import { Value } from 'slate'
 
 import findPoint from './find-point'
-import findDOMPoint from './find-dom-point'
 
 /**
  * Find a Slate range from a DOM `native` selection.
@@ -50,21 +48,6 @@ function findRange(native, editor) {
   const anchor = findPoint(anchorNode, anchorOffset, editor)
   const focus = isCollapsed ? anchor : findPoint(focusNode, focusOffset, editor)
   if (!anchor || !focus) return null
-
-  // COMPAT: ??? The Edge browser seems to have a case where if you select the
-  // last word of a span, it sets the endContainer to the containing span.
-  // `selection-is-backward` doesn't handle this case.
-  if (IS_IE || IS_EDGE) {
-    const domAnchor = findDOMPoint(anchor)
-    const domFocus = findDOMPoint(focus)
-
-    native = {
-      anchorNode: domAnchor.node,
-      anchorOffset: domAnchor.offset,
-      focusNode: domFocus.node,
-      focusOffset: domFocus.offset,
-    }
-  }
 
   const { document } = value
   const range = document.createRange({


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug in Edge. When empty editor is focused, it throws "node of undefined" type error.

#### What's the new behavior?

Only removes browser (edge/ie) specific code. As far as I can see code is not doing anything at all.

Cannot reproduce bug described in PR #1574. (Tested in Edge/18.18262)

#### How does this change work?

Removes unused edge/ie code.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reverts code added in PR #1574. I was not able to reproduce issue in #1574 using Edge/18.18262.
