### PR TITLE
Fix deleting backwards when there are only inlines

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -377,9 +377,10 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
   let node = text
   let offset = 0
   let traversed = focus.offset
+  let prevNode = document.getPreviousText(node.key)
 
-  while (n > traversed) {
-    node = document.getPreviousText(node.key)
+  while (prevNode && n > traversed) {
+    node = prevNode
     const next = traversed + node.text.length
 
     if (n <= next) {
@@ -388,6 +389,8 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
     } else {
       traversed = next
     }
+
+    prevNode = document.getPreviousText(node.key)
   }
 
   range = range.moveAnchorTo(node.key, offset)

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -375,26 +375,38 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
 
   // Otherwise, we need to see how many nodes backwards to go.
   let node = text
-  let offset = 0
   let traversed = focus.offset
-  let prevNode = document.getPreviousText(node.key)
+  const prevSibling = document.getPreviousSibling(node.key)
 
-  while (prevNode && n > traversed) {
-    node = prevNode
-    const next = traversed + node.text.length
+  // If the next sibling is an inline, has no text and the focus offset is 0,
+  // then delete the inline
+  if (
+    traversed === 0 &&
+    Inline.isInline(prevSibling) &&
+    prevSibling.text === ''
+  ) {
+    editor.removeNodeByKey(prevSibling.key)
+  } else {
+    let offset = 0
+    let prevNode = document.getPreviousText(node.key)
 
-    if (n <= next) {
-      offset = next - n
-      break
-    } else {
-      traversed = next
+    while (prevNode && n > traversed) {
+      node = prevNode
+      const next = traversed + node.text.length
+
+      if (n <= next) {
+        offset = next - n
+        break
+      } else {
+        traversed = next
+      }
+
+      prevNode = document.getPreviousText(node.key)
     }
 
-    prevNode = document.getPreviousText(node.key)
+    range = range.moveAnchorTo(node.key, offset)
+    editor.deleteAtRange(range)
   }
-
-  range = range.moveAnchorTo(node.key, offset)
-  editor.deleteAtRange(range)
 }
 
 /**


### PR DESCRIPTION
This is a fix for #2621.

The bug happens when there are no text nodes between the cursor and the start of the document.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Deletes an inline without erroring.

#### How does this change work?

If the previous node is an Inline, the focus offset is 0 and the text value of the inline is empty, then the inline is deleted.

#### Have you checked that...?

* [YES] The new code matches the existing patterns and styles.
* [YES] The tests pass with `yarn test`.
* [YES] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [YES] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2621 
