### PR TITLE
Fix splitNode range update when selection is backward

### DIFF
--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -798,16 +798,16 @@ class Value extends Record(DEFAULTS) {
 
     value = value.mapRanges(range => {
       const next = newDocument.getNextText(node.key)
-      const { start, end } = range
+      const { anchor, focus } = range
 
-      // If the start was after the split, move it to the next node.
-      if (node.key === start.key && position <= start.offset) {
-        range = range.moveStartTo(next.key, start.offset - position)
+      // If the anchor was after the split, move it to the next node.
+      if (node.key === anchor.key && position <= anchor.offset) {
+        range = range.moveAnchorTo(next.key, anchor.offset - position)
       }
 
-      // If the end was after the split, move it to the next node.
-      if (node.key === end.key && position <= end.offset) {
-        range = range.moveEndTo(next.key, end.offset - position)
+      // If the focus was after the split, move it to the next node.
+      if (node.key === focus.key && position <= focus.offset) {
+        range = range.moveFocusTo(next.key, focus.offset - position)
       }
 
       range = range.updatePoints(point => point.setPath(null))

--- a/packages/slate/test/commands/at-current-range/remove-mark/part-of-mark-backward.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/part-of-mark-backward.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.removeMark('bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          wor<focus />d<anchor />
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>wor</b>
+        <focus />d<anchor />
+      </paragraph>
+    </document>
+  </value>
+)

--- a/packages/slate/test/commands/at-current-range/remove-mark/part-of-mark.js
+++ b/packages/slate/test/commands/at-current-range/remove-mark/part-of-mark.js
@@ -1,0 +1,30 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  editor.removeMark('bold')
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <b>
+          wor<anchor />d<focus />
+        </b>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <b>wor</b>
+        <anchor />d<focus />
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This fixes a bug

#### What's the new behavior?

| Before | After |
|---|---|
| <img src="https://user-images.githubusercontent.com/3692274/61561255-d1734000-aa44-11e9-871c-ea41ff406841.gif" width="434" /> | <img src="https://user-images.githubusercontent.com/3692274/61561260-d3d59a00-aa44-11e9-9231-658685ac2272.gif" width="434"  /> |

#### How does this change work?

When splitting a node, [every ranges inside the value are re-normalized](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/models/value.js#L799-L816). This includes selection and annotations for example. But this is done using `range.start` and `range.end`. 

- Due to the order in which those are done, a very special case could move start **after** the end, before the end is normalized
- This is then passed to [`range.setEnd`](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/interfaces/range.js#L530-L533) which check if the [`range.isBackward`](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/interfaces/range.js#L50-L52) which returns nulls, because points are [`isUnset`](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/models/point.js#L110) (path is null at this point).
- This result of `point.start` to be set instead of `point.end`

To avoid aving to check `isBackward` and having the wring order, a very simple fix is to normalize `anchor` then `focus` as the order does not matter here.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: 🤷‍♂️
Reviewers: @ianstormtaylor 
