### PR TITLE
Fix findPoint with annotations

### DIFF
--- a/packages/slate-react/src/constants/selectors.js
+++ b/packages/slate-react/src/constants/selectors.js
@@ -17,4 +17,5 @@ export default {
   TEXT: `[${DATA_ATTRS.OBJECT}="text"]`,
   VOID: `[${DATA_ATTRS.VOID}]`,
   ZERO_WIDTH: `[${DATA_ATTRS.ZERO_WIDTH}]`,
+  ANNOTATION: `[${DATA_ATTRS.OBJECT}="annotation"]`,
 }

--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -309,9 +309,12 @@ function QueriesPlugin() {
       range.setStart(textNode, 0)
       range.setEnd(nearestNode, nearestOffset)
       const contents = range.cloneContents()
-      const zeroWidths = contents.querySelectorAll(SELECTORS.ZERO_WIDTH)
+      const utilityNodes = contents.querySelectorAll([
+        SELECTORS.ZERO_WIDTH,
+        SELECTORS.ANNOTATION,
+      ])
 
-      Array.from(zeroWidths).forEach(el => {
+      Array.from(utilityNodes).forEach(el => {
         el.parentNode.removeChild(el)
       })
 

--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -311,7 +311,7 @@ function QueriesPlugin() {
       const contents = range.cloneContents()
       const utilityNodes = contents.querySelectorAll([
         SELECTORS.ZERO_WIDTH,
-        SELECTORS.ANNOTATION,
+        `${SELECTORS.ANNOTATION} *:not(${SELECTORS.STRING})`,
       ])
 
       Array.from(utilityNodes).forEach(el => {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug. Current selection behavior with annotations present:
![](https://user-images.githubusercontent.com/8127927/58077874-b9e71a80-7bad-11e9-9351-431bd857107b.gif)

What the `findPoint` code does in this scenario is roughly this:
```js
const range = window.document.createRange()
range.setStart(textNode, 0)
range.setEnd(nearestNode, nearestOffset)
const contents = range.cloneContents()
offset = contents.textContent.length
```
now, the `contents` contain annotation's DOM nodes and any text rendered inside them is included in the `offset`. But this offset is being calculated for Slate's internal offset on a text node inside `value.document` which has no knowledge of annotations. So the offset is wrong and fallbacks to select the end of the block.

#### What's the new behavior?
![](https://user-images.githubusercontent.com/8127927/58077944-e13de780-7bad-11e9-93e5-04667df793d0.gif)
If we remove the annotations DOM nodes before the `contents.textContent.length` runs. The offset is calculated correctly and selection works as expected.

#### How does this change work?
Doesn't consider annotations DOM nodes when calculating native selection offset.

To elaborate more on the ugly selector:
```js
${SELECTORS.ANNOTATION} *:not(${SELECTORS.STRING})
```
this is necessary because of how annotations render. They render **around** `document` nodes. We need to have those to calculate the correct `offset` but we need to get rid of everything else that came out of `renderAnnotation`. This selector does exactly that. Select everything inside an annotation DOM node that is not coming from `document`. There might probably be some cleaner way to make this distinction?

#### Have you checked that...?
* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
Fixes an issue where Slate would fail to reconcile the native selection with internal selection because of annotation DOM nodes.

Reviewers: @ianstormtaylor 
