### PR TITLE
Deduplicate dirty paths for normalization.

### DIFF
--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -110,6 +110,7 @@ class Editor {
     const pathIndex = {}
     this.tmp.dirty = []
 
+    // PERF: De-dupe the paths so we don't do extra normalization.
     dirty.forEach(dirtyPath => {
       const key = dirtyPath.join(',')
 

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -107,7 +107,18 @@ class Editor {
       return memo
     }, newDirtyPaths)
 
-    this.tmp.dirty = dirty
+    const pathIndex = {}
+    this.tmp.dirty = []
+
+    dirty.forEach(dirtyPath => {
+      const key = dirtyPath.join(',')
+
+      if (!pathIndex[key]) {
+        this.tmp.dirty.push(dirtyPath)
+      }
+
+      pathIndex[key] = true
+    })
 
     // If we're not already, queue the flushing process on the next tick.
     if (!this.tmp.flushing) {


### PR DESCRIPTION
Hi,

Paths accumulated for normalization are not deduplicated which leads to poor performance in case we wait with flushing for some reasons.

Thanks.