### PR TITLE
fix document.getPath with node key as input in findPath util function

### DIFF
--- a/packages/slate-react/src/utils/find-path.js
+++ b/packages/slate-react/src/utils/find-path.js
@@ -23,7 +23,7 @@ function findPath(element, editor) {
 
   const { value } = editor
   const { document } = value
-  const path = document.getPath(node)
+  const path = document.getPath(node.key)
   return path
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

Fixing a bug.

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

In `slate-react/utils`, `findPath` function does not work as expected, as `document.getPath` function required a node key as input. 

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

`document.getPath` should take node `key` as input. 

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
