### PR TITLE
Add redo hotkey for Windows (Ctrl+Shift+Z)

### DIFF
--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -43,7 +43,7 @@ const APPLE_HOTKEYS = {
 const WINDOWS_HOTKEYS = {
   deleteWordBackward: 'ctrl+shift?+backspace',
   deleteWordForward: 'ctrl+shift?+delete',
-  redo: 'ctrl+y',
+  redo: ['ctrl+y', 'ctrl+shift+z'],
 }
 
 /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Adding a feature - Slate should support Ctrl+Shift+Z as a hotkey for 'redo'.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
The hotkey Ctrl+Shift+Z will now trigger 'redo' inside Slate. This is a very simple change that just involved adding an additional hotkey sequence for the Windows 'redo' inside the hotkey mapping dictionary.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
When isRedo() is evaluated from slate-react, there will now be an additional hotkey sequence that qualifies as an undo hotkey according to the hotkey dictionary (for Windows).

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [X] The new code matches the existing patterns and styles.
* [X] The tests pass with `yarn test`.
* [X] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [X] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
