### PR TITLE
Include data and type when converting set_annotation to JS

### DIFF
--- a/packages/slate/src/models/operation.js
+++ b/packages/slate/src/models/operation.js
@@ -278,7 +278,8 @@ class Operation extends Record(DEFAULTS) {
         if ('anchor' in value) v.anchor = value.anchor.toJS()
         if ('focus' in value) v.focus = value.focus.toJS()
         if ('key' in value) v.key = value.key
-        if ('mark' in value) v.mark = value.mark.toJS()
+        if ('data' in value) v.data = value.data.toJS()
+        if ('type' in value) v.type = value.type
         value = v
       }
 


### PR DESCRIPTION
### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

When converting `set_annotation` operations to JS objects, they now include `type` and `data`.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
