### PR TITLE
Editable: onDOMBeforeInput should be optional

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -38,7 +38,7 @@ import {
 
 export const Editable = (props: {
   decorate?: (entry: NodeEntry) => Range[]
-  onDOMBeforeInput: (event: Event) => void
+  onDOMBeforeInput?: (event: Event) => void
   placeholder?: string
   readOnly?: boolean
   role?: string


### PR DESCRIPTION
Typescript error:

```
Property 'onDOMBeforeInput' is missing in type '{}' but required in type ...
```

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->
The following works when using typescript
```
<Slate editor={editor} defaultValue={defaultValue}>
  <Editable />
</Slate>
```

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->
Make onDOMBeforeInput optional

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)


