### PR TITLE
Gracefully handle null content ref in slate-react findDOMNode query

### DIFF
--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -23,6 +23,10 @@ function QueriesPlugin() {
     path = PathUtils.create(path)
     const content = editor.tmp.contentRef.current
 
+    if (!content) {
+      return null
+    }
+
     if (!path.size) {
       return content.ref.current || null
     }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

Return null instead of raising exception if missing content ref.  I started seeing these intermittently after upgrading to slate-react 0.22.0

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
