### PR TITLE
Add a mark in the search highlight example

### DIFF
--- a/examples/search-highlighting/index.js
+++ b/examples/search-highlighting/index.js
@@ -117,6 +117,7 @@ class SearchHighlighting extends React.Component {
           defaultValue={initialValue}
           schema={this.schema}
           renderAnnotation={this.renderAnnotation}
+          renderMark={this.renderMark}
           spellCheck
         />
       </div>
@@ -140,6 +141,24 @@ class SearchHighlighting extends React.Component {
             {children}
           </span>
         )
+      default:
+        return next()
+    }
+  }
+
+  /**
+   * Render a Slate mark.
+   *
+   * @param {Object} props
+   * @return {Element}
+   */
+
+  renderMark = (props, editor, next) => {
+    const { children, mark, attributes } = props
+
+    switch (mark.type) {
+      case 'bold':
+        return <strong {...attributes}>{children}</strong>
       default:
         return next()
     }

--- a/examples/search-highlighting/value.json
+++ b/examples/search-highlighting/value.json
@@ -19,8 +19,7 @@
           },
           {
             "object": "text",
-            "text":
-              " marks to them in realtime."
+            "text": " marks to them in realtime."
           }
         ]
       },

--- a/examples/search-highlighting/value.json
+++ b/examples/search-highlighting/value.json
@@ -10,7 +10,17 @@
           {
             "object": "text",
             "text":
-              "This is editable text that you can search. As you search, it looks for matching strings of text, and adds \"annotation\" marks to them in realtime."
+              "This is editable text that you can search. As you search, it looks for matching strings of text, and adds "
+          },
+          {
+            "object": "text",
+            "text": "annotation",
+            "marks": [{ "object": "mark", "type": "bold" }]
+          },
+          {
+            "object": "text",
+            "text":
+              " marks to them in realtime."
           }
         ]
       },


### PR DESCRIPTION
I just wanted to add this to start a discussion on how we can make the decorations and marks work together in a better way. I thought it could give us some more chances to find a solution for this case.

The problem I see with marks is that right now they inherently modify the structure of the document by splitting the `text` nodes which invalidates any `range` that decorations reference. This makes it quite difficult to apply decorations consistently when marks are added/removed as you need to apply multiple of them for every text node and hence set of marks. Also, decorations don't seem to work across text nodes.