### PR TITLE
Text documentation update

### DIFF
--- a/docs/reference/slate/text.md
+++ b/docs/reference/slate/text.md
@@ -11,6 +11,8 @@ A text node in a Slate [`Document`](./document.md). Text nodes are always the bo
 ```js
 Text({
   key: String,
+  text: String,
+  marks: Immutable.List<Mark>,
 })
 ```
 
@@ -20,19 +22,23 @@ Text({
 
 A unique identifier for the node.
 
+### `text`
+
+`String`
+
+The text contents of this node.
+
+### `marks`
+
+`Immutable.List<Mark>,`
+
+A list of marks for this node.
+
 ### `object`
 
 `String`
 
 An immutable string value of `'text'` for easily separating this node from [`Inline`](./inline.md) or [`Block`](./block.md) nodes.
-
-## Computed Properties
-
-### `text`
-
-`String`
-
-A concatenated string of all of the characters in the text node.
 
 ## Static Methods
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Docs

#### What's the new behavior?

Update Text for latest changes. `text` property is no longer computed. Add `marks` field.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

