### PR TITLE
fix selection after pasting inline nodes

### DIFF
--- a/packages/slate/src/commands/with-intent.js
+++ b/packages/slate/src/commands/with-intent.js
@@ -283,13 +283,14 @@ Commands.insertFragment = (editor, fragment) => {
     // these have to be skipped.
     const { nodes } = lastBlock
     const lastIndex = nodes.findLastIndex(
-      node => node && node.object == 'inline'
+      node => node && node.object === 'inline'
     )
     const remainingTexts = nodes.takeLast(nodes.size - lastIndex - 1)
     const remainingTextLength = remainingTexts.reduce(
       (acc, val) => acc + val.text.length,
       0
     )
+    editor.moveToStartOfNode(newText).moveForward(remainingTextLength)
   }
 }
 

--- a/packages/slate/src/commands/with-intent.js
+++ b/packages/slate/src/commands/with-intent.js
@@ -278,7 +278,18 @@ Commands.insertFragment = (editor, fragment) => {
   if (newText && (lastInline || isInserting)) {
     editor.moveToEndOfNode(newText)
   } else if (newText) {
-    editor.moveToStartOfNode(newText).moveForward(lastBlock.text.length)
+    // The position within the last text node needs to be calculated. This is the length
+    // of all text nodes within the last block, but if the last block contains inline nodes,
+    // these have to be skipped.
+    const { nodes } = lastBlock
+    const lastIndex = nodes.findLastIndex(
+      node => node && node.object == 'inline'
+    )
+    const remainingTexts = nodes.takeLast(nodes.size - lastIndex - 1)
+    const remainingTextLength = remainingTexts.reduce(
+      (acc, val) => acc + val.text.length,
+      0
+    )
   }
 }
 

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-inline-node.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-inline-node.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.insertFragment(
+    <document>
+      <paragraph>
+        <text>one</text>
+        <inline type="link">Some inline stuff</inline>
+        <text>two</text>
+      </paragraph>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        A<cursor />B
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        Aone<inline type="link">Some inline stuff</inline>two<cursor />B
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix

#### What's the new behavior?

After pasting a fragment with inline nodes, the selection is moved to the correct postition (after the inserted fragment). See the [Link example](https://www.slatejs.org/#/links).

#### How does this change work?

Skip inline nodes before summing up the length of all text nodes, 

#### Have you checked that...?

* [x ] The new code matches the existing patterns and styles.
* [x ] The tests pass with `yarn test`.
* [x ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2582
Reviewers: @
