### PR TITLE
Fix slate-react plugin documentation

### DIFF
--- a/docs/reference/slate-react/plugins.md
+++ b/docs/reference/slate-react/plugins.md
@@ -125,6 +125,27 @@ renderEditor: (props, editor, next) => {
 }
 ```
 
+### `renderMark`
+
+`Function renderMark(props: Object, editor: Editor, next: Function) => ReactNode|Void`
+
+Render a `Mark` with `props`. The `props` object contains:
+
+```js
+{
+  attributes: Object,
+  children: ReactNode,
+  editor: Editor,
+  mark: Mark,
+  marks: Set<Mark>,
+  node: Node,
+  offset: Number,
+  text: String,
+}
+```
+
+You must spread the `props.attributes` onto the top-level DOM node you use to render the mark.
+
 ### `renderDecoration`
 
 `Function renderDecoration(props: Object, editor: Editor, next: Function) => ReactNode|Void`
@@ -136,7 +157,7 @@ Render a `Decoration` with `props`. The `props` object contains:
   attributes: Object,
   children: ReactNode,
   editor: Editor,
-  mark: Mark,
+  decoration: Decoration,
   marks: Set<Mark>,
   node: Node,
   offset: Number,
@@ -157,7 +178,7 @@ Render an `Annotation` with `props`. The `props` object contains:
   attributes: Object,
   children: ReactNode,
   editor: Editor,
-  mark: Mark,
+  annotation: Annotation,
   marks: Set<Mark>,
   node: Node,
   offset: Number,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving documentation

#### What's the new behavior?

- `renderMark` is documented
- `renderDecoration` & `renderAnnotation` reflect actual code

#### How does this change work?

The `slate-react` documentation has recently been updated to reflect lastest breaking changes, but `renderMark` has been wrongfully removed. This also fixe some incoherent props for `renderDecoration` & `renderAnnotation`.

#### Have you checked that...?

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
