### PR TITLE
Fix getRelative range on text level.

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -288,7 +288,7 @@ function getRelativeRange(node, index, range) {
     start = start.setPath(startPath.rest())
   } else if (startIndex < index && index <= endIndex) {
     if (child.object === 'text') {
-      start = start.moveTo(PathUtils.create([index]), 0).setKey(child.key)
+      start = start.moveTo(PathUtils.create([]), 0).setKey(child.key)
     } else {
       const [first] = child.texts()
       const [firstNode, firstPath] = first
@@ -303,7 +303,7 @@ function getRelativeRange(node, index, range) {
   } else if (startIndex <= index && index < endIndex) {
     if (child.object === 'text') {
       const length = child.text.length
-      end = end.moveTo(PathUtils.create([index]), length).setKey(child.key)
+      end = end.moveTo(PathUtils.create([]), length).setKey(child.key)
     } else {
       const [last] = child.texts({ direction: 'backward' })
       const [lastNode, lastPath] = last


### PR DESCRIPTION
Hi,

It looks like there is an inconstistency in `getRelativeRange` on text level. The path on this level should be empty in my opinion, as we cannot go to a lower level (we are already on the lowest node - namely text node).

I do not know whether this causes any bugs, but it looks like inconsistency in the function.

Cheers.