### PR TITLE
Prevent scrolling when no user actions are performed

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -198,6 +198,7 @@ class Content extends React.Component {
     debug.update('componentDidUpdate')
 
     this.updateSelection()
+    this.props.editor.clearUserActionPerformed()
 
     this.props.onEvent('onComponentDidUpdate')
   }
@@ -316,8 +317,11 @@ class Content extends React.Component {
         }
       }
 
-      // Scroll to the selection, in case it's out of view.
-      scrollToSelection(native)
+      // Only scroll to selection when a user action is performed
+      if (editor.userActionPerformed() === true) {
+        // Scroll to the selection, in case it's out of view.
+        scrollToSelection(native)
+      }
 
       // Then unset the `isUpdatingSelection` flag after a delay.
       setTimeout(() => {

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -30,6 +30,7 @@ function BeforePlugin() {
   let isComposing = false
   let isCopying = false
   let isDragging = false
+  let isUserActionPerformed = false
 
   /**
    * On before input.
@@ -42,6 +43,7 @@ function BeforePlugin() {
   function onBeforeInput(event, editor, next) {
     const isSynthetic = !!event.nativeEvent
     if (editor.readOnly) return
+    isUserActionPerformed = true
 
     // COMPAT: If the browser supports Input Events Level 2, we will have
     // attached a custom handler for the real `beforeinput` events, instead of
@@ -111,6 +113,7 @@ function BeforePlugin() {
 
   function onCompositionEnd(event, editor, next) {
     const n = compositionCount
+    isUserActionPerformed = true
 
     // The `count` check here ensures that if another composition starts
     // before the timeout has closed out this one, we will abort unsetting the
@@ -134,6 +137,7 @@ function BeforePlugin() {
 
   function onClick(event, editor, next) {
     debug('onClick', { event })
+    isUserActionPerformed = true
     next()
   }
 
@@ -151,6 +155,7 @@ function BeforePlugin() {
 
     const { value } = editor
     const { selection } = value
+    isUserActionPerformed = true
 
     if (!selection.isCollapsed) {
       // https://github.com/ianstormtaylor/slate/issues/1879
@@ -322,6 +327,7 @@ function BeforePlugin() {
 
   function onDrop(event, editor, next) {
     if (editor.readOnly) return
+    isUserActionPerformed = true
 
     // Prevent default so the DOM's value isn't corrupted.
     event.preventDefault()
@@ -371,6 +377,7 @@ function BeforePlugin() {
   function onInput(event, editor, next) {
     if (isComposing) return
     if (editor.value.selection.isBlurred) return
+    isUserActionPerformed = true
     debug('onInput', { event })
     next()
   }
@@ -415,6 +422,7 @@ function BeforePlugin() {
       event.preventDefault()
     }
 
+    isUserActionPerformed = true
     debug('onKeyDown', { event })
     next()
   }
@@ -429,6 +437,7 @@ function BeforePlugin() {
 
   function onPaste(event, editor, next) {
     if (editor.readOnly) return
+    isUserActionPerformed = true
 
     // Prevent defaults so the DOM state isn't corrupted.
     event.preventDefault()
@@ -454,9 +463,19 @@ function BeforePlugin() {
     // Save the new `activeElement`.
     const window = getWindow(event.target)
     activeElement = window.document.activeElement
+    isUserActionPerformed = true
 
     debug('onSelect', { event })
     next()
+  }
+
+  function userActionPerformed() {
+    return isUserActionPerformed
+  }
+
+  function clearUserActionPerformed() {
+    isUserActionPerformed = false
+    return null
   }
 
   /**
@@ -485,6 +504,8 @@ function BeforePlugin() {
     onKeyDown,
     onPaste,
     onSelect,
+    queries: { userActionPerformed },
+    commands: { clearUserActionPerformed },
   }
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
By default, the editor will not scroll on changes on the selection. Instead it will only scroll to make the cursor caret visible when a user action is performed
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

Some events on the `BeforePlugin` has been marked as *user action*. The plugin will set a local variable to `true` when a user event is triggered. Then, the `updateSelection` will check if a user action was done and will use a query to do that. A new command is added to put it back to `false` when the update is finished.

I'm not perfectly used to the codebase yet. If there is concerns or design changes to be done, I'll be happy to learn and make those changes!

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes:  #2967
Reviewers: @ianstormtaylor 
