### PR TITLE
Fix MacOS long-press accented char bug

### DIFF
--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -38,6 +38,7 @@ const APPLE_HOTKEYS = {
   extendLineForward: 'opt+shift+down',
   redo: 'cmd+shift+z',
   transposeCharacter: 'ctrl+t',
+  longPressSelect: ['1', '2', '3', '4', '5', '6', '7', '8', '9'],
 }
 
 const WINDOWS_HOTKEYS = {

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -79,6 +79,8 @@ function AfterPlugin(options = {}) {
         } else {
           editor.insertText(event.data)
         }
+      } else {
+        editor.insertText(event.data)
       }
 
       return next()


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

#### What's the new behavior?

See #982 for details on the bug.

![Screen Shot 2019-10-06 at 1 03 11 PM](https://user-images.githubusercontent.com/431251/66272596-c527a380-e839-11e9-9a26-e5c2269d106d.png)

#### How does this change work?

The change works by trying to guess when an insertion from the popover is occurring. It does this by comparing the last `keyDown` value with the value of `onBeforeInput` (which is triggered after a selection is made). If the values are different, and the last `keyDown` value was a number between 1-9, and the text for `onBeforeInput` falls within the unicode range of an accented character, it will insert the character at the specified range. The range is specified as the current selection, with the focus moved back one character, thereby replacing the non-accented character that was inserted when the long press was initiated.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #982
Reviewers: @ianstormtaylor
