### PR TITLE
Fix when clear search text, all text split by blank

### DIFF
--- a/examples/search-highlighting/index.js
+++ b/examples/search-highlighting/index.js
@@ -185,23 +185,25 @@ class SearchHighlighting extends React.Component {
         }
       })
 
-      for (const [node, path] of document.texts()) {
-        const { key, text } = node
-        const parts = text.split(string)
-        let offset = 0
+      if (string) {
+        for (const [node, path] of document.texts()) {
+          const { key, text } = node
+          const parts = text.split(string)
+          let offset = 0
 
-        parts.forEach((part, i) => {
-          if (i !== 0) {
-            editor.addAnnotation({
-              key: getHighlightKey(),
-              type: 'highlight',
-              anchor: { path, key, offset: offset - string.length },
-              focus: { path, key, offset },
-            })
-          }
+          parts.forEach((part, i) => {
+            if (i !== 0) {
+              editor.addAnnotation({
+                key: getHighlightKey(),
+                type: 'highlight',
+                anchor: { path, key, offset: offset - string.length },
+                focus: { path, key, offset },
+              })
+            }
 
-          offset = offset + part.length + string.length
-        })
+            offset = offset + part.length + string.length
+          })
+        }
       }
     })
   }


### PR DESCRIPTION
In search-highlighting example, when search text is empty, no need to split text and addAnnotation.
Note dom changes in the right

![hjhj](https://user-images.githubusercontent.com/22700758/66997092-65b47800-f104-11e9-8f61-16eadca51948.gif)
![jjjjhhh](https://user-images.githubusercontent.com/22700758/66997179-8aa8eb00-f104-11e9-883a-4faa08653e7c.gif)
