### PR TITLE
Fix move_node behaviour in PathUtils.transform

### DIFF
--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -375,19 +375,23 @@ function transform(path, operation) {
     if (pAbove || pEqual) {
       // We are comparing something that was moved
       // The new path is unaffected unless the old path was the left-sibling of an ancestor
-      if (isYounger(p, np) && p.size < np.size) {
+      if (isYounger(p, np) && p.size <= np.size) {
         path = decrement(np, 1, min(np, p) - 1).concat(path.slice(p.size))
       } else {
         path = np.concat(path.slice(p.size))
       }
     } else {
+      const npYounger = isYounger(np, path)
+      const npEqual = isEqual(np, path)
+      const npAbove = isAbove(np, path)
+
       // This is equivalent logic to remove_node for path
       if (pYounger) {
         path = decrement(path, 1, pIndex)
       }
 
       // This is the equivalent logic to insert_node for newPath
-      if (isYounger(np, path) || isEqual(np, path) || isAbove(np, path)) {
+      if (npYounger || npEqual || npAbove) {
         path = increment(path, 1, np.size - 1)
       }
     }

--- a/packages/slate/test/commands/by-key/move-node-by-key/block.js
+++ b/packages/slate/test/commands/by-key/move-node-by-key/block.js
@@ -3,7 +3,7 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  editor.moveNodeByKey('a', 'b', 1)
+  editor.moveNodeByKey('a', 'b', 2)
 }
 
 export const input = (

--- a/packages/slate/test/commands/by-key/move-node-by-key/inline.js
+++ b/packages/slate/test/commands/by-key/move-node-by-key/inline.js
@@ -3,7 +3,8 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  editor.moveNodeByKey('a', 'b', 3)
+  // It's 4, because every link node is surrounded by empty text nodes
+  editor.moveNodeByKey('a', 'b', 4)
 }
 
 export const input = (

--- a/packages/slate/test/commands/by-path/move-node-by-path/sibling-swap.js
+++ b/packages/slate/test/commands/by-path/move-node-by-path/sibling-swap.js
@@ -8,7 +8,7 @@ const pathA = PathUtils.create([0, 0])
 const pathB = PathUtils.create([0])
 
 export default function(editor) {
-  editor.moveNodeByPath(pathA, pathB, 1)
+  editor.moveNodeByPath(pathA, pathB, 2)
   assert(editor.operations.size >= 1)
 }
 

--- a/packages/slate/test/utils/path-utils/transform/move-node/from-younger.js
+++ b/packages/slate/test/utils/path-utils/transform/move-node/from-younger.js
@@ -26,5 +26,5 @@ export default () => {
 
   const after_new = PathUtils.create([0, 1, 2, 0, 2])
   const result_after_new = PathUtils.transform(after_new, op).first()
-  assertEqualPaths(result_after_new, PathUtils.create([0, 1, 1, 0, 2]))
+  assertEqualPaths(result_after_new, PathUtils.create([0, 1, 1, 0, 3]))
 }

--- a/packages/slate/test/utils/path-utils/transform/move-node/siblings-forward-by-1.js
+++ b/packages/slate/test/utils/path-utils/transform/move-node/siblings-forward-by-1.js
@@ -10,8 +10,8 @@ export default () => {
   const op = Operation.create({ path, newPath, type: 'move_node' })
 
   const moved_node_result = PathUtils.transform(path, op).first()
-  assertEqualPaths(moved_node_result, newPath)
+  assertEqualPaths(moved_node_result, PathUtils.create([0]))
 
   const sibling_result = PathUtils.transform(newPath, op).first()
-  assertEqualPaths(sibling_result, path)
+  assertEqualPaths(sibling_result, PathUtils.create([1]))
 }

--- a/packages/slate/test/utils/path-utils/transform/move-node/siblings-forward-by-2.js
+++ b/packages/slate/test/utils/path-utils/transform/move-node/siblings-forward-by-2.js
@@ -1,0 +1,21 @@
+import assert from 'assert'
+import { PathUtils, Operation } from 'slate'
+
+const assertEqualPaths = (p1, p2) =>
+  assert.deepEqual(p1.toArray(), p2.toArray())
+
+export default () => {
+  const path = PathUtils.create([0])
+  const newPath = PathUtils.create([2])
+  const op = Operation.create({ path, newPath, type: 'move_node' })
+
+  const moved_node_result = PathUtils.transform(path, op).first()
+  assertEqualPaths(moved_node_result, PathUtils.create([1]))
+
+  const new_path_result = PathUtils.transform(newPath, op).first()
+  assertEqualPaths(new_path_result, newPath)
+
+  const sibling = PathUtils.create([1])
+  const sibling_result = PathUtils.transform(sibling, op).first()
+  assertEqualPaths(sibling_result, PathUtils.create([0]))
+}


### PR DESCRIPTION
Hi,

We have a fix for two bugs in move_node in path transform. The problem is that in some cases the path does not get transformed correctly, which leads to assertions being thrown.

The first bug exists because the check against `op.newPath` is done after the transformation against `op.path`. This leads to unexpected behaviour in scenario that the path is transformed in such a way that the second check matches, but should not.

The second problem is the check against path size which should be `<=` and not `<` in our opinion. After this fix, some test cases begin to throw, but this is because what we believe there is a problem in those testcases. If we have two siblings [0] and [1], and move the first to the path [1], the item should not move at all, because path [1] is *before* the second element. That is how we understand this, but however please confirm this finding.

Thanks in advance for reviewing it.


