### PR TITLE
Update Applying Custom Formatting walkthrough

### DIFF
--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -110,7 +110,7 @@ const BoldMark = props => {
 
 Pretty familiar, right?
 
-And now, let's tell Slate about that mark. To do that, we'll pass in the `renderMark` prop to our editor. Also, let's allow our mark to be toggled by changing `addMark` to `toggleMark`.
+And now, let's tell Slate about that mark. To do that, we'll pass in the `renderMark` prop to our editor. Also, let's allow our mark to be toggled by calling either `addMarks` or `removeMarks`.
 
 ```js
 const App = () => {
@@ -162,7 +162,12 @@ const App = () => {
 
             case 'b': {
               event.preventDefault()
-              Editor.addMarks(editor, [{ type: 'bold' }])
+              const isBold = Editor.activeMarks(editor).some(m => m.type === 'bold');
+              if (isBold) {
+                Editor.addMarks(editor, [{ type: 'bold' }])
+              } else {          
+                Editor.removeMarks(editor, [{ type: 'bold' }])
+              }
               break
             }
           }


### PR DESCRIPTION
The doc mentions "toggleMarks" but this function no longer exists (see #3170). This change updates the code example to use addMarks / removeMarks.

#### Is this adding or improving a _feature_ or fixing a _bug_?
No


#### What's the new behavior?
Documentation change. 



#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?
No