### PR TITLE
Add lifecycle event handlers

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -158,6 +158,8 @@ class Content extends React.Component {
     }
 
     this.updateSelection()
+
+    this.props.onEvent('onComponentDidMount', { target: this.ref.current })
   }
 
   /**
@@ -180,6 +182,8 @@ class Content extends React.Component {
         this.handlers.onBeforeInput
       )
     }
+
+    this.props.onEvent('onComponentWillUnmount', { target: this.ref.current })
   }
 
   /**
@@ -188,7 +192,10 @@ class Content extends React.Component {
 
   componentDidUpdate() {
     debug.update('componentDidUpdate')
+
     this.updateSelection()
+
+    this.props.onEvent('onComponentDidUpdate', { target: this.ref.current })
   }
 
   /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

Adds Plugin events for the following React lifecycle events:

- componentDidMount
- componentDidUpdate
- componentWillUnmount

As per the issue discussed here: https://github.com/ianstormtaylor/slate/issues/2832

#### How does this change work?

in `content.js` where the Editor contents are rendered, I added calls like `this.props.onEvent('onComponentDidMount', {target: this.ref.current})` for each lifecycle callback.

Note that the `event` object passed through has a `target` property similar to what one would see in an actual event. This makes it easy to get the DOM element that represents the Editor element. Since this is likely the primary use case for these events, it felt useful to add them.

### Development Notes

For the time being, I added these lifecycle events as `componentDidMount` as opposed to @brendancarney preference to go with the `unstable_componentDidMount` names but will be happy to rename if @ianstormtaylor agrees this is preferable. I defaulted to keeping it `componentDidMount` which is a guess based on a previous preference by @ianstormtaylor to keep the names clean.

Also, @brendancarney I'm fine changing this to another method to achieve the same goals if we find a better solution so I'm not disregarding your desire for a better option. I can take this out no problem if/when we find a better solution.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #https://github.com/ianstormtaylor/slate/issues/2832
Reviewers: @ianstormtaylor 
