### PR TITLE
Add noop plugin as detached plugin

### DIFF
--- a/packages/slate-react/src/plugins/debug/noop.js
+++ b/packages/slate-react/src/plugins/debug/noop.js
@@ -1,0 +1,45 @@
+import EVENT_HANDLERS from '../../constants/event-handlers'
+
+/**
+ * This plugin prevents events from going any further and is useful in dev.
+ *
+ * The purpose is to see how the editor events and mutations behave without
+ * the noise of the editor also adding its own events and mutations.
+ *
+ * IMPORTANT:
+ *
+ * This plugin is detached (i.e. there is no way to turn it on in Slate).
+ * You must hard code it into `plugins/react/index`.
+ *
+ * @return {Object}
+ */
+
+function NoopPlugin() {
+  /**
+   * Plugin Object
+   *
+   * @type {Object}
+   */
+
+  const plugin = {}
+
+  for (const eventName of EVENT_HANDLERS) {
+    plugin[eventName] = function(event, editor, next) {}
+  }
+
+  /**
+   * Return the plugin.
+   *
+   * @type {Object}
+   */
+
+  return plugin
+}
+
+/**
+ * Export.
+ *
+ * @type {Function}
+ */
+
+export default NoopPlugin


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### What's the new behavior?

Added a NoopPlugin which eats events so that Slate can't react to them. This helps us see DOM mutations and events while ignoring the noise that comes from what Slate itself is doing to DOM mutations and adding events.

#### How does this change work?

Using the list of EVENT_HANDLERS, it creates functions that do nothing. In particular, they don't call the `next` method. Unlike the previous rejected version, the Plugin is detached. It must be hard-coded into the plugin chain for it to work.

For those following, this approach was approved in a Slack chat by @ianstormtaylor 

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
