### PR TITLE
fix: ts error

### DIFF
--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -28,7 +28,7 @@ export const SlateContext = createContext<[Editor] | null>(null)
 
 export const Slate = (props: {
   editor: Editor
-  children: JSX.Element
+  children: JSX.Element | JSX.Element[]
   defaultValue?: Node[]
   onChange?: (children: Node[], operations: Operation[]) => void
 }) => {


### PR DESCRIPTION
This JSX tag's 'children' prop expects a single child of type 'Element', but multiple children were provided.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

ts error

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
