### PR TITLE
Capitalise references to Mark for consistency

### DIFF
--- a/docs/reference/slate/commands.md
+++ b/docs/reference/slate/commands.md
@@ -12,7 +12,7 @@ These commands act on the `document` based on the current `selection`. They are 
 `addMark(properties: Object) => Editor` <br/>
 `addMark(type: String) => Editor`
 
-Add a [`mark`](./mark.md) to the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Add a [`Mark`](./mark.md) to the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `delete`
 
@@ -91,7 +91,7 @@ Split the [`Inline`](./inline.md) node in the current selection by `depth` level
 `removeMark(properties: Object) => Editor` <br/>
 `removeMark(type: String) => Editor`
 
-Remove a [`mark`](./mark.md) from the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Remove a [`Mark`](./mark.md) from the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `replaceMark`
 
@@ -99,7 +99,7 @@ Remove a [`mark`](./mark.md) from the characters in the current selection. For c
 `replaceMark(oldProperties: Object, newProperties: Object) => Editor` <br/>
 `replaceMark(oldType: String, newType: String) => Editor`
 
-Replace a [`mark`](./mark.md) in the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Replace a [`Mark`](./mark.md) in the characters in the current selection. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `toggleMark`
 
@@ -107,7 +107,7 @@ Replace a [`mark`](./mark.md) in the characters in the current selection. For co
 `toggleMark(properties: Object) => Editor` <br/>
 `toggleMark(type: String) => Editor`
 
-Add or remove a [`mark`](./mark.md) from the characters in the current selection, depending on it already exists on any or not. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Add or remove a [`Mark`](./mark.md) from the characters in the current selection, depending on it already exists on any or not. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `unwrapBlock`
 
@@ -273,7 +273,7 @@ These commands act on a specific [`Range`](./range.md) of the document.
 `addMarkAtRange(range: Range, properties: Object) => Editor` <br/>
 `addMarkAtRange(range: Range, type: String) => Editor`
 
-Add a [`mark`](./mark.md) to the characters in a `range`. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Add a [`Mark`](./mark.md) to the characters in a `range`. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `deleteAtRange`
 
@@ -352,7 +352,7 @@ Split the [`Inline`](./inline.md) node in a `range` by `depth` levels. If the se
 `removeMarkAtRange(range: Range, properties: Object) => Editor` <br/>
 `removeMarkAtRange(range: Range, type: String) => Editor`
 
-Remove a [`mark`](./mark.md) from the characters in a `range`. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Remove a [`Mark`](./mark.md) from the characters in a `range`. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `toggleMarkAtRange`
 
@@ -360,7 +360,7 @@ Remove a [`mark`](./mark.md) from the characters in a `range`. For convenience, 
 `toggleMarkAtRange(range: Range, properties: Object) => Editor` <br/>
 `toggleMarkAtRange(range: Range, type: String) => Editor`
 
-Add or remove a [`mark`](./mark.md) from the characters in a `range`, depending on whether any of them already have the mark. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
+Add or remove a [`Mark`](./mark.md) from the characters in a `range`, depending on whether any of them already have the mark. For convenience, you can pass a `type` string or `properties` object to implicitly create a [`Mark`](./mark.md) of that type.
 
 ### `unwrapBlockAtRange`
 
@@ -475,7 +475,7 @@ Remove `length` characters of text starting at an `offset` in a [`Node`](./node.
 `setMarkByKey(key: String, offset: Number, length: Number, properties: Object, newProperties: Object) => Editor`
 `setMarkByPath(path: List, offset: Number, length: Number, properties: Object, newProperties: Object) => Editor`
 
-Set a dictionary of `newProperties` on a [`mark`](./mark.md) on a [`Node`](./node.md) by its `key` or `path`.
+Set a dictionary of `newProperties` on a [`Mark`](./mark.md) on a [`Node`](./node.md) by its `key` or `path`.
 
 ### `setNodeByKey/Path`
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
- feature: improving docs

#### What's the new behavior?
- Capitalises references to "Mark" in the `commands.md` docs. 
- Currently both `mark` and `Mark` are used frequently and which could lead to confusion around whether they are the same thing - at least for me.
- They all link to the same page and it appears they are referring to the same entity.
- In `mark.md` the capitalised `Mark` is used so I thought it should be standardised on that.
- Screenshot of current situation
![image](https://user-images.githubusercontent.com/2720466/65592999-8ff09b00-df87-11e9-9e1b-89970495268f.png)
- Screenshot with changes
![image](https://user-images.githubusercontent.com/2720466/65593678-eb6f5880-df88-11e9-8acb-2a784e947351.png)

#### How does this change work?
- Trivial docs update for clarity

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: n/a
Reviewers: Any