### PR TITLE
Fix renderBlock() in paste-html example

### DIFF
--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -192,6 +192,8 @@ class PasteHtml extends React.Component {
     const { attributes, children, node, isFocused } = props
 
     switch (node.type) {
+      case 'paragraph':
+        return <p {...attributes}>{children}</p>;
       case 'quote':
         return <blockquote {...attributes}>{children}</blockquote>
       case 'code':

--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -193,7 +193,7 @@ class PasteHtml extends React.Component {
 
     switch (node.type) {
       case 'paragraph':
-        return <p {...attributes}>{children}</p>;
+        return <p {...attributes}>{children}</p>
       case 'quote':
         return <blockquote {...attributes}>{children}</blockquote>
       case 'code':


### PR DESCRIPTION
It appears that render block is missing a case for rendering `paragraph`. Without this paragraphs are being rendered as `<div>`s.

#### Is this adding or improving a _feature_ or fixing a _bug_?

It is fixing a bug in the example

#### What's the new behavior?

paragraphs are now rendered as `<p>` tags

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

No

Fixes: #
Reviewers: @
