### PR TITLE
Fix Hot Module Reload for plugins

### DIFF
--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -145,7 +145,14 @@ class Editor extends React.Component {
 
     // Re-resolve the controller if needed based on memoized props.
     const { commands, placeholder, plugins, queries, schema } = this.props
-    this.resolveController(plugins, schema, commands, queries, placeholder)
+    this.resolveController(
+      plugins,
+      schema,
+      commands,
+      queries,
+      placeholder,
+      ReactPlugin
+    )
 
     // Set the current props on the controller.
     const { options, readOnly, value: valueFromProps } = this.props
@@ -208,7 +215,7 @@ class Editor extends React.Component {
    */
 
   resolveController = memoizeOne(
-    (plugins = [], schema, commands, queries, placeholder) => {
+    (plugins = [], schema, commands, queries, placeholder, ReactPlugin) => {
       // If we've resolved a few times already, and it's exactly in line with
       // the updates, then warn the user that they may be doing something wrong.
       warning(

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -145,6 +145,7 @@ class Editor extends React.Component {
 
     // Re-resolve the controller if needed based on memoized props.
     const { commands, placeholder, plugins, queries, schema } = this.props
+
     this.resolveController(
       plugins,
       schema,
@@ -215,7 +216,7 @@ class Editor extends React.Component {
    */
 
   resolveController = memoizeOne(
-    (plugins = [], schema, commands, queries, placeholder, ReactPlugin) => {
+    (plugins = [], schema, commands, queries, placeholder, TheReactPlugin) => {
       // If we've resolved a few times already, and it's exactly in line with
       // the updates, then warn the user that they may be doing something wrong.
       warning(
@@ -224,7 +225,7 @@ class Editor extends React.Component {
       )
 
       this.tmp.resolves++
-      const react = ReactPlugin({
+      const react = TheReactPlugin({
         ...this.props,
         editor: this,
         value: this.props.value || this.state.value,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Previously Hot Module Reload doesn't work when making a change to plugins. This fix means that making changes to plugins including any of the core plugins are reflected in the instance of the Editor without having to do a full reload.

#### How does this change work?

In `slate-react/src/components/editor` there is a method called `resolveController`. It uses the method `memoizeOne` so that Slate is not rebuilding the controller on each `render`.

Previously `ReactPlugin` was not passed into the `resolveController` call so even if the `ReactPlugin` changed, it did not create a new version of the controller.

We now add `ReactPlugin` to the `this.resolveController` call in the `render` method. This makes sure that when `ReactPlugin` changes we get an updated controller.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2709
Reviewers:
