### PR TITLE
Improve mentions example by including scroll calculation

### DIFF
--- a/examples/mentions/Suggestions.js
+++ b/examples/mentions/Suggestions.js
@@ -100,8 +100,8 @@ class Suggestions extends React.PureComponent {
     const anchorRect = anchor.getBoundingClientRect()
 
     this.setState({
-      top: anchorRect.bottom,
-      left: anchorRect.left,
+      top: anchorRect.bottom + window.pageYOffset,
+      left: anchorRect.left + window.pageXOffset,
     })
   }
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving an example (not technically a bug fix, but a UI/UX designer would call it a bug fix)

#### What's the new behavior?

Currently, if you type `@` in the mentions example, it initiates the creation of an annotation wrapper. That wrapper is the target of the suggestions list dropdown.

Because of the use of `React.createPortal` to keep the suggestion list outside the editor's HTML, if you scroll before typing anything after `@` then the positions of the list will be incorrect relative to the cursor. (Note: you need to make the example contain enough text such that the page scrolls to replicate.)

#### How does this change work?

By including the current scroll position in the absolute positions of the list, we ensure that it is always in the correct spot relative to the cursor regardless of the scroll position of the page.

NOTE: this fix will not fix the issue of if the user type `@` and then changes the window size before typing anything further. That would require a listening HOC which would ensure the component re-renders on every window size change.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

N/A
