### PR TITLE
Fix selection normalization at text node boundaries

### DIFF
--- a/benchmark/slate/models/get-active-marks-at-range.js
+++ b/benchmark/slate/models/get-active-marks-at-range.js
@@ -4,8 +4,8 @@
 const h = require('../../helpers/h')
 const { Editor } = require('slate')
 
-module.exports.default = function(value) {
-  value.document.getActiveMarksAtRange(value.selection)
+module.exports.default = function(editor) {
+  editor.getActiveMarksAtRange(editor.value.selection, editor.value.document)
 }
 
 let value = (
@@ -32,5 +32,5 @@ editor.moveToRangeOfDocument()
 value = editor.value
 
 module.exports.input = function() {
-  return value
+  return editor
 }

--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -131,7 +131,7 @@ class RichTextExample extends React.Component {
 
   hasMark = type => {
     const { value } = this.state
-    return value.activeMarks.some(mark => mark.type === type)
+    return value.getActiveMarks(this.editor).some(mark => mark.type === type)
   }
 
   /**

--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -131,8 +131,7 @@ class RichTextExample extends React.Component {
 
   hasMark = type => {
     if (!this.editor) return false
-    const { value } = this.state
-    return value.getActiveMarks(this.editor).some(mark => mark.type === type)
+    return this.editor.getActiveMarks().some(mark => mark.type === type)
   }
 
   /**

--- a/examples/composition/index.js
+++ b/examples/composition/index.js
@@ -130,6 +130,7 @@ class RichTextExample extends React.Component {
    */
 
   hasMark = type => {
+    if (!this.editor) return false
     const { value } = this.state
     return value.getActiveMarks(this.editor).some(mark => mark.type === type)
   }

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -9,7 +9,7 @@ import { Button, Icon, Menu } from '../components'
 
 const MarkButton = ({ editor, type, icon }) => {
   const { value } = editor
-  const isActive = value.activeMarks.some(mark => mark.type === type)
+  const isActive = value.getActiveMarks(editor).some(mark => mark.type === type)
   return (
     <Button
       reversed

--- a/examples/hovering-menu/index.js
+++ b/examples/hovering-menu/index.js
@@ -8,8 +8,7 @@ import { css } from 'emotion'
 import { Button, Icon, Menu } from '../components'
 
 const MarkButton = ({ editor, type, icon }) => {
-  const { value } = editor
-  const isActive = value.getActiveMarks(editor).some(mark => mark.type === type)
+  const isActive = editor.getActiveMarks().some(mark => mark.type === type)
   return (
     <Button
       reversed

--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -50,6 +50,7 @@ class RichTextExample extends React.Component {
    */
 
   hasMark = type => {
+    if (!this.editor) return false
     const { value } = this.state
     return value.getActiveMarks(this.editor).some(mark => mark.type === type)
   }

--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -51,7 +51,7 @@ class RichTextExample extends React.Component {
 
   hasMark = type => {
     const { value } = this.state
-    return value.activeMarks.some(mark => mark.type === type)
+    return value.getActiveMarks(this.editor).some(mark => mark.type === type)
   }
 
   /**

--- a/examples/rich-text/index.js
+++ b/examples/rich-text/index.js
@@ -51,8 +51,7 @@ class RichTextExample extends React.Component {
 
   hasMark = type => {
     if (!this.editor) return false
-    const { value } = this.state
-    return value.getActiveMarks(this.editor).some(mark => mark.type === type)
+    return this.editor.getActiveMarks().some(mark => mark.type === type)
   }
 
   /**

--- a/examples/syncing-operations/index.js
+++ b/examples/syncing-operations/index.js
@@ -57,8 +57,7 @@ class SyncingEditor extends React.Component {
 
   hasMark = type => {
     if (!this.editor) return false
-    const { value } = this.state
-    return value.getActiveMarks(this.editor).some(mark => mark.type === type)
+    return this.editor.getActiveMarks().some(mark => mark.type === type)
   }
 
   /**

--- a/examples/syncing-operations/index.js
+++ b/examples/syncing-operations/index.js
@@ -57,7 +57,7 @@ class SyncingEditor extends React.Component {
 
   hasMark = type => {
     const { value } = this.state
-    return value.activeMarks.some(mark => mark.type === type)
+    return value.getActiveMarks(this.editor).some(mark => mark.type === type)
   }
 
   /**

--- a/examples/syncing-operations/index.js
+++ b/examples/syncing-operations/index.js
@@ -56,6 +56,7 @@ class SyncingEditor extends React.Component {
    */
 
   hasMark = type => {
+    if (!this.editor) return false
     const { value } = this.state
     return value.getActiveMarks(this.editor).some(mark => mark.type === type)
   }

--- a/packages/slate-hyperscript/src/creators.js
+++ b/packages/slate-hyperscript/src/creators.js
@@ -350,10 +350,10 @@ export function createValue(tagName, attributes, children) {
     selection = Selection.create()
   }
 
-  selection = selection.resolveToTextNodes(document)
+  selection = document.createSelection(selection)
 
   if (annotations.length > 0) {
-    annotations = annotations.map(a => a.resolveToTextNodes(document))
+    annotations = annotations.map(a => document.createAnnotation(a))
   }
 
   const value = Value.fromJSON({

--- a/packages/slate-hyperscript/src/creators.js
+++ b/packages/slate-hyperscript/src/creators.js
@@ -350,10 +350,10 @@ export function createValue(tagName, attributes, children) {
     selection = Selection.create()
   }
 
-  selection = selection.normalize(document)
+  selection = selection.resolveToTextNodes(document)
 
   if (annotations.length > 0) {
-    annotations = annotations.map(a => a.normalize(document))
+    annotations = annotations.map(a => a.resolveToTextNodes(document))
   }
 
   const value = Value.fromJSON({

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -475,7 +475,7 @@ class Content extends React.Component {
    * @param {Event} event
    */
 
-  onNativeSelectionChange = throttle(event => {
+  throttledOnNativeSelectionChange = throttle(event => {
     if (this.props.readOnly) return
 
     const window = getWindow(event.target)
@@ -489,6 +489,11 @@ class Content extends React.Component {
 
     this.props.onEvent('onSelect', event)
   }, 100)
+
+  onNativeSelectionChange = event => {
+    if (this.tmp.isUpdatingSelection) return
+    this.throttledOnNativeSelectionChange(event)
+  }
 
   /**
    * Render the editor content.

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -175,7 +175,7 @@ function CompositionManager(editor) {
       .moveAnchorTo(diff.path, diff.start)
       .moveFocusTo(diff.path, diff.end)
 
-    entire = document.resolveRange(entire, editor)
+    entire = editor.getInsertRange(entire, document)
 
     editor.insertTextAtRange(entire, diff.insertText)
   }
@@ -431,9 +431,9 @@ function CompositionManager(editor) {
     const { value } = editor
     const { document, selection } = value
     const node = editor.findNode(domNode)
-    const nodeSelection = document.resolveRange(
+    const nodeSelection = editor.getInsertRange(
       selection.moveToRangeOfNode(node),
-      editor
+      document
     )
 
     renderSync(editor, () => {

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -175,7 +175,7 @@ function CompositionManager(editor) {
       .moveAnchorTo(diff.path, diff.start)
       .moveFocusTo(diff.path, diff.end)
 
-    entire = document.resolveRange(entire)
+    entire = document.resolveRange(entire, editor)
 
     editor.insertTextAtRange(entire, diff.insertText)
   }
@@ -432,7 +432,8 @@ function CompositionManager(editor) {
     const { document, selection } = value
     const node = editor.findNode(domNode)
     const nodeSelection = document.resolveRange(
-      selection.moveToRangeOfNode(node)
+      selection.moveToRangeOfNode(node),
+      editor
     )
 
     renderSync(editor, () => {

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -281,7 +281,7 @@ function AfterPlugin(options = {}) {
       editor.moveToRangeOfNode(node)
     }
 
-    const fragment = editor.value.fragment
+    const fragment = editor.value.getFragment(editor)
     const encoded = Base64.serializeNode(fragment)
     setEventTransfer(event, 'fragment', encoded)
     next()
@@ -641,7 +641,7 @@ function AfterPlugin(options = {}) {
       if (editor.isVoid(startBlock)) return next()
 
       const defaultBlock = startBlock
-      const defaultMarks = document.getInsertMarksAtRange(selection)
+      const defaultMarks = document.getInsertMarksAtRange(selection, editor)
       const frag = Plain.deserialize(text, { defaultBlock, defaultMarks })
         .document
       editor.insertFragment(frag)

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -123,7 +123,11 @@ function AfterPlugin(options = {}) {
 
         if (text == null) break
 
-        editor.insertTextAtRange(range, text, selection.marks)
+        const marks =
+          selection.marks ||
+          value.document.getInsertMarksAtRange(value.selection, editor)
+
+        editor.insertTextAtRange(range, text, marks)
 
         // If the text was successfully inserted, and the selection had marks
         // on it, unset the selection's marks.

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -125,7 +125,7 @@ function AfterPlugin(options = {}) {
 
         const marks =
           selection.marks ||
-          value.document.getInsertMarksAtRange(value.selection, editor)
+          editor.getInsertMarksAtRange(value.selection, value.document)
 
         editor.insertTextAtRange(range, text, marks)
 
@@ -285,7 +285,7 @@ function AfterPlugin(options = {}) {
       editor.moveToRangeOfNode(node)
     }
 
-    const fragment = editor.value.getFragment(editor)
+    const fragment = editor.getFragment()
     const encoded = Base64.serializeNode(fragment)
     setEventTransfer(event, 'fragment', encoded)
     next()
@@ -645,7 +645,7 @@ function AfterPlugin(options = {}) {
       if (editor.isVoid(startBlock)) return next()
 
       const defaultBlock = startBlock
-      const defaultMarks = document.getInsertMarksAtRange(selection, editor)
+      const defaultMarks = editor.getInsertMarksAtRange(selection, document)
       const frag = Plain.deserialize(text, { defaultBlock, defaultMarks })
         .document
       editor.insertFragment(frag)

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -40,8 +40,6 @@ function CommandsPlugin() {
 
     let entire = selection.moveAnchorTo(path, 0).moveFocusTo(path, text.length)
 
-    entire = editor.getInsertRange(entire, document)
-
     // Change the current value to have the leaf's text replaced.
     editor.insertTextAtRange(entire, domText, node.marks)
     return

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -40,7 +40,7 @@ function CommandsPlugin() {
 
     let entire = selection.moveAnchorTo(path, 0).moveFocusTo(path, text.length)
 
-    entire = document.resolveRange(entire)
+    entire = document.resolveRange(entire, editor)
 
     // Change the current value to have the leaf's text replaced.
     editor.insertTextAtRange(entire, domText, node.marks)

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -40,7 +40,7 @@ function CommandsPlugin() {
 
     let entire = selection.moveAnchorTo(path, 0).moveFocusTo(path, text.length)
 
-    entire = document.resolveRange(entire, editor)
+    entire = editor.getInsertRange(entire, document)
 
     // Change the current value to have the leaf's text replaced.
     editor.insertTextAtRange(entire, domText, node.marks)

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -38,7 +38,9 @@ function CommandsPlugin() {
     // If the text is no different, abort.
     if (text === domText) return
 
-    let entire = selection.moveAnchorTo(path, 0).moveFocusTo(path, text.length)
+    const entire = selection
+      .moveAnchorTo(path, 0)
+      .moveFocusTo(path, text.length)
 
     // Change the current value to have the leaf's text replaced.
     editor.insertTextAtRange(entire, domText, node.marks)

--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -378,9 +378,9 @@ function QueriesPlugin() {
 
     const { value } = editor
     const { document } = value
-    const point = document
-      .createPoint({ path, offset })
-      .normalize(document, editor)
+    const point = editor.getInsertionPoint(
+      document.createPoint({ path, offset })
+    )
     return point
   }
 

--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -378,8 +378,9 @@ function QueriesPlugin() {
 
     const { value } = editor
     const { document } = value
-    const point = editor.getInsertionPoint(
-      document.createPoint({ path, offset })
+    const point = editor.getInsertPoint(
+      document.createPoint({ path, offset }),
+      document
     )
     return point
   }

--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -1,5 +1,5 @@
 import getWindow from 'get-window'
-import { PathUtils } from 'slate'
+import { Range, PathUtils } from 'slate'
 
 import DATA_ATTRS from '../../constants/data-attributes'
 import SELECTORS from '../../constants/selectors'
@@ -180,14 +180,14 @@ function QueriesPlugin() {
           ? x - rect.left < rect.left + rect.width - x
           : y - rect.top < rect.top + rect.height - y
 
-      const range = document.createRange().normalize(document, editor)
+      const range = editor.getInsertRange(document.createRange(), document)
       const move = isPrevious ? 'moveToEndOfNode' : 'moveToStartOfNode'
       const entry = document[isPrevious ? 'getPreviousText' : 'getNextText'](
         path
       )
 
       if (entry) {
-        return range[move](entry).normalize(editor)
+        return range[move](entry)
       }
 
       return null
@@ -434,12 +434,10 @@ function QueriesPlugin() {
     }
 
     const { document } = value
-    const range = document
-      .createRange({
-        anchor,
-        focus,
-      })
-      .normalize(document, editor)
+    const range = editor.getInsertRange(
+      Range.create({ anchor, focus }),
+      document
+    )
 
     return range
   }
@@ -490,7 +488,10 @@ function QueriesPlugin() {
       range = range.setFocus(focus.setOffset(0))
     }
 
-    let selection = document.createSelection(range).normalize(document, editor)
+    let selection = editor.getInsertRange(
+      document.createSelection(range),
+      document
+    )
 
     // COMPAT: Ensure that the `isFocused` argument is set.
     selection = selection.setIsFocused(true)

--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -180,14 +180,14 @@ function QueriesPlugin() {
           ? x - rect.left < rect.left + rect.width - x
           : y - rect.top < rect.top + rect.height - y
 
-      const range = document.createRange()
+      const range = document.createRange().normalize(document, editor)
       const move = isPrevious ? 'moveToEndOfNode' : 'moveToStartOfNode'
       const entry = document[isPrevious ? 'getPreviousText' : 'getNextText'](
         path
       )
 
       if (entry) {
-        return range[move](entry)
+        return range[move](entry).normalize(editor)
       }
 
       return null
@@ -378,7 +378,9 @@ function QueriesPlugin() {
 
     const { value } = editor
     const { document } = value
-    const point = document.createPoint({ path, offset })
+    const point = document
+      .createPoint({ path, offset })
+      .normalize(document, editor)
     return point
   }
 
@@ -431,10 +433,12 @@ function QueriesPlugin() {
     }
 
     const { document } = value
-    const range = document.createRange({
-      anchor,
-      focus,
-    })
+    const range = document
+      .createRange({
+        anchor,
+        focus,
+      })
+      .normalize(document, editor)
 
     return range
   }
@@ -464,10 +468,6 @@ function QueriesPlugin() {
     }
 
     const { anchor, focus } = range
-    const anchorText = document.getNode(anchor.path)
-    const focusText = document.getNode(focus.path)
-    const anchorInline = document.getClosestInline(anchor.path)
-    const focusInline = document.getClosestInline(focus.path)
     const focusBlock = document.getClosestBlock(focus.path)
     const anchorBlock = document.getClosestBlock(anchor.path)
 
@@ -489,44 +489,7 @@ function QueriesPlugin() {
       range = range.setFocus(focus.setOffset(0))
     }
 
-    // COMPAT: If the selection is at the end of a non-void inline node, and
-    // there is a node after it, put it in the node after instead. This
-    // standardizes the behavior, since it's indistinguishable to the user.
-    if (
-      anchorInline &&
-      !editor.isVoid(anchorInline) &&
-      anchor.offset === anchorText.text.length
-    ) {
-      const block = document.getClosestBlock(anchor.path)
-      const depth = document.getDepth(block.key)
-      const relativePath = PathUtils.drop(anchor.path, depth)
-      const [next] = block.texts({ path: relativePath })
-
-      if (next) {
-        const [, nextPath] = next
-        const absolutePath = anchor.path.slice(0, depth).concat(nextPath)
-        range = range.moveAnchorTo(absolutePath, 0)
-      }
-    }
-
-    if (
-      focusInline &&
-      !editor.isVoid(focusInline) &&
-      focus.offset === focusText.text.length
-    ) {
-      const block = document.getClosestBlock(focus.path)
-      const depth = document.getDepth(block.key)
-      const relativePath = PathUtils.drop(focus.path, depth)
-      const [next] = block.texts({ path: relativePath })
-
-      if (next) {
-        const [, nextPath] = next
-        const absolutePath = focus.path.slice(0, depth).concat(nextPath)
-        range = range.moveFocusTo(absolutePath, 0)
-      }
-    }
-
-    let selection = document.createSelection(range)
+    let selection = document.createSelection(range).normalize(document, editor)
 
     // COMPAT: Ensure that the `isFocused` argument is set.
     selection = selection.setIsFocused(true)

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -28,8 +28,9 @@ function cloneFragment(event, editor, callback = () => undefined) {
 
   const window = getWindow(event.target)
   const native = window.getSelection()
+  const fragment = editor.getFragment()
   const { value } = editor
-  const { document, fragment, selection } = value
+  const { document, selection } = value
   const { start, end } = selection
   const startVoid = document.getClosestVoid(start.path, editor)
   const endVoid = document.getClosestVoid(end.path, editor)

--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -86,7 +86,9 @@ function findPoint(nativeNode, nativeOffset, editor) {
   const { value } = editor
   if (!value.document.hasDescendant(key)) return null
 
-  const point = value.document.createPoint({ key, offset })
+  const point = value.document
+    .createPoint({ key, offset })
+    .normalize(value.document, editor)
   return point
 }
 

--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -86,9 +86,7 @@ function findPoint(nativeNode, nativeOffset, editor) {
   const { value } = editor
   if (!value.document.hasDescendant(key)) return null
 
-  const point = value.document
-    .createPoint({ key, offset })
-    .normalize(value.document, editor)
+  const point = value.document.createPoint({ key, offset })
   return point
 }
 

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -56,10 +56,12 @@ function findRange(native, editor) {
   if (!anchor || !focus) return null
 
   const { document } = value
-  const range = document.createRange({
-    anchor,
-    focus,
-  })
+  const range = document
+    .createRange({
+      anchor,
+      focus,
+    })
+    .normalize(document, editor)
 
   return range
 }

--- a/packages/slate-react/src/utils/find-range.js
+++ b/packages/slate-react/src/utils/find-range.js
@@ -56,12 +56,10 @@ function findRange(native, editor) {
   if (!anchor || !focus) return null
 
   const { document } = value
-  const range = document
-    .createRange({
-      anchor,
-      focus,
-    })
-    .normalize(document, editor)
+  const range = document.createRange({
+    anchor,
+    focus,
+  })
 
   return range
 }

--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -49,7 +49,7 @@ function getEventRange(event, editor) {
         ? x - rect.left < rect.left + rect.width - x
         : y - rect.top < rect.top + rect.height - y
 
-    const range = document.createRange().normalize(document, editor)
+    const range = document.createRange()
     const move = isPrevious ? 'moveToEndOfNode' : 'moveToStartOfNode'
     const entry = document[isPrevious ? 'getPreviousText' : 'getNextText'](path)
 

--- a/packages/slate-react/src/utils/get-event-range.js
+++ b/packages/slate-react/src/utils/get-event-range.js
@@ -49,7 +49,7 @@ function getEventRange(event, editor) {
         ? x - rect.left < rect.left + rect.width - x
         : y - rect.top < rect.top + rect.height - y
 
-    const range = document.createRange()
+    const range = document.createRange().normalize(document, editor)
     const move = isPrevious ? 'moveToEndOfNode' : 'moveToStartOfNode'
     const entry = document[isPrevious ? 'getPreviousText' : 'getNextText'](path)
 

--- a/packages/slate-react/src/utils/get-selection-from-dom.js
+++ b/packages/slate-react/src/utils/get-selection-from-dom.js
@@ -1,4 +1,5 @@
 import warning from 'tiny-warning'
+import { PathUtils } from 'slate'
 
 import findRange from './find-range'
 
@@ -25,6 +26,10 @@ export default function getSelectionFromDOM(window, editor, domSelection) {
   }
 
   const { anchor, focus } = range
+  const anchorText = document.getNode(anchor.path)
+  const focusText = document.getNode(focus.path)
+  const anchorInline = document.getClosestInline(anchor.path)
+  const focusInline = document.getClosestInline(focus.path)
   const focusBlock = document.getClosestBlock(focus.path)
   const anchorBlock = document.getClosestBlock(anchor.path)
 
@@ -46,7 +51,44 @@ export default function getSelectionFromDOM(window, editor, domSelection) {
     range = range.setFocus(focus.setOffset(0))
   }
 
-  let selection = document.createSelection(range).normalize(document, editor)
+  // COMPAT: If the selection is at the end of a non-void inline node, and
+  // there is a node after it, put it in the node after instead. This
+  // standardizes the behavior, since it's indistinguishable to the user.
+  if (
+    anchorInline &&
+    !editor.isVoid(anchorInline) &&
+    anchor.offset === anchorText.text.length
+  ) {
+    const block = document.getClosestBlock(anchor.path)
+    const depth = document.getDepth(block.key)
+    const relativePath = PathUtils.drop(anchor.path, depth)
+    const [next] = block.texts({ path: relativePath })
+
+    if (next) {
+      const [, nextPath] = next
+      const absolutePath = anchor.path.slice(0, depth).concat(nextPath)
+      range = range.moveAnchorTo(absolutePath, 0)
+    }
+  }
+
+  if (
+    focusInline &&
+    !editor.isVoid(focusInline) &&
+    focus.offset === focusText.text.length
+  ) {
+    const block = document.getClosestBlock(focus.path)
+    const depth = document.getDepth(block.key)
+    const relativePath = PathUtils.drop(focus.path, depth)
+    const [next] = block.texts({ path: relativePath })
+
+    if (next) {
+      const [, nextPath] = next
+      const absolutePath = focus.path.slice(0, depth).concat(nextPath)
+      range = range.moveFocusTo(absolutePath, 0)
+    }
+  }
+
+  let selection = document.createSelection(range)
   selection = selection.setIsFocused(true)
 
   // Preserve active marks from the current selection.

--- a/packages/slate-react/src/utils/get-selection-from-dom.js
+++ b/packages/slate-react/src/utils/get-selection-from-dom.js
@@ -1,5 +1,4 @@
 import warning from 'tiny-warning'
-import { PathUtils } from 'slate'
 
 import findRange from './find-range'
 
@@ -26,10 +25,6 @@ export default function getSelectionFromDOM(window, editor, domSelection) {
   }
 
   const { anchor, focus } = range
-  const anchorText = document.getNode(anchor.path)
-  const focusText = document.getNode(focus.path)
-  const anchorInline = document.getClosestInline(anchor.path)
-  const focusInline = document.getClosestInline(focus.path)
   const focusBlock = document.getClosestBlock(focus.path)
   const anchorBlock = document.getClosestBlock(anchor.path)
 
@@ -51,44 +46,7 @@ export default function getSelectionFromDOM(window, editor, domSelection) {
     range = range.setFocus(focus.setOffset(0))
   }
 
-  // COMPAT: If the selection is at the end of a non-void inline node, and
-  // there is a node after it, put it in the node after instead. This
-  // standardizes the behavior, since it's indistinguishable to the user.
-  if (
-    anchorInline &&
-    !editor.isVoid(anchorInline) &&
-    anchor.offset === anchorText.text.length
-  ) {
-    const block = document.getClosestBlock(anchor.path)
-    const depth = document.getDepth(block.key)
-    const relativePath = PathUtils.drop(anchor.path, depth)
-    const [next] = block.texts({ path: relativePath })
-
-    if (next) {
-      const [, nextPath] = next
-      const absolutePath = anchor.path.slice(0, depth).concat(nextPath)
-      range = range.moveAnchorTo(absolutePath, 0)
-    }
-  }
-
-  if (
-    focusInline &&
-    !editor.isVoid(focusInline) &&
-    focus.offset === focusText.text.length
-  ) {
-    const block = document.getClosestBlock(focus.path)
-    const depth = document.getDepth(block.key)
-    const relativePath = PathUtils.drop(focus.path, depth)
-    const [next] = block.texts({ path: relativePath })
-
-    if (next) {
-      const [, nextPath] = next
-      const absolutePath = focus.path.slice(0, depth).concat(nextPath)
-      range = range.moveFocusTo(absolutePath, 0)
-    }
-  }
-
-  let selection = document.createSelection(range)
+  let selection = document.createSelection(range).normalize(document, editor)
   selection = selection.setIsFocused(true)
 
   // Preserve active marks from the current selection.

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -24,7 +24,7 @@ function deleteExpandedAtRange(editor, range) {
   if (document.hasDescendant(start.path)) {
     range = range.moveToStart()
   } else {
-    range = editor.getInsertionPoint(range.moveTo(end.path, 0))
+    range = editor.getInsertPoint(range.moveTo(end.path, 0), document)
   }
 
   return range

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -24,7 +24,7 @@ function deleteExpandedAtRange(editor, range) {
   if (document.hasDescendant(start.path)) {
     range = range.moveToStart()
   } else {
-    range = range.moveTo(end.path, 0).normalize(document)
+    range = editor.getInsertionPoint(range.moveTo(end.path, 0))
   }
 
   return range
@@ -1119,7 +1119,7 @@ Commands.toggleMarkAtRange = (editor, range, mark) => {
 
   const { value } = editor
   const { document } = value
-  const marks = document.getActiveMarksAtRange(range)
+  const marks = document.getActiveMarksAtRange(range, editor)
   const exists = marks.some(m => m.equals(mark))
 
   if (exists) {

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -24,7 +24,7 @@ function deleteExpandedAtRange(editor, range) {
   if (document.hasDescendant(start.path)) {
     range = range.moveToStart()
   } else {
-    range = editor.getInsertPoint(range.moveTo(end.path, 0), document)
+    range = range.moveTo(end.path, 0)
   }
 
   return range
@@ -1070,7 +1070,6 @@ Commands.splitBlockAtRange = (editor, range, height = 1) => {
         range = range.moveFocusTo(range.anchor.key, end.offset - start.offset)
       }
 
-      range = editor.getResolvedRange(range, document)
       editor.deleteAtRange(range)
     }
   })

--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -1070,7 +1070,7 @@ Commands.splitBlockAtRange = (editor, range, height = 1) => {
         range = range.moveFocusTo(range.anchor.key, end.offset - start.offset)
       }
 
-      range = document.resolveRange(range)
+      range = editor.getResolvedRange(range, document)
       editor.deleteAtRange(range)
     }
   })
@@ -1119,7 +1119,7 @@ Commands.toggleMarkAtRange = (editor, range, mark) => {
 
   const { value } = editor
   const { document } = value
-  const marks = document.getActiveMarksAtRange(range, editor)
+  const marks = editor.getActiveMarksAtRange(range, document)
   const exists = marks.some(m => m.equals(mark))
 
   if (exists) {

--- a/packages/slate/src/commands/on-selection.js
+++ b/packages/slate/src/commands/on-selection.js
@@ -710,7 +710,8 @@ function pointBackward(editor, point, n = 1) {
   const p = selection[point]
   const hasVoidParent = document.hasVoidParent(p.path, editor)
 
-  // what is this?
+  // If point is simply moving to another position within the node,
+  // just adjust the offset.
   if (!hasVoidParent && p.offset - n >= 0) {
     const range = selection[`move${Point}Backward`](n)
     editor.select(range)
@@ -724,13 +725,17 @@ function pointBackward(editor, point, n = 1) {
   const isInBlock = block.hasNode(previous.key)
   const isPreviousInVoid =
     previous && document.hasVoidParent(previous.key, editor)
-  editor[`move${Point}ToEndOfNode`](previous)
+  let range = editor.value.selection[`move${Point}ToEndOfNode`](previous)
 
-  // when is this called?
+  // If point is moving from a text / non-void node into a text /
+  // non-void node under the same parent, move the point backward one
+  // more step. Otherwise point will move from the first position of a
+  // node to the last position of the previous node, which means the
+  // cursor doesn't actually move.
   if (!hasVoidParent && !isPreviousInVoid && isInBlock) {
-    const range = editor.value.selection[`move${Point}Backward`](n)
-    editor.select(range)
+    range = range[`move${Point}Backward`](n)
   }
+  editor.select(range)
 }
 
 function pointForward(editor, point, n = 1) {
@@ -744,7 +749,8 @@ function pointForward(editor, point, n = 1) {
   const text = document.getNode(p.path)
   const hasVoidParent = document.hasVoidParent(p.path, editor)
 
-  // what is this?
+  // If point is simply moving to another position within the node,
+  // just adjust the offset.
   if (!hasVoidParent && p.offset + n <= text.text.length) {
     const range = selection[`move${Point}Forward`](n)
     editor.select(range)

--- a/packages/slate/src/commands/on-selection.js
+++ b/packages/slate/src/commands/on-selection.js
@@ -594,7 +594,7 @@ Commands.select = (editor, properties, options = {}) => {
   const { document, selection } = value
   const newProperties = {}
   let next = selection.setProperties(properties)
-  next = document.resolveSelection(next, editor)
+  next = document.createSelection(next)
 
   // Re-compute the properties, to ensure that we get their normalized values.
   properties = pick(next, Object.keys(properties))

--- a/packages/slate/src/commands/on-selection.js
+++ b/packages/slate/src/commands/on-selection.js
@@ -594,7 +594,7 @@ Commands.select = (editor, properties, options = {}) => {
   const { document, selection } = value
   const newProperties = {}
   let next = selection.setProperties(properties)
-  next = document.resolveSelection(next)
+  next = document.resolveSelection(next, editor)
 
   // Re-compute the properties, to ensure that we get their normalized values.
   properties = pick(next, Object.keys(properties))
@@ -735,6 +735,7 @@ function pointBackward(editor, point, n = 1) {
   if (!hasVoidParent && !isPreviousInVoid && isInBlock) {
     range = range[`move${Point}Backward`](n)
   }
+
   editor.select(range)
 }
 

--- a/packages/slate/src/commands/on-value.js
+++ b/packages/slate/src/commands/on-value.js
@@ -48,12 +48,12 @@ Commands.removeAnnotation = (editor, annotation) => {
 }
 
 Commands.setAnnotation = (editor, annotation, newProperties) => {
-  annotation = Annotation.create(annotation)
+  const properties = Annotation.createProperties(annotation)
   newProperties = Annotation.createProperties(newProperties)
 
   editor.applyOperation({
     type: 'set_annotation',
-    properties: annotation,
+    properties,
     newProperties,
   })
 }

--- a/packages/slate/src/commands/with-intent.js
+++ b/packages/slate/src/commands/with-intent.js
@@ -46,7 +46,7 @@ Commands.addMark = (editor, mark) => {
     const sel = selection.set('marks', marks)
     editor.select(sel)
   } else {
-    const marks = document.getActiveMarksAtRange(selection, editor).add(mark)
+    const marks = editor.getActiveMarksAtRange(selection, document).add(mark)
     const sel = selection.set('marks', marks)
     editor.select(sel)
   }
@@ -326,7 +326,7 @@ Commands.insertText = (editor, text, marks) => {
   marks =
     marks ||
     selection.marks ||
-    document.getInsertMarksAtRange(selection, editor)
+    editor.getInsertMarksAtRange(selection, document)
 
   editor.withoutNormalizing(() => {
     editor.insertTextAtRange(selection, text, marks)
@@ -358,7 +358,7 @@ Commands.removeMark = (editor, mark) => {
     const sel = selection.set('marks', marks)
     editor.select(sel)
   } else {
-    const marks = document.getActiveMarksAtRange(selection, editor).remove(mark)
+    const marks = editor.getActiveMarksAtRange(selection, document).remove(mark)
     const sel = selection.set('marks', marks)
     editor.select(sel)
   }
@@ -416,7 +416,7 @@ Commands.splitBlock = (editor, depth = 1) => {
   const { value } = editor
   const { selection, document } = value
   const marks =
-    selection.marks || document.getInsertMarksAtRange(selection, editor)
+    selection.marks || editor.getInsertMarksAtRange(selection, document)
   editor.splitBlockAtRange(selection, depth).moveToEnd()
 
   if (marks && marks.size !== 0) {
@@ -448,8 +448,7 @@ Commands.splitInline = (editor, height) => {
 
 Commands.toggleMark = (editor, mark) => {
   mark = Mark.create(mark)
-  const { value } = editor
-  const exists = value.getActiveMarks(editor).has(mark)
+  const exists = editor.getActiveMarks().has(mark)
 
   if (exists) {
     editor.removeMark(mark)

--- a/packages/slate/src/commands/with-intent.js
+++ b/packages/slate/src/commands/with-intent.js
@@ -46,7 +46,7 @@ Commands.addMark = (editor, mark) => {
     const sel = selection.set('marks', marks)
     editor.select(sel)
   } else {
-    const marks = document.getActiveMarksAtRange(selection).add(mark)
+    const marks = document.getActiveMarksAtRange(selection, editor).add(mark)
     const sel = selection.set('marks', marks)
     editor.select(sel)
   }
@@ -322,7 +322,11 @@ Commands.insertText = (editor, text, marks) => {
 
   const { value } = editor
   const { document, selection } = value
-  marks = marks || selection.marks || document.getInsertMarksAtRange(selection)
+
+  marks =
+    marks ||
+    selection.marks ||
+    document.getInsertMarksAtRange(selection, editor)
 
   editor.withoutNormalizing(() => {
     editor.insertTextAtRange(selection, text, marks)
@@ -354,7 +358,7 @@ Commands.removeMark = (editor, mark) => {
     const sel = selection.set('marks', marks)
     editor.select(sel)
   } else {
-    const marks = document.getActiveMarksAtRange(selection).remove(mark)
+    const marks = document.getActiveMarksAtRange(selection, editor).remove(mark)
     const sel = selection.set('marks', marks)
     editor.select(sel)
   }
@@ -411,7 +415,8 @@ Commands.splitBlock = (editor, depth = 1) => {
 
   const { value } = editor
   const { selection, document } = value
-  const marks = selection.marks || document.getInsertMarksAtRange(selection)
+  const marks =
+    selection.marks || document.getInsertMarksAtRange(selection, editor)
   editor.splitBlockAtRange(selection, depth).moveToEnd()
 
   if (marks && marks.size !== 0) {
@@ -444,7 +449,7 @@ Commands.splitInline = (editor, height) => {
 Commands.toggleMark = (editor, mark) => {
   mark = Mark.create(mark)
   const { value } = editor
-  const exists = value.activeMarks.has(mark)
+  const exists = value.getActiveMarks(editor).has(mark)
 
   if (exists) {
     editor.removeMark(mark)

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -95,7 +95,7 @@ class Editor {
 
     // Apply the operation to the value.
     debug('apply', { operation })
-    this.value = operation.apply(value).resolveRanges(this.controller)
+    this.value = operation.apply(value)
     this.operations = operations.push(operation)
 
     // Get the paths of the affected nodes, and mark them as dirty.
@@ -219,6 +219,34 @@ class Editor {
     if (selection.isUnset && document.nodes.size) {
       controller.moveToStartOfDocument()
     }
+
+    return controller
+  }
+
+  /**
+   * Check the selection and annotations for errors and disambiguate
+   * ambiguous positions (at the end of nodes, for example)
+   *
+   * @return {Editor}
+   */
+
+  normalizeSelection() {
+    let { value } = this
+    const { controller } = this
+    const { document, selection, annotations } = value
+
+    value = value.set(
+      'selection',
+      controller.getInsertRange(selection, document)
+    )
+
+    const anns = annotations.map(annotation =>
+      controller.getInsertRange(annotation, document)
+    )
+
+    value = value.set('annotations', anns)
+
+    this.value = value
 
     return controller
   }
@@ -388,7 +416,7 @@ class Editor {
 
   setValue(value, options = {}) {
     const { normalize = value !== this.value } = options
-    this.value = value.resolveRanges(this.controller)
+    this.value = value
 
     if (normalize) {
       this.normalize()
@@ -575,6 +603,8 @@ function normalizeDirtyPaths(editor) {
   if (!editor.tmp.normalize) {
     return
   }
+
+  editor.normalizeSelection()
 
   if (!editor.tmp.dirty.length) {
     return

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -138,6 +138,7 @@ class Editor {
    */
 
   flush() {
+    this.normalizeSelection()
     this.run('onChange')
     const { value, operations, controller } = this
     const change = { value, operations }
@@ -420,6 +421,7 @@ class Editor {
 
     if (normalize) {
       this.normalize()
+      this.normalizeSelection()
     }
 
     return this
@@ -603,8 +605,6 @@ function normalizeDirtyPaths(editor) {
   if (!editor.tmp.normalize) {
     return
   }
-
-  editor.normalizeSelection()
 
   if (!editor.tmp.dirty.length) {
     return

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -95,7 +95,7 @@ class Editor {
 
     // Apply the operation to the value.
     debug('apply', { operation })
-    this.value = operation.apply(value)
+    this.value = operation.apply(value).resolveRanges(this.controller)
     this.operations = operations.push(operation)
 
     // Get the paths of the affected nodes, and mark them as dirty.
@@ -388,7 +388,7 @@ class Editor {
 
   setValue(value, options = {}) {
     const { normalize = value !== this.value } = options
-    this.value = value
+    this.value = value.resolveRanges(this.controller)
 
     if (normalize) {
       this.normalize()

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -232,7 +232,7 @@ class Editor {
    */
 
   normalizeSelection() {
-    let { value } = this
+    const { value } = this
     const { controller } = this
 
     this.value = value.mapRanges(range =>

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -234,20 +234,10 @@ class Editor {
   normalizeSelection() {
     let { value } = this
     const { controller } = this
-    const { document, selection, annotations } = value
 
-    value = value.set(
-      'selection',
-      controller.getInsertRange(selection, document)
+    this.value = value.mapRanges(range =>
+      controller.getInsertRange(range, value.document)
     )
-
-    const anns = annotations.map(annotation =>
-      controller.getInsertRange(annotation, document)
-    )
-
-    value = value.set('annotations', anns)
-
-    this.value = value
 
     return controller
   }

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1102,13 +1102,10 @@ class ElementInterface {
    * Get the offset from a `range`.
    *
    * @param {Range} range
-   * @param {Editor} editor
    * @return {Number}
    */
 
-  getOffsetAtRange(range, editor) {
-    range = editor.getInsertRange(range, this)
-
+  getOffsetAtRange(range) {
     if (range.isUnset) {
       throw new Error('The range cannot be unset to calculcate its offset.')
     }
@@ -1469,13 +1466,11 @@ class ElementInterface {
    *
    * @param {List|String} path
    * @param {Range} range
-   * @param {Editor} editor
    * @return {Node}
    */
 
-  isInRange(path, range, editor) {
+  isInRange(path, range) {
     path = this.resolvePath(path)
-    range = editor.getInsertRange(range, this)
 
     if (range.isUnset) {
       return false
@@ -1724,67 +1719,52 @@ class ElementInterface {
   }
 
   /**
-   * Resolve a `annotation`, relative to the node, ensuring that the keys and
-   * offsets in the annotation exist and that they are synced with the paths.
-   *
-   * @param {Annotation|Object} annotation
-   * @param {Editor} editor
-   * @return {Annotation}
+   * Deprecated.
    */
 
   resolveAnnotation(annotation, editor) {
+    warning(
+      false,
+      'As of slate@0.48 the `resolveAnnotation` method is deprecated. You should use the `getInsertRange` editor query instead.'
+    )
+
     annotation = Annotation.create(annotation)
-    annotation = annotation.normalize(this, editor)
+    annotation = annotation.normalize(this)
     return annotation
   }
 
   /**
-   * Resolve a `decoration`, relative to the node, ensuring that the keys and
-   * offsets in the decoration exist and that they are synced with the paths.
-   *
-   * @param {Decoration|Object} decoration
-   * @param {Editor} editor
-   * @return {Decoration}
+   * Deprecated.
    */
 
-  resolveDecoration(decoration, editor) {
+  resolveDecoration(decoration) {
+    warning(
+      false,
+      'As of slate@0.48 the `resolveDecoration` method is deprecated. You should use the `getInsertRange` editor query instead.'
+    )
+
     decoration = Decoration.create(decoration)
-    decoration = decoration.normalize(this, editor)
+    decoration = decoration.normalize(this)
     return decoration
   }
 
   /**
-   * Resolve a `point`, relative to the node, ensuring that the keys and
-   * offsets in the point exist and that they are synced with the paths.
-   *
-   * @param {Point|Object} point
-   * @param {Editor} editor
-   * @return {Point}
+   * Deprecated.
    */
 
-  resolvePoint(point, editor) {
+  resolvePoint(point) {
+    warning(
+      false,
+      'As of slate@0.48 the `resolvePoint` method is deprecated. You should use the `getInsertPoint` editor query instead.'
+    )
+
     point = Point.create(point)
-
-    if (editor == null) {
-      warning(
-        false,
-        'As of slate@0.48 the `resolvePoint` method takes an `Editor` as an argument. You should use the `getInsertPoint` Editor query instead.'
-      )
-
-      point = point.resolveToTextNode(this)
-    } else {
-      point = editor.getInsertPoint(point, this)
-    }
-
+    point = point.normalize(this)
     return point
   }
 
   /**
-   * Resolve a `range`, relative to the node, ensuring that the keys and
-   * offsets in the range exist and that they are synced with the paths.
-   *
-   * @param {Range|Object} range
-   * @return {Range}
+   * Deprecated.
    */
 
   resolveRange(range) {
@@ -1799,17 +1779,17 @@ class ElementInterface {
   }
 
   /**
-   * Resolve a `selection`, relative to the node, ensuring that the keys and
-   * offsets in the selection exist and that they are synced with the paths.
-   *
-   * @param {Selection|Object} selection
-   * @param {Editor} editor
-   * @return {Selection}
+   * Deprecated.
    */
 
-  resolveSelection(selection, editor) {
+  resolveSelection(selection) {
+    warning(
+      false,
+      'As of slate@0.48 the `resolveSelection` method is deprecated. You should use the `getInsertRange` editor query instead.'
+    )
+
     selection = Selection.create(selection)
-    selection = selection.normalize(this, editor)
+    selection = selection.normalize(this)
     return selection
   }
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -324,7 +324,7 @@ class ElementInterface {
 
   createPoint(properties) {
     properties = Point.createProperties(properties)
-    const point = Point.create(properties).resolveToTextNodes(this)
+    const point = Point.create(properties).resolveToTextNode(this)
     return point
   }
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1757,12 +1757,12 @@ class ElementInterface {
     if (editor == null) {
       warning(
         false,
-        'As of slate@0.48 the `resolvePoint` method takes an `Editor` as an argument. You should use the `getInsertionPoint` Editor query instead.'
+        'As of slate@0.48 the `resolvePoint` method takes an `Editor` as an argument. You should use the `getInsertPoint` Editor query instead.'
       )
 
       point = point.resolveToTextNode(this)
     } else {
-      point = editor.getInsertionPoint(point, this)
+      point = editor.getInsertPoint(point, this)
     }
 
     return point

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -427,12 +427,16 @@ class ElementInterface {
    * probably doing unnecessary work.
    *
    * @param {Range} range
-   * @param {Editor} editor
    * @return {Set<Mark>}
    */
 
-  getActiveMarksAtRange(range, editor) {
-    range = this.resolveRange(range, editor)
+  getActiveMarksAtRange(range) {
+    warning(
+      false,
+      'As of slate@0.48 the `getActiveMarksAtRange` method is deprecated. You should use the `getActiveMarksAtRange` editor query instead.'
+    )
+
+    range = this.resolveRange(range)
 
     if (range.isUnset) {
       return Set()
@@ -440,7 +444,7 @@ class ElementInterface {
 
     if (range.isCollapsed) {
       const { start } = range
-      return this.getInsertMarksAtPoint(start, editor)
+      return this.getInsertMarksAtPoint(start)
     }
 
     const { start, end } = range
@@ -721,12 +725,16 @@ class ElementInterface {
    * Get a fragment of the node at a `range`.
    *
    * @param {Range} range
-   * @param {Editor} editor
    * @return {Document}
    */
 
-  getFragmentAtRange(range, editor) {
-    range = this.resolveRange(range, editor)
+  getFragmentAtRange(range) {
+    warning(
+      false,
+      'As of slate@0.48 the `getFragmentAtRange` method is deprecated. You should use the `getFragmentAtRange` editor query instead.'
+    )
+
+    range = this.resolveRange(range)
 
     if (range.isUnset) {
       return Document.create()
@@ -853,12 +861,11 @@ class ElementInterface {
    * node. This mimics expected rich text editing behaviors of mark contiuation.
    *
    * @param {Point} point
-   * @param {Editor} editor
    * @return {Set<Mark>}
    */
 
-  getInsertMarksAtPoint(point, editor) {
-    point = this.resolvePoint(point, editor)
+  getInsertMarksAtPoint(point) {
+    point = this.resolvePoint(point)
     const { path, offset } = point
     const text = this.getDescendant(path)
 
@@ -901,12 +908,16 @@ class ElementInterface {
    * This mimics expected rich text editing behaviors of mark contiuation.
    *
    * @param {Range} range
-   * @param {Editor} editor
    * @return {Set<Mark>}
    */
 
-  getInsertMarksAtRange(range, editor) {
-    range = this.resolveRange(range, editor)
+  getInsertMarksAtRange(range) {
+    warning(
+      false,
+      'As of slate@0.48 the `getInsertMarksAtRange` method is deprecated. You should use the `getInsertMarksAtRange` editor query instead.'
+    )
+
+    range = this.resolveRange(range)
     const { start } = range
 
     if (range.isUnset) {
@@ -914,7 +925,7 @@ class ElementInterface {
     }
 
     if (range.isCollapsed) {
-      return this.getInsertMarksAtPoint(start, editor)
+      return this.getInsertMarksAtPoint(start)
     }
 
     const text = this.getDescendant(start.path)
@@ -1096,7 +1107,7 @@ class ElementInterface {
    */
 
   getOffsetAtRange(range, editor) {
-    range = this.resolveRange(range, editor)
+    range = editor.getInsertRange(range, this)
 
     if (range.isUnset) {
       throw new Error('The range cannot be unset to calculcate its offset.')
@@ -1464,7 +1475,7 @@ class ElementInterface {
 
   isInRange(path, range, editor) {
     path = this.resolvePath(path)
-    range = this.resolveRange(range, editor)
+    range = editor.getInsertRange(range, this)
 
     if (range.isUnset) {
       return false
@@ -1773,13 +1784,17 @@ class ElementInterface {
    * offsets in the range exist and that they are synced with the paths.
    *
    * @param {Range|Object} range
-   * @param {Editor} editor
    * @return {Range}
    */
 
-  resolveRange(range, editor) {
+  resolveRange(range) {
+    warning(
+      false,
+      'As of slate@0.48 the `resolveRange` method is deprecated. You should use the `getInsertRange` editor query instead.'
+    )
+
     range = Range.create(range)
-    range = range.normalize(this, editor)
+    range = range.normalize(this)
     return range
   }
 

--- a/packages/slate/src/interfaces/range.js
+++ b/packages/slate/src/interfaces/range.js
@@ -501,12 +501,11 @@ class RangeInterface {
    * and focus nodes of the range always refer to leaf text nodes.
    *
    * @param {Node} node
-   * @param {Editor} editor
    * @return {Range}
    */
 
-  normalize(node, editor) {
-    return this.updatePoints(point => node.resolvePoint(point, editor))
+  normalize(node) {
+    return this.updatePoints(point => point.normalize(node))
   }
 
   /**

--- a/packages/slate/src/interfaces/range.js
+++ b/packages/slate/src/interfaces/range.js
@@ -501,11 +501,26 @@ class RangeInterface {
    * and focus nodes of the range always refer to leaf text nodes.
    *
    * @param {Node} node
+   * @param {Editor} editor
    * @return {Range}
    */
 
-  normalize(node) {
-    return this.updatePoints(point => point.normalize(node))
+  normalize(node, editor) {
+    return this.updatePoints(point => node.resolvePoint(point, editor))
+  }
+
+  /**
+   * Normalize the range, relative to a `node`, ensuring that the
+   * anchor and focus nodes of the range always refer to leaf text
+   * nodes. Unlike `normalize`, this will not resolve ambiguities at
+   * the edges of nodes.
+   *
+   * @param {Node} node
+   * @return {Range}
+   */
+
+  resolveToTextNodes(node) {
+    return this.updatePoints(point => point.resolveToTextNode(node))
   }
 
   /**

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -347,7 +347,7 @@ class Point extends Record(DEFAULTS) {
    * @return {Point}
    */
 
-  normalize(node) {
+  resolveToTextNode(node) {
     // If both the key and path are null, there's no reference to a node, so
     // make sure it is entirely unset.
     if (this.key == null && this.path == null) {
@@ -374,7 +374,7 @@ class Point extends Record(DEFAULTS) {
     }
 
     if (!target) {
-      warning(false, "A point's `path` or `key` invalid and was reset!")
+      warning(false, "A point's `path` or `key` was invalid and was reset!")
 
       const text = node.getFirstText()
       if (!text) return Point.create()
@@ -408,31 +408,26 @@ class Point extends Record(DEFAULTS) {
       // TODO: if we look up by path above and it differs by key, do we want to reset it to looking up by key?
     }
 
-    let point = this.merge({
+    const point = this.merge({
       key: target.key,
       path: path == null ? node.getPath(target.key) : path,
       offset: offset == null ? 0 : Math.min(offset, target.text.length),
     })
 
-    // COMPAT: There is an ambiguity, since a point can exist at the end of a
-    // text node, or at the start of the following one. To eliminate it we
-    // enforce that if there is a following text node, we always move it there.
-    if (point.offset === target.text.length) {
-      const block = node.getClosestBlock(point.path)
-      const depth = node.getDepth(block.key)
-      const relativePath = PathUtils.drop(point.path, depth)
-      const next = block.getNextText(relativePath)
-
-      if (next) {
-        point = point.merge({
-          key: next.key,
-          path: node.getPath(next.key),
-          offset: 0,
-        })
-      }
-    }
-
     return point
+  }
+
+  /**
+   * Deprecated.
+   */
+
+  normalize(point) {
+    warning(
+      false,
+      'As of slate@0.48 the `normalize` method has been deprecated. Use the `getInsertionPoint` editor query instead.'
+    )
+
+    return this.resolveToTextNode(point)
   }
 
   /**

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -424,7 +424,7 @@ class Point extends Record(DEFAULTS) {
   normalize(point) {
     warning(
       false,
-      'As of slate@0.48 the `normalize` method has been deprecated. Use the `getInsertionPoint` editor query instead.'
+      'As of slate@0.48 the `normalize` method has been deprecated. Use the `getInsertPoint` editor query instead.'
     )
 
     return this.resolveToTextNode(point)

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -419,8 +419,9 @@ class Point extends Record(DEFAULTS) {
     // enforce that if there is a following text node, we always move it there.
     if (point.offset === target.text.length) {
       const block = node.getClosestBlock(point.path)
-      // TODO: this next line is broken because `getNextText` takes a path
-      const next = block.getNextText()
+      const depth = node.getDepth(block.key)
+      const relativePath = PathUtils.drop(point.path, depth)
+      const next = block.getNextText(relativePath)
 
       if (next) {
         point = point.merge({

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -437,11 +437,10 @@ class Value extends Record(DEFAULTS) {
    */
 
   addAnnotation(annotation) {
-    annotation = Annotation.create(annotation)
     let value = this
     let { annotations, document } = value
     const { key } = annotation
-    annotation = annotation.normalize(document)
+    annotation = document.createAnnotation(annotation)
     annotations = annotations.set(key, annotation)
     value = value.set('annotations', annotations)
     return value
@@ -574,30 +573,6 @@ class Value extends Record(DEFAULTS) {
     document = document.moveNode(path, newPath, newIndex)
     value = value.set('document', document)
     value = value.mapPoints(point => point.setPath(null))
-    return value
-  }
-
-  /**
-   * Resolve all ranges, ensuring that the keys and offsets in the
-   * range exist, refer to leaf text nodes, and that they are synced
-   * with the paths.
-   *
-   * @param {Editor} editor
-   * @returns {Value}
-   */
-
-  resolveRanges(editor) {
-    let value = this
-    const { document, selection, annotations } = value
-
-    value = value.set('selection', selection.normalize(document, editor))
-
-    const anns = annotations.map(annotation =>
-      annotation.normalize(document, editor)
-    )
-
-    value = value.set('annotations', anns)
-
     return value
   }
 

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -707,7 +707,12 @@ class Value extends Record(DEFAULTS) {
   setAnnotation(properties, newProperties) {
     newProperties = Annotation.createProperties(newProperties)
     const annotation = Annotation.create(properties)
-    const next = annotation.merge(newProperties)
+    let next = annotation.merge(newProperties)
+
+    if (!next.isSet) {
+      next = this.document.createAnnotation(next)
+    }
+
     let value = this
     let { annotations } = value
     const { key } = annotation

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -353,7 +353,7 @@ class Value extends Record(DEFAULTS) {
   get marks() {
     warning(
       false,
-      'As of Slate 0.48, the `value.marks` property no longer exists. Use `value.getMarks(editor)` instead.'
+      'As of Slate 0.48, the `value.marks` property no longer exists. Use the `getMarks()` query instead.'
     )
     return this.selection.isUnset
       ? new Set()
@@ -367,7 +367,7 @@ class Value extends Record(DEFAULTS) {
   get activeMarks() {
     warning(
       false,
-      'As of Slate 0.48, the `value.activeMarks` property no longer exists. Use `value.getActiveMarks(editor)` instead.'
+      'As of Slate 0.48, the `value.activeMarks` property no longer exists. Use the `getActiveMarks()` query instead.'
     )
     return this.selection.isUnset
       ? new Set()
@@ -396,7 +396,7 @@ class Value extends Record(DEFAULTS) {
   get fragment() {
     warning(
       false,
-      'As of Slate 0.48, the `value.fragment` property no longer exists. Use `value.getFragment(editor)` instead.'
+      'As of Slate 0.48, the `value.fragment` property no longer exists. Use the `getFragment()` query instead.'
     )
 
     return this.selection.isUnset
@@ -462,47 +462,6 @@ class Value extends Record(DEFAULTS) {
     document = document.addMark(path, mark)
     value = value.set('document', document)
     return value
-  }
-
-  /**
-   * Get the marks of the current selection.
-   *
-   * @param {Editor} editor
-   * @return {Set<Mark>}
-   */
-
-  getMarks(editor) {
-    return this.selection.isUnset
-      ? new Set()
-      : this.selection.marks ||
-          this.document.getMarksAtRange(this.selection, editor)
-  }
-
-  /**
-   * Get the active marks of the current selection.
-   *
-   * @param {Editor} editor
-   * @return {Set<Mark>}
-   */
-
-  getActiveMarks(editor) {
-    return this.selection.isUnset
-      ? new Set()
-      : this.selection.marks ||
-          this.document.getActiveMarksAtRange(this.selection, editor)
-  }
-
-  /**
-   * Get the fragment of the current selection.
-   *
-   * @param {Editor} editor
-   * @return {Document}
-   */
-
-  getFragment(editor) {
-    return this.selection.isUnset
-      ? Document.create()
-      : this.document.getFragmentAtRange(this.selection, editor)
   }
 
   /**

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -102,6 +102,10 @@ class Value extends Record(DEFAULTS) {
       selection = document.createSelection(selection)
     }
 
+    annotations = annotations.map(
+      a => (a.isSet ? a : document.createAnnotation(a))
+    )
+
     const value = new Value({
       annotations,
       data,

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -1,5 +1,6 @@
 import isPlainObject from 'is-plain-object'
 import invariant from 'tiny-invariant'
+import warning from 'tiny-warning'
 import { Record, Set, List } from 'immutable'
 
 import Annotation from './annotation'
@@ -350,7 +351,7 @@ class Value extends Record(DEFAULTS) {
    */
 
   get marks() {
-    invariant(
+    warning(
       false,
       'As of Slate 0.48, the `value.marks` property no longer exists. Use `value.getMarks(editor)` instead.'
     )
@@ -364,7 +365,7 @@ class Value extends Record(DEFAULTS) {
    */
 
   get activeMarks() {
-    invariant(
+    warning(
       false,
       'As of Slate 0.48, the `value.activeMarks` property no longer exists. Use `value.getActiveMarks(editor)` instead.'
     )
@@ -393,7 +394,7 @@ class Value extends Record(DEFAULTS) {
    */
 
   get fragment() {
-    invariant(
+    warning(
       false,
       'As of Slate 0.48, the `value.fragment` property no longer exists. Use `value.getFragment(editor)` instead.'
     )

--- a/packages/slate/src/plugins/core.js
+++ b/packages/slate/src/plugins/core.js
@@ -1,5 +1,6 @@
-import AtPoint from '../queries/at-point'
-import AtRange from '../commands/at-range'
+import AtPointQueries from '../queries/at-point'
+import AtRangeCommands from '../commands/at-range'
+import AtRangeQueries from '../queries/at-range'
 import ByPath from '../commands/by-path'
 import Commands from './commands'
 import OnHistory from '../commands/on-history'
@@ -8,7 +9,8 @@ import OnValue from '../commands/on-value'
 import Queries from './queries'
 import Schema from './schema'
 import Text from '../models/text'
-import WithIntent from '../commands/with-intent'
+import WithIntentCommands from '../commands/with-intent'
+import WithIntentQueries from '../queries/with-intent'
 
 /**
  * A plugin that defines the core Slate logic.
@@ -27,12 +29,12 @@ function CorePlugin(options = {}) {
    */
 
   const commands = Commands({
-    ...AtRange,
+    ...AtRangeCommands,
     ...ByPath,
     ...OnHistory,
     ...OnSelection,
     ...OnValue,
-    ...WithIntent,
+    ...WithIntentCommands,
   })
 
   /**
@@ -44,7 +46,9 @@ function CorePlugin(options = {}) {
   const queries = Queries({
     isAtomic: () => false,
     isVoid: () => false,
-    ...AtPoint,
+    ...AtPointQueries,
+    ...AtRangeQueries,
+    ...WithIntentQueries,
   })
 
   /**

--- a/packages/slate/src/plugins/core.js
+++ b/packages/slate/src/plugins/core.js
@@ -1,3 +1,4 @@
+import AtPoint from '../queries/at-point'
 import AtRange from '../commands/at-range'
 import ByPath from '../commands/by-path'
 import Commands from './commands'
@@ -43,6 +44,7 @@ function CorePlugin(options = {}) {
   const queries = Queries({
     isAtomic: () => false,
     isVoid: () => false,
+    ...AtPoint,
   })
 
   /**

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -1,6 +1,3 @@
-import { Set } from 'immutable'
-
-import Document from '../models/document'
 import PathUtils from '../utils/path-utils'
 
 /**
@@ -10,160 +7,6 @@ import PathUtils from '../utils/path-utils'
  */
 
 const Queries = {}
-
-/**
- * Get the active marks of the current selection.
- *
- * @param {Editor} editor
- * @return {Set<Mark>}
- */
-
-Queries.getActiveMarks = editor => {
-  const { document, selection } = editor.value
-  return selection.isUnset
-    ? new Set()
-    : selection.marks || editor.getActiveMarksAtRange(selection, document)
-}
-
-/**
- * Get a set of the active marks in a `range`. Active marks are marks that are
- * on every text node in a given range. This is a common distinction for
- * highlighting toolbar buttons for example.
- *
- * TODO: this method needs to be cleaned up, it's very hard to follow and
- * probably doing unnecessary work.
- *
- * @param {Editor} editor
- * @param {Range} range
- * @param {Node} node
- * @return {Set<Mark>}
- */
-
-Queries.getActiveMarksAtRange = (editor, range, node) => {
-  if (range.isUnset) {
-    return Set()
-  }
-
-  if (range.isCollapsed) {
-    const { start } = range
-    return editor.getInsertMarksAtPoint(start, node)
-  }
-
-  const { start, end } = range
-  let startPath = start.path
-  let startOffset = start.offset
-  let endPath = end.path
-  let endOffset = end.offset
-  let startText = node.getDescendant(startPath)
-  let endText = node.getDescendant(endPath)
-
-  if (!startPath.equals(endPath)) {
-    while (!startPath.equals(endPath) && endOffset === 0) {
-      ;[[endText, endPath]] = node.texts({
-        path: endPath,
-        direction: 'backward',
-      })
-
-      endOffset = endText.text.length
-    }
-
-    while (
-      !startPath.equals(endPath) &&
-      startOffset === startText.text.length
-    ) {
-      ;[[startText, startPath]] = node.texts({ path: startPath })
-      startOffset = 0
-    }
-  }
-
-  if (startPath.equals(endPath)) {
-    return startText.marks
-  }
-
-  const startMarks = startText.marks
-
-  // PERF: if start marks is empty we can return early.
-  if (startMarks.size === 0) {
-    return Set()
-  }
-
-  const endMarks = endText.marks
-  let marks = startMarks.intersect(endMarks)
-
-  // If marks is already empty, the active marks is empty
-  if (marks.size === 0) {
-    return marks
-  }
-
-  ;[[startText, startPath]] = node.texts({ path: startPath })
-
-  while (!startPath.equals(endPath)) {
-    if (startText.text.length !== 0) {
-      marks = marks.intersect(startText.marks)
-
-      if (marks.size === 0) {
-        return Set()
-      }
-    }
-
-    ;[[startText, startPath]] = node.texts({ path: startPath })
-  }
-
-  return marks
-}
-
-/**
- * Get the fragment of the current selection.
- *
- * @param {Editor} editor
- * @return {Document}
- */
-
-Queries.getFragment = editor => {
-  const { document, selection } = editor.value
-  return selection.isUnset
-    ? Document.create()
-    : editor.getFragmentAtRange(selection, document)
-}
-
-/**
- * Get a fragment of the node at a `range`.
- *
- * @param {Editor} editor
- * @param {Range} range
- * @param {Range} node
- * @return {Document}
- */
-
-Queries.getFragmentAtRange = (editor, range, node) => {
-  if (range.isUnset) {
-    return Document.create()
-  }
-
-  const { start, end } = range
-  let targetPath = end.path
-  let targetPosition = end.offset
-  let side = 'end'
-
-  while (targetPath.size) {
-    const index = targetPath.last()
-    node = node.splitNode(targetPath, targetPosition)
-    targetPosition = index + 1
-    targetPath = PathUtils.lift(targetPath)
-
-    if (!targetPath.size && side === 'end') {
-      targetPath = start.path
-      targetPosition = start.offset
-      side = 'start'
-    }
-  }
-
-  const startIndex = start.path.first() + 1
-  const endIndex = end.path.first() + 2
-  const nodes = node.nodes.slice(startIndex, endIndex)
-  const fragment = Document.create({ nodes })
-  return fragment
-}
 
 /**
  * Get a set of marks that would occur on the next insert at a `point` in the
@@ -211,31 +54,6 @@ Queries.getInsertMarksAtPoint = (editor, point, node) => {
   // Otherwise, continue with the previous text node's marks instead.
   const [previousText] = previous
   return previousText.marks
-}
-
-/**
- * Get a set of marks that would occur on the next insert at a `range`.
- * This mimics expected rich text editing behaviors of mark contiuation.
- *
- * @param {Editor} editor
- * @param {Range} range
- * @param {Node} node
- * @return {Set<Mark>}
- */
-
-Queries.getInsertMarksAtRange = (editor, range, node) => {
-  const { start } = range
-
-  if (range.isUnset) {
-    return Set()
-  }
-
-  if (range.isCollapsed) {
-    return editor.getInsertMarksAtPoint(start, node)
-  }
-
-  const text = node.getDescendant(start.path)
-  return text.marks
 }
 
 /**
@@ -291,34 +109,6 @@ Queries.getInsertPoint = (editor, point, node) => {
   }
 
   return resolvedPoint
-}
-
-/**
- * Resolve a `range`, relative to the node, ensuring that the keys and
- * offsets in the range exist and that they are synced with the paths.
- *
- * @param {Editor} editor
- * @param {Range} range
- * @param {Node} node
- * @return {Range}
- */
-
-Queries.getInsertRange = (editor, range, node) => {
-  return range.updatePoints(point => editor.getInsertPoint(point, node))
-}
-
-/**
- * Get the marks of the current selection.
- *
- * @param {Editor} editor
- * @return {Set<Mark>}
- */
-
-Queries.getMarks = editor => {
-  const { document, selection } = editor.value
-  return selection.isUnset
-    ? new Set()
-    : selection.marks || document.getMarksAtRange(selection, editor)
 }
 
 export default Queries

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -1,0 +1,62 @@
+import PathUtils from '../utils/path-utils'
+
+/**
+ * Queries.
+ *
+ * @type {Object}
+ */
+
+const Queries = {}
+
+/**
+ * Returns the point closest to a point where text can be
+ * inserted. When the point is ambiguous (for example, in between two
+ * nodes), it will be normalized to the beginning of the following
+ * node.
+ *
+ * @param {Editor} editor
+ * @param {Point} point
+ * @param {Node} node (optional)
+ * @return {Point}
+ */
+
+Queries.getInsertionPoint = (editor, point, node) => {
+  let resolvedPoint = point.resolveToTextNode(node || editor.value.document)
+  if (resolvedPoint.path == null) return resolvedPoint
+
+  let closestInline = node.getClosestInline(resolvedPoint.path)
+  let resolvedNode = node.getNode(resolvedPoint.path)
+
+  // COMPAT: There is an ambiguity, since a point can exist at the end of a
+  // text node, or at the start of the following one. To eliminate it we
+  // enforce that if there is a following text node, we always move it there.
+  while (
+    resolvedPoint.offset === resolvedNode.text.length &&
+    (!closestInline || !editor.isVoid(closestInline))
+  ) {
+    const block = node.getClosestBlock(resolvedPoint.path)
+    const depth = node.getDepth(block.key)
+    const relativePath = PathUtils.drop(resolvedPoint.path, depth)
+    const [next] = block.texts({ path: relativePath })
+
+    if (next) {
+      const [, nextPath] = next
+      const absolutePath = resolvedPoint.path.slice(0, depth).concat(nextPath)
+
+      resolvedPoint = resolvedPoint.merge({
+        key: next.key,
+        path: absolutePath,
+        offset: 0,
+      })
+    } else {
+      break
+    }
+
+    closestInline = node.getClosestInline(resolvedPoint.path)
+    resolvedNode = node.getNode(resolvedPoint.path)
+  }
+
+  return resolvedPoint
+}
+
+export default Queries

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -40,11 +40,11 @@ Queries.getInsertPoint = (editor, point, node) => {
     const [next] = block.texts({ path: relativePath })
 
     if (next) {
-      const [, nextPath] = next
+      const [nextText, nextPath] = next
       const absolutePath = resolvedPoint.path.slice(0, depth).concat(nextPath)
 
       resolvedPoint = resolvedPoint.merge({
-        key: next.key,
+        key: nextText.key,
         path: absolutePath,
         offset: 0,
       })

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -1,4 +1,8 @@
+import { Set } from 'immutable'
+
+import Document from '../models/document'
 import PathUtils from '../utils/path-utils'
+import Range from '../models/range'
 
 /**
  * Queries.
@@ -7,6 +11,239 @@ import PathUtils from '../utils/path-utils'
  */
 
 const Queries = {}
+
+/**
+ * Get the active marks of the current selection.
+ *
+ * @param {Editor} editor
+ * @return {Set<Mark>}
+ */
+
+Queries.getActiveMarks = editor => {
+  const { document, selection } = editor.value
+  return selection.isUnset
+    ? new Set()
+    : selection.marks || editor.getActiveMarksAtRange(selection, document)
+}
+
+/**
+ * Get a set of the active marks in a `range`. Active marks are marks that are
+ * on every text node in a given range. This is a common distinction for
+ * highlighting toolbar buttons for example.
+ *
+ * TODO: this method needs to be cleaned up, it's very hard to follow and
+ * probably doing unnecessary work.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Node} node
+ * @return {Set<Mark>}
+ */
+
+Queries.getActiveMarksAtRange = (editor, range, node) => {
+  range = editor.getInsertRange(range, node)
+
+  if (range.isUnset) {
+    return Set()
+  }
+
+  if (range.isCollapsed) {
+    const { start } = range
+    return editor.getInsertMarksAtPoint(start, node)
+  }
+
+  const { start, end } = range
+  let startPath = start.path
+  let startOffset = start.offset
+  let endPath = end.path
+  let endOffset = end.offset
+  let startText = node.getDescendant(startPath)
+  let endText = node.getDescendant(endPath)
+
+  if (!startPath.equals(endPath)) {
+    while (!startPath.equals(endPath) && endOffset === 0) {
+      ;[[endText, endPath]] = node.texts({
+        path: endPath,
+        direction: 'backward',
+      })
+
+      endOffset = endText.text.length
+    }
+
+    while (
+      !startPath.equals(endPath) &&
+      startOffset === startText.text.length
+    ) {
+      ;[[startText, startPath]] = node.texts({ path: startPath })
+      startOffset = 0
+    }
+  }
+
+  if (startPath.equals(endPath)) {
+    return startText.marks
+  }
+
+  const startMarks = startText.marks
+
+  // PERF: if start marks is empty we can return early.
+  if (startMarks.size === 0) {
+    return Set()
+  }
+
+  const endMarks = endText.marks
+  let marks = startMarks.intersect(endMarks)
+
+  // If marks is already empty, the active marks is empty
+  if (marks.size === 0) {
+    return marks
+  }
+
+  ;[[startText, startPath]] = node.texts({ path: startPath })
+
+  while (!startPath.equals(endPath)) {
+    if (startText.text.length !== 0) {
+      marks = marks.intersect(startText.marks)
+
+      if (marks.size === 0) {
+        return Set()
+      }
+    }
+
+    ;[[startText, startPath]] = node.texts({ path: startPath })
+  }
+
+  return marks
+}
+
+/**
+ * Get the fragment of the current selection.
+ *
+ * @param {Editor} editor
+ * @return {Document}
+ */
+
+Queries.getFragment = editor => {
+  const { document, selection } = editor.value
+  return selection.isUnset
+    ? Document.create()
+    : editor.getFragmentAtRange(selection, document)
+}
+
+/**
+ * Get a fragment of the node at a `range`.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Range} node
+ * @return {Document}
+ */
+
+Queries.getFragmentAtRange = (editor, range, node) => {
+  range = editor.getInsertRange(range, node)
+
+  if (range.isUnset) {
+    return Document.create()
+  }
+
+  const { start, end } = range
+  let targetPath = end.path
+  let targetPosition = end.offset
+  let side = 'end'
+
+  while (targetPath.size) {
+    const index = targetPath.last()
+    node = node.splitNode(targetPath, targetPosition)
+    targetPosition = index + 1
+    targetPath = PathUtils.lift(targetPath)
+
+    if (!targetPath.size && side === 'end') {
+      targetPath = start.path
+      targetPosition = start.offset
+      side = 'start'
+    }
+  }
+
+  const startIndex = start.path.first() + 1
+  const endIndex = end.path.first() + 2
+  const nodes = node.nodes.slice(startIndex, endIndex)
+  const fragment = Document.create({ nodes })
+  return fragment
+}
+
+/**
+ * Get a set of marks that would occur on the next insert at a `point` in the
+ * node. This mimics expected rich text editing behaviors of mark contiuation.
+ *
+ * @param {Editor} editor
+ * @param {Point} point
+ * @param {Node} node
+ * @return {Set<Mark>}
+ */
+
+Queries.getInsertMarksAtPoint = (editor, point, node) => {
+  point = editor.getInsertPoint(point, node)
+  const { path, offset } = point
+  const text = node.getDescendant(path)
+
+  // PERF: we can exit early if the offset isn't at the start of the node.
+  if (offset !== 0) {
+    return text.marks
+  }
+
+  let blockNode
+  let blockPath
+
+  for (const entry of node.ancestors(path)) {
+    const [n, p] = entry
+
+    if (n.object === 'block') {
+      blockNode = n
+      blockPath = p
+    }
+  }
+
+  const relativePath = PathUtils.drop(path, blockPath.size)
+  const [previous] = blockNode.texts({
+    path: relativePath,
+    direction: 'backward',
+  })
+
+  // If there's no previous text, we're at the start of the block, so use
+  // the current text nodes marks.
+  if (!previous) {
+    return text.marks
+  }
+
+  // Otherwise, continue with the previous text node's marks instead.
+  const [previousText] = previous
+  return previousText.marks
+}
+
+/**
+ * Get a set of marks that would occur on the next insert at a `range`.
+ * This mimics expected rich text editing behaviors of mark contiuation.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Node} node
+ * @return {Set<Mark>}
+ */
+
+Queries.getInsertMarksAtRange = (editor, range, node) => {
+  range = editor.getInsertRange(range, node)
+  const { start } = range
+
+  if (range.isUnset) {
+    return Set()
+  }
+
+  if (range.isCollapsed) {
+    return editor.getInsertMarksAtPoint(start, node)
+  }
+
+  const text = node.getDescendant(start.path)
+  return text.marks
+}
 
 /**
  * Returns the point closest to a point, under a node, where text can
@@ -61,6 +298,36 @@ Queries.getInsertPoint = (editor, point, node) => {
   }
 
   return resolvedPoint
+}
+
+/**
+ * Resolve a `range`, relative to the node, ensuring that the keys and
+ * offsets in the range exist and that they are synced with the paths.
+ *
+ * @param {Editor} editor
+ * @param {Range|Object} range
+ * @param {Node} node
+ * @return {Range}
+ */
+
+Queries.getInsertRange = (editor, range, node) => {
+  range = Range.create(range)
+  range = range.normalize(node, editor)
+  return range
+}
+
+/**
+ * Get the marks of the current selection.
+ *
+ * @param {Editor} editor
+ * @return {Set<Mark>}
+ */
+
+Queries.getMarks = editor => {
+  const { document, selection } = editor.value
+  return selection.isUnset
+    ? new Set()
+    : selection.marks || document.getMarksAtRange(selection, editor)
 }
 
 export default Queries

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -9,18 +9,18 @@ import PathUtils from '../utils/path-utils'
 const Queries = {}
 
 /**
- * Returns the point closest to a point where text can be
- * inserted. When the point is ambiguous (for example, in between two
- * nodes), it will be normalized to the beginning of the following
+ * Returns the point closest to a point, under a node, where text can
+ * be inserted. When the point is ambiguous (for example, in between
+ * two nodes), it will be normalized to the beginning of the following
  * node.
  *
  * @param {Editor} editor
  * @param {Point} point
- * @param {Node} node (optional)
+ * @param {Node} node
  * @return {Point}
  */
 
-Queries.getInsertionPoint = (editor, point, node = editor.value.document) => {
+Queries.getInsertPoint = (editor, point, node) => {
   let resolvedPoint = point.resolveToTextNode(node)
   if (resolvedPoint.path == null) return resolvedPoint
 

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -40,8 +40,6 @@ Queries.getActiveMarks = editor => {
  */
 
 Queries.getActiveMarksAtRange = (editor, range, node) => {
-  range = editor.getInsertRange(range, node)
-
   if (range.isUnset) {
     return Set()
   }
@@ -138,8 +136,6 @@ Queries.getFragment = editor => {
  */
 
 Queries.getFragmentAtRange = (editor, range, node) => {
-  range = editor.getInsertRange(range, node)
-
   if (range.isUnset) {
     return Document.create()
   }
@@ -180,7 +176,6 @@ Queries.getFragmentAtRange = (editor, range, node) => {
  */
 
 Queries.getInsertMarksAtPoint = (editor, point, node) => {
-  point = editor.getInsertPoint(point, node)
   const { path, offset } = point
   const text = node.getDescendant(path)
 
@@ -229,7 +224,6 @@ Queries.getInsertMarksAtPoint = (editor, point, node) => {
  */
 
 Queries.getInsertMarksAtRange = (editor, range, node) => {
-  range = editor.getInsertRange(range, node)
   const { start } = range
 
   if (range.isUnset) {

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -20,8 +20,8 @@ const Queries = {}
  * @return {Point}
  */
 
-Queries.getInsertionPoint = (editor, point, node) => {
-  let resolvedPoint = point.resolveToTextNode(node || editor.value.document)
+Queries.getInsertionPoint = (editor, point, node = editor.value.document) => {
+  let resolvedPoint = point.resolveToTextNode(node)
   if (resolvedPoint.path == null) return resolvedPoint
 
   let closestInline = node.getClosestInline(resolvedPoint.path)

--- a/packages/slate/src/queries/at-point.js
+++ b/packages/slate/src/queries/at-point.js
@@ -2,7 +2,6 @@ import { Set } from 'immutable'
 
 import Document from '../models/document'
 import PathUtils from '../utils/path-utils'
-import Range from '../models/range'
 
 /**
  * Queries.
@@ -305,15 +304,13 @@ Queries.getInsertPoint = (editor, point, node) => {
  * offsets in the range exist and that they are synced with the paths.
  *
  * @param {Editor} editor
- * @param {Range|Object} range
+ * @param {Range} range
  * @param {Node} node
  * @return {Range}
  */
 
 Queries.getInsertRange = (editor, range, node) => {
-  range = Range.create(range)
-  range = range.normalize(node, editor)
-  return range
+  return range.updatePoints(point => editor.getInsertPoint(point, node))
 }
 
 /**

--- a/packages/slate/src/queries/at-range.js
+++ b/packages/slate/src/queries/at-range.js
@@ -1,0 +1,179 @@
+import { Set } from 'immutable'
+
+import Document from '../models/document'
+import PathUtils from '../utils/path-utils'
+
+/**
+ * Queries.
+ *
+ * @type {Object}
+ */
+
+const Queries = {}
+
+/**
+ * Get a set of the active marks in a `range`. Active marks are marks that are
+ * on every text node in a given range. This is a common distinction for
+ * highlighting toolbar buttons for example.
+ *
+ * TODO: this method needs to be cleaned up, it's very hard to follow and
+ * probably doing unnecessary work.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Node} node
+ * @return {Set<Mark>}
+ */
+
+Queries.getActiveMarksAtRange = (editor, range, node) => {
+  if (range.isUnset) {
+    return Set()
+  }
+
+  if (range.isCollapsed) {
+    const { start } = range
+    return editor.getInsertMarksAtPoint(start, node)
+  }
+
+  const { start, end } = range
+  let startPath = start.path
+  let startOffset = start.offset
+  let endPath = end.path
+  let endOffset = end.offset
+  let startText = node.getDescendant(startPath)
+  let endText = node.getDescendant(endPath)
+
+  if (!startPath.equals(endPath)) {
+    while (!startPath.equals(endPath) && endOffset === 0) {
+      ;[[endText, endPath]] = node.texts({
+        path: endPath,
+        direction: 'backward',
+      })
+
+      endOffset = endText.text.length
+    }
+
+    while (
+      !startPath.equals(endPath) &&
+      startOffset === startText.text.length
+    ) {
+      ;[[startText, startPath]] = node.texts({ path: startPath })
+      startOffset = 0
+    }
+  }
+
+  if (startPath.equals(endPath)) {
+    return startText.marks
+  }
+
+  const startMarks = startText.marks
+
+  // PERF: if start marks is empty we can return early.
+  if (startMarks.size === 0) {
+    return Set()
+  }
+
+  const endMarks = endText.marks
+  let marks = startMarks.intersect(endMarks)
+
+  // If marks is already empty, the active marks is empty
+  if (marks.size === 0) {
+    return marks
+  }
+
+  ;[[startText, startPath]] = node.texts({ path: startPath })
+
+  while (!startPath.equals(endPath)) {
+    if (startText.text.length !== 0) {
+      marks = marks.intersect(startText.marks)
+
+      if (marks.size === 0) {
+        return Set()
+      }
+    }
+
+    ;[[startText, startPath]] = node.texts({ path: startPath })
+  }
+
+  return marks
+}
+
+/**
+ * Get a fragment of the node at a `range`.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Range} node
+ * @return {Document}
+ */
+
+Queries.getFragmentAtRange = (editor, range, node) => {
+  if (range.isUnset) {
+    return Document.create()
+  }
+
+  const { start, end } = range
+  let targetPath = end.path
+  let targetPosition = end.offset
+  let side = 'end'
+
+  while (targetPath.size) {
+    const index = targetPath.last()
+    node = node.splitNode(targetPath, targetPosition)
+    targetPosition = index + 1
+    targetPath = PathUtils.lift(targetPath)
+
+    if (!targetPath.size && side === 'end') {
+      targetPath = start.path
+      targetPosition = start.offset
+      side = 'start'
+    }
+  }
+
+  const startIndex = start.path.first() + 1
+  const endIndex = end.path.first() + 2
+  const nodes = node.nodes.slice(startIndex, endIndex)
+  const fragment = Document.create({ nodes })
+  return fragment
+}
+
+/**
+ * Get a set of marks that would occur on the next insert at a `range`.
+ * This mimics expected rich text editing behaviors of mark contiuation.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Node} node
+ * @return {Set<Mark>}
+ */
+
+Queries.getInsertMarksAtRange = (editor, range, node) => {
+  const { start } = range
+
+  if (range.isUnset) {
+    return Set()
+  }
+
+  if (range.isCollapsed) {
+    return editor.getInsertMarksAtPoint(start, node)
+  }
+
+  const text = node.getDescendant(start.path)
+  return text.marks
+}
+
+/**
+ * Resolve a `range`, relative to the node, ensuring that the keys and
+ * offsets in the range exist and that they are synced with the paths.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ * @param {Node} node
+ * @return {Range}
+ */
+
+Queries.getInsertRange = (editor, range, node) => {
+  return range.updatePoints(point => editor.getInsertPoint(point, node))
+}
+
+export default Queries

--- a/packages/slate/src/queries/with-intent.js
+++ b/packages/slate/src/queries/with-intent.js
@@ -1,0 +1,55 @@
+import { Set } from 'immutable'
+
+import Document from '../models/document'
+
+/**
+ * Queries.
+ *
+ * @type {Object}
+ */
+
+const Queries = {}
+
+/**
+ * Get the active marks of the current selection.
+ *
+ * @param {Editor} editor
+ * @return {Set<Mark>}
+ */
+
+Queries.getActiveMarks = editor => {
+  const { document, selection } = editor.value
+  return selection.isUnset
+    ? new Set()
+    : selection.marks || editor.getActiveMarksAtRange(selection, document)
+}
+
+/**
+ * Get the fragment of the current selection.
+ *
+ * @param {Editor} editor
+ * @return {Document}
+ */
+
+Queries.getFragment = editor => {
+  const { document, selection } = editor.value
+  return selection.isUnset
+    ? Document.create()
+    : editor.getFragmentAtRange(selection, document)
+}
+
+/**
+ * Get the marks of the current selection.
+ *
+ * @param {Editor} editor
+ * @return {Set<Mark>}
+ */
+
+Queries.getMarks = editor => {
+  const { document, selection } = editor.value
+  return selection.isUnset
+    ? new Set()
+    : selection.marks || document.getMarksAtRange(selection, editor)
+}
+
+export default Queries

--- a/packages/slate/test/commands/at-current-range/delete-backward/inline-before.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/inline-before.js
@@ -10,8 +10,11 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        a<cursor />
-        <link>two</link>
+        a
+        <link>
+          <cursor />
+          two
+        </link>
       </paragraph>
     </document>
   </value>
@@ -21,8 +24,10 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <cursor />
-        <link>two</link>
+        <link>
+          <cursor />
+          two
+        </link>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-backward/inline-inside.js
+++ b/packages/slate/test/commands/at-current-range/delete-backward/inline-inside.js
@@ -10,9 +10,9 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        one<link>
-          a<cursor />
-        </link>two
+        one<link>a</link>
+        <cursor />
+        two
       </paragraph>
     </document>
   </value>
@@ -22,9 +22,9 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        one<link>
-          <cursor />
-        </link>two
+        one<link />
+        <cursor />
+        two
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-char-backward/inline-end-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-char-backward/inline-end-emoji.js
@@ -10,9 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          word📛<cursor />
-        </link>
+        <link>word📛</link>
+        <cursor />
       </paragraph>
     </document>
   </value>
@@ -22,9 +21,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <link>
-          word<cursor />
-        </link>
+        <link>word</link>
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-char-backward/inline-only-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-char-backward/inline-only-emoji.js
@@ -10,9 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          📛<cursor />
-        </link>
+        <link>📛</link>
+        <cursor />
       </paragraph>
     </document>
   </value>
@@ -22,9 +21,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <link>
-          <cursor />
-        </link>
+        <link />
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-char-forward/inline-before-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-char-forward/inline-before-emoji.js
@@ -10,7 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <cursor />📛<link>word</link>
+        <cursor />
+        📛<link>word</link>
       </paragraph>
     </document>
   </value>
@@ -20,8 +21,10 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <cursor />
-        <link>word</link>
+        <link>
+          <cursor />
+          word
+        </link>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-forward/inside-inline-sibling.js
+++ b/packages/slate/test/commands/at-current-range/delete-forward/inside-inline-sibling.js
@@ -10,9 +10,11 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        one<link>
+        one
+        <link>
           <cursor />a
-        </link>two
+        </link>
+        two
       </paragraph>
     </document>
   </value>
@@ -22,9 +24,9 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        one<link>
-          <cursor />
-        </link>two
+        one<link />
+        <cursor />
+        two
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-forward/join-blocks-with-inline-void.js
+++ b/packages/slate/test/commands/at-current-range/delete-forward/join-blocks-with-inline-void.js
@@ -20,13 +20,17 @@ export const input = (
   </value>
 )
 
+// Normalization runs after positioning the cursor, so we need to
+// manually add the text node inside the emoji void -- otherwise the
+// cursor will move into the wrong node.
 export const output = (
   <value>
     <document>
       <paragraph>
         word
+        <cursor />
         <emoji>
-          <cursor />
+          <text />
         </emoji>
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/delete-forward/join-blocks-with-inline-void.js
+++ b/packages/slate/test/commands/at-current-range/delete-forward/join-blocks-with-inline-void.js
@@ -10,7 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        word<cursor />
+        word
+        <cursor />
       </paragraph>
       <paragraph>
         <emoji />
@@ -23,8 +24,10 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        word<cursor />
-        <emoji />
+        word
+        <emoji>
+          <cursor />
+        </emoji>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-line-forward/inline-middle-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-line-forward/inline-middle-emoji.js
@@ -21,8 +21,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <cursor />
         <link />
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-word-backward/inline-middle-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-word-backward/inline-middle-emoji.js
@@ -10,9 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          wo📛rd<cursor />
-        </link>
+        <link>wo📛rd</link>
+        <cursor />
       </paragraph>
     </document>
   </value>
@@ -22,9 +21,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <link>
-          <cursor />
-        </link>
+        <link />
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete-word-forward/inline-after-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-word-forward/inline-after-emoji.js
@@ -10,8 +10,11 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <cursor />
-        <link>word</link>📛
+        <link>
+          <cursor />
+          word
+        </link>
+        📛
       </paragraph>
     </document>
   </value>
@@ -21,6 +24,7 @@ export const output = (
   <value>
     <document>
       <paragraph>
+        <link />
         <cursor />
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/delete-word-forward/inline-middle-emoji.js
+++ b/packages/slate/test/commands/at-current-range/delete-word-forward/inline-middle-emoji.js
@@ -21,8 +21,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <cursor />
         <link />
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete/inside-inline-sibling.js
+++ b/packages/slate/test/commands/at-current-range/delete/inside-inline-sibling.js
@@ -10,9 +10,12 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        one<link>
-          <anchor />a<focus />
-        </link>two
+        one
+        <link>
+          <anchor />a
+        </link>
+        <focus />
+        two
       </paragraph>
     </document>
   </value>
@@ -22,9 +25,9 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        one<link>
-          <cursor />
-        </link>two
+        one<link />
+        <cursor />
+        two
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/delete/whole-inline.js
+++ b/packages/slate/test/commands/at-current-range/delete/whole-inline.js
@@ -11,8 +11,10 @@ export const input = (
     <document>
       <paragraph>
         <link>
-          <anchor />word<focus />
+          <anchor />
+          word
         </link>
+        <focus />
       </paragraph>
     </document>
   </value>
@@ -22,9 +24,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <link>
-          <cursor />
-        </link>
+        <link />
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-multiple-marks.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-multiple-marks.js
@@ -18,7 +18,9 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        wo<cursor />rd
+        wo
+        <cursor />
+        rd
       </paragraph>
     </document>
   </value>
@@ -31,9 +33,8 @@ export const output = (
         wo
         <b>b</b>
         <u>u</u>
-        <i>
-          i<cursor />
-        </i>
+        <i>i</i>
+        <cursor />
         rd
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-single-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-single-inline.js
@@ -17,7 +17,9 @@ export const input = (
     <document>
       <code>
         <paragraph>
-          Foo<cursor />baz
+          Foo
+          <cursor />
+          baz
         </paragraph>
       </code>
     </document>
@@ -30,9 +32,8 @@ export const output = (
       <code>
         <paragraph>
           Foo
-          <inline type="link">
-            bar<cursor />
-          </inline>
+          <inline type="link">bar</inline>
+          <cursor />
           baz
         </paragraph>
       </code>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/fragment-single-mark.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/fragment-single-mark.js
@@ -17,7 +17,9 @@ export const input = (
     <document>
       <code>
         <paragraph>
-          Foo<cursor />baz
+          Foo
+          <cursor />
+          baz
         </paragraph>
       </code>
     </document>
@@ -30,9 +32,8 @@ export const output = (
       <code>
         <paragraph>
           Foo
-          <b>
-            bar<cursor />
-          </b>
+          <b>bar</b>
+          <cursor />
           baz
         </paragraph>
       </code>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/middle-inline-fragment-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/middle-inline-fragment-inline.js
@@ -17,7 +17,9 @@ export const input = (
     <document>
       <paragraph>
         <link>
-          wo<cursor />rd
+          wo
+          <cursor />
+          rd
         </link>
       </paragraph>
     </document>
@@ -29,10 +31,11 @@ export const output = (
     <document>
       <paragraph>
         <link>wo</link>
-        <hashtag>
-          fragment<cursor />
-        </hashtag>
-        <link>rd</link>
+        <hashtag>fragment</hashtag>
+        <link>
+          <cursor />
+          rd
+        </link>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/middle-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/middle-inline.js
@@ -15,7 +15,9 @@ export const input = (
     <document>
       <paragraph>
         <link>
-          wo<cursor />rd
+          wo
+          <cursor />
+          rd
         </link>
       </paragraph>
     </document>
@@ -27,8 +29,11 @@ export const output = (
     <document>
       <paragraph>
         <link>wo</link>
-        fragment<cursor />
-        <link>rd</link>
+        fragment
+        <link>
+          <cursor />
+          rd
+        </link>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-fragment/start-inline.js
+++ b/packages/slate/test/commands/at-current-range/insert-fragment/start-inline.js
@@ -14,8 +14,10 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <cursor />
-        <link>word</link>
+        <link>
+          <cursor />
+          word
+        </link>
       </paragraph>
     </document>
   </value>
@@ -25,8 +27,11 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        fragment<cursor />
-        <link>word</link>
+        fragment
+        <link>
+          <cursor />
+          word
+        </link>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-text/after-mark.js
+++ b/packages/slate/test/commands/at-current-range/insert-text/after-mark.js
@@ -10,9 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        w<b>
-          or<cursor />
-        </b>d
+        w<b>or</b>
+        <cursor />d
       </paragraph>
     </document>
   </value>
@@ -22,9 +21,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        w<b>
-          ora<cursor />
-        </b>d
+        w<b>ora</b>
+        <cursor />d
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/insert-text/before-mark.js
+++ b/packages/slate/test/commands/at-current-range/insert-text/before-mark.js
@@ -10,8 +10,12 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        w<cursor />
-        <b>or</b>d
+        w
+        <b>
+          <cursor />
+          or
+        </b>
+        d
       </paragraph>
     </document>
   </value>
@@ -21,8 +25,12 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        wa<cursor />
-        <b>or</b>d
+        wa
+        <b>
+          <cursor />
+          or
+        </b>
+        d
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/remove-mark/across-blocks.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/across-blocks.js
@@ -10,12 +10,16 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        wo<anchor />
-        <b>rd</b>
+        wo
+        <b>
+          <anchor />
+          rd
+        </b>
       </paragraph>
       <paragraph>
         <b>an</b>
-        <focus />other
+        <focus />
+        other
       </paragraph>
     </document>
   </value>
@@ -25,10 +29,14 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        wo<anchor />rd
+        wo
+        <anchor />
+        rd
       </paragraph>
       <paragraph>
-        an<focus />other
+        an
+        <focus />
+        other
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/remove-mark/across-inlines.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/across-inlines.js
@@ -11,14 +11,18 @@ export const input = (
     <document>
       <paragraph>
         <link>
-          wo<anchor />
-          <b>rd</b>
+          wo
+          <b>
+            <anchor />
+            rd
+          </b>
         </link>
       </paragraph>
       <paragraph>
         <link>
           <b>an</b>
-          <focus />other
+          <focus />
+          other
         </link>
       </paragraph>
     </document>
@@ -30,12 +34,16 @@ export const output = (
     <document>
       <paragraph>
         <link>
-          wo<anchor />rd
+          wo
+          <anchor />
+          rd
         </link>
       </paragraph>
       <paragraph>
         <link>
-          an<focus />other
+          an
+          <focus />
+          other
         </link>
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/remove-mark/existing-marks.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/existing-marks.js
@@ -10,12 +10,15 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <anchor />
         <b>
-          <i>wo</i>
+          <i>
+            <anchor />
+            wo
+          </i>
         </b>
         <i>
-          <focus />rd
+          <focus />
+          rd
         </i>
       </paragraph>
     </document>
@@ -27,7 +30,10 @@ export const output = (
     <document>
       <paragraph>
         <i>
-          <anchor />wo<focus />rd
+          <anchor />
+          wo
+          <focus />
+          rd
         </i>
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/remove-mark/first-character.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/first-character.js
@@ -10,9 +10,11 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <anchor />
-        <b>w</b>
-        <focus />ord
+        <b>
+          <anchor />w
+        </b>
+        <focus />
+        ord
       </paragraph>
     </document>
   </value>
@@ -22,7 +24,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />w<focus />ord
+        <anchor />w<focus />
+        ord
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/remove-mark/whole-word.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/whole-word.js
@@ -10,8 +10,10 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <anchor />
-        <b>word</b>
+        <b>
+          <anchor />
+          word
+        </b>
         <focus />
       </paragraph>
     </document>
@@ -22,7 +24,9 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />word<focus />
+        <anchor />
+        word
+        <focus />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/remove-mark/with-mark-object.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/with-mark-object.js
@@ -16,9 +16,11 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <anchor />
-        <b thing="value">w</b>
-        <focus />ord
+        <b thing="value">
+          <anchor />w
+        </b>
+        <focus />
+        ord
       </paragraph>
     </document>
   </value>
@@ -28,7 +30,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />w<focus />ord
+        <anchor />w<focus />
+        ord
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/remove-mark/with-plain-object.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/with-plain-object.js
@@ -14,8 +14,10 @@ export const input = (
     <document>
       <paragraph>
         <b thing="value">
-          <anchor />w<focus />
-        </b>ord
+          <anchor />w
+        </b>
+        <focus />
+        ord
       </paragraph>
     </document>
   </value>
@@ -25,7 +27,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />w<focus />ord
+        <anchor />w<focus />
+        ord
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/replace-mark/existing-marks.js
+++ b/packages/slate/test/commands/at-current-range/replace-mark/existing-marks.js
@@ -11,7 +11,10 @@ export const input = (
     <document>
       <paragraph>
         <i>
-          <anchor />wo<focus />rd
+          <anchor />
+          wo
+          <focus />
+          rd
         </i>
       </paragraph>
     </document>
@@ -22,10 +25,13 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />
-        <b>wo</b>
+        <b>
+          <anchor />
+          wo
+        </b>
         <i>
-          <focus />rd
+          <focus />
+          rd
         </i>
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/replace-mark/first-character.js
+++ b/packages/slate/test/commands/at-current-range/replace-mark/first-character.js
@@ -10,9 +10,11 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <anchor />
-        <i>w</i>
-        <focus />ord
+        <i>
+          <anchor />w
+        </i>
+        <focus />
+        ord
       </paragraph>
     </document>
   </value>
@@ -22,9 +24,11 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />
-        <b>w</b>
-        <focus />ord
+        <b>
+          <anchor />w
+        </b>
+        <focus />
+        ord
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/split-inline/block-end.js
+++ b/packages/slate/test/commands/at-current-range/split-inline/block-end.js
@@ -10,22 +10,21 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          word<cursor />
-        </link>
+        <link>word</link>
+        <cursor />
       </paragraph>
     </document>
   </value>
 )
 
+// The cursor is normalized to the next text node, so splitInline has
+// no effect.
 export const output = (
   <value>
     <document>
       <paragraph>
         <link>word</link>
-        <link>
-          <cursor />
-        </link>
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/toggle-mark/remove-with-mark-object.js
+++ b/packages/slate/test/commands/at-current-range/toggle-mark/remove-with-mark-object.js
@@ -17,8 +17,9 @@ export const input = (
     <document>
       <paragraph>
         <b thing="value">
-          <anchor />w<focus />
+          <anchor />w
         </b>
+        <focus />
         ord
       </paragraph>
     </document>
@@ -29,7 +30,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />w<focus />ord
+        <anchor />w<focus />
+        ord
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/toggle-mark/remove-with-plain-object.js
+++ b/packages/slate/test/commands/at-current-range/toggle-mark/remove-with-plain-object.js
@@ -14,8 +14,9 @@ export const input = (
     <document>
       <paragraph>
         <b thing="value">
-          <anchor />w<focus />
+          <anchor />w
         </b>
+        <focus />
         ord
       </paragraph>
     </document>
@@ -26,7 +27,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        <anchor />w<focus />ord
+        <anchor />w<focus />
+        ord
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/unwrap-inline/across-inlines.js
+++ b/packages/slate/test/commands/at-current-range/unwrap-inline/across-inlines.js
@@ -10,17 +10,20 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        <link>
-          wo<anchor />
-        </link>
+        <link>wo</link>
         <hashtag>
-          <link>rd</link>
+          <link>
+            <anchor />
+            rd
+          </link>
         </hashtag>
         <hashtag>
           <link>an</link>
         </hashtag>
         <link>
-          ot<focus />her
+          ot
+          <focus />
+          her
         </link>
       </paragraph>
     </document>
@@ -31,13 +34,16 @@ export const output = (
   <value>
     <document>
       <paragraph>
+        <link>wo</link>
         <link>
-          wo<anchor />
+          <anchor />
+          rd
         </link>
-        <link>rd</link>
         <link>an</link>
         <link>
-          ot<focus />her
+          ot
+          <focus />
+          her
         </link>
       </paragraph>
     </document>

--- a/packages/slate/test/commands/at-current-range/unwrap-inline/nested-block.js
+++ b/packages/slate/test/commands/at-current-range/unwrap-inline/nested-block.js
@@ -11,10 +11,12 @@ export const input = (
     <document>
       <quote>
         <paragraph>
-          w<anchor />
+          w
           <hashtag>
-            or<focus />
-          </hashtag>d
+            <anchor />
+            or
+          </hashtag>
+          <focus />d
         </paragraph>
       </quote>
     </document>
@@ -26,7 +28,9 @@ export const output = (
     <document>
       <quote>
         <paragraph>
-          w<anchor />or<focus />d
+          w<anchor />
+          or
+          <focus />d
         </paragraph>
       </quote>
     </document>

--- a/packages/slate/test/commands/at-current-range/unwrap-inline/only-one.js
+++ b/packages/slate/test/commands/at-current-range/unwrap-inline/only-one.js
@@ -10,9 +10,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        he<hashtag>ll</hashtag>o <anchor />w<hashtag>
-          or<focus />
-        </hashtag>d
+        he<hashtag>ll</hashtag>o <anchor />w<hashtag>or</hashtag>
+        <focus />d
       </paragraph>
     </document>
   </value>
@@ -22,7 +21,9 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        he<hashtag>ll</hashtag>o <anchor />wor<focus />d
+        he<hashtag>ll</hashtag>o <anchor />
+        wor
+        <focus />d
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/unwrap-inline/single-block.js
+++ b/packages/slate/test/commands/at-current-range/unwrap-inline/single-block.js
@@ -10,10 +10,12 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        w<anchor />
+        w
         <hashtag>
-          or<focus />
-        </hashtag>d
+          <anchor />
+          or
+        </hashtag>
+        <focus />d
       </paragraph>
     </document>
   </value>
@@ -23,7 +25,9 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        w<anchor />or<focus />d
+        w<anchor />
+        or
+        <focus />d
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/wrap-inline/inside-inlines-end.js
+++ b/packages/slate/test/commands/at-current-range/wrap-inline/inside-inlines-end.js
@@ -12,27 +12,29 @@ export const input = (
       <paragraph>
         <text />
         <link>
-          hel<anchor />lo<focus />
+          hel
+          <anchor />
+          lo
         </link>
-        <text />
+        <focus />
       </paragraph>
     </document>
   </value>
 )
 
-// TODO: this selection logic isn't right
 export const output = (
   <value>
     <document>
       <paragraph>
         <text />
-        <link>
-          hel<hashtag>lo</hashtag>
-          <text>
-            <cursor />
-          </text>
-        </link>
-        <text />
+        <link>hel</link>
+        <hashtag>
+          <link>
+            <anchor />
+            lo
+          </link>
+        </hashtag>
+        <focus />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/at-current-range/wrap-inline/inside-inlines-with-marks.js
+++ b/packages/slate/test/commands/at-current-range/wrap-inline/inside-inlines-with-marks.js
@@ -13,7 +13,8 @@ export const input = (
         <text />
         <link>
           <b>
-            h<anchor />ell
+            h<anchor />
+            ell
           </b>
           <focus />o
         </link>
@@ -23,7 +24,6 @@ export const input = (
   </value>
 )
 
-// TODO: this selection logic isn't right
 export const output = (
   <value>
     <document>
@@ -32,11 +32,9 @@ export const output = (
         <link>
           <b>h</b>
           <hashtag>
-            <b>
-              ell<anchor />
-            </b>
+            <b>ell</b>
           </hashtag>
-          <focus />o
+          <cursor />o
         </link>
         <text />
       </paragraph>

--- a/packages/slate/test/commands/by-key/remove-text-by-key/inline-nested-last-character.js
+++ b/packages/slate/test/commands/by-key/remove-text-by-key/inline-nested-last-character.js
@@ -27,10 +27,9 @@ export const output = (
     <document>
       <paragraph>
         <link>
-          <hashtag>
-            <cursor />
-          </hashtag>
+          <hashtag />
         </link>
+        <cursor />
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/history/undo/split-node-by-key-block.js
+++ b/packages/slate/test/history/undo/split-node-by-key-block.js
@@ -13,10 +13,11 @@ export const input = (
       <paragraph key="a">
         <text />
         <link>one</link>
-        <text>
+        <text />
+        <link>
           <cursor />
-        </text>
-        <link>two</link>
+          two
+        </link>
         <text />
       </paragraph>
     </document>

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -122,6 +122,7 @@ describe('slate', () => {
 
     editor.setValue(input)
     fn(editor)
+    editor.flush()
     const actual = editor.value.toJSON(opts)
 
     editor.setValue(output)

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -163,6 +163,19 @@ describe('slate', () => {
     assert.deepEqual(actual, expected)
   })
 
+  fixtures(__dirname, 'queries', ({ module }) => {
+    const { input, output, plugins: module_plugins } = module
+    const fn = module.default
+    const editor = new Editor({
+      plugins: module_plugins ? plugins.concat(module_plugins) : plugins,
+    })
+
+    editor.setValue(input)
+    const actual = fn(editor)
+    const expected = output
+    assert.deepEqual(actual, expected)
+  })
+
   fixtures(__dirname, 'utils/path-utils', ({ module }) => {
     const fn = module.default
     fn()

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/different-marks-across-blocks.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/different-marks-across-blocks.js
@@ -2,12 +2,14 @@
 
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        wo<anchor />
+        wo
+        <anchor />
         <mark type="a">rd</mark>
       </paragraph>
       <paragraph>
@@ -19,7 +21,9 @@ export const input = (
       <paragraph>unmarked</paragraph>
       <paragraph>
         <mark type="c">
-          an<focus />other
+          an
+          <focus />
+          other
         </mark>
         <mark type="d">unselected marked text</mark>
       </paragraph>
@@ -27,8 +31,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getActiveMarksAtRange(selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getActiveMarksAtRange(selection, editor)
 }
 
 export const output = Set()

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/different-marks-across-blocks.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/different-marks-across-blocks.js
@@ -34,7 +34,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getActiveMarksAtRange(selection, editor)
+  return editor.getActiveMarksAtRange(selection, document)
 }
 
 export const output = Set()

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/mixed-marks-across-range.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/mixed-marks-across-range.js
@@ -3,13 +3,17 @@
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
 import { Mark } from 'slate'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        wo<anchor />
-        <mark type="a">rd</mark>
+        wo
+        <mark type="a">
+          <anchor />
+          rd
+        </mark>
       </paragraph>
       <paragraph>
         <paragraph>
@@ -22,7 +26,9 @@ export const input = (
       <paragraph>
         <mark type="b">
           <mark type="a">
-            an<focus />other
+            an
+            <focus />
+            other
           </mark>
         </mark>
         <mark type="c">unselected marked text</mark>
@@ -31,8 +37,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getActiveMarksAtRange(selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getActiveMarksAtRange(selection, editor)
 }
 
 export const output = Set.of(Mark.create('a'))

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/mixed-marks-across-range.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/mixed-marks-across-range.js
@@ -40,7 +40,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getActiveMarksAtRange(selection, editor)
+  return editor.getActiveMarksAtRange(selection, document)
 }
 
 export const output = Set.of(Mark.create('a'))

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/same-mark-across-blocks.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/same-mark-across-blocks.js
@@ -3,13 +3,17 @@
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
 import { Mark } from 'slate'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        wo<anchor />
-        <mark type="a">rd</mark>
+        wo
+        <mark type="a">
+          <anchor />
+          rd
+        </mark>
       </paragraph>
       <paragraph>
         <paragraph>
@@ -19,7 +23,9 @@ export const input = (
       </paragraph>
       <paragraph>
         <mark type="a">
-          an<focus />other
+          an
+          <focus />
+          other
         </mark>
         <mark type="b">unselected marked text</mark>
       </paragraph>
@@ -27,8 +33,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getActiveMarksAtRange(selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getActiveMarksAtRange(selection, editor)
 }
 
 export const output = Set.of(Mark.create('a'))

--- a/packages/slate/test/models/node/get-active-marks-at-range.js/same-mark-across-blocks.js
+++ b/packages/slate/test/models/node/get-active-marks-at-range.js/same-mark-across-blocks.js
@@ -36,7 +36,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getActiveMarksAtRange(selection, editor)
+  return editor.getActiveMarksAtRange(selection, document)
 }
 
 export const output = Set.of(Mark.create('a'))

--- a/packages/slate/test/models/node/get-fragment-at-range/across-block-with-marks.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/across-block-with-marks.js
@@ -30,7 +30,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getFragmentAtRange(selection, editor)
+  return editor.getFragmentAtRange(selection, document)
 }
 
 export const output = (

--- a/packages/slate/test/models/node/get-fragment-at-range/across-block-with-marks.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/across-block-with-marks.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -8,7 +9,8 @@ export const input = (
       <paragraph>
         wo
         <b>
-          <anchor />rd
+          <anchor />
+          rd
         </b>
       </paragraph>
       <paragraph>
@@ -16,15 +18,19 @@ export const input = (
       </paragraph>
       <paragraph>
         <b>
-          an<focus />other
+          an
+          <focus />
+          other
         </b>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getFragmentAtRange(selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getFragmentAtRange(selection, editor)
 }
 
 export const output = (

--- a/packages/slate/test/models/node/get-fragment-at-range/block-across.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/block-across.js
@@ -22,7 +22,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getFragmentAtRange(selection, editor)
+  return editor.getFragmentAtRange(selection, document)
 }
 
 export const output = (

--- a/packages/slate/test/models/node/get-fragment-at-range/block-across.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/block-across.js
@@ -1,23 +1,28 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        on<anchor />e
+        on
+        <anchor />e
       </paragraph>
       <paragraph>two</paragraph>
       <paragraph>
-        th<focus /> ree
+        th
+        <focus /> ree
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getFragmentAtRange(selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getFragmentAtRange(selection, editor)
 }
 
 export const output = (

--- a/packages/slate/test/models/node/get-fragment-at-range/block.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/block.js
@@ -18,7 +18,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getFragmentAtRange(selection, editor)
+  return editor.getFragmentAtRange(selection, document)
 }
 
 export const output = (

--- a/packages/slate/test/models/node/get-fragment-at-range/block.js
+++ b/packages/slate/test/models/node/get-fragment-at-range/block.js
@@ -1,19 +1,24 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        one <anchor />two<focus /> three
+        one <anchor />
+        two
+        <focus /> three
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getFragmentAtRange(selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getFragmentAtRange(selection, editor)
 }
 
 export const output = (

--- a/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-no-previous-text.js
+++ b/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-no-previous-text.js
@@ -3,21 +3,25 @@
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
 import { Mark } from 'slate'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
         <b>
-          <cursor />Cat is Cute
+          <cursor />
+          Cat is Cute
         </b>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getInsertMarksAtPoint(selection.start)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getInsertMarksAtPoint(selection.start, editor)
 }
 
 export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-no-previous-text.js
+++ b/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-no-previous-text.js
@@ -21,7 +21,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getInsertMarksAtPoint(selection.start, editor)
+  return editor.getInsertMarksAtPoint(selection.start, document)
 }
 
 export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-previous-text-not-in-the-same-block.js
+++ b/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-previous-text-not-in-the-same-block.js
@@ -3,6 +3,7 @@
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
 import { Mark } from 'slate'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -12,15 +13,18 @@ export const input = (
       </paragraph>
       <paragraph>
         <b>
-          <cursor />Dog is Delightful
+          <cursor />
+          Dog is Delightful
         </b>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getInsertMarksAtPoint(selection.start)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getInsertMarksAtPoint(selection.start, editor)
 }
 
 export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-previous-text-not-in-the-same-block.js
+++ b/packages/slate/test/models/node/get-marks-at-point/marked-text-with-zero-offset-with-previous-text-not-in-the-same-block.js
@@ -24,7 +24,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getInsertMarksAtPoint(selection.start, editor)
+  return editor.getInsertMarksAtPoint(selection.start, document)
 }
 
 export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-point/marked-text.js
+++ b/packages/slate/test/models/node/get-marks-at-point/marked-text.js
@@ -3,13 +3,15 @@
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
 import { Mark } from 'slate'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
         <i>
-          C<cursor />at{' '}
+          C<cursor />
+          at{' '}
         </i>
         is
         <b> Cute</b>
@@ -18,8 +20,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getInsertMarksAtPoint(selection.start)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getInsertMarksAtPoint(selection.start, editor)
 }
 
 export const output = Set.of(Mark.create('italic'))

--- a/packages/slate/test/models/node/get-marks-at-point/marked-text.js
+++ b/packages/slate/test/models/node/get-marks-at-point/marked-text.js
@@ -23,7 +23,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getInsertMarksAtPoint(selection.start, editor)
+  return editor.getInsertMarksAtPoint(selection.start, document)
 }
 
 export const output = Set.of(Mark.create('italic'))

--- a/packages/slate/test/models/node/get-marks-at-point/text-with-zero-offset.js
+++ b/packages/slate/test/models/node/get-marks-at-point/text-with-zero-offset.js
@@ -3,6 +3,7 @@
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
 import { Mark } from 'slate'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -14,7 +15,8 @@ export const input = (
         <b>Dog is</b>
         <link>
           <text>
-            <cursor />Delightful
+            <cursor />
+            Delightful
           </text>
         </link>
         <text />
@@ -23,8 +25,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getInsertMarksAtPoint(selection.start)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getInsertMarksAtPoint(selection.start, editor)
 }
 
 export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-point/text-with-zero-offset.js
+++ b/packages/slate/test/models/node/get-marks-at-point/text-with-zero-offset.js
@@ -28,7 +28,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getInsertMarksAtPoint(selection.start, editor)
+  return editor.getInsertMarksAtPoint(selection.start, document)
 }
 
 export const output = Set.of(Mark.create('bold'))

--- a/packages/slate/test/models/node/get-marks-at-point/unmarked-text.js
+++ b/packages/slate/test/models/node/get-marks-at-point/unmarked-text.js
@@ -20,7 +20,7 @@ export const input = (
 export default function(value) {
   const editor = new Editor({ value })
   const { document, selection } = value
-  return document.getInsertMarksAtPoint(selection.start, editor)
+  return editor.getInsertMarksAtPoint(selection.start, document)
 }
 
 export const output = Set.of()

--- a/packages/slate/test/models/node/get-marks-at-point/unmarked-text.js
+++ b/packages/slate/test/models/node/get-marks-at-point/unmarked-text.js
@@ -2,21 +2,25 @@
 
 import h from '../../../helpers/h'
 import { Set } from 'immutable'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
     <document>
       <paragraph>
         <text>
-          C<cursor />at is Cute
+          C<cursor />
+          at is Cute
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.getInsertMarksAtPoint(selection.start)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.getInsertMarksAtPoint(selection.start, editor)
 }
 
 export const output = Set.of()

--- a/packages/slate/test/models/node/is-in-range/block-above-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/block-above-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('a', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('a', selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-above-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/block-above-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('a', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('a', selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-above.js
+++ b/packages/slate/test/models/node/is-in-range/block-above.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([0], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([0], selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-above.js
+++ b/packages/slate/test/models/node/is-in-range/block-above.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([0], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([0], selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-below-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/block-below-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -34,10 +33,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('k', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('k', selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-below-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/block-below-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,7 +23,8 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
       <paragraph key="k">
@@ -31,8 +34,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('k', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('k', selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-below.js
+++ b/packages/slate/test/models/node/is-in-range/block-below.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -34,10 +33,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([4], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([4], selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/block-below.js
+++ b/packages/slate/test/models/node/is-in-range/block-below.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,7 +23,8 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
       <paragraph key="k">
@@ -31,8 +34,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([4], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([4], selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/first-block-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/first-block-inside-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('c', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('c', selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-block-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/first-block-inside-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('c', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('c', selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-block-inside.js
+++ b/packages/slate/test/models/node/is-in-range/first-block-inside.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([1], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([1], selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-block-inside.js
+++ b/packages/slate/test/models/node/is-in-range/first-block-inside.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([1], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([1], selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-text-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/first-text-inside-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('d', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('d', selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-text-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/first-text-inside-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('d', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('d', selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-text-inside.js
+++ b/packages/slate/test/models/node/is-in-range/first-text-inside.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([1, 0], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([1, 0], selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/first-text-inside.js
+++ b/packages/slate/test/models/node/is-in-range/first-text-inside.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([1, 0], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([1, 0], selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-block-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/last-block-inside-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('g', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('g', selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-block-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/last-block-inside-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('g', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('g', selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-block-inside.js
+++ b/packages/slate/test/models/node/is-in-range/last-block-inside.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([3], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([3], selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-block-inside.js
+++ b/packages/slate/test/models/node/is-in-range/last-block-inside.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([3], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([3], selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-text-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/last-text-inside-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('j', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('j', selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-text-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/last-text-inside-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('j', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('j', selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-text-inside.js
+++ b/packages/slate/test/models/node/is-in-range/last-text-inside.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([3, 1], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([3, 1], selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/last-text-inside.js
+++ b/packages/slate/test/models/node/is-in-range/last-text-inside.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([3, 1], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([3, 1], selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/text-above-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/text-above-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('b', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('b', selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-above-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/text-above-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('b', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('b', selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-above.js
+++ b/packages/slate/test/models/node/is-in-range/text-above.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([0, 0], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([0, 0], selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-above.js
+++ b/packages/slate/test/models/node/is-in-range/text-above.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([0, 0], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([0, 0], selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-below-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/text-below-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,7 +23,8 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
       <paragraph key="k">
@@ -31,8 +34,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('l', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('l', selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-below-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/text-below-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -34,10 +33,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('l', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('l', selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-below.js
+++ b/packages/slate/test/models/node/is-in-range/text-below.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,7 +23,8 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
       <paragraph key="k">
@@ -31,8 +34,10 @@ export const input = (
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([4, 0], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([4, 0], selection, editor)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-below.js
+++ b/packages/slate/test/models/node/is-in-range/text-below.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -34,10 +33,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([4, 0], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([4, 0], selection)
 }
 
 export const output = false

--- a/packages/slate/test/models/node/is-in-range/text-in-middle-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/text-in-middle-inside-using-key.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange('f', selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange('f', selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/text-in-middle-inside-using-key.js
+++ b/packages/slate/test/models/node/is-in-range/text-in-middle-inside-using-key.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange('f', selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange('f', selection)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/text-in-middle-inside.js
+++ b/packages/slate/test/models/node/is-in-range/text-in-middle-inside.js
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
+import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -10,7 +11,8 @@ export const input = (
       </paragraph>
       <paragraph key="c">
         <text key="d">
-          tw<anchor />o
+          tw
+          <anchor />o
         </text>
       </paragraph>
       <image key="e" src="https://example.com/image2.png">
@@ -21,15 +23,18 @@ export const input = (
           <text key="i">three</text>
         </inline>
         <text key="j">
-          <focus />four
+          <focus />
+          four
         </text>
       </paragraph>
     </document>
   </value>
 )
 
-export default function({ document, selection }) {
-  return document.isInRange([2, 0], selection)
+export default function(value) {
+  const editor = new Editor({ value })
+  const { document, selection } = value
+  return document.isInRange([2, 0], selection, editor)
 }
 
 export const output = true

--- a/packages/slate/test/models/node/is-in-range/text-in-middle-inside.js
+++ b/packages/slate/test/models/node/is-in-range/text-in-middle-inside.js
@@ -1,7 +1,6 @@
 /** @jsx h */
 
 import h from '../../../helpers/h'
-import { Editor } from 'slate'
 
 export const input = (
   <value>
@@ -31,10 +30,8 @@ export const input = (
   </value>
 )
 
-export default function(value) {
-  const editor = new Editor({ value })
-  const { document, selection } = value
-  return document.isInRange([2, 0], selection, editor)
+export default function({ document, selection }) {
+  return document.isInRange([2, 0], selection)
 }
 
 export const output = true

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-after.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-after.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a
+        <link>
+          word
+          <cursor />
+        </link>
+        here
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 2],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-before.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-before.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a<cursor />
+        <link>word</link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 1, 0],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-between.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-between.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a
+        <link>
+          word
+          <cursor />
+        </link>
+        <link>here</link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 3, 0],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-end.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-end.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a
+        <link>
+          word
+          <cursor />
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 2],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-middle.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-middle.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a
+        <link>
+          wo
+          <cursor />
+          rd
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 1, 0],
+  offset: 2,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-start.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-start.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a
+        <link>
+          <cursor />
+          word
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 1, 0],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-void-after.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-void-after.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a<emoji />
+        <cursor />
+        word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 2],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-void-before.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-void-before.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a<cursor />
+        <emoji />
+        word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 0],
+  offset: 1,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/inline-void-inside.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/inline-void-inside.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a
+        <emoji>
+          <cursor />
+        </emoji>
+        word
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 1, 0],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/mark-before.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/mark-before.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a<cursor />
+        <b>word</b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 1],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/mark-between.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/mark-between.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a{' '}
+        <b>
+          word
+          <cursor />
+        </b>
+        <i> here</i>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 2],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/mark-end-of-block.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/mark-end-of-block.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a{' '}
+        <b>
+          word
+          <cursor />
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 1],
+  offset: 4,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/mark-end.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/mark-end.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a{' '}
+        <b>
+          word
+          <cursor />
+        </b>
+        here
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 2],
+  offset: 0,
+}

--- a/packages/slate/test/queries/at-point/get-insert-point/nested-inline-end.js
+++ b/packages/slate/test/queries/at-point/get-insert-point/nested-inline-end.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { document, selection } = editor.value
+  return editor.getInsertPoint(selection.anchor, document).toJSON()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        a{' '}
+        <link>
+          wo
+          <link>
+            rd
+            <cursor />
+          </link>
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = {
+  object: 'point',
+  path: [0, 2],
+  offset: 0,
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

Selections now prefer to be at the beginning of a node rather than the end of the previous node.

#### How does this change work?

Slate used to normalize the selection to prefer the first offset of a node instead of the last offset of a previous node. It looks like this behavior was lost during the leaves refactoring -- there was a TODO that was never handled.

Fixing this TODO exposed another bug. `pointBackward` called `editor.movePointToEndOfNode`, which normalizes the selection. Since the selection gets normalized to the beginning of the next node, the following `editor.value.selection.movePointBackward` call will move to offset -1, which is incorrect. Neither of these calls should normalize the selection until we call `select` at the very end of the method.

Finally, I moved this logic into a query, so it can be overridden by other plugins.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2973
Fixes: #2813 
Relates to: #2865
Reviewers: @ianstormtaylor 