### PR TITLE
Tighten mark addition logic against zero-length marks.

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -60,10 +60,12 @@ Commands.addMarkAtRange = (editor, range, mark) => {
       let index = 0
       let length = node.text.length
 
-      if (key === start.key) index = start.offset
       if (key === end.key) length = end.offset
-      if (key === start.key && key === end.key)
-        length = end.offset - start.offset
+
+      if (key === start.key) {
+        index = start.offset
+        length -= start.offset
+      }
 
       editor.addMarkByKey(key, index, length, mark)
     })

--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -39,6 +39,12 @@ Commands.addMarksByPath = (editor, path, offset, length, marks) => {
   const { document } = value
   const node = document.assertNode(path)
 
+  // Adding zero-length mark makes only sense on zero-length node, otherwise
+  // it will be pruned by normalization anyway.
+  if (length === 0 && node.text.length > 0) {
+    return
+  }
+
   editor.withoutNormalizing(() => {
     // If it ends before the end of the node, we'll need to split to create a new
     // text with different marks.


### PR DESCRIPTION
Hi,

When adding marks to multi-line range it might happen that a mark is added to zero-length text node. Although such situation is corrected then by normalization, extra operations are generated unnecessarily.

This fix tightens the logic.

Thanks.