### PR TITLE
Add render event for plugins

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -514,6 +514,8 @@ class Content extends React.Component {
 
     debug('render', { props })
 
+    this.props.onEvent('onRender', {})
+
     const data = {
       [DATA_ATTRS.EDITOR]: true,
       [DATA_ATTRS.KEY]: document.key,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

This just add to https://github.com/ianstormtaylor/slate/pull/2833 with an `onRender` method.

In particular, this is useful because we need to stop listening to mutations when Slate is doing them then we wish to listen to mutations that user's make.

There was code in a number of places to switch listening off immediately before sending commands to Slate but it turns out to be a lot easier to just turn listening to mutations off as soon as `render` gets called and then turn them on once `componentDidUpdate` gets called.

Tried it and works great.

#### How does this change work?

Calls `this.props.onEvent('onRender', {})` in the `render` method of `content.js`

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
