### PR TITLE
Fix mark removal at the edges of text nodes

### DIFF
--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -106,10 +106,10 @@ Commands.insertNodeByPath = (editor, path, index, node) => {
  * @param {Set<Mark>} marks (optional)
  */
 
-Commands.insertTextByPath = (editor, path, offset, text, marks) => {
-  marks = Mark.createSet(marks)
+Commands.insertTextByPath = (editor, path, offset, text, marksArg) => {
   const { value } = editor
   const { annotations, document } = value
+  const marks = Mark.createSet(marksArg)
   document.assertNode(path)
 
   editor.withoutNormalizing(() => {
@@ -140,8 +140,12 @@ Commands.insertTextByPath = (editor, path, offset, text, marks) => {
       text,
     })
 
+    // If there are marks, add them. If an empty Set is explicitly passed in,
+    // the intent is to insert text with no marks.
     if (marks.size) {
       editor.addMarksByPath(path, offset, text.length, marks)
+    } else if (marksArg && marks.size === 0) {
+      editor.removeAllMarksByPath(path, offset, text.length)
     }
   })
 }
@@ -269,16 +273,23 @@ Commands.removeMarksByPath = (editor, path, offset, length, marks) => {
  *
  * @param {Editor} editor
  * @param {Array} path
+ * @param {Number} offset (optional)
+ * @param {Number} length (optional)
  */
 
-Commands.removeAllMarksByPath = (editor, path) => {
-  const { state } = editor
-  const { document } = state
+Commands.removeAllMarksByPath = (editor, path, offset, length) => {
+  const { value } = editor
+  const { document } = value
   const node = document.assertNode(path)
 
   editor.withoutNormalizing(() => {
     if (node.object === 'text') {
-      editor.removeMarksByPath(path, 0, node.text.length, node.marks)
+      editor.removeMarksByPath(
+        path,
+        offset || 0,
+        length || node.text.length,
+        node.marks
+      )
       return
     }
 

--- a/packages/slate/src/commands/with-intent.js
+++ b/packages/slate/src/commands/with-intent.js
@@ -323,7 +323,12 @@ Commands.insertInline = (editor, inline) => {
  */
 
 Commands.insertText = (editor, text, marks) => {
-  deleteExpanded(editor)
+  // If no marks are received and the selection is expanded, apply marks from
+  // the replaced text to the inserted text.
+  if (editor.value.selection.isExpanded && (!marks || !marks.size)) {
+    marks = editor.value.document.getInsertMarksAtRange(editor.value.selection)
+    deleteExpanded(editor)
+  }
 
   const { value } = editor
   const { document, selection } = value

--- a/packages/slate/test/commands/at-current-range/delete-backward/only-character-with-mark.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/only-character-with-mark.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.deleteBackward()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          a<cursor />
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/toggle-mark/remove-collapsed-selection-after-mark.js
+++ b/packages/slate/test/commands/at-current-range/toggle-mark/remove-collapsed-selection-after-mark.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.toggleMark('bold').insertText('s')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          word<cursor />
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>word</b>s<cursor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/toggle-mark/remove-collapsed-selection-beginning-after-mark.js
+++ b/packages/slate/test/commands/at-current-range/toggle-mark/remove-collapsed-selection-beginning-after-mark.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.toggleMark('bold').insertText('a')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          <cursor />word
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        a<b>
+          <cursor />word
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/toggle-mark/remove-middle-collapsed-selection.js
+++ b/packages/slate/test/commands/at-current-range/toggle-mark/remove-middle-collapsed-selection.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.toggleMark('bold').insertText('s')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          wo<cursor />rd
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>wo</b>
+        s<cursor />
+        <b>rd</b>
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/toggle-mark/remove-some-collapsed-selection.js
+++ b/packages/slate/test/commands/at-current-range/toggle-mark/remove-some-collapsed-selection.js
@@ -1,0 +1,43 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.toggleMark('bold').insertText('s')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          <i>
+            wo<cursor />rd
+          </i>
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          <i>
+            wo
+          </i>
+        </b>
+        <i>
+          s<cursor />
+        </i>
+        <b>
+          <i>
+            rd
+          </i>
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bugfix

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Toggling a mark off at the end of a text node and then continuing typing currently results in the mark becoming active again. This can also result in an empty editor with active marks, which can only be removed by selecting marked text and then toggling marks off.

This fix restores the original behavior.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

- Previously a set of marks could be passed to `insertTextByPath` for inclusion, but there was no way to ensure that _no_ marks were used, as an empty set was ignored. With this change, an empty set passed as the `marks` arg ensures that no marks are applied to the inserted text.
- `removeAllMarksByPath`, a currently unused and undocumented command, now has an extended signature to support the new behavior in `insertTextByPath`, optionally accepting an offset and text length so that marks can be removed at certain points within a node rather than from the entire node.
- `insertText`, as a higher level abstraction, will override this new behavior in `insertTextByPath` by giving preference to the marks collected from the selection, if any, as is this is the generally expected outcome as evidenced by Slate's tests.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->



#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2736
