### PR TITLE
Add prop to optionally enable grammarly

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -4,6 +4,7 @@ import Types from 'prop-types'
 import getWindow from 'get-window'
 import warning from 'tiny-warning'
 import throttle from 'lodash/throttle'
+import omit from 'lodash/omit'
 import { List } from 'immutable'
 import {
   IS_ANDROID,
@@ -541,8 +542,11 @@ class Content extends React.Component {
       [DATA_ATTRS.KEY]: document.key,
     }
 
+    const domProps = omit(this.props, Object.keys(Content.propTypes))
+
     return (
       <Container
+        {...domProps}
         key={this.tmp.contentKey}
         {...handlers}
         {...data}
@@ -559,7 +563,9 @@ class Content extends React.Component {
         // COMPAT: The Grammarly Chrome extension works by changing the DOM out
         // from under `contenteditable` elements, which leads to weird behaviors
         // so we have to disable it like this. (2017/04/24)
-        data-gramm={false}
+
+        // just the existence of the flag is disabling the extension irrespective of its value
+        data-gramm={domProps['data-gramm'] ? undefined : false}
       >
         <Node
           annotations={value.annotations}

--- a/packages/slate-react/src/components/editor.js
+++ b/packages/slate-react/src/components/editor.js
@@ -5,6 +5,7 @@ import Types from 'prop-types'
 import invariant from 'tiny-invariant'
 import memoizeOne from 'memoize-one'
 import warning from 'tiny-warning'
+import omit from 'lodash/omit'
 import { Editor as Controller } from 'slate'
 
 import EVENT_HANDLERS from '../constants/event-handlers'
@@ -174,8 +175,11 @@ class Editor extends React.Component {
       tagName,
     } = this.props
 
+    const domProps = omit(this.props, Object.keys(Editor.propTypes))
+
     const children = (
       <Content
+        {...domProps}
         ref={this.tmp.contentRef}
         autoCorrect={autoCorrect}
         className={className}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Feature(i guess): This enables the user to optionally pass a prop to enable Grammarly which was previously disabled in [#733](https://github.com/ianstormtaylor/slate/issues/733).

#### What's the new behavior?
![slate-grammarly](https://user-images.githubusercontent.com/3082747/59019987-abb02400-8866-11e9-87f9-91cf518066f4.gif)


You can also check it here [sandbox](https://49zhg.codesandbox.io/). You will, of course, need to install the Grammarly extension. The above demo was tested on version 14.915.2321

#### How does this change work?
Since Grammarly has moved to an API based content modification, it would be really helpful for users to be able to enable Grammarly if it suits them. So I have added a prop to enable the same. The only non-trivial part is that the extension doesn't seem to work as long as the prop `data-gramm` exists irrespective of its value.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #733
Reviewers:
