### PR TITLE
Improve performance on large documents with many nodes

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -162,6 +162,7 @@ class Content extends React.Component {
     const window = getWindow(this.element)
     const native = window.getSelection()
     const { activeElement } = window.document
+
     if (debug.enabled) {
       debug.update('updateSelection', { selection: selection.toJSON() })
     }

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -162,7 +162,9 @@ class Content extends React.Component {
     const window = getWindow(this.element)
     const native = window.getSelection()
     const { activeElement } = window.document
-    debug.update('updateSelection', { selection: selection.toJSON() })
+    if (debug.enabled) {
+      debug.update('updateSelection', { selection: selection.toJSON() })
+    }
 
     // COMPAT: In Firefox, there's a but where `getSelection` can return `null`.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=827585 (2018/11/07)
@@ -274,7 +276,7 @@ class Content extends React.Component {
       })
     }
 
-    if (updated) {
+    if (updated && debug.enabled) {
       debug('updateSelection', { selection, native, activeElement })
       debug.update('updateSelection-applied', { selection })
     }
@@ -483,11 +485,13 @@ class Content extends React.Component {
 
     debug('render', { props })
 
-    debug.update('render', {
-      text: value.document.text,
-      selection: value.selection.toJSON(),
-      value: value.toJSON(),
-    })
+    if (debug.enabled) {
+      debug.update('render', {
+        text: value.document.text,
+        selection: value.selection.toJSON(),
+        value: value.toJSON(),
+      })
+    }
 
     return (
       <Container


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Some debug payloads contain expressions that need to be evaluated, which can be expensive. (for example calling `value.toJSON()` on a large document with many nodes)

This PR makes sure that those payloads are only evaluated if debugging is actually enabled, thereby improving performance in production.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->
#### How does this change work?
We simply call `if (debug.enabled)` before those debug calls. This way, if debugging is indeed disabled, the contained expressions are not needlessly evaluated.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
