### PR TITLE
Fixed a crash when editing with softbreaks

### DIFF
--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -355,8 +355,21 @@ function CompositionManager(editor) {
 
     const firstMutation = mutations[0]
 
+    const matchCharacterDataParent = () => {
+      if (firstMutation.target.parentNode !== null) {
+        return firstMutation.target.parentNode
+      } else {
+        const mutationRemoveTarget = mutations.find(m => {
+          if (m.type !== 'childList') return false
+          return m.removedNodes[0] === firstMutation.target
+        })
+
+        return mutationRemoveTarget && mutationRemoveTarget.target
+      }
+    }
+
     if (firstMutation.type === 'characterData') {
-      resolveDOMNode(firstMutation.target.parentNode)
+      resolveDOMNode(matchCharacterDataParent())
     } else if (firstMutation.type === 'childList') {
       if (firstMutation.removedNodes.length > 0) {
         if (mutations.length === 1) {

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -358,7 +358,7 @@ function CompositionManager(editor) {
     const matchCharacterDataParent = () => {
       if (
         firstMutation.target.parentNode &&
-        firstMutation.target.parentNode.closest(`[data-key]`)
+        firstMutation.target.parentNode.closest(`[data-slate-editor]`)
       ) {
         return firstMutation.target.parentNode
       } else {
@@ -372,7 +372,11 @@ function CompositionManager(editor) {
     }
 
     if (firstMutation.type === 'characterData') {
-      resolveDOMNode(matchCharacterDataParent())
+      const parent = matchCharacterDataParent()
+
+      if (parent) {
+        resolveDOMNode(matchCharacterDataParent())
+      }
     } else if (firstMutation.type === 'childList') {
       if (firstMutation.removedNodes.length > 0) {
         if (mutations.length === 1) {

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -356,7 +356,10 @@ function CompositionManager(editor) {
     const firstMutation = mutations[0]
 
     const matchCharacterDataParent = () => {
-      if (firstMutation.target.parentNode !== null) {
+      if (
+        firstMutation.target.parentNode &&
+        firstMutation.target.parentNode.closest(`[data-key]`)
+      ) {
         return firstMutation.target.parentNode
       } else {
         const mutationRemoveTarget = mutations.find(m => {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

Given this softbreak plugin that is compatible with android:
```js
export default function SoftBreak(options = {}) {
  return {
    onCommand(command, editor, next) {
      const { type, args } = command

      if (type === 'splitBlock') {
        const [n] = args

        if (n === undefined) {
          return editor.insertText('\n')
        }
      }

      return next()
    },
  }
}
```
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
No crash happen when deleting a (still composed) character on the last line when using soft breaks.

[Old behaviour](https://i.imgur.com/edfC6O3.mp4) (crash)
[New behaviour](https://i.imgur.com/lGR7SqZ.mp4) (same sequence, no crash)

#### How does this change work?

With softbreak, the android keyboard may separate the text content of a span into multiple text nodes. When deleting a node completely, a node is removed.

However, the removed node was also the target for character data.

Here's a representation of the mutations:
```js
{
  MutationRecord{type: "characterData"} // removes the 'J' letter
  MutationRecord{type: "childList"}     // removes the node that contained the 'J' letter
  MutationRecord{type: "childList"}     // adds a <br /> node
}
```

The thing is when a node is removed from the node, it is detached and it's parent is null, resulting in a crash.

The fix work by taking the target of the second mutation as the parent to the first one. Since the target of the second mutation is the parent of the removed node, it's equivalent is yeild the correct result.

```js
secondMutation.removedNodes[0] === firstMutation.target   // true
secondMutation.target === firstMutation.target.parentNode // true if the node wasn't removed
```

Of course, a matching is done to find the mutation removing the node targeted by the character data mutation.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @thesunny @ianstormtaylor 
