### PR TITLE
Fix marks incorrect behavior on insertText

### DIFF
--- a/packages/slate/test/commands/by-key/replace-marks-by-key/different-set-of-marks.js
+++ b/packages/slate/test/commands/by-key/replace-marks-by-key/different-set-of-marks.js
@@ -3,20 +3,15 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  const { anchor } = editor.value.selection
-
-  editor.replaceTextByKey(anchor.key, anchor.offset, 3, 'cat is cute', [
-    { type: 'italic' },
-  ])
+  editor.replaceMarksByKey('a', 0, 2, [{ type: 'italic' }])
 }
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <b>
-          <cursor />word.
+        <b key="a" thing="value">
+          word
         </b>
       </paragraph>
     </document>
@@ -27,10 +22,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow, <i>cat is cute</i>
-        <b>
-          <cursor />d.
-        </b>
+        <i>wo</i>
+        <b thing="value">rd</b>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/by-key/replace-marks-by-key/empty-set.js
+++ b/packages/slate/test/commands/by-key/replace-marks-by-key/empty-set.js
@@ -3,20 +3,15 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  const { anchor } = editor.value.selection
-
-  editor.replaceTextByKey(anchor.key, anchor.offset, 3, 'cat is cute', [
-    { type: 'italic' },
-  ])
+  editor.replaceMarksByKey('a', 0, 2, [])
 }
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <b>
-          <cursor />word.
+        <b key="a" thing="value">
+          word
         </b>
       </paragraph>
     </document>
@@ -27,10 +22,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow, <i>cat is cute</i>
-        <b>
-          <cursor />d.
-        </b>
+        wo
+        <b thing="value">rd</b>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/by-key/replace-marks-by-key/same-marks-different-data.js
+++ b/packages/slate/test/commands/by-key/replace-marks-by-key/same-marks-different-data.js
@@ -3,10 +3,8 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  const { anchor } = editor.value.selection
-
-  editor.replaceTextByKey(anchor.key, anchor.offset, 3, 'cat is cute', [
-    { type: 'italic' },
+  editor.replaceMarksByKey('a', 0, 2, [
+    { type: 'bold', data: { thing: 'new value' } },
   ])
 }
 
@@ -14,9 +12,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <b>
-          <cursor />word.
+        <b key="a" thing="value">
+          word
         </b>
       </paragraph>
     </document>
@@ -27,10 +24,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow, <i>cat is cute</i>
-        <b>
-          <cursor />d.
-        </b>
+        <b thing="new value">wo</b>
+        <b thing="value">rd</b>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/by-key/replace-text-by-key/replace-with-active-marks-with-data.js
+++ b/packages/slate/test/commands/by-key/replace-text-by-key/replace-with-active-marks-with-data.js
@@ -27,10 +27,7 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <fontSize size={16}>
-          <fontSize size={12}>cat is cute</fontSize>
-        </fontSize>
+        Meow, <fontSize size={16}>cat is cute</fontSize>
         <fontSize size={12}>
           <cursor />d.
         </fontSize>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?
before:
![before](https://user-images.githubusercontent.com/3536055/61498033-783cdb00-a976-11e9-80b4-08d669f4b429.gif)

after:
![after](https://user-images.githubusercontent.com/3536055/61498043-825ed980-a976-11e9-9928-3216d12ad92c.gif)

#### How does this change work?

`insertTextByPath` should replace marks on the inserted text with the once that are provided

It were trying to add those marks that are passed to the function to the existing once,
but it should replace them instead.

Example error behavior was:
* put cursor at the end of the marked text
* toggle marks
* enter text

expected:
text is being added without toggled marks

actual:
text is added with those marks applied

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2848 
Reviewers: @adjourn, @erquhart
