### PR TITLE
Add value inspector to composition example

### DIFF
--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -9,6 +9,7 @@ import insert from './insert.js'
 import special from './special.js'
 import { isKeyHotkey } from 'is-hotkey'
 import { Button, Icon, Toolbar } from '../components'
+import { ANDROID_API_VERSION } from 'slate-dev-environment'
 
 /**
  * Define the default node type.
@@ -45,6 +46,13 @@ const Tab = styled(TabLink)`
   padding: 0.25em 0.5em;
   border-radius: 0.25em;
   margin-right: 0.25em;
+`
+
+const Version = styled('div')`
+  float: right;
+  padding: 0.5em;
+  font-size: 75%;
+  color: #808080;
 `
 
 const EditorText = styled('div')`
@@ -190,6 +198,11 @@ class RichTextExample extends React.Component {
                 </Tab>
               )
             })}
+            <Version>
+              {ANDROID_API_VERSION
+                ? `Android API ${ANDROID_API_VERSION}`
+                : null}
+            </Version>
           </Tabs>
           <div>{this.state.text}</div>
         </Instruction>

--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -47,6 +47,34 @@ const Tab = styled(TabLink)`
   margin-right: 0.25em;
 `
 
+const EditorText = styled('div')`
+  color: #808080;
+  background: #f0f0f0;
+  font: 12px monospace;
+  white-space: pre-wrap;
+  margin: 1em -1em;
+  padding: 0.5em;
+  div {
+    margin: 0 0 0.5em;
+  }
+`
+
+const EditorTextCaption = styled('div')`
+  color: white;
+  background: #808080;
+  padding: 0.5em;
+`
+
+/**
+ * Extract lines of text from `Value`
+ *
+ * @return {String[]}
+ */
+
+function getTextLines(value) {
+  return value.document.nodes.map(node => node.text).toArray()
+}
+
 /**
  * Subpages which are each a smoke test.
  *
@@ -145,6 +173,7 @@ class RichTextExample extends React.Component {
   render() {
     const { text } = this.state
     if (text == null) return <Redirect to="/composition/split-join" />
+    const textLines = getTextLines(this.state.value)
     return (
       <div>
         <Instruction>
@@ -186,6 +215,12 @@ class RichTextExample extends React.Component {
           renderNode={this.renderNode}
           renderMark={this.renderMark}
         />
+        <EditorText>
+          <EditorTextCaption>Text in Slate's `Value`</EditorTextCaption>
+          {textLines.map((line, index) => (
+            <div key={index}>{line.length > 0 ? line : ' '}</div>
+          ))}
+        </EditorText>
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "peerDependencies": {
     "slate": "*",
     "slate-dev-benchmark": "*",
+    "slate-dev-environment": "*",
     "slate-dev-test-utils": "*",
     "slate-html-serializer": "*",
     "slate-plain-serializer": "*",


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving examples

#### What's the new behavior?

Adds a text box below the editor in the compositions example that shows the text inside the internal state of Slate. This is important because there can be bugs in compositions where the DOM correctly displays some content but that text has not been reconciled to Slate's internal `Value` yet.

This lets us see what's inside Slate as well as what's in the DOM.

#### How does this change work?

Converts Slate's Value to an array of Strings (one string per top level block) then converts each item into a `div` displayed below the Editor.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
