### PR TITLE
Separate out EditorValue component for examples

### DIFF
--- a/examples/components.js
+++ b/examples/components.js
@@ -19,6 +19,43 @@ export const Button = React.forwardRef(
   )
 )
 
+export const EditorValue = React.forwardRef(({ value, ...props }, ref) => {
+  const textLines = value.document.nodes
+    .map(node => node.text)
+    .toArray()
+    .join('\n')
+  return (
+    <div {...props}>
+      <div
+        className={css`
+          margin: 1em 0 0;
+          font-size: 14px;
+          padding: 0.5em 1em;
+          color: #404040;
+          background: #e0e0e0;
+        `}
+      >
+        Slate's value as text
+      </div>
+      <div
+        {...props}
+        className={css`
+          color: #404040;
+          background: #f0f0f0;
+          font: 12px monospace;
+          white-space: pre-wrap;
+          padding: 1em;
+          div {
+            margin: 0 0 0.5em;
+          }
+        `}
+      >
+        {textLines}
+      </div>
+    </div>
+  )
+})
+
 export const Icon = React.forwardRef(({ className, ...props }, ref) => (
   <span
     {...props}

--- a/examples/components.js
+++ b/examples/components.js
@@ -19,42 +19,51 @@ export const Button = React.forwardRef(
   )
 )
 
-export const EditorValue = React.forwardRef(({ value, ...props }, ref) => {
-  const textLines = value.document.nodes
-    .map(node => node.text)
-    .toArray()
-    .join('\n')
-  return (
-    <div {...props}>
+export const EditorValue = React.forwardRef(
+  ({ className, value, ...props }, ref) => {
+    const textLines = value.document.nodes
+      .map(node => node.text)
+      .toArray()
+      .join('\n')
+    return (
       <div
-        className={css`
-          margin: 1em 0 0;
-          font-size: 14px;
-          padding: 0.5em 1em;
-          color: #404040;
-          background: #e0e0e0;
-        `}
-      >
-        Slate's value as text
-      </div>
-      <div
+        ref={ref}
         {...props}
-        className={css`
-          color: #404040;
-          background: #f0f0f0;
-          font: 12px monospace;
-          white-space: pre-wrap;
-          padding: 1em;
-          div {
-            margin: 0 0 0.5em;
-          }
-        `}
+        className={cx(
+          className,
+          css`
+            margin: 30px -20px 0;
+          `
+        )}
       >
-        {textLines}
+        <div
+          className={css`
+            font-size: 14px;
+            padding: 5px 20px;
+            color: #404040;
+            border-top: 2px solid #eeeeee;
+            background: #f8f8f8;
+          `}
+        >
+          Slate's value as text
+        </div>
+        <div
+          className={css`
+            color: #404040;
+            font: 12px monospace;
+            white-space: pre-wrap;
+            padding: 10px 20px;
+            div {
+              margin: 0 0 0.5em;
+            }
+          `}
+        >
+          {textLines}
+        </div>
       </div>
-    </div>
-  )
-})
+    )
+  }
+)
 
 export const Icon = React.forwardRef(({ className, ...props }, ref) => (
   <span

--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -8,7 +8,7 @@ import splitJoin from './split-join.js'
 import insert from './insert.js'
 import special from './special.js'
 import { isKeyHotkey } from 'is-hotkey'
-import { Button, Icon, Toolbar } from '../components'
+import { Button, EditorValue, Icon, Toolbar } from '../components'
 import { ANDROID_API_VERSION } from 'slate-dev-environment'
 
 /**
@@ -72,45 +72,6 @@ const Version = props => (
     `}
   />
 )
-
-const EditorText = props => (
-  <div
-    {...props}
-    className={css`
-      color: #808080;
-      background: #f0f0f0;
-      font: 12px monospace;
-      white-space: pre-wrap;
-      margin: 1em -1em;
-      padding: 0.5em;
-
-      div {
-        margin: 0 0 0.5em;
-      }
-    `}
-  />
-)
-
-const EditorTextCaption = props => (
-  <div
-    {...props}
-    className={css`
-      color: white;
-      background: #808080;
-      padding: 0.5em;
-    `}
-  />
-)
-
-/**
- * Extract lines of text from `Value`
- *
- * @return {String[]}
- */
-
-function getTextLines(value) {
-  return value.document.nodes.map(node => node.text).toArray()
-}
 
 /**
  * Subpages which are each a smoke test.
@@ -210,7 +171,7 @@ class RichTextExample extends React.Component {
   render() {
     const { text } = this.state
     if (text == null) return <Redirect to="/composition/split-join" />
-    const textLines = getTextLines(this.state.value)
+    // const textLines = getTextLines(this.state.value)
     return (
       <div>
         <Instruction>
@@ -257,12 +218,7 @@ class RichTextExample extends React.Component {
           renderBlock={this.renderBlock}
           renderMark={this.renderMark}
         />
-        <EditorText>
-          <EditorTextCaption>Text in Slate's `Value`</EditorTextCaption>
-          {textLines.map((line, index) => (
-            <div key={index}>{line.length > 0 ? line : ' '}</div>
-          ))}
-        </EditorText>
+        <EditorValue value={this.state.value} />
       </div>
     )
   }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement

#### What's the new behavior?

Move the `value` preview into its own component for the examples. Feel like this could be useful in other examples where we need to pay attention to what's inside Slate vs what's being rendered.

#### How does this change work?

Just refactored into a separate examples components and matched the style.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
