### PR TITLE
Hook debug-mutations into lifecycle events

### DIFF
--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -60,9 +60,24 @@ function DebugMutationsPlugin({ editor }) {
     debug(`${array.length} Mutations`, ...array)
   })
 
-  // `findDOMNode` does not exist until later so we use `setTimeout`
-  setTimeout(() => {
+  /**
+   * The previously observed DOM node
+   *
+   * @type {DOMNode}
+   */
+
+  let prevRootEl = null
+
+  /**
+   * Start observing the DOM node for mutations if it isn't being observed
+   */
+
+  function start() {
     const rootEl = editor.findDOMNode([])
+
+    if (rootEl === prevRootEl) return
+
+    debug('start')
 
     observer.observe(rootEl, {
       childList: true,
@@ -71,7 +86,26 @@ function DebugMutationsPlugin({ editor }) {
       subtree: true,
       characterDataOldValue: true,
     })
-  })
+
+    prevRootEl = rootEl
+  }
+
+  /**
+   * Stop observing the DOM node for mutations
+   */
+
+  function stop() {
+    debug('stop')
+
+    observer.disconnect()
+    prevRootEl = null
+  }
+
+  return {
+    onComponentDidMount: start,
+    onComponentDidUpdate: start,
+    onComponentWillUnmount: stop,
+  }
 }
 
 export default DebugMutationsPlugin


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

There is currently a `debug-mutations` plugin that lets us observe mutations on the Editor element.

However, it has two issues:

- It uses `setTimeout` to set up the mutation which is hacky because it relies on React having to have rendered to the DOM before the `setTimeout` executes. This is not necessarily guaranteed.
- When we call `restoreDOM`, the root element is destroyed and recreated. The mutations are now on the wrong element and we can't see mutations in our Editor.

#### How does this change work?

Uses Slate's currently unstable lifecycle events to add the mutation observers when the Editor's `content` first mounts during `componentDidMount` fixing issue 1.

It then re-observes during `componentDidUpdate` if the root element for the editor has changed.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
