### PR TITLE
Fix IME issue when typing Vietnamese

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ packages/*/yarn.lock
 
 # Editor files
 .tern-port
+
+tags*

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -163,14 +163,15 @@ class Content extends React.Component {
     const native = window.getSelection()
     const { activeElement } = window.document
 
-    if (debug.enabled) {
-      debug.update('updateSelection', { selection: selection.toJSON() })
-    }
-
     // COMPAT: In Firefox, there's a but where `getSelection` can return `null`.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=827585 (2018/11/07)
-    if (!native) {
+    // or the IME is turned on and is composing
+    if (!native || editor.isComposing()) {
       return
+    }
+
+    if (debug.enabled) {
+      debug.update('updateSelection', { selection: selection.toJSON() })
     }
 
     const { rangeCount, anchorNode } = native

--- a/packages/slate-react/src/plugins/after.js
+++ b/packages/slate-react/src/plugins/after.js
@@ -643,6 +643,32 @@ function AfterPlugin(options = {}) {
   }
 
   /**
+   * On composition end.
+   *
+   * @param {Event} event
+   * @param {Editor} editor
+   * @param {Function} next
+   */
+
+  function onCompositionEnd(event, editor, next) {
+    debug('onCompositionEnd', { event })
+
+    const { data } = event
+
+    // A reliable way for adding text from IME
+    // For example, when typing Vietnamese if the user finishes a word without
+    // whitespace or enter (no onCompositionEnd yet) and suddenly change the
+    // selection (onCompositionEnd occurred) then no text was inserted, but the
+    // component still displays the text which causes that text to disappear if
+    // the user does other edit commands (text input, bold,...)
+    window.requestAnimationFrame(() => {
+      editor.insertText(data)
+    })
+
+    next()
+  }
+
+  /**
    * Return the plugin.
    *
    * @type {Object}
@@ -664,6 +690,7 @@ function AfterPlugin(options = {}) {
     onMouseUp,
     onPaste,
     onSelect,
+    onCompositionEnd,
   }
 }
 

--- a/packages/slate-react/src/plugins/before.js
+++ b/packages/slate-react/src/plugins/before.js
@@ -33,6 +33,16 @@ function BeforePlugin() {
   let isDragging = false
 
   /**
+   * The before plugin queries.
+   *
+   * @type {Object}
+   */
+
+  const queries = {
+    isComposing: () => isComposing,
+  }
+
+  /**
    * On before input.
    *
    * @param {Event} event
@@ -42,7 +52,7 @@ function BeforePlugin() {
 
   function onBeforeInput(event, editor, next) {
     const isSynthetic = !!event.nativeEvent
-    if (editor.readOnly) return
+    if (editor.readOnly || isComposing) return
 
     // COMPAT: If the browser supports Input Events Level 2, we will have
     // attached a custom handler for the real `beforeinput` events, instead of
@@ -461,6 +471,7 @@ function BeforePlugin() {
    */
 
   return {
+    queries,
     onBeforeInput,
     onBlur,
     onClick,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This is the bug when typing Vietnamese with macOS IME. Please take a look at the following video:

[![Vietnamese typing issue](https://img.youtube.com/vi/-S895BFqg5U/0.jpg)](https://www.youtube.com/watch?v=-S895BFqg5U)

When typing Vietnamese if the user finishes a word without whitespace or enter (no `onCompositionEnd` yet) and suddenly change the selection (`onCompositionEnd` occurred) then no text was inserted, but the view still displays the text which causes that text to disappear if the user does other edit commands (text input, bold,...).

*Note*: to type "tiếng Việt", turn on macOS `Telex` IME then type "tieesng Vieejt".

#### What's the new behavior?

User can input Vietnamese using macOS IME like this:

[![Fix Vietnamese typing issue](https://img.youtube.com/vi/ULCj7H5a_sE/0.jpg)](https://www.youtube.com/watch?v=ULCj7H5a_sE)

#### How does this change work?

Based on @yunwuxin work (fixed the cursor when typing and flashing when IME on) I add one more command `insertText` when `onCompositionEnd` occurred to explicitly sync the text in the view with the editor state.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Based on the work of @yunwuxin in https://github.com/ianstormtaylor/slate/pull/2415
