### PR TITLE
Add remove composition example

### DIFF
--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -8,6 +8,7 @@ import splitJoin from './split-join.js'
 import insert from './insert.js'
 import special from './special.js'
 import empty from './empty.js'
+import remove from './remove.js'
 import { isKeyHotkey } from 'is-hotkey'
 import { Button, EditorValue, Icon, Instruction, Toolbar } from '../components'
 import { ANDROID_API_VERSION } from 'slate-dev-environment'
@@ -75,6 +76,7 @@ const SUBPAGES = [
   ['Insertion', insert, 'insert'],
   ['Special', special, 'special'],
   ['Empty', empty, 'empty'],
+  ['Remove', remove, 'remove'],
 ]
 
 /**

--- a/examples/composition/remove.js
+++ b/examples/composition/remove.js
@@ -1,13 +1,13 @@
 import { p, text, bold } from './util'
 
 export default {
-  text: `Select from start to end then press backspace. Move cursor to end. Backspace over all the remaining content.`,
+  text: `Select from ANCHOR to FOCUS then press backspace. Move cursor to end. Backspace over all the remaining content.`,
   document: {
     nodes: [
-      p(bold('Select'), text(' from START and then')),
+      p(text('Go and '), bold('select'), text(' from this ANCHOR and then')),
       p(text('go and select')),
-      p(text('to the END then press '), bold('backspace.')),
-      p(text('After you have done that move selection to very end')),
+      p(text('to this FOCUS then press '), bold('backspace.')),
+      p(text('After you have done that move selection to very end.')),
       p(
         text('Then try '),
         bold('backspacing'),

--- a/examples/composition/remove.js
+++ b/examples/composition/remove.js
@@ -1,0 +1,18 @@
+import { p, text, bold } from './util'
+
+export default {
+  text: `Select from start to end then press backspace. Move cursor to end. Backspace over all the remaining content.`,
+  document: {
+    nodes: [
+      p(bold('Select'), text(' from START and then')),
+      p(text('go and select')),
+      p(text('to the END then press '), bold('backspace.')),
+      p(text('After you have done that move selection to very end')),
+      p(
+        text('Then try '),
+        bold('backspacing'),
+        text(' over all remaining text.')
+      ),
+    ],
+  },
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### What's the new behavior?

Backspacing and otherwise removing content is a big part of implementing compositions and there are many edge cases related to it.

This gives us a few basic tests that allow us to make sure they are working.

#### How does this change work?

Just add another example. It's straightforward.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
