### PR TITLE
Fix mark toggle bugs

### DIFF
--- a/docs/reference/slate/commands.md
+++ b/docs/reference/slate/commands.md
@@ -426,7 +426,7 @@ Insert a [`Fragment`](./fragment.md) at `index` inside a parent [`Node`](./node.
 `insertTextByKey(key: String, offset: Number, text: String, [marks: Set]) => Editor`
 `insertTextByPath(path: List, offset: Number, text: String, [marks: Set]) => Editor`
 
-Insert `text` at an `offset` in a [`Text Node`](./text.md) by its `key` with optional `marks`.
+Insert `text` at an `offset` in a [`Text Node`](./text.md) by its `key` with optional `marks`. [`Text Node`](./text.md) marks apply to inserted `text`, you can avoid that by passing empty `Set` as `marks`.
 
 ### `mergeNodeByKey/Path`
 

--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -158,6 +158,7 @@ Commands.insertTextByPath = (editor, path, offset, text, marks) => {
       if (node.marks.size > markSet.size) {
         const remove = node.marks.subtract(markSet)
         editor.removeMarksByPath(path, offset, text.length, remove)
+        return
       }
 
       // If equal sizes but not equal marks, marks were added.

--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -40,18 +40,17 @@ Commands.addMarksByPath = (editor, path, offset, length, marks) => {
   const node = document.assertNode(path)
 
   editor.withoutNormalizing(() => {
-    // If it ends before the end of the node, we'll need to split to create a new
-    // text with different marks.
+    // If it ends before the end of the node, we'll need to
+    // split to create a new text with different marks.
     if (offset + length < node.text.length) {
       editor.splitNodeByPath(path, offset + length)
     }
 
-    // Same thing if it starts after the start. But in that case, we need to
-    // update our path and offset to point to the new start.
+    // Same thing if it starts after the start. But in that case, we
+    // need to update our path and offset to point to the new start.
     if (offset > 0) {
       editor.splitNodeByPath(path, offset)
       path = PathUtils.increment(path)
-      offset = 0
     }
 
     marks.forEach(mark => {
@@ -148,21 +147,15 @@ Commands.insertTextByPath = (editor, path, offset, text, marks) => {
       if (offset > 0) {
         editor.splitNodeByPath(path, offset)
         path = PathUtils.increment(path)
-        offset = 0
       }
 
       // Remove all marks from Text node that was created by splitting.
       // TODO: diff old and new marks and only remove/add based on that.
+      // Not sure if more performant, hints: Set.subtract(), Set.intersect().
       editor.removeAllMarksByPath(path)
 
       if (marks.size) {
-        marks.forEach(mark => {
-          editor.applyOperation({
-            type: 'add_mark',
-            path,
-            mark,
-          })
-        })
+        editor.addMarksByPath(path, 0, text.length, marks)
       }
     }
   })
@@ -260,26 +253,23 @@ Commands.removeMarksByPath = (editor, path, offset, length, marks) => {
   const node = document.assertNode(path)
 
   editor.withoutNormalizing(() => {
-    // If it ends before the end of the node, we'll need to split to create a new
-    // text with different marks.
+    // If it ends before the end of the node, we'll need to
+    // split to create a new text with different marks.
     if (offset + length < node.text.length) {
       editor.splitNodeByPath(path, offset + length)
     }
 
-    // Same thing if it starts after the start. But in that case, we need to
-    // update our path and offset to point to the new start.
+    // Same thing if it starts after the start. But in that case, we
+    // need to update our path and offset to point to the new start.
     if (offset > 0) {
       editor.splitNodeByPath(path, offset)
       path = PathUtils.increment(path)
-      offset = 0
     }
 
     marks.forEach(mark => {
       editor.applyOperation({
         type: 'remove_mark',
         path,
-        offset,
-        length,
         mark,
       })
     })
@@ -450,7 +440,6 @@ Commands.setMarkByPath = (
     if (offset > 0) {
       editor.splitNodeByPath(path, offset)
       path = PathUtils.increment(path)
-      offset = 0
     }
 
     editor.applyOperation({

--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -106,7 +106,9 @@ Commands.insertNodeByPath = (editor, path, index, node) => {
  */
 
 Commands.insertTextByPath = (editor, path, offset, text, marks) => {
-  marks = Mark.createSet(marks)
+  // `marks` and `markSet` are different variables because we
+  // allow empty `marks` Set in order to insert text without any marks.
+  const markSet = Mark.createSet(marks)
   const { value } = editor
   const { annotations, document } = value
   const node = document.assertNode(path)
@@ -139,7 +141,7 @@ Commands.insertTextByPath = (editor, path, offset, text, marks) => {
       text,
     })
 
-    if (!node.marks.equals(marks)) {
+    if (!node.marks.equals(markSet)) {
       if (offset + text.length < node.text.length) {
         editor.splitNodeByPath(path, offset + text.length)
       }
@@ -149,13 +151,14 @@ Commands.insertTextByPath = (editor, path, offset, text, marks) => {
         path = PathUtils.increment(path)
       }
 
-      // Remove all marks from Text node that was created by splitting.
-      // TODO: diff old and new marks and only remove/add based on that.
-      // Not sure if more performant, hints: Set.subtract(), Set.intersect().
-      editor.removeAllMarksByPath(path)
+      if (marks) {
+        // TODO: diff old and new marks and only remove/add based on that.
+        // Not sure if >performant, hints: Set.subtract(), Set.intersect().
+        editor.removeAllMarksByPath(path)
 
-      if (marks.size) {
-        editor.addMarksByPath(path, 0, text.length, marks)
+        if (markSet.size > 0) {
+          editor.addMarksByPath(path, 0, text.length, markSet)
+        }
       }
     }
   })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug fix. Most mark related commands are broken (e.g `toggleMark`, `insertText*`, etc) because `insertTextByPath` fails to split node and remove marks in most situations.

#### What's the new behavior?

When text is inserted into node and they have different marks (current node marks _vs_ inserted text marks), node is correctly split and marks are applied to new node.

```jsx
// Starting state
<paragraph>
  <text marks=["bold", "italic"]>
    Hello Worl<selection marks=["bold", "italic"] />
  </text>
</paragraph> 

// Bold and Italic are disabled and character "d" is insterted

// Current Slate
<paragraph>
  <text marks=["bold", "italic"]>
    Hello World<selection marks=[] />
  </text>
</paragraph> 

// After this PR
<paragraph>
  <text marks=["bold", "italic"]>
    Hello Worl
  </text>
  <text marks=[]>
    d<selection marks=[] />
  </text>
</paragraph> 
```

#### How does this change work?

Currently `insertTextByPath` invokes `addMarksByPath` only when marks are provided.

If no marks are provided (optional argument) and text is inserted into node with marks, `addMarksByPath` isn't invoked, node doesn't get split and characters are inserted into same node. Additionally command fails in many other scenarios if you combine more than one type of marks.

Even worse, it's usually unclear which marks to add or remove because `marks` doesn't carry that information. Fortunately I found a way without changing command or marks signature.

---

Compare current Text node marks and incoming marks argument:

* if equal, don't do anything, marks stay the same
* if not equal
  * if incoming marks is empty Set, remove all marks (a way to enforce mark-less text)
  * if incoming marks have more entries than node marks, add difference marks
  * if node marks have more entries than incoming marks, remove difference marks
  * if same amount of marks but different types, add incoming marks

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2736 