### PR TITLE
Fix range normalization for node removal and split.

### DIFF
--- a/packages/slate/src/models/value.js
+++ b/packages/slate/src/models/value.js
@@ -622,18 +622,18 @@ class Value extends Record(DEFAULTS) {
     value = value.set('document', document)
 
     value = value.mapRanges(range => {
-      const { start, end } = range
+      const { anchor, focus } = range
 
-      if (node.hasNode(start.key)) {
+      if (node.hasNode(anchor.key)) {
         range = prev
-          ? range.moveStartTo(prev.key, prev.text.length)
-          : next ? range.moveStartTo(next.key, 0) : range.unset()
+          ? range.moveAnchorTo(prev.key, prev.text.length)
+          : next ? range.moveAnchorTo(next.key, 0) : range.unset()
       }
 
-      if (node.hasNode(end.key)) {
+      if (node.hasNode(focus.key)) {
         range = prev
-          ? range.moveEndTo(prev.key, prev.text.length)
-          : next ? range.moveEndTo(next.key, 0) : range.unset()
+          ? range.moveFocusTo(prev.key, prev.text.length)
+          : next ? range.moveFocusTo(next.key, 0) : range.unset()
       }
 
       range = range.updatePoints(point => point.setPath(null))


### PR DESCRIPTION
Hi,

In 'splitNode' and 'removeNode' range normalization start/end should be changed to anchor/focus, as those might change during normalization and the order might be reversed - leading to a point being set twice and the other not being set at all.

Thanks.