### PR TITLE
Destructure texts iterable causing an error on backward shift+arrow selection

### DIFF
--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -552,7 +552,7 @@ function AfterPlugin(options = {}) {
 
     if (Hotkeys.isExtendBackward(event)) {
       const startText = document.getNode(start.path)
-      const prevEntry = document.texts({
+      const [prevEntry] = document.texts({
         path: start.path,
         direction: 'backward',
       })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

As it was intended, error free.

#### How does this change work?

It's pretty easy to understand the fix if you compare the following two (`document.texts`):

https://github.com/ianstormtaylor/slate/blob/a5a25f97dde1de06ef0746e6f5285c04e503351c/packages/slate-react/src/plugins/dom/after.js#L553-L571

https://github.com/ianstormtaylor/slate/blob/a5a25f97dde1de06ef0746e6f5285c04e503351c/packages/slate-react/src/plugins/dom/after.js#L573-L587

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2761
Reviewers: @ianstormtaylor 
