### PR TITLE
fix: lost redos when trigger set_selection (fix #3140)

### DIFF
--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -104,7 +104,7 @@ export const withHistory = (editor: Editor): Editor => {
           undos.shift()
         }
 
-        if (shouldEmptyRedos(op)) {
+        if (shouldClear(op)) {
           history.redos = []
         }
       }
@@ -176,10 +176,13 @@ const shouldOverwrite = (
 }
 
 /**
- * Check whether empty redos after one operation.
+ * Check whether an operation should clear the redos stack.
  */
 
-const shouldEmptyRedos = (op: Operation): boolean => {
-  if (['set_selection'].includes(op.type)) return false
+const shouldClear = (op: Operation): boolean => {
+  if (op.type === 'set_selection') {
+    return false
+  }
+
   return true
 }

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -104,7 +104,9 @@ export const withHistory = (editor: Editor): Editor => {
           undos.shift()
         }
 
-        history.redos = []
+        if (shouldEmptyRedos(op)) {
+          history.redos = []
+        }
       }
     }
 
@@ -171,4 +173,13 @@ const shouldOverwrite = (
   }
 
   return false
+}
+
+/**
+ * Check whether empty redos after one operation.
+ */
+
+const shouldEmptyRedos = (op: Operation): boolean => {
+  if (['set_selection'].includes(op.type)) return false
+  return true
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fix bug

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
![Jietu20191130-192733-HD](https://user-images.githubusercontent.com/12322740/69899906-a8c26600-13a7-11ea-83b6-553de2c5309b.gif)

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Do not clean redos on some specific operations.
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3140 
Reviewers: @
