### PR TITLE
Reintroduce non leaf inline and block accessors to value

### DIFF
--- a/docs/reference/slate/node.md
+++ b/docs/reference/slate/node.md
@@ -65,7 +65,7 @@ Get all of the bottom-most [`Block`](./block.md) node descendants.
 
 `getLeafBlocksAtRange(range: Range) => List`
 
-Get all of the bottom-most [`Block`](./block.md) nodes in a `range`.
+Get all of the leaf [`Block`](./block.md) nodes in a `range`.
 
 ### `getBlocksByType`
 
@@ -186,7 +186,7 @@ Get all of the top-most [`Inline`](./inline.md) nodes in a node.
 
 `getLeafInlinesAtRange(range: Range) => List`
 
-Get all of the bottom-most [`Inline`](./inline.md) nodes in a `range`.
+Get all of the leaf [`Inline`](./inline.md) nodes in a `range`.
 
 ### `getInlinesByType`
 

--- a/docs/reference/slate/value.md
+++ b/docs/reference/slate/value.md
@@ -79,7 +79,13 @@ Get a subset of the [`Marks`](./mark.md) that are present in _all_ the character
 
 `List`
 
-Get a list of the lowest-depth [`Block`](./block.md) nodes in the current selection.
+Get a list of the [`Block`](./block.md) nodes in the current selection.
+
+### `leafBlocks`
+
+`List`
+
+Get a list of any leaf [`Block`](./block.md) nodes in the current selection.
 
 ### `fragment`
 
@@ -91,7 +97,13 @@ Get a [`Document`](./document.md) fragment of the current selection.
 
 `List`
 
-Get a list of the lowest-depth [`Inline`](./inline.md) nodes in the current selection.
+Get a list of the [`Inline`](./inline.md) nodes in the current selection.
+
+### `leafInlines`
+
+`List`
+
+Get a list of any leaf [`Inline`](./inline.md) nodes in the current selection.
 
 ### `texts`
 

