### PR TITLE
Fix bugs in getRelativeRange.

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -288,11 +288,11 @@ function getRelativeRange(node, index, range) {
     start = start.setPath(startPath.rest())
   } else if (startIndex < index && index <= endIndex) {
     if (child.object === 'text') {
-      start = start.moveTo(PathUtils.create([index]), 0)
+      start = start.moveTo(PathUtils.create([index]), 0).setKey(child.key)
     } else {
       const [first] = child.texts()
-      const [, firstPath] = first
-      start = start.moveTo(firstPath, 0)
+      const [firstNode, firstPath] = first
+      start = start.moveTo(firstPath, 0).setKey(firstNode.key)
     }
   } else {
     start = null
@@ -302,11 +302,12 @@ function getRelativeRange(node, index, range) {
     end = end.setPath(endPath.rest())
   } else if (startIndex <= index && index < endIndex) {
     if (child.object === 'text') {
-      end = end.moveTo(PathUtils.create([index]), child.text.length)
+      const length = child.text.length
+      end = end.moveTo(PathUtils.create([index]), length).setKey(child.key)
     } else {
       const [last] = child.texts({ direction: 'backward' })
       const [lastNode, lastPath] = last
-      end = end.moveTo(lastPath, lastNode.text.length)
+      end = end.moveTo(lastPath, lastNode.text.length).setKey(lastNode.key)
     }
   } else {
     end = null
@@ -316,8 +317,8 @@ function getRelativeRange(node, index, range) {
     return null
   }
 
-  range = range.setStart(start)
-  range = range.setEnd(end)
+  range = range.setAnchor(start)
+  range = range.setFocus(end)
   return range
 }
 


### PR DESCRIPTION
Hi,

There are problems with annotations that span across multiple blocks or other nodes after they are recomputed with `getRelativeRange`. 

The first problem is with `setStart` and `setEnd` called subsequently, because they do a check against the "backwardness" to set the anchor or focus relatively. But the check is done after the first point was already set, which might change the order, and lead to the same point being set twice. 

The second problem is that after the annotation is split, the keys do not get set, which leads to this annotation being omited, because the anchor or focus point is treated as unset (both path and key must be set).

Thanks in advance for reviewing it.