### PR TITLE
Replace renderNode with renderBlock in the docs

### DIFF
--- a/docs/walkthroughs/defining-custom-block-nodes.md
+++ b/docs/walkthroughs/defining-custom-block-nodes.md
@@ -89,18 +89,18 @@ class App extends React.Component {
 
   render() {
     return (
-      // Pass in the `renderNode` prop...
+      // Pass in the `renderBlock` prop...
       <Editor
         value={this.state.value}
         onChange={this.onChange}
         onKeyDown={this.onKeyDown}
-        renderNode={this.renderNode}
+        renderBlock={this.renderBlock}
       />
     )
   }
 
-  // Add a `renderNode` method to render a `CodeNode` for code blocks.
-  renderNode = (props, editor, next) => {
+  // Add a `renderBlock` method to render a `CodeNode` for code blocks.
+  renderBlock = (props, editor, next) => {
     switch (props.node.type) {
       case 'code':
         return <CodeNode {...props} />
@@ -148,12 +148,12 @@ class App extends React.Component {
         value={this.state.value}
         onChange={this.onChange}
         onKeyDown={this.onKeyDown}
-        renderNode={this.renderNode}
+        renderBlock={this.renderBlock}
       />
     )
   }
 
-  renderNode = (props, editor, next) => {
+  renderBlock = (props, editor, next) => {
     switch (props.node.type) {
       case 'code':
         return <CodeNode {...props} />
@@ -206,12 +206,12 @@ class App extends React.Component {
         value={this.state.value}
         onChange={this.onChange}
         onKeyDown={this.onKeyDown}
-        renderNode={this.renderNode}
+        renderBlock={this.renderBlock}
       />
     )
   }
 
-  renderNode = (props, editor, next) => {
+  renderBlock = (props, editor, next) => {
     switch (props.node.type) {
       case 'code':
         return <CodeNode {...props} />


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This is updating the docs in response to a recent API change.
https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/Changelog.md#0220--may-8-2019

#### What's the new behavior?

No change in behavior, just updating the docs.

There are still some docs that reference `renderNode` and `renderMark`, but I don't know enough about the new API (or event he old one, for that matter!) to make changes to those. It's just that this inconsistency personally tripped me up for awhile while I was going through the docs trying to get a basic example working, and wanted to get the ball rolling on updating the docs.

#### How does this change work?

...

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

No.