### PR TITLE
Send selection to editor.select on android

### DIFF
--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -31,6 +31,20 @@ function renderSync(editor, fn) {
 }
 
 /**
+ * Takes a the range and the editor. It will take the selection from the editor
+ * and apply the range's anchor and focus on it.
+ *
+ * @param {Editor} editor
+ * @param {Range} range
+ */
+
+function selectionFromRange(editor, range) {
+  return editor.value.selection
+    .moveAnchorTo(range.anchor)
+    .moveFocusTo(range.focus)
+}
+
+/**
  * Takes text from a dom node and an offset within that text and returns an
  * object with fixed text and fixed offset which removes zero width spaces
  * and adjusts the offset.
@@ -191,7 +205,7 @@ function CompositionManager(editor) {
       applyDiff()
 
       if (last.range) {
-        editor.select(last.range)
+        editor.select(selectionFromRange(editor, last.range))
       } else {
         debug('splitBlock:NO-SELECTION')
       }
@@ -232,7 +246,7 @@ function CompositionManager(editor) {
         applyDiff()
 
         editor
-          .select(last.range)
+          .select(selectionFromRange(editor, last.range))
           .deleteBackward()
           .focus()
           .restoreDOM()
@@ -308,7 +322,7 @@ function CompositionManager(editor) {
     if (last.range && !last.range.isCollapsed) {
       renderSync(editor, () => {
         editor
-          .select(last.range)
+          .select(selectionFromRange(editor, last.range))
           .deleteBackward()
           .focus()
           .restoreDOM()
@@ -437,7 +451,7 @@ function CompositionManager(editor) {
 
     renderSync(editor, () => {
       editor
-        .select(nodeSelection)
+        .select(selectionFromRange(editor, nodeSelection))
         .delete()
         .restoreDOM()
     })
@@ -504,7 +518,7 @@ function CompositionManager(editor) {
            */
 
           editor
-            .select(range)
+            .select(selectionFromRange(editor, range))
             .focus()
             .restoreDOM()
         })
@@ -601,7 +615,7 @@ function CompositionManager(editor) {
         last.diff === null &&
         !isRangesEqual(editor.value.selection, range)
       ) {
-        editor.select(range)
+        editor.select(selectionFromRange(editor, range))
       }
 
       last.range = range

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -583,15 +583,7 @@ function CompositionManager(editor) {
       }
 
       const isPointsEqual = (point1, point2) => {
-        if (point1.path.size !== point2.path.size) {
-          return false
-        }
-
-        if (point1.offset !== point2.offset) {
-          return false
-        }
-
-        return point1.key === point2.key
+        return point1.offset === point2.offset && point1.key === point2.key
       }
 
       const isRangesEqual = (range1, range2) => {

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -582,6 +582,36 @@ function CompositionManager(editor) {
         clearAction()
       }
 
+      const isPointsEqual = (point1, point2) => {
+        if (point1.path.size !== point2.path.size) {
+          return false
+        }
+
+        if (point1.offset !== point2.offset) {
+          return false
+        }
+
+        return point1.key === point2.key
+      }
+
+      const isRangesEqual = (range1, range2) => {
+        return (
+          isPointsEqual(range1.anchor, range2.anchor) &&
+          isPointsEqual(range1.focus, range2.focus)
+        )
+      }
+
+      // It's important that we don't run the select middleware or commit the
+      // selection to the value when the diff has a value. When the diff is
+      // non-null, the text structure in the value is different compared to the DOM.
+      if (
+        range.isSet &&
+        last.diff === null &&
+        !isRangesEqual(editor.value.selection, range)
+      ) {
+        editor.select(range)
+      }
+
       last.range = range
       last.node = domSelection.anchorNode
     })

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -39,9 +39,7 @@ function renderSync(editor, fn) {
  */
 
 function selectionFromRange(editor, range) {
-  return editor.value.selection
-    .moveAnchorTo(range.anchor)
-    .moveFocusTo(range.focus)
+  return editor.value.selection.setAnchor(range.anchor).setFocus(range.focus)
 }
 
 /**


### PR DESCRIPTION
This pull request depends on #3023 

#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Selections are sent to the `editor.select` command instead of ranges
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Instead of sending ranges, we take the existing selection from the editor and apply the range's anchor and focus.
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @ianstormtaylor 
