### PR TITLE
fixing paste html example

### DIFF
--- a/examples/paste-html/index.js
+++ b/examples/paste-html/index.js
@@ -295,6 +295,7 @@ class PasteHtml extends React.Component {
    */
 
   onPaste = (event, editor, next) => {
+    event.preventDefault()
     const transfer = getEventTransfer(event)
     if (transfer.type !== 'html') return next()
     const { document } = serializer.deserialize(transfer.html)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug fix

#### What's the new behavior?

Paste HTML is working and not pasting content twice

#### How does this change work?

Prevent default handler solves the issue.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2988
Reviewers: @
