### PR TITLE
fix: passing Boolean to non-Boolean attribute

### DIFF
--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -124,7 +124,7 @@ class RichTextExample extends React.Component {
 
     return (
       <Button
-        active={isActive}
+        active={isActive.toString()}
         onMouseDown={event => this.onClickMark(event, type)}
       >
         <Icon>{icon}</Icon>
@@ -154,7 +154,7 @@ class RichTextExample extends React.Component {
 
     return (
       <Button
-        active={isActive}
+        active={isActive.toString()}
         onMouseDown={event => this.onClickBlock(event, type)}
       >
         <Icon>{icon}</Icon>


### PR DESCRIPTION
This fixes a console warning caused by passing a Boolean to a non-Boolean attribute `'active'` from the DOM element `button`. The attribute expects a string containing `'true'` or `'false'`;

```
Warning: Received `false` for a non-boolean attribute `active`.

If you want to write it to the DOM, pass a string instead: active="false" or active={value.toString()}.

If you used to conditionally omit it with active={condition && value}, pass active={condition ? value : undefined} instead.
```