### PR TITLE
deleteBackwardAtRange now works when offset is equal to n

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -367,7 +367,7 @@ Commands.deleteBackwardAtRange = (editor, range, n = 1) => {
 
   // If the focus offset is farther than the number of characters to delete,
   // just remove the characters backwards inside the current node.
-  if (n < focus.offset) {
+  if (n <= focus.offset) {
     range = range.moveFocusBackward(n)
     editor.deleteAtRange(range)
     return

--- a/packages/slate/test/commands/at-range/delete-backward-at-range/from-offset.js
+++ b/packages/slate/test/commands/at-range/delete-backward-at-range/from-offset.js
@@ -1,0 +1,38 @@
+/** @jsx h */
+
+import { Point, Range } from 'slate'
+
+import h from '../../../helpers/h'
+
+export default function(editor) {
+  const { key } = editor.value.document.getFirstText()
+  const range = new Range({
+    anchor: new Point({ key, offset: 2, path: [key] }),
+    focus: new Point({ key, offset: 2, path: [key] }),
+  })
+  editor.deleteBackwardAtRange(range, 2)
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <paragraph>
+          Sample <cursor />Text
+        </paragraph>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph>
+        <paragraph>
+          mple <cursor />Text
+        </paragraph>
+      </paragraph>
+    </document>
+  </value>
+)


### PR DESCRIPTION
#### What's the new behavior?
If `editor.deleteBackwardAtRange` is invoked and the range's offset is equal to `n`, `n` characters will be deleted.

#### How does this change work?
Changes the check that `n < focus.offset` to `n <= focus.offset`.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2965
