### PR TITLE
Fix several undo/redo issues related to selection operation

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -11,6 +11,7 @@ import {
   IS_FIREFOX,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
+import Hotkeys from 'slate-hotkeys'
 
 import EVENT_HANDLERS from '../constants/event-handlers'
 import DATA_ATTRS from '../constants/data-attributes'
@@ -395,10 +396,15 @@ class Content extends React.Component {
   onEvent(handler, event) {
     debug('onEvent', handler)
 
+    const nativeEvent = event.nativeEvent || event
+    const isUndoRedo =
+      event.type === 'keydown' &&
+      (Hotkeys.isUndo(nativeEvent) || Hotkeys.isRedo(nativeEvent))
+
     // Ignore `onBlur`, `onFocus` and `onSelect` events generated
     // programmatically while updating selection.
     if (
-      this.tmp.isUpdatingSelection &&
+      (this.tmp.isUpdatingSelection || isUndoRedo) &&
       (handler === 'onSelect' || handler === 'onBlur' || handler === 'onFocus')
     ) {
       return


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
_bug_

Should fix the following issues: #2891, #2729

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)