### PR TITLE
Fix/tables example

### DIFF
--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -173,7 +173,10 @@ class Tables extends React.Component {
       if (prevBlock.type === 'table-cell') {
         if (['Backspace', 'Delete', 'Enter'].includes(event.key)) {
           event.preventDefault()
-          if(value.startBlock.type != 'table-cell' && previous.text.length == 0)
+          if (
+            value.startBlock.type !== 'table-cell' &&
+            previous.text.length === 0
+          )
             editor.setNodeByKey(value.startBlock.key, 'table-cell')
         } else {
           return next()

--- a/examples/tables/index.js
+++ b/examples/tables/index.js
@@ -173,6 +173,8 @@ class Tables extends React.Component {
       if (prevBlock.type === 'table-cell') {
         if (['Backspace', 'Delete', 'Enter'].includes(event.key)) {
           event.preventDefault()
+          if(value.startBlock.type != 'table-cell' && previous.text.length == 0)
+            editor.setNodeByKey(value.startBlock.key, 'table-cell')
         } else {
           return next()
         }


### PR DESCRIPTION
When the last cell of the table is empty AND the cursor is positioned at the start of the text following the table, hitting backspace will remove the cell and replace it with the <div> tag the text is wrapped in. The result will be a table with a visibly missing last cell.

#### Is this adding or improving a _feature_ or fixing a _bug_?

This fixes a bug.

#### What's the new behavior?
Old Behaviour
![old](https://i.giphy.com/LmsBPzIkbF8vx8bbFk.gif)
New behaviour
![new](https://i.giphy.com/kdoJNvVWlLxBFSbfdl.gif)

#### How does this change work?
After Slate replaces the `table-cell` with the `<div>` that wraps the next paragraph, the added code converts the `<div>` to a `table-cell`.
#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
I don't know if this issue has been reported before. I found it myself.