### PR TITLE
Allow deleteAtRange with a zero-length range on the first character

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -114,7 +114,8 @@ Commands.deleteAtRange = (editor, range) => {
     endOffset === 0 &&
     isStartVoid === false &&
     startKey === startBlock.getFirstText().key &&
-    endKey === endBlock.getFirstText().key
+    endKey === endBlock.getFirstText().key &&
+    startKey !== endKey
 
   // If it's a hanging selection, nudge it back to end in the previous text.
   if (isHanging && isEndVoid) {

--- a/packages/slate/test/commands/at-current-range/delete/first-position.js
+++ b/packages/slate/test/commands/at-current-range/delete/first-position.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.delete()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+        word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+        word
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION

#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a bug.

#### What's the new behavior?

Calling `deleteAtRange` with a collapsed selection at the beginning of a text node will both null out the selection and delete the entire text node.

#### How does this change work?

deleteAtRange will consider a zero-length range on the first character of a text node as a hanging selection, which is incorrect. This should not be considered hanging.

Note: It's still possible to hit the [`startKey === endKey && isHanging`](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/commands/at-range.js#L166) conditional if endKey is in a void node, since we will bump the selection to the previous node and update endKey (but then endOffset is no longer 0, so it's not _really_ hanging anymore). We have an existing test for that, and it still passes after this change. 

I thought this was cleaner than recalculating `isHanging` after bumping `endKey` / `endOffset`, since we'd still want to delete the entire text node in that case.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2783