### PR TITLE
Move selection to previous node when it's at the start of a non-void inline node

### DIFF
--- a/packages/slate-react/src/plugins/react/queries.js
+++ b/packages/slate-react/src/plugins/react/queries.js
@@ -526,6 +526,35 @@ function QueriesPlugin() {
       }
     }
 
+    // COMPAT: If the selection is at the start of a non-void inline node, and
+    // there is a node before it, put it in the node before instead. This
+    // standardizes the behavior, since it's indistinguishable to the user.
+    if (anchorInline && !editor.isVoid(anchorInline) && anchor.offset === 0) {
+      const block = document.getClosestBlock(anchor.path)
+      const depth = document.getDepth(block.key)
+      const relativePath = PathUtils.drop(anchor.path, depth)
+      const [prev] = block.texts({ path: relativePath, direction: 'backward' })
+
+      if (prev) {
+        const [prevText, prevPath] = prev
+        const absolutePath = anchor.path.slice(0, depth).concat(prevPath)
+        range = range.moveAnchorTo(absolutePath, prevText.text.length)
+      }
+    }
+
+    if (focusInline && !editor.isVoid(focusInline) && focus.offset === 0) {
+      const block = document.getClosestBlock(focus.path)
+      const depth = document.getDepth(block.key)
+      const relativePath = PathUtils.drop(focus.path, depth)
+      const [prev] = block.texts({ path: relativePath, direction: 'backward' })
+
+      if (prev) {
+        const [prevText, prevPath] = prev
+        const absolutePath = focus.path.slice(0, depth).concat(prevPath)
+        range = range.moveFocusTo(absolutePath, prevText.text.length)
+      }
+    }
+
     let selection = document.createSelection(range)
 
     // COMPAT: Ensure that the `isFocused` argument is set.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
feature

#### What's the new behavior?
![屏幕快照 2019-09-12 上午11 21 41](https://user-images.githubusercontent.com/12724894/64751779-dab5f000-d54f-11e9-8ba2-f2c545e2c608.png)

When user move selection backward to the start of a non-void inline node and start to input words. At current we got a result like this:

![屏幕快照 2019-09-12 上午11 21 11](https://user-images.githubusercontent.com/12724894/64751892-49934900-d550-11e9-8db6-184f51724b78.png)

The character became a part of the link node, and it seems confused to the user. 

Moreover, the editor will show a different result if the user moves selection forward to the start of the link. It is ambiguous because the two kinds of selection are visually equal. 

The new behavior:

![屏幕快照 2019-09-12 上午11 21 27](https://user-images.githubusercontent.com/12724894/64752063-d0482600-d550-11e9-912d-f317c4b398dd.png)

#### How does this change work?

Add COMPAT logic in `findSelection` function.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
