### PR TITLE
Fix placeholder not rendering

### DIFF
--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -70,10 +70,10 @@ function SlateReactPlaceholder(options = {}) {
    * @return {Element}
    */
 
-  function renderMark(props, editor, next) {
-    const { children, mark } = props
+  function renderDecoration(props, editor, next) {
+    const { children, decoration: deco } = props
 
-    if (mark.type === 'placeholder' && mark.data.get('key') === instanceId) {
+    if (deco.type === 'placeholder' && deco.data.get('key') === instanceId) {
       const placeHolderStyle = {
         pointerEvents: 'none',
         display: 'inline-block',
@@ -103,7 +103,7 @@ function SlateReactPlaceholder(options = {}) {
    * @return {Object}
    */
 
-  return { decorateNode, renderMark }
+  return { decorateNode, renderDecoration }
 }
 
 /**

--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -186,15 +186,15 @@ class Text extends Record(DEFAULTS) {
           const offset = o
           o += length
 
-          // If the range starts after the leaf, or ends before it, continue.
-          if (start.offset > offset + length || end.offset <= offset) {
+          // If the range encompases the entire leaf, add the format.
+          if (start.offset <= offset && end.offset >= offset + length) {
+            leaf[kind].push(format)
             next.push(leaf)
             continue
           }
 
-          // If the range encompases the entire leaf, add the format.
-          if (start.offset <= offset && end.offset >= offset + length) {
-            leaf[kind].push(format)
+          // If the range starts after the leaf, or ends before it, continue.
+          if (start.offset > offset + length || end.offset <= offset) {
             next.push(leaf)
             continue
           }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fix bug.

#### What's the new behavior?

If decoration/annotation has both start and end offsets `0` and leaf content length is `0`, decoration/annotation is still added to leaf. 

This makes possible to add decoration/annotation that is content in itself, versus decorating the content that's in leaf. This fixes a bug where placeholder was not added to leaf and was not rendered.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2760 
Reviewers: @ianstormtaylor 
