### PR TITLE
Remove pseudo-event object from lifecycle events

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -159,7 +159,7 @@ class Content extends React.Component {
 
     this.updateSelection()
 
-    this.props.onEvent('onComponentDidMount', { target: this.ref.current })
+    this.props.onEvent('onComponentDidMount')
   }
 
   /**
@@ -183,7 +183,7 @@ class Content extends React.Component {
       )
     }
 
-    this.props.onEvent('onComponentWillUnmount', { target: this.ref.current })
+    this.props.onEvent('onComponentWillUnmount')
   }
 
   /**
@@ -195,7 +195,7 @@ class Content extends React.Component {
 
     this.updateSelection()
 
-    this.props.onEvent('onComponentDidUpdate', { target: this.ref.current })
+    this.props.onEvent('onComponentDidUpdate')
   }
 
   /**
@@ -514,7 +514,7 @@ class Content extends React.Component {
 
     debug('render', { props })
 
-    this.props.onEvent('onRender', {})
+    this.props.onEvent('onRender')
 
     const data = {
       [DATA_ATTRS.EDITOR]: true,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement

#### What's the new behavior?

Remove the pseudo-event object from the lifecycle events as per https://github.com/ianstormtaylor/slate/pull/2833#issuecomment-496648341

#### How does this change work?

I just stop passing the event object through

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
