### PR TITLE
fix cursor jumping to end in embeds example

### DIFF
--- a/examples/embeds/video.js
+++ b/examples/embeds/video.js
@@ -125,15 +125,15 @@ class Video extends React.Component {
 
 const VideoUrlInput = props => {
   const [val, setVal] = React.useState(props.defaultValue)
-  
+
   const onChange = React.useCallback(
     e => {
-      setVal(e.target.value);
-      props.onChange(e.target.value);
+      setVal(e.target.value)
+      props.onChange(e.target.value)
     },
     [props.onChange]
   )
-  
+
   return (
     <input
       value={val}
@@ -141,7 +141,7 @@ const VideoUrlInput = props => {
       onClick={props.onClick}
       style={props.style}
     />
-   )
+  )
 }
 
 /**

--- a/examples/embeds/video.js
+++ b/examples/embeds/video.js
@@ -13,8 +13,7 @@ class Video extends React.Component {
    * @param {Event} e
    */
 
-  onChange = e => {
-    const video = e.target.value
+  onChange = video => {
     const { node, editor } = this.props
     editor.setNodeByKey(node.key, { data: { video } })
   }
@@ -108,14 +107,38 @@ class Video extends React.Component {
     }
 
     return (
-      <input
-        value={video}
+      <VideoUrlInput
+        defaultValue={video}
         onChange={this.onChange}
         onClick={this.onClick}
         style={style}
       />
     )
   }
+}
+
+/**
+ * The video URL input as controlled input to avoid loosing cursor position.
+ *
+ * @type {Component}
+ */
+
+const VideoUrlInput = (props) => {
+  const [val, setVal] = React.useState(props.defaultValue)
+  
+  const onChange = React.useCallback(e => {
+    setVal(e.target.value)
+    props.onChange(e.target.value)
+  }, [props.onChange])
+  
+  return (
+    <input
+      value={val}
+      onChange={onChange}
+      onClick={props.onClick}
+      style={props.style}
+    />
+   )
 }
 
 /**

--- a/examples/embeds/video.js
+++ b/examples/embeds/video.js
@@ -123,13 +123,16 @@ class Video extends React.Component {
  * @type {Component}
  */
 
-const VideoUrlInput = (props) => {
+const VideoUrlInput = props => {
   const [val, setVal] = React.useState(props.defaultValue)
   
-  const onChange = React.useCallback(e => {
-    setVal(e.target.value)
-    props.onChange(e.target.value)
-  }, [props.onChange])
+  const onChange = React.useCallback(
+    e => {
+      setVal(e.target.value);
+      props.onChange(e.target.value);
+    },
+    [props.onChange]
+  )
   
   return (
     <input


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Click on the video embed and change the url _in the middle_. The cursor should stay where you expect it. (instead of jumping to the end of the input)

#### How does this change work?

Controlled inputs can't be backed by the editor state, but need a local state instead, so the solution is to wrap the input in a functional component with state and pass the onChange-handler on.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2504
Reviewers: @
