### PR TITLE
Recover from exception when flushing inside android plugin

### DIFF
--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -273,13 +273,15 @@ function CompositionManager(editor) {
     if (startActionFrameId) window.cancelAnimationFrame(startActionFrameId)
 
     startActionFrameId = window.requestAnimationFrame(() => {
-      if (bufferedMutations.length > 0) {
-        flushAction(bufferedMutations)
+      try {
+        if (bufferedMutations.length > 0) {
+          flushAction(bufferedMutations)
+        }
+      } finally {
+        startActionFrameId = null
+        bufferedMutations = []
+        isFlushing = false
       }
-
-      startActionFrameId = null
-      bufferedMutations = []
-      isFlushing = false
     })
   }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
The plugin will recover its state when an exception is thrown while flushing
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Before, the `startAction` function would simply fush everything and then cleanup the state.

When an exception was thrown, the plugin would not recover correctly. When using error boundaries and then recovering, the editor would simply not flush anymore since the variable `isFlushing` would always be true. Adding the finally can make the editor recover from a throwing plugin or an error in the flush
<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @thesunny @ianstormtaylor 
