### PR TITLE
escape backquote properly

### DIFF
--- a/docs/walkthroughs/defining-custom-block-nodes.md
+++ b/docs/walkthroughs/defining-custom-block-nodes.md
@@ -111,7 +111,7 @@ class App extends React.Component {
 }
 ```
 
-Okay, but now we'll need a way for the user to actually turn a block into a code block. So let's change our `onKeyDown` function to add a `control-\`` shortcut that does just that:
+Okay, but now we'll need a way for the user to actually turn a block into a code block. So let's change our `onKeyDown` function to add a ``control-` `` shortcut that does just that:
 
 ```js
 function CodeNode(props) {
@@ -164,11 +164,11 @@ class App extends React.Component {
 }
 ```
 
-Now, if you press `control-\`` the block your cursor is in should turn into a code block! Magic!
+Now, if you press ``control-` `` the block your cursor is in should turn into a code block! Magic!
 
 _Note: The Edge browser does not currently support `control-...` key events (see [issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/742263/)), so this example won't work on it._
 
-But we forgot one thing. When you hit `control-\`` again, it should change the code block back into a paragraph. To do that, we'll need to add a bit of logic to change the type we set based on whether any of the currently selected blocks are already a code block:
+But we forgot one thing. When you hit ``control-` `` again, it should change the code block back into a paragraph. To do that, we'll need to add a bit of logic to change the type we set based on whether any of the currently selected blocks are already a code block:
 
 ```js
 function CodeNode(props) {
@@ -222,7 +222,7 @@ class App extends React.Component {
 }
 ```
 
-And there you have it! If you press `control-\`` while inside a code block, it should turn back into a paragraph!
+And there you have it! If you press ``control-` `` while inside a code block, it should turn back into a paragraph!
 
 <br/>
 <p align="center"><strong>Next:</strong><br/><a href="./applying-custom-formatting.md">Applying Custom Formatting</a></p>


### PR DESCRIPTION
backquote should be escaped with double backquotes: ``foo`bar`` instead of `foo\`bar`

#### Is this adding or improving a _feature_ or fixing a _bug_?

slightly fixing docs I guess

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
