### PR TITLE
Fix rendering of collapsed annotation at offset zero.

### DIFF
--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -194,7 +194,11 @@ class Text extends Record(DEFAULTS) {
           }
 
           // If the range starts after the leaf, or ends before it, continue.
-          if (start.offset > offset + length || end.offset <= offset) {
+          if (
+            start.offset > offset + length ||
+            end.offset < offset ||
+            (end.offset === offset && offset !== 0)
+          ) {
             next.push(leaf)
             continue
           }


### PR DESCRIPTION
Hi,

`renderAnnotation` is not called for *collapsed* annotation at offset *zero*. This patch fixes it.

Thanks.