### PR TITLE
Corrected placeholder alignement in chrome

### DIFF
--- a/packages/slate-react-placeholder/src/index.js
+++ b/packages/slate-react-placeholder/src/index.js
@@ -81,6 +81,7 @@ function SlateReactPlaceholder(options = {}) {
         maxWidth: '100%',
         whiteSpace: 'nowrap',
         opacity: '0.333',
+        verticalAlign: 'text-top',
         ...style,
       }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### What's the new behavior?

The cursor will be positionned correctly under chrome.

Before, the cursor would have a slightly different position when the mouse is pressed under chrome.

![before](http://g.recordit.co/SvwGbH0zBI.gif)

This doesn't look significant until you apply some styling:

![before](http://g.recordit.co/6yYJlg0JHq.gif)

#### How does this change work?

It works by adding a vertical alignement to the placeholder element so it's aligned to the text-top position.

No matter the size, the placeholder element is aligned with the text top, keeping the cursor position at the right place in chrome.


Here's a gif that shows the behavior in chrome after the fix:

![after](http://g.recordit.co/ZRD3odaVka.gif)
 
Firefox don't seem to be affected by this problem or the fix since it's algorithm to place the cursor seem to behave differently.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
