### PR TITLE
Second attempt at Debug Mutations

### DIFF
--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -39,6 +39,7 @@ const MUTATION_PROPERTIES = [
  */
 
 function DebugMutationsPlugin({ editor }) {
+  console.log('DebugMutationsPlugin', { editor })
   const observer = new window.MutationObserver(mutations => {
     const array = Array.from(mutations).map(mutationRecord => {
       const object = {}

--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -52,6 +52,9 @@ function DebugMutationsPlugin({ editor }) {
 
       return object
     })
+
+    // The first argument must not be the array as `debug` renders the first
+    // argument in a different way than the rest
     debug(`${array.length} Mutations`, ...array)
   })
 

--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -39,7 +39,6 @@ const MUTATION_PROPERTIES = [
  */
 
 function DebugMutationsPlugin({ editor }) {
-  console.log('DebugMutationsPlugin', { editor })
   const observer = new window.MutationObserver(mutations => {
     const array = Array.from(mutations).map(mutationRecord => {
       const object = {}
@@ -53,7 +52,7 @@ function DebugMutationsPlugin({ editor }) {
 
       return object
     })
-    debug(...array)
+    debug(`${array.length} Mutations`, ...array)
   })
 
   // `findDOMNode` does not exist until later so we use `setTimeout`

--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -43,6 +43,8 @@ function DebugMutationsPlugin({ editor }) {
     const array = Array.from(mutations).map(mutationRecord => {
       const object = {}
 
+      // Only add properties that provide meaningful values to the object
+      // to make the debug info easier to read
       MUTATION_PROPERTIES.forEach(key => {
         const value = mutationRecord[key]
         if (value == null) return

--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -1,0 +1,65 @@
+import Debug from 'debug'
+
+const debug = Debug('slate:mutations')
+
+/**
+ * Properties on a MutationRecord
+ *
+ * @type {Object}
+ */
+
+const MUTATION_PROPERTIES = [
+  'type',
+  'oldValue',
+  'target',
+  'addedNodes',
+  'removedNodes',
+  'attributeName',
+  'attributeNamespace',
+  'nextSibling',
+  'previousSibling',
+]
+
+/**
+ * A plugin that sends short easy to digest debug info about each dom mutation
+ * to browser.
+ *
+ * More information about mutations here:
+ *
+ * <https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver>
+ * <https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord>
+ *
+ * @param {Object} options
+ */
+
+function DebugMutationsPlugin({ __editor__ }) {
+  const observer = new window.MutationObserver(function(mutations) {
+    const array = Array.from(mutations).map(mutationRecord => {
+      const object = {}
+
+      MUTATION_PROPERTIES.forEach(key => {
+        const value = mutationRecord[key]
+        if (value == null) return
+        if (value instanceof window.NodeList && value.length === 0) return
+        object[key] = value
+      })
+
+      return object
+    })
+    debug(...array)
+  })
+
+  // `findDOMNode` does not exist until later so we use `setTimeout`
+  setTimeout(() => {
+    const rootEl = __editor__.findDOMNode([])
+    observer.observe(rootEl, {
+      childList: true,
+      characterData: true,
+      attributes: true,
+      subtree: true,
+      characterDataOldValue: true,
+    })
+  })
+}
+
+export default DebugMutationsPlugin

--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -1,5 +1,11 @@
 import Debug from 'debug'
 
+/**
+ * Debug mutations function.
+ *
+ * @type {Function}
+ */
+
 const debug = Debug('slate:mutations')
 
 /**
@@ -32,8 +38,8 @@ const MUTATION_PROPERTIES = [
  * @param {Object} options
  */
 
-function DebugMutationsPlugin({ __editor__ }) {
-  const observer = new window.MutationObserver(function(mutations) {
+function DebugMutationsPlugin({ editor }) {
+  const observer = new window.MutationObserver(mutations => {
     const array = Array.from(mutations).map(mutationRecord => {
       const object = {}
 
@@ -51,7 +57,8 @@ function DebugMutationsPlugin({ __editor__ }) {
 
   // `findDOMNode` does not exist until later so we use `setTimeout`
   setTimeout(() => {
-    const rootEl = __editor__.findDOMNode([])
+    const rootEl = editor.findDOMNode([])
+
     observer.observe(rootEl, {
       childList: true,
       characterData: true,

--- a/packages/slate-react/src/plugins/react/index.js
+++ b/packages/slate-react/src/plugins/react/index.js
@@ -9,6 +9,7 @@ import DOMPlugin from '../dom'
 import RestoreDOMPlugin from './restore-dom'
 import DebugEventsPlugin from '../debug/debug-events'
 import DebugBatchEventsPlugin from '../debug/debug-batch-events'
+import DebugMutationsPlugin from '../debug/debug-mutations'
 
 /**
  * A plugin that adds the React-specific rendering logic to the editor.
@@ -24,6 +25,9 @@ function ReactPlugin(options = {}) {
     : null
   const debugBatchEventsPlugin = Debug.enabled('slate:batch-events')
     ? DebugBatchEventsPlugin(options)
+    : null
+  const debugMutationsPlugin = Debug.enabled('slate:mutations')
+    ? DebugMutationsPlugin(options)
     : null
   const renderingPlugin = RenderingPlugin(options)
   const commandsPlugin = CommandsPlugin(options)
@@ -45,6 +49,7 @@ function ReactPlugin(options = {}) {
   return [
     debugEventsPlugin,
     debugBatchEventsPlugin,
+    debugMutationsPlugin,
     domPlugin,
     restoreDomPlugin,
     placeholderPlugin,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Add a feature

#### What's the new behavior?

Same as earlier it allows developers to see mutations using `MutationObserver` in the context of Slate's DOM.

#### How does this change work?

Add a MutationObserver. This implements all the recommendations from Ian to clean up the code.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
