### PR TITLE
Allow immutable 4.0.0-rc

### DIFF
--- a/packages/slate-html-serializer/package.json
+++ b/packages/slate-html-serializer/package.json
@@ -16,7 +16,7 @@
     "type-of": "^2.0.1"
   },
   "peerDependencies": {
-    "immutable": ">=3.8.1",
+    "immutable": ">=3.8.1 || >4.0.0-rc",
     "react": ">=0.14.0",
     "react-dom": ">=0.14.0",
     "slate": ">=0.32.0"

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -31,7 +31,7 @@
     "tiny-warning": "^0.0.3"
   },
   "peerDependencies": {
-    "immutable": ">=3.8.1",
+    "immutable": ">=3.8.1 || >4.0.0-rc",
     "react": ">=0.14.0",
     "react-dom": ">=0.14.0",
     "slate": ">=0.43.6"

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -23,7 +23,7 @@
     "type-of": "^2.0.1"
   },
   "peerDependencies": {
-    "immutable": ">=3.8.1"
+    "immutable": ">=3.8.1 || >4.0.0-rc"
   },
   "devDependencies": {
     "slate-dev-test-utils": "^0.0.1",


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?

immutable-4.0.0-rc* shall be allowed.  As @denis-sokolov  pointed out, `>= 3.8.0` do not include `4.0.0-rc`
https://github.com/ianstormtaylor/slate/pull/1869#issuecomment-483283872

#### How does this change work?

Fix as https://github.com/ianstormtaylor/slate/pull/1869#issuecomment-483283872

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
