### PR TITLE
Reconcile node

### DIFF
--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -6,21 +6,20 @@
 
 function CommandsPlugin() {
   /**
-   * reconcileDOMNode takes text from inside the `domNode` and uses it to set
-   * the text inside the matching `node` in Slate.
+   * Takes a `node`, find the matching `domNode` and uses it to set the text
+   * in the `node`.
    *
-   * @param {Window} window
    * @param {Editor} editor
-   * @param {Node} domNode
+   * @param {Node} node
    */
 
-  function reconcileDOMNode(editor, domNode) {
+  function reconcileNode(editor, node) {
     const { value } = editor
     const { document, selection } = value
-    const domElement = domNode.parentElement.closest('[data-key]')
-    const point = editor.findPoint(domElement, 0)
-    const node = document.getDescendant(point.path)
-    const block = document.getClosestBlock(point.path)
+    const path = node.path || document.getPath(node.key)
+
+    const domElement = editor.findDOMNode(path)
+    const block = document.getClosestBlock(path)
 
     // Get text information
     const { text } = node
@@ -39,9 +38,7 @@ function CommandsPlugin() {
     // If the text is no different, abort.
     if (text === domText) return
 
-    let entire = selection
-      .moveAnchorTo(point.path, 0)
-      .moveFocusTo(point.path, text.length)
+    let entire = selection.moveAnchorTo(path, 0).moveFocusTo(path, text.length)
 
     entire = document.resolveRange(entire)
 
@@ -50,8 +47,26 @@ function CommandsPlugin() {
     return
   }
 
+  /**
+   * Takes text from the `domNode` and uses it to set the text in the matching
+   * `node` in Slate.
+   *
+   * @param {Window} window
+   * @param {Editor} editor
+   * @param {DOMNode} domNode
+   */
+
+  function reconcileDOMNode(editor, domNode) {
+    const { value } = editor
+    const { document, selection } = value
+    const domElement = domNode.parentElement.closest('[data-key]')
+    const node = editor.findNode(domElement)
+    editor.reconcileNode(node)
+  }
+
   return {
     commands: {
+      reconcileNode,
       reconcileDOMNode,
     },
   }

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -16,7 +16,7 @@ function CommandsPlugin() {
   function reconcileNode(editor, node) {
     const { value } = editor
     const { document, selection } = value
-    const path = node.path || document.getPath(node.key)
+    const path = document.getPath(node.key)
 
     const domElement = editor.findDOMNode(path)
     const block = document.getClosestBlock(path)

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -51,14 +51,11 @@ function CommandsPlugin() {
    * Takes text from the `domNode` and uses it to set the text in the matching
    * `node` in Slate.
    *
-   * @param {Window} window
    * @param {Editor} editor
    * @param {DOMNode} domNode
    */
 
   function reconcileDOMNode(editor, domNode) {
-    const { value } = editor
-    const { document, selection } = value
     const domElement = domNode.parentElement.closest('[data-key]')
     const node = editor.findNode(domElement)
     editor.reconcileNode(node)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Add a feature

#### What's the new behavior?

Add a `reconcileNode` method that uses a Slate node instead of a DOM node to reconcile.

#### How does this change work?

It's pretty straightforward to understand.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
