### PR TITLE
fix links to examples in readme and site

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,16 +103,16 @@ Check out the [**live demo**](http://slatejs.org) of all of the examples!
 
 To get a sense for how you might use Slate, check out a few of the examples:
 
-- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/master/examples/plain-text) — showing the most basic case: a glorified `<textarea>`.
-- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/master/examples/rich-text) — showing the features you'd expect from a basic editor.
-- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/master/examples/markdown-preview) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Links**](https://github.com/ianstormtaylor/slate/tree/master/examples/links) — showing how wrap text in inline nodes with associated data.
-- [**Images**](https://github.com/ianstormtaylor/slate/tree/master/examples/images) — showing how to use void (text-less) nodes to add images.
-- [**Hovering menu**](https://github.com/ianstormtaylor/slate/tree/master/examples/hovering-menu) — showing how a contextual hovering menu can be implemented.
-- [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/examples/tables) — showing how to nest blocks to render more advanced components.
-- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/examples/paste-html) — showing how to use an HTML serializer to handle pasted HTML.
-- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/master/examples/mentions) — showing how to use inline void nodes for simple @-mentions.
-- [**See all the examples...**](https://github.com/ianstormtaylor/slate/tree/master/examples/mentions)
+- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/plain-text.js) — showing the most basic case: a glorified `<textarea>`.
+- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/rich-text.js) — showing the features you'd expect from a basic editor.
+- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/markdown-preview.js) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Links**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/links.js) — showing how wrap text in inline nodes with associated data.
+- [**Images**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/images.js) — showing how to use void (text-less) nodes to add images.
+- [**Hovering menu**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/hovering-menu.js) — showing how a contextual hovering menu can be implemented.
+- [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/tables.js) — showing how to nest blocks to render more advanced components.
+- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
+- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/mentions.js) — showing how to use inline void nodes for simple @-mentions.
+- [**See all the examples...**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/mentions.js)
 
 If you have an idea for an example that shows a common use case, pull request it!
 

--- a/site/examples/Readme.md
+++ b/site/examples/Readme.md
@@ -2,16 +2,16 @@
 
 This directory contains a set of examples that give you an idea for how you might use Slate to implement your own editor. Take a look around!
 
-- [**Plain text**](./plain-text) — showing the most basic case: a glorified `<textarea>`.
-- [**Rich text**](./rich-text) — showing the features you'd expect from a basic editor.
-- [**Forced Layout**](./forced-layout) - showing how to use schema rules to enforce document structure
-- [**Markdown Shortcuts**](./markdown-shortcuts) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Links**](./links) — showing how wrap text in inline nodes with associated data.
-- [**Images**](./images) — showing how to use void (text-less) nodes to add images.
-- [**Hovering menu**](./hovering-menu) — showing how a contextual hovering menu can be implemented.
-- [**Tables**](./tables) — showing how to nest blocks to render more advanced components.
-- [**Paste HTML**](./paste-html) — showing how to use an HTML serializer to handle pasted HTML.
-- [**Code Highlighting**](./code-highlighting) — showing how to use decorations to dynamically mark text.
+- [**Plain text**](./plain-text.js) — showing the most basic case: a glorified `<textarea>`.
+- [**Rich text**](./rich-text.js) — showing the features you'd expect from a basic editor.
+- [**Forced Layout**](./forced-layout.js) - showing how to use schema rules to enforce document structure
+- [**Markdown Shortcuts**](./markdown-shortcuts.js) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Links**](./links.js) — showing how wrap text in inline nodes with associated data.
+- [**Images**](./images.js) — showing how to use void (text-less) nodes to add images.
+- [**Hovering menu**](./hovering-menu.js) — showing how a contextual hovering menu can be implemented.
+- [**Tables**](./tables.js) — showing how to nest blocks to render more advanced components.
+- [**Paste HTML**](./paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
+- [**Code Highlighting**](./code-highlighting.js) — showing how to use decorations to dynamically mark text.
 - ...and more!
 
 If you have an idea for an example that shows a common use case, pull request it!

--- a/site/pages/examples/[example].js
+++ b/site/pages/examples/[example].js
@@ -278,7 +278,7 @@ const ExamplePage = () => {
           <ExampleTitle>
             {name}
             <A
-              href={`https://github.com/ianstormtaylor/slate/blob/master/examples${path}`}
+              href={`https://github.com/ianstormtaylor/slate/blob/master/site/examples/${path}.js`}
             >
               (View Source)
             </A>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

I noticed that the links to examples weren't working. Probably because they've been altered with the Next merge. This PR updates the links to point to the correct location.

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor  
