### PR TITLE
FIX findPoint offset may be include zero width string

### DIFF
--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -51,7 +51,9 @@ function findPoint(nativeNode, nativeOffset, editor) {
     // into \r\n. The bug causes a loop when slate-react attempts to reposition
     // its cursor to match the native position. Use textContent.length instead.
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10291116/
-    offset = range.cloneContents().textContent.length
+    const fragment = range.cloneContents()
+    const zeroWidthStringNodes = fragment.querySelectorAll(`[${DATA_ATTRS.ZERO_WIDTH}]`)
+    offset = fragment.textContent.length - zeroWidthStringNodes.length
   } else {
     // For void nodes, the element with the offset key will be a cousin, not an
     // ancestor, so find it by going down from the nearest void parent.

--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -52,7 +52,9 @@ function findPoint(nativeNode, nativeOffset, editor) {
     // its cursor to match the native position. Use textContent.length instead.
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10291116/
     const fragment = range.cloneContents()
-    const zeroWidthNodes = fragment.querySelectorAll(`[${DATA_ATTRS.ZERO_WIDTH}]`)
+    const zeroWidthNodes = fragment.querySelectorAll(
+      `[${DATA_ATTRS.ZERO_WIDTH}]`
+    )
     offset = fragment.textContent.length - zeroWidthNodes.length
   } else {
     // For void nodes, the element with the offset key will be a cousin, not an

--- a/packages/slate-react/src/utils/find-point.js
+++ b/packages/slate-react/src/utils/find-point.js
@@ -52,8 +52,8 @@ function findPoint(nativeNode, nativeOffset, editor) {
     // its cursor to match the native position. Use textContent.length instead.
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10291116/
     const fragment = range.cloneContents()
-    const zeroWidthStringNodes = fragment.querySelectorAll(`[${DATA_ATTRS.ZERO_WIDTH}]`)
-    offset = fragment.textContent.length - zeroWidthStringNodes.length
+    const zeroWidthNodes = fragment.querySelectorAll(`[${DATA_ATTRS.ZERO_WIDTH}]`)
+    offset = fragment.textContent.length - zeroWidthNodes.length
   } else {
     // For void nodes, the element with the offset key will be a cousin, not an
     // ancestor, so find it by going down from the nearest void parent.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
This fixes a bug.

#### What's the new behavior?

#### Old Behaviour

<img src="https://raw.githubusercontent.com/ibone/git_issue_img/master/ScreenRecording2019-08-27at91709.gif">

#### New Behaviour

<img src="https://raw.githubusercontent.com/ibone/git_issue_img/master/ScreenRecording2019-08-27at92217.gif">

#### How does this change work?
findPoint return offset is wrong
findPoint created a new range, but forget it may be include some zero width string, so i removed
sorry, my English is poor

#### Have you checked that...?

* [ ] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?
 I found it myself.
