### PR TITLE
Fix android call next

### DIFF
--- a/packages/slate-react/src/plugins/android/index.js
+++ b/packages/slate-react/src/plugins/android/index.js
@@ -44,16 +44,18 @@ function AndroidPlugin({ editor }) {
    * handle `onCompositionStart`
    */
 
-  function onCompositionStart() {
+  function onCompositionStart(event, e, next) {
     observer.onCompositionStart()
+    return next()
   }
 
   /**
    * handle `onCompositionEnd`
    */
 
-  function onCompositionEnd() {
+  function onCompositionEnd(event, e, next) {
     observer.onCompositionEnd()
+    return next()
   }
 
   /**
@@ -62,26 +64,29 @@ function AndroidPlugin({ editor }) {
    * @param {Event} event
    */
 
-  function onSelect(event) {
+  function onSelect(event, e, next) {
     const window = getWindow(event.target)
     fixSelectionInZeroWidthBlock(window)
     observer.onSelect(event)
+    return next()
   }
 
   /**
    * handle `onComponentDidMount`
    */
 
-  function onComponentDidMount() {
+  function onComponentDidMount(event, e, next) {
     observer.connect()
+    return next()
   }
 
   /**
    * handle `onComponentDidUpdate`
    */
 
-  function onComponentDidUpdate() {
+  function onComponentDidUpdate(event, e, next) {
     observer.connect()
+    return next()
   }
 
   /**
@@ -90,8 +95,9 @@ function AndroidPlugin({ editor }) {
    * @param {Event} event
    */
 
-  function onComponentWillUnmount() {
+  function onComponentWillUnmount(event, e, next) {
     observer.disconnect()
+    return next()
   }
 
   /**
@@ -100,12 +106,13 @@ function AndroidPlugin({ editor }) {
    * @param {Event} event
    */
 
-  function onRender() {
+  function onRender(event, e, next) {
     observer.disconnect()
 
     // We don't want the `diff` from a previous render to apply to a
     // potentially different value (e.g. when we switch examples)
     observer.clearDiff()
+    return next()
   }
 
   return {

--- a/packages/slate-react/src/plugins/dom/index.js
+++ b/packages/slate-react/src/plugins/dom/index.js
@@ -18,11 +18,17 @@ function DOMPlugin(options = {}) {
   const beforePlugin = BeforePlugin()
   const afterPlugin = AfterPlugin()
 
+  // Activate NoopPlugin only for debugging purposes
+  const noopPluginActivated = false
+
   // COMPAT: Add Android specific handling separately before it gets to the
   // other plugins because it is specific (other browser don't need it) and
   // finicky (it has to come before other plugins to work).
   const androidPlugins = IS_ANDROID
-    ? [AndroidPlugin(options), NoopPlugin(options)]
+    ? [
+        AndroidPlugin(options),
+        noopPluginActivated ? NoopPlugin(options) : undefined,
+      ]
     : []
 
   return [...androidPlugins, beforePlugin, ...plugins, afterPlugin]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

When writing such plugin:
```js
function MyPlugin() {
    return {
        onCompositionStart:() => {
            console.log("hello");
        }
    };
}
```

When starting a composition, `"hello"` is printed in the console. This works today on desktop.

However, this is not the case for Android. On Android, the Noop plugin was activated, and no hooks would call next.

As stated in `noop.js`:

> IMPORTANT:
>
> This plugin is detached (i.e. there is no way to turn it on in Slate).
> You must hard code it into `plugins/react/index`.

However, it was always activated in `dom/index.js`:
```js
  const androidPlugins = IS_ANDROID
    ? [AndroidPlugin(options), NoopPlugin(options)]
```

#### How does this change work?

I added a switch to turn on or off the noop plugin and added calls to `next()` in the hooks of the Android plugin

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
