### PR TITLE
Fixed /placeholder link on Examples page

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -59,7 +59,7 @@ const EXAMPLES = [
   ['Markdown Shortcuts', MarkdownShortcuts, '/markdown-shortcuts'],
   ['Mentions', Mentions, '/mentions'],
   ['Paste HTML', PasteHtml, '/paste-html'],
-  ['Placeholders', Placeholder, '/placeholders'],
+  ['Placeholders', Placeholder, '/placeholder'],
   ['Plain Text', PlainText, '/plain-text'],
   ['Plugins', Plugins, '/plugins'],
   ['Read-only', ReadOnly, '/read-only'],


### PR DESCRIPTION
Spotted that this link was wrong on the Examples page.

The directory is at https://github.com/ianstormtaylor/slate/tree/master/examples/placeholder (without the last `s`)

Thanks for Slate! It's incredible!