### PR TITLE
Fix typo in XX-migrating.md

### DIFF
--- a/docs/concepts/XX-migrating.md
+++ b/docs/concepts/XX-migrating.md
@@ -58,7 +58,7 @@ Previously the `<Editor>` component was doing double duty as a sort of "controll
 
 ### Hooks
 
-In addition to the `useSlate` hook, there are a handful of other hooks. For example the `useSelected` and `useFocused` hooks help with knowing when to render selected states (often for void nodes). And since the use React's Content API they will automatically re-render when their state changes.
+In addition to the `useSlate` hook, there are a handful of other hooks. For example the `useSelected` and `useFocused` hooks help with knowing when to render selected states (often for void nodes). And since they use React's Context API they will automatically re-render when their state changes.
 
 ### `beforeinput`
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
This is typos fixing. 
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
In ### Hooks section under XX-migrating.md file, I suppose it is "they use React's Context API" rather than "the use React's Content API". Please ignore this if it is not a typo. Thanks.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Fixed typos.
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
