### PR TITLE
Fix syntax highlighting

### DIFF
--- a/examples/code-highlighting/index.js
+++ b/examples/code-highlighting/index.js
@@ -1,7 +1,9 @@
 import { Editor } from 'slate-react'
+import { Value } from 'slate'
+
 import Prism from 'prismjs'
 import React from 'react'
-import { Value } from 'slate'
+
 import initialValueAsJson from './value.json'
 
 /**

--- a/examples/code-highlighting/index.js
+++ b/examples/code-highlighting/index.js
@@ -1,8 +1,7 @@
 import { Editor } from 'slate-react'
-import { Value } from 'slate'
-
 import Prism from 'prismjs'
 import React from 'react'
+import { Value } from 'slate'
 import initialValueAsJson from './value.json'
 
 /**
@@ -183,6 +182,7 @@ class CodeHighlighting extends React.Component {
     const others = next() || []
     if (node.type !== 'code') return others
 
+    const { document } = editor.value
     const language = node.data.get('language')
     const texts = node.getTexts().toArray()
     const string = texts.map(t => t.text).join('\n')
@@ -217,13 +217,18 @@ class CodeHighlighting extends React.Component {
       }
 
       if (typeof token !== 'string') {
+        const startPath = document.assertPath(startText.key)
+        const endPath = document.assertPath(endText.key)
+
         const dec = {
           anchor: {
             key: startText.key,
+            path: startPath,
             offset: startOffset,
           },
           focus: {
             key: endText.key,
+            path: endPath,
             offset: endOffset,
           },
           mark: {

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -125,10 +125,12 @@ class Text extends React.Component {
         start.path != null,
         'No path for the decoration start. Not providing one is deprecated.'
       )
+
       warning(
         end.path != null,
         'No path for the decoration end. Not providing one is deprecated.'
       )
+
       const startPath = start.path || document.assertPath(start.key)
       const endPath = end.path || document.assertPath(end.key)
 

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -1,11 +1,11 @@
 import Debug from 'debug'
 import ImmutableTypes from 'react-immutable-proptypes'
+import Leaf from './leaf'
+import { PathUtils } from 'slate'
 import React from 'react'
 import SlateTypes from 'slate-prop-types'
 import Types from 'prop-types'
-import { PathUtils } from 'slate'
-
-import Leaf from './leaf'
+import warning from 'tiny-warning'
 
 /**
  * Debug.
@@ -117,12 +117,26 @@ class Text extends React.Component {
       // Otherwise, if the decoration is in a single node, it's not ours.
       if (start.key === end.key) return false
 
-      // If the node's path is before the start path, ignore it.
       const path = document.assertPath(key)
-      if (PathUtils.compare(path, start.path) === -1) return false
+
+      // Show warnings and revert to key if no path is provided on `start` or
+      // `end` of decoration.
+      warning(
+        start.path != null,
+        'No path for the decoration start. Not providing one is deprecated.'
+      )
+      warning(
+        end.path != null,
+        'No path for the decoration end. Not providing one is deprecated.'
+      )
+      const startPath = start.path || document.assertPath(start.key)
+      const endPath = end.path || document.assertPath(end.key)
+
+      // If the node's path is before the start path, ignore it.
+      if (PathUtils.compare(path, startPath) === -1) return false
 
       // If the node's path is after the end path, ignore it.
-      if (PathUtils.compare(path, end.path) === 1) return false
+      if (PathUtils.compare(path, endPath) === 1) return false
 
       // Otherwise, include it.
       return true

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -77,14 +77,14 @@ class Text extends React.Component {
     // changed, but it's properties will be exactly the same (eg. copy-paste)
     // which this won't catch. But that's rare and not a drag on performance, so
     // for simplicity we just let them through.
-    if (n.node != p.node) return true
+    if (n.node !== p.node) return true
 
     // If the node parent is a block node, and it was the last child of the
     // block, re-render to cleanup extra `\n`.
-    if (n.parent.object == 'block') {
+    if (n.parent.object === 'block') {
       const pLast = p.parent.nodes.last()
       const nLast = n.parent.nodes.last()
-      if (p.node == pLast && n.node != nLast) return true
+      if (p.node === pLast && n.node !== nLast) return true
     }
 
     // Re-render if the current decorations have changed.

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -1,11 +1,11 @@
 import Debug from 'debug'
 import ImmutableTypes from 'react-immutable-proptypes'
-import Leaf from './leaf'
-import { PathUtils } from 'slate'
 import React from 'react'
 import SlateTypes from 'slate-prop-types'
 import Types from 'prop-types'
-import warning from 'tiny-warning'
+import { PathUtils } from 'slate'
+
+import Leaf from './leaf'
 
 /**
  * Debug.
@@ -77,14 +77,14 @@ class Text extends React.Component {
     // changed, but it's properties will be exactly the same (eg. copy-paste)
     // which this won't catch. But that's rare and not a drag on performance, so
     // for simplicity we just let them through.
-    if (n.node !== p.node) return true
+    if (n.node != p.node) return true
 
     // If the node parent is a block node, and it was the last child of the
     // block, re-render to cleanup extra `\n`.
-    if (n.parent.object === 'block') {
+    if (n.parent.object == 'block') {
       const pLast = p.parent.nodes.last()
       const nLast = n.parent.nodes.last()
-      if (p.node === pLast && n.node !== nLast) return true
+      if (p.node == pLast && n.node != nLast) return true
     }
 
     // Re-render if the current decorations have changed.
@@ -117,28 +117,12 @@ class Text extends React.Component {
       // Otherwise, if the decoration is in a single node, it's not ours.
       if (start.key === end.key) return false
 
-      const path = document.assertPath(key)
-
-      // Show warnings and revert to key if no path is provided on `start` or
-      // `end` of decoration.
-      warning(
-        start.path != null,
-        'No path for the decoration start. Not providing one is deprecated.'
-      )
-
-      warning(
-        end.path != null,
-        'No path for the decoration end. Not providing one is deprecated.'
-      )
-
-      const startPath = start.path || document.assertPath(start.key)
-      const endPath = end.path || document.assertPath(end.key)
-
       // If the node's path is before the start path, ignore it.
-      if (PathUtils.compare(path, startPath) === -1) return false
+      const path = document.assertPath(key)
+      if (PathUtils.compare(path, start.path) === -1) return false
 
       // If the node's path is after the end path, ignore it.
-      if (PathUtils.compare(path, endPath) === 1) return false
+      if (PathUtils.compare(path, end.path) === 1) return false
 
       // Otherwise, include it.
       return true


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix bug in https://github.com/ianstormtaylor/slate/issues/2616 and https://github.com/ianstormtaylor/slate/issues/2319

#### What's the new behavior?

Stops the editor from crashing in syntax highlighting when hitting enter in certain places

#### How does this change work?

Generates a path for each decoration. Previously, we were only passing through the key that seems to work sometimes but not others. This is also referenced in a separate PR I made here https://github.com/ianstormtaylor/slate/pull/2697. Both these PRs improve Slate. This one fixes this bug. The other PR fixes all similar issues and provides a nice warning.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2616 #2319 
Reviewers: @
