### PR TITLE
Remove `leaves` property from text nodes in docs

### DIFF
--- a/docs/walkthroughs/installing-slate.md
+++ b/docs/walkthroughs/installing-slate.md
@@ -41,7 +41,7 @@ const initialValue = Value.fromJSON({
           {
             object: 'text',
             marks: [],
-            text: 'A line of text in a paragraph.', 
+            text: 'A line of text in a paragraph.',
           },
         ],
       },
@@ -68,7 +68,7 @@ const initialValue = Value.fromJSON({
           {
             object: 'text',
             marks: [],
-            text: 'A line of text in a paragraph.', 
+            text: 'A line of text in a paragraph.',
           },
         ],
       },

--- a/docs/walkthroughs/installing-slate.md
+++ b/docs/walkthroughs/installing-slate.md
@@ -40,11 +40,8 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             object: 'text',
-            leaves: [
-              {
-                text: 'A line of text in a paragraph.',
-              },
-            ],
+            marks: [],
+            text: 'A line of text in a paragraph.', 
           },
         ],
       },
@@ -70,11 +67,8 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             object: 'text',
-            leaves: [
-              {
-                text: 'A line of text in a paragraph.',
-              },
-            ],
+            marks: [],
+            text: 'A line of text in a paragraph.', 
           },
         ],
       },


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Not changing any code, just updating the docs based on the [0.46.0](https://github.com/ianstormtaylor/slate/compare/slate@0.46.0...master) release.

Specifically replacing the `leaves` property on text nodes.

#### What's the new behavior?

No new behavior, just updating the docs.

Sorry for opening these PRs piecemeal, I'm just fixing them as I encounter them. If there are any plans to update all of the docs in one go, let me know and I'll hold off on opening any more PRs.

#### How does this change work?

N/A

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

N/A