### PR TITLE
Fix delete on Android with a deep document

### DIFF
--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -355,11 +355,22 @@ function CompositionManager(editor) {
 
     const firstMutation = mutations[0]
 
+    // Here we want to filter BR nodes out.
+    // When the content editable choose to remove a node instead of
+    // a 'characterData' mutation, it is usually the only mutation, unless
+    // it's the last node. When it's the last node, the browser also adds a BR.
+    // We want to filter it out so we match the mutation correctly and call `removeNode`
+    const filterBr = () => {
+      return mutations.filter(m => {
+        return !(m.addedNodes[0] && m.addedNodes[0].nodeName === 'BR')
+      })
+    }
+
     if (firstMutation.type === 'characterData') {
       resolveDOMNode(firstMutation.target.parentNode)
     } else if (firstMutation.type === 'childList') {
       if (firstMutation.removedNodes.length > 0) {
-        if (mutations.length === 1) {
+        if (filterBr().length === 1) {
           removeNode(firstMutation.removedNodes[0])
         } else {
           mergeBlock()

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -58,7 +58,14 @@ function CommandsPlugin() {
   function reconcileDOMNode(editor, domNode) {
     const domElement = domNode.parentElement.closest('[data-key]')
     const node = editor.findNode(domElement)
-    editor.reconcileNode(node)
+
+    if (node.object === 'text') {
+      editor.reconcileNode(node)
+    } else {
+      node.getTexts().forEach(textNode => {
+        editor.reconcileNode(textNode)
+      })
+    }
   }
 
   return {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug
<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Deleting correctly when operating on a document with a deep structure.

Consider this document:

```js
  document: {
    object: "document",
    data: {},
    nodes: [
      {
        object: "block",
        type: "depth1",
        data: {},
        nodes: [
          {
            object: "block",
            type: "depth2",
            data: {},
            nodes: [
              {
                object: "block",
                type: "depth3",
                data: {},
                nodes: [
                  {
                    object: "text",
                    text: "T",
                    marks: []
                  },
                  {
                    object: "text",
                    text: " ",
                    marks: [
                      {
                        object: "mark",
                        type: "style1",
                        data: {}
                      }
                    ]
                  }
                ]
              }
            ]
          }
        ]
      }
    ]
  }
```
[Video: Crash when deleting a parent node with swipe delete](https://i.imgur.com/YIe116R.mp4)
[Video: Crash when pressing backspace](https://i.imgur.com/oLEApVD.mp4)

[Video: Editor with the patches](https://i.imgur.com/E5H1ooo.mp4)
<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

When pressing a single backspace, the node with the style gets deleted. This is a single mutation that is removing the node. The composition manager catches that and match on single mutation that removes nodes.

When pressing backspace on the last character, the node get deleted, the browser also adds a `<br />` node. This screws the matching, since it's two mutations instead of one.

The solution for that was to filter out `<br />` additions.

There was another problem with the swipe delete. Swipe delete removed the parent span containing the text node.

The problem with that is that `reconcileDOMNode` expect to alway find the span node where the focused text node is, but none is there, instead a nearby block is found:

```js
function reconcileDOMNode(editor, domNode) {
  // finds a block, there is no span anymore!
  const domElement = domNode.parentElement.closest('[data-key]') 
  const node = editor.findNode(domElement)
  // ...
}
``` 

My solution was to take the block and call `reconcileNode` on each on its text nodes. I'm unsure if this is necessary or if only calling `reconcileNode` on the first one is enough.

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @ianstormtaylor @thesunny 
