### PR TITLE
Add annotation-related ops to path.transform. (#2)

### DIFF
--- a/packages/slate/src/utils/path-utils.js
+++ b/packages/slate/src/utils/path-utils.js
@@ -319,6 +319,9 @@ function transform(path, operation) {
     type === 'set_node' ||
     type === 'set_selection' ||
     type === 'set_value' ||
+    type === 'add_annotation' ||
+    type === 'remove_annotation' ||
+    type === 'set_annotation' ||
     path.size === 0
   ) {
     return List([path])


### PR DESCRIPTION
Hi,

Annotation-related operations are not listed in path transform which leads to a crash, when we try to transform any path by such an operation. The result should be the path itself, as annotation-related op do not interfere with the tree.

Thanks in advance.