### PR TITLE
Fix: prop name

### DIFF
--- a/docs/walkthroughs/saving-and-loading-html-content.md
+++ b/docs/walkthroughs/saving-and-loading-html-content.md
@@ -258,7 +258,7 @@ class App extends React.Component {
         value={this.state.value}
         onChange={this.onChange}
         // Add the ability to render our nodes and marks...
-        renderNode={this.renderNode}
+        renderBlock={this.renderNode}
         renderMark={this.renderMark}
       />
     )


### PR DESCRIPTION
Nodes weren't properly rendering because the Editor was trying to call the function prop renderBlock but instead another called renderNode was passed.