### PR TITLE
Use native rendering for character insertion when possible to avoid spellcheck flicker.

### DIFF
--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -379,6 +379,9 @@ function BeforePlugin() {
     if (editor.value.selection.isBlurred) return
     isUserActionPerformed = true
     debug('onInput', { event })
+    // Native operations are applied to the DOM at this point.
+    // Apply the operations to the editor's `value`.
+    editor.controller.flushQueuedNativeOperations()
     next()
   }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

See the original bug ticket for original behavior.

Before:

![slate-bug-before](https://user-images.githubusercontent.com/4415988/67333775-fceb4800-f4d5-11e9-9f0d-8eaa4b843b73.gif)

After:

![slate-bug](https://user-images.githubusercontent.com/4415988/67333602-aed64480-f4d5-11e9-8688-04712c6cbfc0.gif)

#### How does this change work?

Slate will re-render after each slate editor document operation. The most
noticeable and visually jarring behavior is when typing single characters
into the editor. Each character will cause the browser spellcheck underline
to re-render the block the insertion is in. This re-rendering also causes
the spellcheck to re-evaluate each misspelled word as letters are added
to it, instead of the usual behavior of waiting for typing to stop for a
period of time.

This change looks for when a single character is input in the `onBeforeInput`
method and when certain conditions are met, such as:

1. The selection is collapsed (only want to handle the simplest case right now)
2. The selection is not at the start of a text node (Chrome natively handles this inconsistently)

The editor command for this insertion is wrapped in a new `asNativeOperation`
function which will queue the operation generated by any command in the function
until flushed. The event is not prevented to allow the default behavior.

This queue is flushed in the `onInput` event, which happens right after the dom
is natively updated with the operation.

The leaf text nodes are updated to keep a reference to their DOM elements and
not render if their `textContent` matches what it will try to render. Since the
shadow DOM state is different than the actual DOM state for text nodes, we must
force it to update by changing the `key` on the node after each update. Otherwise
React thinks it doesn't need to change anything.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [X] The new code matches the existing patterns and styles.
* [X] The tests pass with `yarn test`.
* [X] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [X] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2061 
Reviewers: @ianstormtaylor 
