### PR TITLE
Fix undo a removeMark re-add mark to wrong nodes

### DIFF
--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -237,6 +237,10 @@ Commands.removeMarksByPath = (editor, path, offset, length, marks) => {
   const { document } = value
   const node = document.assertNode(path)
 
+  if (marks.intersect(node.marks).isEmpty()) {
+    return
+  }
+
   editor.withoutNormalizing(() => {
     // If it ends before the end of the node, we'll need to split to create a new
     // text with different marks.

--- a/packages/slate/test/history/undo/toggle-mark.js
+++ b/packages/slate/test/history/undo/toggle-mark.js
@@ -1,0 +1,33 @@
+/** @jsx h */
+
+import h from '../../helpers/h'
+
+export default function(editor) {
+  editor.addMark('bold')
+  editor.flush().removeMark('bold')
+  editor.flush().undo()
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        one <anchor />two<focus /> three
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        one{' '}
+        <b>
+          <anchor />two
+        </b>
+        <focus /> three
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This fixes a bug

#### What's the new behavior?


| Before | After |
|---|---|
| ![Screen Recording 2019-07-26 at 15 46 06 2019-07-26 15_49_15](https://user-images.githubusercontent.com/3692274/61974726-9d0c0080-afbd-11e9-809f-1dbd6c41c5bd.gif) | ![Screen Recording 2019-07-26 at 15 46 41 2019-07-26 15_50_45](https://user-images.githubusercontent.com/3692274/61974745-a5643b80-afbd-11e9-8488-b1aa7c46dcef.gif) |

#### How does this change work?

When adding a mark or selecting text around one, and then removing the mark, it results in an unwanted `remove_mark` operation on the next following text node. Undoing it would then result in an improperly reapplied mark.

A very naive fix is to check if the marks we are trying to remove are in the node beforehand.

<details>
<summary>👉 Click for a more detailed step by step 👈</summary>

```xml
<!-- Initial step -->
<paragraph>
  One <anchor />two<focus /> three
</paragraph>

<!-- After addMark -->
<paragraph>
  One <b><anchor />two</b><focus /> three
</paragraph>
<!-- 👆 The focus position here is very important -->
```

At this moment, the paragraph has three nodes:
- "One "
- "two", with the anchor and the bold mark
- " three", with the focus

Removing the mark at this very moment with result in a bunch of operations:
1. `remove_mark` on second node
2. `merge_node` on second node
3. `remove_mark` on third node <-- 🚨 That's where the bug is 
4. `merge_node` on third node

Undoing this will then generate this:
1. `split_node` around "two"
2. `add_mark` on second node
4. `add_mark` on third node <-- 🚨 There was no mark here, but the operation is correctly inverted

</details>

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2926
Reviewers: @ianstormtaylor @justinweiss 