--- a/packages/slate/src/interfaces/element.js
+++ b/packages/slate/src/interfaces/element.js
@@ -1887,12 +1887,10 @@ class ElementInterface {
    */
 
   getBlocksAtRange(range) {
-    warning(
-      false,
-      'As of slate@0.44 the `node.getBlocksAtRange` method has been renamed to `getLeafBlocksAtRange`.'
-    )
-
-    return this.getLeafBlocksAtRange(range)
+    const iterable = this.blocks({ range })
+    const array = Array.from(iterable, ([node]) => node)
+    const list = List(array)
+    return list
   }
 
   getBlocksAtRangeAsArray(range) {
@@ -1905,12 +1903,10 @@ class ElementInterface {
   }
 
   getInlinesAtRange(range) {
-    warning(
-      false,
-      'As of slate@0.44 the `node.getInlinesAtRange` method has been renamed to `getLeafInlinesAtRange`.'
-    )
-
-    return this.getLeafInlinesAtRange(range)
+    const iterable = this.inlines({ range })
+    const array = Array.from(iterable, ([node]) => node)
+    const list = List(array)
+    return list
   }
 
   getInlinesAtRangeAsArray(range) {

--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -379,6 +379,18 @@ class Value extends Record(DEFAULTS) {
   get blocks() {
     return this.selection.isUnset
       ? new List()
+      : this.document.getBlocksAtRange(this.selection)
+  }
+
+  /**
+   * Get the bottom-most block nodes in the current selection.
+   *
+   * @return {List<Block>}
+   */
+
+  get leafBlocks() {
+    return this.selection.isUnset
+      ? new List()
       : this.document.getLeafBlocksAtRange(this.selection)
   }
 
@@ -395,12 +407,24 @@ class Value extends Record(DEFAULTS) {
   }
 
   /**
-   * Get the bottom-most inline nodes in the current selection.
+   * Get the inline nodes in the current selection.
    *
    * @return {List<Inline>}
    */
 
   get inlines() {
+    return this.selection.isUnset
+      ? new List()
+      : this.document.getInlinesAtRange(this.selection)
+  }
+
+  /**
+   * Get the bottom-most inline nodes in the current selection.
+   *
+   * @return {List<Inline>}
+   */
+
+  get leafInlines() {
     return this.selection.isUnset
       ? new List()
       : this.document.getLeafInlinesAtRange(this.selection)

--- a/packages/slate/test/models/node/get-blocks-at-range/multiple-blocks.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/multiple-blocks.js
@@ -1,0 +1,36 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <inline type="link" key="h">
+          <text key="i">three</text>
+        </inline>
+        <text key="j">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['c', 'e', 'g'])

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-cursor-in-first-leaf-of-first-parent.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-cursor-in-first-leaf-of-first-parent.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">
+              on<cursor />e
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="e">
+        <text key="f">two</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a', 'b', 'c'])

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-cursor-in-first-leaf-of-second-parent.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-cursor-in-first-leaf-of-second-parent.js
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">one</text>
+          </paragraph>
+          <paragraph key="e">
+            <text key="f">two</text>
+          </paragraph>
+        </quote>
+        <quote key="g">
+          <paragraph key="h">
+            <text key="i">
+              three
+              <cursor />
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a', 'g', 'h'])

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-cursor-in-second-leaf-of-first-parent.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-cursor-in-second-leaf-of-first-parent.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">one</text>
+          </paragraph>
+          <paragraph key="e">
+            <text key="f">
+              <cursor />
+              two
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="g">
+        <text key="h">three</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a', 'b', 'e'])

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-overlapping-multiple-blocks.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-overlapping-multiple-blocks.js
@@ -43,4 +43,4 @@ export default function({ document, selection }) {
     .toArray()
 }
 
-export const output = [ 'a', 'c', 'd', 'e', 'g', 'h', 'j']
+export const output = ['a', 'c', 'd', 'e', 'g', 'h', 'j']

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-overlapping-multiple-blocks.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-overlapping-multiple-blocks.js
@@ -1,0 +1,46 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document key="zz">
+      <paragraph key="a">
+        <text key="b">
+          <focus />
+          one
+        </text>
+      </paragraph>
+      <quote key="c">
+        <quote key="d">
+          <paragraph key="e">
+            <text key="f">two</text>
+          </paragraph>
+        </quote>
+        <quote key="g">
+          <paragraph key="h">
+            <text key="i">three</text>
+          </paragraph>
+          <paragraph key="j">
+            <text key="k">
+              <anchor />
+              four
+            </text>
+          </paragraph>
+          <paragraph key="l">
+            <text key="m">five</text>
+          </paragraph>
+        </quote>
+      </quote>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document
+    .getBlocksAtRange(selection)
+    .map(n => n.key)
+    .toArray()
+}
+
+export const output = [ 'a', 'c', 'd', 'e', 'g', 'h', 'j']

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-overlapping-texts-in-second-parent.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-overlapping-texts-in-second-parent.js
@@ -1,0 +1,42 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">one</text>
+          </paragraph>
+        </quote>
+        <quote key="e">
+          <paragraph key="f">
+            <text key="g">
+              <anchor />two
+            </text>
+          </paragraph>
+          <paragraph key="h">
+            <text key="i">three</text>
+          </paragraph>
+          <paragraph key="j">
+            <text key="k">
+              f<focus />our
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="l">
+        <text key="m">five</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a', 'e', 'f', 'h', 'j'])

--- a/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-spanning-first-text.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/nested-blocks-selection-spanning-first-text.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <quote key="a">
+        <quote key="b">
+          <paragraph key="c">
+            <text key="d">
+              <anchor />one<focus />
+            </text>
+          </paragraph>
+        </quote>
+      </quote>
+      <paragraph key="e">
+        <text key="f">two</text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a', 'b', 'c'])

--- a/packages/slate/test/models/node/get-blocks-at-range/single-block-with-inline.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/single-block-with-inline.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+        <inline type="link" key="c">
+          <text key="d">
+            tw<cursor />o
+          </text>
+        </inline>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a'])

--- a/packages/slate/test/models/node/get-blocks-at-range/single-block.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/single-block.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          <cursor />
+          two
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['c'])

--- a/packages/slate/test/models/node/get-blocks-at-range/single-void-block.js
+++ b/packages/slate/test/models/node/get-blocks-at-range/single-void-block.js
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <image key="a" src="https://example.com/image2.png">
+        <text key="b" />
+      </image>
+    </document>
+    <selection isFocused={false}>
+      <anchor key="b" offset={0} />
+      <focus key="b" offset={0} />
+    </selection>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getBlocksAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['a'])

--- a/packages/slate/test/models/node/get-inlines-at-range/multiple-blocks-no-inline.js
+++ b/packages/slate/test/models/node/get-inlines-at-range/multiple-blocks-no-inline.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+      </paragraph>
+      <image key="e" src="https://example.com/image2.png">
+        <text key="f" />
+      </image>
+      <paragraph key="g">
+        <text key="h">
+          <focus />four
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getInlinesAtRange(selection).map(n => n.key)
+}
+
+export const output = List()

