### PR TITLE
Remove leaves from docs

### DIFF
--- a/docs/walkthroughs/installing-slate.md
+++ b/docs/walkthroughs/installing-slate.md
@@ -40,11 +40,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             object: 'text',
-            leaves: [
-              {
-                text: 'A line of text in a paragraph.',
-              },
-            ],
+            text: 'A line of text in a paragraph.',
           },
         ],
       },
@@ -70,11 +66,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             object: 'text',
-            leaves: [
-              {
-                text: 'A line of text in a paragraph.',
-              },
-            ],
+            text: 'A line of text in a paragraph.',
           },
         ],
       },

--- a/docs/walkthroughs/saving-to-a-database.md
+++ b/docs/walkthroughs/saving-to-a-database.md
@@ -23,11 +23,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             object: 'text',
-            leaves: [
-              {
-                text: 'A line of text in a paragraph.',
-              },
-            ],
+            text: 'A line of text in a paragraph.',
           },
         ],
       },
@@ -66,11 +62,7 @@ const initialValue = Value.fromJSON({
         nodes: [
           {
             object: 'text',
-            leaves: [
-              {
-                text: 'A line of text in a paragraph.',
-              },
-            ],
+            text: 'A line of text in a paragraph.',
           },
         ],
       },
@@ -114,11 +106,7 @@ const initialValue = Value.fromJSON(
           nodes: [
             {
               object: 'text',
-              leaves: [
-                {
-                  text: 'A line of text in a paragraph.',
-                },
-              ],
+              text: 'A line of text in a paragraph.',
             },
           ],
         },
@@ -161,11 +149,7 @@ const initialValue = Value.fromJSON(
           nodes: [
             {
               object: 'text',
-              leaves: [
-                {
-                  text: 'A line of text in a paragraph.',
-                },
-              ],
+              text: 'A line of text in a paragraph.',
             },
           ],
         },


### PR DESCRIPTION
As a new user not being able to go through the walkthrough docs was somewhat harder than it need to be. Something else that could be improved is that the error message in the console told me what was wrong but not how to fix it.

This is a partial fix for #2754. I'd remove other references to leaves in the docs but I'm not yet up to speed on the project as a whole to understand the changes that need to be made.