### PR TITLE
Simplify logic of selection extend forward.

### DIFF
--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -570,19 +570,8 @@ function AfterPlugin(options = {}) {
     }
 
     if (Hotkeys.isExtendForward(event)) {
-      const startText = document.getNode(start.path)
-      const [nextEntry] = document.texts({ path: start.path })
-      let isNextInVoid = false
-
-      if (nextEntry) {
-        const [, nextPath] = nextEntry
-        isNextInVoid = document.hasVoidParent(nextPath, editor)
-      }
-
-      if (hasVoidParent || isNextInVoid || startText.text === '') {
-        event.preventDefault()
-        return editor.moveFocusForward()
-      }
+      event.preventDefault()
+      return editor.moveFocusForward()
     }
 
     next()


### PR DESCRIPTION
Hi,

There is a problem with "code highlighting" example - extending selection forward has no effect when we reach a zero-width span with "&#65279". 

To reproduce:
1. go to code highlighting example.
2. put the cursor in the second code line (at offset zero)
3. Hold shift and press the right arrow several times
4. At some point the selection stops moving.

I do not understand why slate has different logic for handling the selection between "rightarrow" and "shift+rightarrow" cases, but simplyfing the later seems to help.

Can you please have a look at this, whether the logic can be removed, or there is a case for it ?

Thanks in advance!