### PR TITLE
Add editor to plugin options

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -219,6 +219,7 @@ class Editor extends React.Component {
       this.tmp.resolves++
       const react = ReactPlugin({
         ...this.props,
+        editor: this,
         value: this.props.value || this.state.value,
       })
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

Make the `editor` available to plugins

#### How does this change work?

Passes the `editor` object to plugins through the call to `ReactPlugin({ ..., editor: this })`

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
