### PR TITLE
Fix leaf memoization bug

### DIFF
--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -201,15 +201,13 @@ Leaf.propTypes = {
 
 const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
   return (
+    next.block === prev.block &&
     next.index === prev.index &&
     next.marks === prev.marks &&
     next.parent === prev.parent &&
-    next.block === prev.block &&
+    next.text === prev.text &&
     next.annotations.equals(prev.annotations) &&
-    next.decorations.equals(prev.decorations) &&
-    // This is necessary for rerendering leaves when only
-    // content changes, e.g first leaf on search highlight.
-    next.text === prev.text
+    next.decorations.equals(prev.decorations)
   )
 })
 

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -206,7 +206,10 @@ const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
     next.parent === prev.parent &&
     next.block === prev.block &&
     next.annotations.equals(prev.annotations) &&
-    next.decorations.equals(prev.decorations)
+    next.decorations.equals(prev.decorations) &&
+    // This is necessary for rerendering leaves when only
+    // content changes, e.g first leaf on search highlight.
+    next.text === prev.text
   )
 })
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

This fix is necessary to ensure leaf re-rendering when only content changes. Good example of that would be Slate search highlighting example. First try the [old version](https://www.slatejs.org/#/search-highlighting) and then netlify deployment below. 

This happens because all the other conditions still pass, only the text content changes. If you search for `h`, previous leaf content was `This is editable text that you can search. As you search, it looks for matching strings of text, and adds "annotation" marks to them in realtime.`, new one is `T`. Everything else is the same, including parent, index `0`, no annotations, etc.

#### How does this change work?

Also compare text content when deciding if to re-render or not.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2767 