### PR TITLE
Add noop plugin

### DIFF
--- a/packages/slate-react/src/plugins/debug/noop.js
+++ b/packages/slate-react/src/plugins/debug/noop.js
@@ -1,0 +1,41 @@
+import EVENT_HANDLERS from '../../constants/event-handlers'
+
+/**
+ * A plugin immediately after any Debug plugins that prevents events from
+ * going any further.
+ *
+ * The purpose is to see how the editor events and mutations behave without
+ * the noise of the editor also adding its own events and mutations.
+ *
+ * @return {Object}
+ */
+
+function NoopPlugin() {
+  /**
+   * Plugin Object
+   *
+   * @type {Object}
+   */
+
+  const plugin = {}
+
+  for (const eventName of EVENT_HANDLERS) {
+    plugin[eventName] = function(event, editor, next) {}
+  }
+
+  /**
+   * Return the plugin.
+   *
+   * @type {Object}
+   */
+
+  return plugin
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default NoopPlugin

--- a/packages/slate-react/src/plugins/react/index.js
+++ b/packages/slate-react/src/plugins/react/index.js
@@ -9,6 +9,7 @@ import DOMPlugin from '../dom'
 import RestoreDOMPlugin from './restore-dom'
 import DebugEventsPlugin from '../debug/debug-events'
 import DebugBatchEventsPlugin from '../debug/debug-batch-events'
+import NoopPlugin from '../debug/noop'
 
 /**
  * A plugin that adds the React-specific rendering logic to the editor.
@@ -25,6 +26,7 @@ function ReactPlugin(options = {}) {
   const debugBatchEventsPlugin = Debug.enabled('slate:batch-events')
     ? DebugBatchEventsPlugin(options)
     : null
+  const noopPlugin = Debug.enabled('slate:noop') ? NoopPlugin(options) : null
   const renderingPlugin = RenderingPlugin(options)
   const commandsPlugin = CommandsPlugin(options)
   const queriesPlugin = QueriesPlugin(options)
@@ -45,6 +47,7 @@ function ReactPlugin(options = {}) {
   return [
     debugEventsPlugin,
     debugBatchEventsPlugin,
+    noopPlugin,
     domPlugin,
     restoreDomPlugin,
     placeholderPlugin,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

There is know way to know how the browser behaves natively within the context of Slate's DOM.

The `noop` plugin which is enabled by adding debug to localStorage (like all other debug) with a value of `slate:noop`.

All of the debug plugins will run before `noop` Plugin but after that, all the events aren't passed through the rest of Slate's stack. This means Slate's `value` is never updated and the Editor is never re-rendered.

#### How does this change work?

The plugin simple doesn't call `next` on any of the `EVENT_HANDLERS` defined for Slate.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
