### PR TITLE
[Android] Update the selection value whenever possible

### DIFF
--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -583,15 +583,7 @@ function CompositionManager(editor) {
       }
 
       const isPointsEqual = (point1, point2) => {
-        if (point1.path.size !== point2.path.size) {
-          return false
-        }
-
-        if (point1.offset !== point2.offset) {
-          return false
-        }
-
-        return point1.key === point2.key
+        return point1.offset === point2.offset && point1.key === point2.key
       }
 
       const isRangesEqual = (range1, range2) => {

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -582,6 +582,36 @@ function CompositionManager(editor) {
         clearAction()
       }
 
+      const isPointsEqual = (point1, point2) => {
+        if (point1.path.size !== point2.path.size) {
+          return false
+        }
+
+        if (point1.offset !== point2.offset) {
+          return false
+        }
+
+        return point1.key === point2.key
+      }
+
+      const isRangesEqual = (range1, range2) => {
+        return (
+          isPointsEqual(range1.anchor, range2.anchor) &&
+          isPointsEqual(range1.focus, range2.focus)
+        )
+      }
+
+      // It's important that we don't run the select middleware or commit the
+      // selection to the value when the diff has a value. When the diff is
+      // non-null, the text structure in the value is different compared to the DOM.
+      if (
+        range.isSet &&
+        last.diff === null &&
+        !isRangesEqual(editor.value.selection, range)
+      ) {
+        editor.select(range)
+      }
+
       last.range = range
       last.node = domSelection.anchorNode
     })

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -487,22 +487,6 @@ function CompositionManager(editor) {
         renderSync(editor, () => {
           applyDiff()
 
-          const domRange = win.getSelection().getRangeAt(0)
-          const domText = domRange.startContainer.textContent
-          const offset = domRange.startOffset
-
-          const fix = fixTextAndOffset(domText, offset)
-
-          const range = editor
-            .findRange({
-              anchorNode: domRange.startContainer,
-              anchorOffset: 0,
-              focusNode: domRange.startContainer,
-              focusOffset: 0,
-              isCollapsed: true,
-            })
-            .moveTo(fix.offset)
-
           /**
            * We must call `restoreDOM` even though this is applying a `diff` which
            * should not require it. But if you type `it me. no.` on a blank line
@@ -514,10 +498,7 @@ function CompositionManager(editor) {
            * `enter` in such a scenario.
            */
 
-          editor
-            .select(range)
-            .focus()
-            .restoreDOM()
+          editor.restoreDOM()
         })
       }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug

[Video showing the bug](https://i.imgur.com/EE3SRTu.mp4)
Notice the selection not being updated in the slate's value.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
The selection is now committed to the value when a selection event is triggered.

When the user moves the cursor either with a swipe or using the handle, the slate value should reflect the new, updated value.

[Video of the new behavior](https://i.imgur.com/0EDnSHG.mp4)
Notice the selection state being updated. Also notice the toolbar being updated.

#### How does this change work?

Inside the `onSelect` function in the android plugin, we check if we can commit the selection and call `editor.select` with the range.

We commit the selection when all of those are true:
 - The range extracted from the DOM is set (`range.isSet`)
 - The diff from the composition is empty (`last.diff === null`)
 - The range is different than the current selection from the value (to reduce superfluous calls)

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @thesunny @ianstormtaylor 

I also noticed that ranges were sent to the `editor.select` function. I will make a followup pull request to fix that too.