### PR TITLE
Fix composition editing in Safari

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -9,6 +9,7 @@ import { List } from 'immutable'
 import {
   IS_ANDROID,
   IS_FIREFOX,
+  IS_SAFARI,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
 import Hotkeys from 'slate-hotkeys'
@@ -450,7 +451,9 @@ class Content extends React.Component {
     // at the end of a block. The selection ends up to the left of the inserted
     // character instead of to the right. This behavior continues even if
     // you enter more than one character. (2019/01/03)
-    if (!IS_ANDROID && handler === 'onSelect') {
+    //
+    // SAFARI: The updateSelection causes a premature onCompositionEnd to fire.
+    if (!IS_ANDROID && !IS_SAFARI && handler === 'onSelect') {
       const { editor } = this.props
       const { value } = editor
       const { selection } = value

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -452,7 +452,8 @@ class Content extends React.Component {
     // character instead of to the right. This behavior continues even if
     // you enter more than one character. (2019/01/03)
     //
-    // SAFARI: The updateSelection causes a premature onCompositionEnd to fire.
+    // SAFARI: When composing, the updateSelection causes a premature
+    // onCompositionEnd to fire. (2019/09/28)
     if (!IS_ANDROID && !IS_SAFARI && handler === 'onSelect') {
       const { editor } = this.props
       const { value } = editor

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -111,6 +111,7 @@ function AfterPlugin(options = {}) {
 
       case 'insertFromYank':
       case 'insertReplacementText':
+      case 'insertFromComposition':
       case 'insertText': {
         // COMPAT: `data` should have the text for the `insertText` input type
         // and `dataTransfer` should have the text for the

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -115,7 +115,14 @@ function BeforePlugin() {
     // The `count` check here ensures that if another composition starts
     // before the timeout has closed out this one, we will abort unsetting the
     // `isComposing` flag, since a composition is still in affect.
-    window.requestAnimationFrame(() => {
+    //
+    // COMPAT: Safari: When selecting a composition by pressing 'enter',
+    // we want to prevent the default behavior of inserting a new line.
+    // However using requestAnimationFrame here will set isComposing to false
+    // *before* the onKeyDown event for 'enter' is fired. So when the onKeyDown
+    // event is fired for 'enter', it will think that composition has already
+    // ended and will insert a new line.
+    setTimeout(() => {
       if (compositionCount > n) return
       isComposing = false
     })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

In Safari, composition input was broken in at least two ways:

1. Pressing option + an accent character, e.g. opt+n to insert a ~, then pressing n again to compose that into an ñ.
2. Using an IME to input something like Japanese or Korean.

For method 1., the old behavior was that a normal 'n' character would be inserted instead of an 'ñ'. The new behavior is that the `ñ' gets inserted.

For method 2. this was just completely broken and behaving all kinds of unexpected ways.

#### How does this change work?

The the main issue is that immediately after `onCompositionStart` is fired, an `onSelect` event is fired which updates the selection and triggers an `onCompositionEnd` to fire, thus interrupting the composition before the user is able to complete it.

In addition to the above, specific to method 1. Safari would fire a `insertFromComposition` when the `n` was pressed a second time, which was not being handled.

Specific to 2. when an IME composition is selected with 'enter' it was completing the composition (firing `onCompositionEnd`), and *also* inserting a new line. This is because the `onCompositionEnd` is handled *before* `onKeydown` (or whichever event triggers the new line). By ensuring that `isComposing` is set to false *after* the `onKeydown` is handled, we can prevent the default behavior of inserting a new line.

Instead of blocking `updateSelection` outright in Safari, we could store the composition state in `this.tmp.isComposing` and conditionally block `updateSelection` based on that. I decided to block it outright to simplify the code, and following the Android exception.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2781 #2499 #2743
Doesn't fix:  ~~#2979~~
Reviewers: @ianstormtaylor @thesunny 
