### PR TITLE
Fix long pressed accents on Chrome+macOS

### DIFF
--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -60,7 +60,11 @@ function AfterPlugin(options = {}) {
         const window = getWindow(event.target)
         const domSelection = window.getSelection()
 
-        if (!domSelection.isCollapsed && value.selection.isCollapsed) {
+        if (
+          !domSelection.isCollapsed &&
+          value.selection.isCollapsed &&
+          !editor.isInCompositionMode()
+        ) {
           const range = editor.findRange(domSelection)
           editor.insertTextAtRange(range, event.data)
         } else {

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -478,6 +478,10 @@ function BeforePlugin() {
     return null
   }
 
+  function isInCompositionMode() {
+    return isComposing
+  }
+
   /**
    * Return the plugin.
    *
@@ -504,7 +508,7 @@ function BeforePlugin() {
     onKeyDown,
     onPaste,
     onSelect,
-    queries: { userActionPerformed },
+    queries: { userActionPerformed, isInCompositionMode },
     commands: { clearUserActionPerformed },
   }
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

On macOS, long press triggers an IME to insert an accent. Browsers that implements `beforeinput` event uses the `insertReplacementText` and a proper range. Chrome is instead selecting the character to replace, **right when the input is triggered**.

| **Before** | **After** |
| -- | -- |
|![][before]|![][after]|

[before]: https://user-images.githubusercontent.com/3692274/68779241-9b318000-0634-11ea-9c41-be9be33972e4.gif
[after]: https://user-images.githubusercontent.com/3692274/68779245-9cfb4380-0634-11ea-896f-83272a0a0763.gif


#### How does this change work?

If we detect macOS && Chrome, the we proceed to check if the DOM selection has been updated before the input event and a detection of a selection change. The check is very naive but enough for this particular case. This can't happen when previous editor selection was expanded I guess.

I had to expose through a query the composition state of the before plugin, this is used to discard completely this fix in case of a user using another IME.

This issue was also fixed by #3041 but the fix is more trustworthy in my opinion, as we are not relying on any previous input.

I couldn't figured out how to test this with the current toolchain.

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #982 
Reviewers: @ianstormtaylor @knubie 
