### PR TITLE
Fix extracting relative ranges from decorations.

### DIFF
--- a/packages/slate-react/src/components/node.js
+++ b/packages/slate-react/src/components/node.js
@@ -177,9 +177,9 @@ class Node extends React.Component {
       const sel = selection && getRelativeRange(node, i, selection)
 
       const decs = newDecorations
+        .concat(decorations)
         .map(d => getRelativeRange(node, i, d))
         .filter(d => d)
-        .concat(decorations)
 
       const anns = annotations
         .map(a => getRelativeRange(node, i, a))


### PR DESCRIPTION
Hi,

It looks like all decorations, those passed from `decorateNode` for the current node, and those received from the parent, should go through relative range mapping.

The bug is evident when decorating text with existing marks as then decorations do not comply well.

Thanks.