### PR TITLE
Normalize target node in debug mutations

### DIFF
--- a/packages/slate-react/src/plugins/debug/debug-mutations.js
+++ b/packages/slate-react/src/plugins/debug/debug-mutations.js
@@ -26,10 +26,16 @@ const MUTATION_PROPERTIES = [
   'previousSibling',
 ]
 
+/**
+ * Takes a DOM node and returns an easily readable version of it.
+ *
+ * @param {DOMNode} node
+ */
+
 function normalizeNode(node) {
-  if (node.nodeType === Node.TEXT_NODE) {
+  if (node.nodeType === window.Node.TEXT_NODE) {
     return node.textContent
-  } else if (node.nodeType === Node.ELEMENT_NODE) {
+  } else if (node.nodeType === window.Node.ELEMENT_NODE) {
     const { outerHTML, innerHTML } = node
     if (outerHTML == null) return JSON.stringify(node.textContent)
     return outerHTML.slice(0, outerHTML.indexOf(innerHTML))


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature

#### What's the new behavior?

Mutation targets that are text node are rendered to debug as a String. This is an improvement because otherwise the reference is to the text node itself. The `textContent` of the node will often have changed so in the previous method with the reference we would never have known what the `textContent` was at the time of the mutation.

#### How does this change work?

- Takes the prettifying code out into a separate `normalizeNode` method
- Returns the `textContent` of the node if the `nodeType` is of type `TEXT_NODE`

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
