### PR TITLE
fix: Unknown event handler property `onEvent`

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -57,6 +57,7 @@ class Content extends React.Component {
     contentKey: Types.number,
     editor: Types.object.isRequired,
     id: Types.string,
+    onEvent: Types.func,
     readOnly: Types.bool.isRequired,
     role: Types.string,
     spellCheck: Types.bool.isRequired,

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -57,7 +57,7 @@ class Content extends React.Component {
     contentKey: Types.number,
     editor: Types.object.isRequired,
     id: Types.string,
-    onEvent: Types.func,
+    onEvent: Types.func.isRequired,
     readOnly: Types.bool.isRequired,
     role: Types.string,
     spellCheck: Types.bool.isRequired,


### PR DESCRIPTION


#### fixing a _bug_

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

```
index.js:1 Warning: Unknown event handler property `onEvent`. It will be ignored.
	in div (created by Content)
    in Content (created by Editor)
```

Will gone.

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

Simply add a line of proptype.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: I'm using a local copy of the latest master and found this bug.
Reviewers: 
