### PR TITLE
Fix several errors in the deprecated `getEventRange`

### DIFF
--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -3,7 +3,7 @@ import invariant from 'tiny-invariant'
 import warning from 'tiny-warning'
 import { Value } from 'slate'
 
-import findPath from './find-node'
+import findPath from './find-path'
 import findRange from './find-range'
 
 /**
@@ -50,13 +50,11 @@ function getEventRange(event, editor) {
         : y - rect.top < rect.top + rect.height - y
 
     const range = document.createRange()
-    const iterable = isPrevious ? 'previousTexts' : 'nextTexts'
     const move = isPrevious ? 'moveToEndOfNode' : 'moveToStartOfNode'
-    const entry = document[iterable](path)
+    const entry = document[isPrevious ? 'getPreviousText' : 'getNextText'](path)
 
     if (entry) {
-      const [n] = entry
-      return range[move](n)
+      return range[move](entry)
     }
 
     return null


### PR DESCRIPTION


#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

`getEventRange` no longer crashes when called.

#### How does this change work?

This version of the method has drifted from `editor.findEventRange`, and now crashes when it's being used. This commit fixes an import and changes some code to match the new code in `editor.findEventRange`.


#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
