### PR TITLE
fixing order of blocks if inserted at start of node

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -700,7 +700,7 @@ const getInsertionMode = (editor, range) => {
   const { value } = editor
   const { document } = value
   const { start } = range
-  let startKey = start.key
+  const startKey = start.key
   const startBlock = document.getClosestBlock(startKey)
   const startInline = document.getClosestInline(startKey)
 
@@ -771,6 +771,7 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
       const insertionMode = getInsertionMode(editor, range)
       const nodes =
         insertionMode === 'before' ? fragment.nodes : fragment.nodes.reverse()
+
       nodes.forEach(node => {
         editor.insertBlockAtRange(range, node)
       })

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -661,15 +661,11 @@ Commands.insertBlockAtRange = (editor, range, block) => {
   const startInline = document.getClosestInline(startKey)
   const parent = document.getParent(startBlock.key)
   const index = parent.nodes.indexOf(startBlock)
+  const insertionMode = getInsertionMode(editor, range)
 
-  if (editor.isVoid(startBlock)) {
-    const extra = start.isAtEndOfNode(startBlock) ? 1 : 0
-    editor.insertNodeByKey(parent.key, index + extra, block)
-  } else if (!startInline && startBlock.text === '') {
-    editor.insertNodeByKey(parent.key, index + 1, block)
-  } else if (start.isAtStartOfNode(startBlock)) {
+  if (insertionMode === 'before') {
     editor.insertNodeByKey(parent.key, index, block)
-  } else if (start.isAtEndOfNode(startBlock)) {
+  } else if (insertionMode === 'behind') {
     editor.insertNodeByKey(parent.key, index + 1, block)
   } else {
     if (startInline && editor.isVoid(startInline)) {
@@ -691,6 +687,34 @@ Commands.insertBlockAtRange = (editor, range, block) => {
       editor.insertNodeByKey(parent.key, index + 1, block)
     })
   }
+}
+
+/**
+ * Check if current block should be split or new block should be added before or behind it.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ */
+
+const getInsertionMode = (editor, range) => {
+  const { value } = editor
+  const { document } = value
+  const { start } = range
+  let startKey = start.key
+  const startBlock = document.getClosestBlock(startKey)
+  const startInline = document.getClosestInline(startKey)
+
+  if (editor.isVoid(startBlock)) {
+    if (start.isAtEndOfNode(startBlock)) return 'behind'
+    else return 'before'
+  } else if (!startInline && startBlock.text === '') {
+    return 'behind'
+  } else if (start.isAtStartOfNode(startBlock)) {
+    return 'before'
+  } else if (start.isAtEndOfNode(startBlock)) {
+    return 'behind'
+  }
+  return 'split'
 }
 
 /**
@@ -743,7 +767,11 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
       insertionNode === fragment &&
       (firstChild.hasBlockChildren() || lastChild.hasBlockChildren())
     ) {
-      fragment.nodes.reverse().forEach(node => {
+      // check if reversal is necessary or not
+      const insertionMode = getInsertionMode(editor, range)
+      const nodes =
+        insertionMode === 'before' ? fragment.nodes : fragment.nodes.reverse()
+      nodes.forEach(node => {
         editor.insertBlockAtRange(range, node)
       })
       return

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-end-of-node.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-end-of-node.js
@@ -9,9 +9,7 @@ export default function(editor) {
         <quote>one</quote>
         <quote>two</quote>
       </quote>
-      <paragraph>
-        after quote
-      </paragraph>
+      <paragraph>after quote</paragraph>
     </document>
   )
 }
@@ -29,9 +27,7 @@ export const input = (
 export const output = (
   <value>
     <document>
-      <paragraph>
-        word
-      </paragraph>
+      <paragraph>word</paragraph>
       <quote>
         <quote>one</quote>
         <quote>two</quote>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-end-of-node.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-end-of-node.js
@@ -1,0 +1,44 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.insertFragment(
+    <document>
+      <quote>
+        <quote>one</quote>
+        <quote>two</quote>
+      </quote>
+      <paragraph>
+        after quote
+      </paragraph>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        word<cursor />
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        word
+      </paragraph>
+      <quote>
+        <quote>one</quote>
+        <quote>two</quote>
+      </quote>
+      <paragraph>
+        after quote<cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-start-of-node.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-start-of-node.js
@@ -9,9 +9,7 @@ export default function(editor) {
         <quote>one</quote>
         <quote>two</quote>
       </quote>
-      <paragraph>
-        after quote
-      </paragraph>
+      <paragraph>after quote</paragraph>
     </document>
   )
 }
@@ -36,9 +34,7 @@ export const output = (
       <paragraph>
         after quote<cursor />
       </paragraph>
-      <paragraph>
-        word
-      </paragraph>
+      <paragraph>word</paragraph>
     </document>
   </value>
 )

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-start-of-node.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-nested-blocks-start-of-node.js
@@ -1,0 +1,44 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.insertFragment(
+    <document>
+      <quote>
+        <quote>one</quote>
+        <quote>two</quote>
+      </quote>
+      <paragraph>
+        after quote
+      </paragraph>
+    </document>
+  )
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <quote>
+        <quote>one</quote>
+        <quote>two</quote>
+      </quote>
+      <paragraph>
+        after quote<cursor />
+      </paragraph>
+      <paragraph>
+        word
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bugfix

#### What's the new behavior?

The order of blocks is correct (and not reversed) after pasting in some edge cases

#### How does this change work?

insertBlockAtRange() determines if a block should be added before/behind a block or the block should be splitted. The PR refactors this logic into a separate function `getInsertionMode`, which can be called inside insertFragmentAtRange() to find out whether the blocks should be added in normal or reversed order (to end up in the correct order)

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2771 
Reviewers: @
