### PR TITLE
Support decorations without path

### DIFF
--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -125,10 +125,12 @@ class Text extends React.Component {
         start.path != null,
         'No path for the decoration start. Not providing one is deprecated.'
       )
+
       warning(
         end.path != null,
         'No path for the decoration end. Not providing one is deprecated.'
       )
+
       const startPath = start.path || document.assertPath(start.key)
       const endPath = end.path || document.assertPath(end.key)
 

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -118,19 +118,6 @@ class Text extends React.Component {
       if (start.key === end.key) return false
 
       const path = document.assertPath(key)
-
-      // Show warnings and revert to key if no path is provided on `start` or
-      // `end` of decoration.
-      warning(
-        start.path != null,
-        'No path for the decoration start. Not providing one is deprecated.'
-      )
-
-      warning(
-        end.path != null,
-        'No path for the decoration end. Not providing one is deprecated.'
-      )
-
       const startPath = start.path || document.assertPath(start.key)
       const endPath = end.path || document.assertPath(end.key)
 

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -5,7 +5,6 @@ import { PathUtils } from 'slate'
 import React from 'react'
 import SlateTypes from 'slate-prop-types'
 import Types from 'prop-types'
-import warning from 'tiny-warning'
 
 /**
  * Debug.

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -1,11 +1,11 @@
 import Debug from 'debug'
 import ImmutableTypes from 'react-immutable-proptypes'
+import Leaf from './leaf'
+import { PathUtils } from 'slate'
 import React from 'react'
 import SlateTypes from 'slate-prop-types'
 import Types from 'prop-types'
-import { PathUtils } from 'slate'
-
-import Leaf from './leaf'
+import warning from 'tiny-warning'
 
 /**
  * Debug.
@@ -117,12 +117,26 @@ class Text extends React.Component {
       // Otherwise, if the decoration is in a single node, it's not ours.
       if (start.key === end.key) return false
 
-      // If the node's path is before the start path, ignore it.
       const path = document.assertPath(key)
-      if (PathUtils.compare(path, start.path) === -1) return false
+
+      // Show warnings and revert to key if no path is provided on `start` or
+      // `end` of decoration.
+      warning(
+        start.path != null,
+        'No path for the decoration start. Not providing one is deprecated.'
+      )
+      warning(
+        end.path != null,
+        'No path for the decoration end. Not providing one is deprecated.'
+      )
+      const startPath = start.path || document.assertPath(start.key)
+      const endPath = end.path || document.assertPath(end.key)
+
+      // If the node's path is before the start path, ignore it.
+      if (PathUtils.compare(path, startPath) === -1) return false
 
       // If the node's path is after the end path, ignore it.
-      if (PathUtils.compare(path, end.path) === 1) return false
+      if (PathUtils.compare(path, endPath) === 1) return false
 
       // Otherwise, include it.
       return true


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

Helps with
- https://github.com/ianstormtaylor/slate/issues/2319
- https://github.com/ianstormtaylor/slate/issues/2616

#### What's the new behavior?

Instead of throwing on decorations without a path but a key, use the key to generate the path but display a warning. The syntax highlighting example is causing this issue and I had to deep dive to figure out the cause. This warning will let everything still work while giving us the opportunity to figure out the source of the path not being on the decoration.

My guess is that the example used to work but broke at some point when the `path` suddenly was required and the `key` wasn't enough.

#### How does this change work?

If a path is missing on a decoration's `start` or `end` it will provide a warning but will use `document.assertPath` to deriver the path and the editor won't crash. 
#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/2616 https://github.com/ianstormtaylor/slate/issues/2696 https://github.com/ianstormtaylor/slate/issues/2319
Reviewers: @ianstormtaylor 

Note that I don't believe it 100% fixes 2616 or 2319 because those should probably have `path` in them but (a) it stops the crashing and it kinda works again and (b) it helps us provide a safe path to getting syntax highlighting fixed without having crashing editors.