### PR TITLE
No longer tries removing marks that aren't there - fixes erroneous en…

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "lint:eslint": "eslint benchmark packages/*/src packages/*/test examples/*/*.js examples/dev/*/*.js",
     "lint:prettier": "prettier --list-different '**/*.{md,json,css}'",
     "open": "open http://localhost:8080",
-    "prettier": "prettier --write '**/*.{js,jsx,md,json,css}'",
+    "prettier": "prettier --write \"**/*.{js,jsx,md,json,css}\"",
     "release": "yarn build:production && yarn test && yarn lint && lerna publish && yarn gh-pages",
     "server": "webpack-dev-server --config ./support/webpack/config.js",
     "start": "npm-run-all --parallel --print-label watch server",

--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -229,13 +229,19 @@ Commands.removeMarkByPath = (editor, path, offset, length, mark) => {
 Commands.removeMarksByPath = (editor, path, offset, length, marks) => {
   marks = Mark.createSet(marks)
 
-  if (!marks.size) {
-    return
-  }
-
   const { value } = editor
   const { document } = value
   const node = document.assertNode(path)
+
+  // filter out marks that this node does not have
+  // otherwise, this will create an inverse operation to add the mark in the undo stack
+  marks = marks.filter(mark => {
+    return node.marks.has(mark)
+  })
+
+  if (!marks.size) {
+    return
+  }
 
   editor.withoutNormalizing(() => {
     // If it ends before the end of the node, we'll need to split to create a new

--- a/packages/slate/test/commands/at-current-range/remove-mark/without-mark.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/without-mark.js
@@ -14,9 +14,7 @@ export default function(editor) {
 export const input = (
   <value>
     <document>
-      <paragraph>
-        Text
-      </paragraph>
+      <paragraph>Text</paragraph>
     </document>
   </value>
 )

--- a/packages/slate/test/commands/at-current-range/remove-mark/without-mark.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/without-mark.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  // simply calling removeMark on text that does not have that mark should not
+  // create an undo history to later add the mark.
+  editor
+    .moveToRangeOfDocument()
+    .removeMark('bold')
+    .undo()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        Text
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = input


### PR DESCRIPTION
…tries in the undo history

#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Marks are no longer "removed" if they don't exist to begin with. This fixes an erroneous entry that gets added to the undo history which would add that mark which did not exist to begin with.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
This simply checks that a node (Text) has a mark before it tries removing it. This problem was introduced by removing leaves and putting Marks on Text.

When a Mark is added, the node is split. In that logic, it moves the Focus to the beginning of the next node instead of staying on the end of the Mark/Text that was created. Then, if you go to toggle that Mark off, it tries removing the Mark both from the Text that has the Mark, and the Text directly after it. Since the code allows removing marks from nodes that don't have that mark, an entry in the history is created to add the mark to the text that never had it to begin with.

Perhaps a more comprehensive solution is later needed, but regardless, calling removeMark on Text that does not have that mark should do nothing.

#### How to reproduce in the current code
Go to the [example of rich text](https://www.slatejs.org/#/rich-text), select some text, click bold twice (once to add, one to remove), and then Ctrl+z to undo the removal of the bold.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [X] The new code matches the existing patterns and styles.
* [X] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.) - Note: I'm running on Windows with my git config to autocrlf (so it should pick up the current file line ending), but when running `yarn lint` I get a lot of errors ("error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style"). It may be helpful to add a .gitattributes file, but I will leave this up to you: https://help.github.com/en/articles/dealing-with-line-endings#per-repository-settings
* [X] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2870
Reviewers: @ianstormtaylor 
