### PR TITLE
fixed #1237 which calls Selection.getRangeAt(0) when Selection.type = 'None'

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -250,7 +250,7 @@ class Content extends React.Component {
 
     // Otherwise, figure out which DOM nodes should be selected...
     if (selection.isFocused && selection.isSet) {
-      const current = !!rangeCount && native.getRangeAt(0)
+      const current = !!native.rangeCount && native.getRangeAt(0)
       const range = editor.findDOMRange(selection)
 
       if (!range) {


### PR DESCRIPTION

it should check the latest rangeCount, not the previous memorized one

#### Is this adding or improving a _feature_ or fixing a _bug_?
It fixes #1237 

#### What's the new behavior?

Always check `rangeCount` with the latest Selection object

#### How does this change work?


#### Have you checked that...?
* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #1237
Reviewers: @dmitrizzle @ianstormtaylor 
