### PR TITLE
Add empty composition example

### DIFF
--- a/examples/composition/empty.js
+++ b/examples/composition/empty.js
@@ -1,0 +1,8 @@
+import { p, text, bold } from './util'
+
+export default {
+  text: `Type "hello world" enter "hi" enter "bye" backspace over everything`,
+  document: {
+    nodes: [p(text(''))],
+  },
+}

--- a/examples/composition/empty.js
+++ b/examples/composition/empty.js
@@ -1,4 +1,4 @@
-import { p, text, bold } from './util'
+import { p, text } from './util'
 
 export default {
   text: `Type "hello world" enter "hi" enter "bye" backspace over everything`,

--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -7,6 +7,7 @@ import { Link, Redirect } from 'react-router-dom'
 import splitJoin from './split-join.js'
 import insert from './insert.js'
 import special from './special.js'
+import empty from './empty.js'
 import { isKeyHotkey } from 'is-hotkey'
 import { Button, EditorValue, Icon, Instruction, Toolbar } from '../components'
 import { ANDROID_API_VERSION } from 'slate-dev-environment'
@@ -73,6 +74,7 @@ const SUBPAGES = [
   ['Split/Join', splitJoin, 'split-join'],
   ['Insertion', insert, 'insert'],
   ['Special', special, 'special'],
+  ['Empty', empty, 'empty'],
 ]
 
 /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

Adds an example in compositions with no content and some instructions

#### How does this change work?

Very straightforward.

Because an empty block has a special zero width container, we need to make sure to handle the use case and therefore a way to test is required.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
