### PR TITLE
Replace deprecated findDOMNode with editor.findDOMNode in cloneFragment

### DIFF
--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -7,7 +7,6 @@ import { Value } from 'slate'
 
 import TRANSFER_TYPES from '../constants/transfer-types'
 import removeAllRanges from './remove-all-ranges'
-import findDOMNode from './find-dom-node'
 import DATA_ATTRS from '../constants/data-attributes'
 import SELECTORS from '../constants/selectors'
 
@@ -56,9 +55,13 @@ function cloneFragment(event, editor, callback = () => undefined) {
   // content, since the spacer is before void's content in the DOM.
   if (endVoid) {
     const r = range.cloneRange()
-    const node = findDOMNode(endVoid, window)
-    r.setEndAfter(node)
-    contents = r.cloneContents()
+    const path = document.getPath(endVoid.key)
+
+    if (path) {
+      const node = editor.findDOMNode(path)
+      r.setEndAfter(node)
+      contents = r.cloneContents()
+    }
   }
 
   // COMPAT: If the start node is a void node, we need to attach the encoded


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Update deprecated function usage.

#### What's the new behavior?

No waring in the chrome console.

#### How does this change work?

Replace deprecated findDOMNode with editor.findDOMNode in cloneFragment.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