--- a/packages/slate/test/models/node/get-inlines-at-range/multiple-blocks.js
+++ b/packages/slate/test/models/node/get-inlines-at-range/multiple-blocks.js
@@ -1,0 +1,44 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <text key="b">one</text>
+      </paragraph>
+      <paragraph key="c">
+        <text key="d">
+          tw<anchor />o
+        </text>
+        <inline type="link" key="e">
+          <text key="f">three</text>
+        </inline>
+      </paragraph>
+      <image key="g" src="https://example.com/image2.png">
+        <text key="h" />
+      </image>
+      <paragraph key="i">
+        <inline type="link" key="j">
+          <inline type="link-part" key="k">
+            <text key="l">four</text>
+          </inline>
+          <inline type="link-part" key="m">
+            <text key="n">five</text>
+          </inline>
+        </inline>
+        <text key="o">
+          <focus />six
+        </text>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getInlinesAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['e', 'j', 'k', 'm'])

--- a/packages/slate/test/models/node/get-inlines-at-range/nested-with-text-on-every-level.js
+++ b/packages/slate/test/models/node/get-inlines-at-range/nested-with-text-on-every-level.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+import h from '../../../helpers/h'
+
+export const input = (
+  <value>
+    <document>
+      <paragraph key="a">
+        <inline type="i1" key="b">
+          <inline type="i2" key="c">
+            <inline type="i3" key="d">
+              <text key="e">
+                o<anchor />ne
+              </text>
+            </inline>
+          </inline>
+          <inline type="i2" key="f">
+            <inline type="i3" key="g">
+              <text key="h">two</text>
+            </inline>
+            <text key="i">three</text>
+          </inline>
+          <text key="j">
+            four<focus />
+          </text>
+        </inline>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export default function({ document, selection }) {
+  return document.getInlinesAtRange(selection).map(n => n.key)
+}
+
+export const output = List(['b', 'c', 'd', 'f', 'g'])


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Improving and adding.
#### What's the new behavior?
This reverts `value.inlines` and `value.blocks` to not filtering for only leaf nodes and adds specific `value.leafInlines` and `value.leafBlocks`.

The new behavior is that `value.inlines` and `value.blocks` return all respective nodes of those types and `value.leafInlines` and `value.leafBlocks` have been added to access leaf nodes specifically. 

#### How does this change work?
This issue has a few different levels and I think this change is the most straight-forward way to resolve them. The main issue is that currently if the selection is in a node that is not a leaf of its type in the document tree, but the selection does not include the actual leaf nodes, `value.inlines` or '.blocks' will be completely empty even though the selection contains nodes of those types.

This is due to this line [here](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/interfaces/element.js#L1364) where we check whether the node is a leaf node, but don't give the context of the desired range. Thus the described behavior of "bottom-most {nodes of type} in a range" is not really accurate, as it will only return inlines if they are leaf nodes in the context of the document tree as a whole, not just for the selection.

An alternate approach to make this behavior less confusing would be to pass the context of the range to the check for whether the node is a leaf node or not, but I think this raises some questions about the nature of leaf nodes and whether the context of a range should affect whether a node is considered a leaf node or not. Can a node be a leaf for just a current range? To me that seems kind of unintuitive. For example, if `getLeafInlinesAtRange` performed as it's described and returned the "bottom-most" nodes in the range then we could likely be returning "leaf" nodes that have children of their same object type in the document tree as a whole which seems very unintuitive. 

Thus I think the solution that makes the most sense is to keep the functionality for `getLeafInlinesAtRange` as it is but not use it to source inlines for `value.inlines`, and instead add a separate property `leafInlines` to the value model. I think this should resolve confusion going forward. 

On a higher level design note I also think it just plain doesn't make sense to have `value.inlines` and `value.blocks` make non-explicit assumptions about what sort of nodes are desired. Even without adding `.leafInlines` or `.leafBlocks` if the user wants only leaf or root nodes of those types than they can filter them as they wish! It is unintuitive to have a generic `.inlines` property and then only have it return a subset of the inlines.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
🤷‍♂ 