### PR TITLE
Add div to editor as editor.el

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -112,6 +112,17 @@ class Content extends React.Component {
   ref = React.createRef()
 
   /**
+   * Set both `this.ref` and `editor.el`
+   *
+   * @type {DOMElement}
+   */
+
+  setRef = el => {
+    this.ref.current = el
+    this.props.editor.el = el
+  }
+
+  /**
    * Create a set of bound event handlers.
    *
    * @type {Object}
@@ -506,7 +517,7 @@ class Content extends React.Component {
         key={this.props.contentKey}
         {...handlers}
         {...data}
-        ref={this.ref}
+        ref={this.setRef}
         contentEditable={readOnly ? null : true}
         suppressContentEditableWarning
         id={id}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

As per https://github.com/ianstormtaylor/slate/issues/2548 this PR adds the editor's DOM element to the `editor` object.

#### How does this change work?

`content.js` uses a `ref` prop with `this.ref` which was a `React.createRef()` in order for other methods like `updateSelection` to access the DOM element within `content.js` itself.

I switched the `ref` prop to `this.setRef`.

Within `this.setRef`, I set both `this.ref.current` and `editor.el` to the DOM element.

This maintains backwards compatibility but adds the `editor.el` property.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2548
Reviewers: @
