### PR TITLE
Add point normalization to addAnnotation.

### DIFF
--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -429,8 +429,9 @@ class Value extends Record(DEFAULTS) {
   addAnnotation(annotation) {
     annotation = Annotation.create(annotation)
     let value = this
-    let { annotations } = value
+    let { annotations, document } = value
     const { key } = annotation
+    annotation = annotation.updatePoints(point => point.normalize(document))
     annotations = annotations.set(key, annotation)
     value = value.set('annotations', annotations)
     return value


### PR DESCRIPTION
Hi,

It looks like the annotation should be normalized when it is inserted and the anchor's and focus's keys should be populated to allow subsequent operations in `mapRanges`.