### PR TITLE
Add a way to completely disable the default placeholder plugin

### DIFF
--- a/packages/slate-react/src/plugins/react/index.js
+++ b/packages/slate-react/src/plugins/react/index.js
@@ -40,7 +40,7 @@ function ReactPlugin(options = {}) {
   // Disable placeholder for Android because it messes with reconciliation
   // and doesn't disappear until composition is complete.
   // e.g. In empty, type "h" and autocomplete on Android 9 and deletes all text.
-  const placeholderPlugin = IS_ANDROID
+  const placeholderPlugin = IS_ANDROID || placeholder === null
     ? null
     : PlaceholderPlugin({
         placeholder,

--- a/packages/slate-react/src/plugins/react/index.js
+++ b/packages/slate-react/src/plugins/react/index.js
@@ -40,16 +40,17 @@ function ReactPlugin(options = {}) {
   // Disable placeholder for Android because it messes with reconciliation
   // and doesn't disappear until composition is complete.
   // e.g. In empty, type "h" and autocomplete on Android 9 and deletes all text.
-  const placeholderPlugin = IS_ANDROID || placeholder === null
-    ? null
-    : PlaceholderPlugin({
-        placeholder,
-        when: (editor, node) =>
-          node.object === 'document' &&
-          node.text === '' &&
-          node.nodes.size === 1 &&
-          Array.from(node.texts()).length === 1,
-      })
+  const placeholderPlugin =
+    IS_ANDROID || placeholder === null
+      ? null
+      : PlaceholderPlugin({
+          placeholder,
+          when: (editor, node) =>
+            node.object === 'document' &&
+            node.text === '' &&
+            node.nodes.size === 1 &&
+            Array.from(node.texts()).length === 1,
+        })
 
   return [
     debugEventsPlugin,


### PR DESCRIPTION
I'd like to use slate-react, along with a custom placeholder.
The problem I'm running into though is that slate-react _always_ adds the PlaceholderPlugin pretty much.  Even setting the placeholder to an empty string will still actually add a magic div to the dom, and that's what breaking for me.

So, I figured adding support for passing _exactly_ null in to disable the plugin would work well.  Folks that don't pass in anything will still get the "default" of an "empty placeholder" so hopefully nothing breaks.

#### Is this adding or improving a _feature_ or fixing a _bug_?
Improving a feature

#### What's the new behavior?
The placeholder plugin will not be added to the editor if the placeholder prop is exactly null.

#### How does this change work?
The placeholder plugin will not be added to the editor if the placeholder prop is exactly null.

#### Have you checked that...?

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
