### PR TITLE
Update slate-react plugin documentation with breaking changes from 0.22.0

### DIFF
--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -22,8 +22,10 @@ In addition to the [core plugin hooks](../slate/plugins.md), when using `slate-r
   onPaste: Function,
   onSelect: Function,
   renderEditor: Function,
-  renderMark: Function,
-  renderNode: Function,
+  renderAnnotation: Function,
+  renderDecoration: Function,
+  renderBlock: Function,
+  renderInline: Function,
   shouldNodeComponentUpdate: Function,
 }
 ```
@@ -123,11 +125,11 @@ renderEditor: (props, editor, next) => {
 }
 ```
 
-### `renderMark`
+### `renderDecoration`
 
-`Function renderMark(props: Object, editor: Editor, next: Function) => ReactNode|Void`
+`Function renderDecoration(props: Object, editor: Editor, next: Function) => ReactNode|Void`
 
-Render a `Mark` with `props`. The `props` object contains:
+Render a `Decoration` with `props`. The `props` object contains:
 
 ```js
 {
@@ -142,13 +144,34 @@ Render a `Mark` with `props`. The `props` object contains:
 }
 ```
 
-You must spread the `props.attributes` onto the top-level DOM node you use to render the mark.
+You must spread the `props.attributes` onto the top-level DOM node you use to render the annotation.
 
-### `renderNode`
+### `renderAnnotation`
 
-`Function renderNode(props: Object, editor: Editor, next: Function) => ReactNode|Void`
+`Function renderAnnotation(props: Object, editor: Editor, next: Function) => ReactNode|Void`
 
-Render a `Node` with `props`. The `props` object contains:
+Render an `Annotation` with `props`. The `props` object contains:
+
+```js
+{
+  attributes: Object,
+  children: ReactNode,
+  editor: Editor,
+  mark: Mark,
+  marks: Set<Mark>,
+  node: Node,
+  offset: Number,
+  text: String,
+}
+```
+
+You must spread the `props.attributes` onto the top-level DOM node you use to render the annotation.
+
+### `renderBlock`
+
+`Function renderBlock(props: Object, editor: Editor, next: Function) => ReactNode|Void`
+
+Render a Block `Node` with `props`. The `props` object contains:
 
 ```js
 {
@@ -163,7 +186,28 @@ Render a `Node` with `props`. The `props` object contains:
 }
 ```
 
-You must spread the `props.attributes` onto the top-level DOM node you use to render the node.
+You must spread the `props.attributes` onto the top-level DOM node you use to render the node. You must also be sure to assign `attributes.ref` to the native DOM component being rendered (using `forwardRef` or `innerRef` if necessary).
+
+### `renderInline`
+
+`Function renderInline(props: Object, editor: Editor, next: Function) => ReactNode|Void`
+
+Render an Inline `Node` with `props`. The `props` object contains:
+
+```js
+{
+  attributes: Object,
+  children: ReactNode,
+  editor: Editor,
+  isFocused: Boolean,
+  isSelected: BOolean,
+  node: Node,
+  parent: Node,
+  readOnly: Boolean,
+}
+```
+
+You must spread the `props.attributes` onto the top-level DOM node you use to render the node. You must also be sure to assign `attributes.ref` to the native DOM component being rendered (using `forwardRef` or `innerRef` if necessary).
 
 ### `shouldNodeComponentUpdate`
 


### PR DESCRIPTION
## Is this adding or improving a _feature_ or fixing a _bug_?

Improving slate-react plugin documentation.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Explicitly mentioning breaking API changes from 0.22.0, removing deprecated and unused functions.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

The markdown is different than it was and now includes the new API.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

No code changes.

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: N/A
Reviewers: @ianstormtaylor 
