### PR TITLE
Update glossary.md with definition of `match`

### DIFF
--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -66,6 +66,10 @@ A _"keys"_ is a unique identifier assigned to a node in Slate and is used to ref
 
 A _"mark"_ represents formatting data that is attached to characters within text. Standard formatting such as **bold**, _italic_, `code`, or custom formatting for your application can be implemented using marks.
 
+### Match
+
+A `match`, is an object with possible fields of `type` and `object` that are used to _match_ `Nodes` when defining rules in a [Schema](../reference/slate/schema.md). An example of `match` could be `{type: 'paragraph'}`, `{objet: 'inline', type: '@-tag'}`, etc.
+
 ### Merge
 
 ### Model


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Documentation improvement

#### What's the new behavior?
`match` get's used a number of times within the slate/schema.md but it does not appear to be explicitly defined anywhere. This term seems like a great candidate for the Glossary.

#### How does this change work?
The change is was trivial and only to the documentation


#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [N/A ] The new code matches the existing patterns and styles.
* [N/A ] The tests pass with `yarn test`.
* [ N/A] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ N/A] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
No

Fixes: #
Reviewers: @
