### PR TITLE
feat: allow MarkTransforms methods  to take a single mark (resolve #3…

### DIFF
--- a/docs/concepts/07-editor.md
+++ b/docs/concepts/07-editor.md
@@ -111,7 +111,7 @@ Editor.insertNodes(editor, [element], { at: path })
 Editor.splitNodes(editor, { at: point })
 
 // Add a mark to all the text in a range.
-Editor.addMarks(editor, [mark], { at: range })
+Editor.addMarks(editor, mark, { at: range })
 ```
 
 The editor-specific helpers are the ones you'll use most often when working with Slate editors, so it pays to become very familiar with them.

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -81,7 +81,7 @@ const App = () => {
             // When "B" is pressed, add a bold mark to the text.
             case 'b': {
               event.preventDefault()
-              Editor.addMarks(editor, [{ type: 'bold' }])
+              Editor.addMarks(editor, { type: 'bold' })
               break
             }
           }
@@ -154,7 +154,7 @@ const App = () => {
 
             case 'b': {
               event.preventDefault()
-              Editor.addMarks(editor, [{ type: 'bold' }])
+              Editor.addMarks(editor, { type: 'bold' })
               break
             }
           }

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -55,7 +55,7 @@ const App = () => {
 
             case 'b': {
               event.preventDefault()
-              Editor.addMarks(editor, [{ type: 'bold' }])
+              Editor.addMarks(editor, { type: 'bold' })
               break
             }
           }

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -89,7 +89,7 @@ export const createEditor = (): Editor => {
       if (Command.isCoreCommand(command)) {
         switch (command.type) {
           case 'add_mark': {
-            Editor.addMarks(editor, [command.mark])
+            Editor.addMarks(editor, command.mark)
             break
           }
 

--- a/packages/slate/src/interfaces/editor/transforms/mark.ts
+++ b/packages/slate/src/interfaces/editor/transforms/mark.ts
@@ -7,7 +7,7 @@ export const MarkTransforms = {
 
   addMarks(
     editor: Editor,
-    marks: Mark[],
+    mark: Mark | Mark[],
     options: {
       at?: Location
       hanging?: boolean
@@ -21,18 +21,19 @@ export const MarkTransforms = {
       }
 
       // De-dupe the marks being added to ensure the set is unique.
+      const marks = Array.isArray(mark) ? mark : [mark]
       const set: Mark[] = []
 
-      for (const mark of marks) {
-        if (!Mark.exists(mark, set)) {
-          set.push(mark)
+      for (const m of marks) {
+        if (!Mark.exists(m, set)) {
+          set.push(m)
         }
       }
 
       for (const [node, path] of Editor.texts(editor, { at })) {
-        for (const mark of set) {
-          if (!Mark.exists(mark, node.marks)) {
-            editor.apply({ type: 'add_mark', path, mark })
+        for (const m of set) {
+          if (!Mark.exists(m, node.marks)) {
+            editor.apply({ type: 'add_mark', path, mark: m })
           }
         }
       }
@@ -41,7 +42,7 @@ export const MarkTransforms = {
 
   removeMarks(
     editor: Editor,
-    marks: Mark[],
+    mark: Mark | Mark[],
     options: {
       at?: Location
       hanging?: boolean
@@ -51,9 +52,10 @@ export const MarkTransforms = {
       const at = splitLocation(editor, options)
 
       if (at) {
-        for (const [mark, i, node, path] of Editor.marks(editor, { at })) {
-          if (Mark.exists(mark, marks)) {
-            editor.apply({ type: 'remove_mark', path, mark })
+        const marks = Array.isArray(mark) ? mark : [mark]
+        for (const [m, i, node, path] of Editor.marks(editor, { at })) {
+          if (Mark.exists(m, marks)) {
+            editor.apply({ type: 'remove_mark', path, mark: m })
           }
         }
       }
@@ -62,7 +64,7 @@ export const MarkTransforms = {
 
   setMarks(
     editor: Editor,
-    marks: Mark[],
+    mark: Mark | Mark[],
     props: Partial<Mark>,
     options: {
       at?: Location
@@ -73,12 +75,13 @@ export const MarkTransforms = {
       const at = splitLocation(editor, options)
 
       if (at) {
-        for (const [mark, i, node, path] of Editor.marks(editor, { at })) {
-          if (Mark.exists(mark, marks)) {
+        const marks = Array.isArray(mark) ? mark : [mark]
+        for (const [m, i, node, path] of Editor.marks(editor, { at })) {
+          if (Mark.exists(m, marks)) {
             const newProps = {}
 
             for (const k in props) {
-              if (props[k] !== mark[k]) {
+              if (props[k] !== m[k]) {
                 newProps[k] = props[k]
               }
             }
@@ -87,7 +90,7 @@ export const MarkTransforms = {
               editor.apply({
                 type: 'set_mark',
                 path,
-                properties: mark,
+                properties: m,
                 newProperties: newProps,
               })
             }

--- a/packages/slate/test/transforms/addMarks/path/basic.js
+++ b/packages/slate/test/transforms/addMarks/path/basic.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }], { at: [0, 0] })
+  Editor.addMarks(editor, { key: 'a' }, { at: [0, 0] })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/range/basic.js
+++ b/packages/slate/test/transforms/addMarks/range/basic.js
@@ -4,12 +4,16 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }], {
-    at: {
-      anchor: { path: [0, 0], offset: 1 },
-      focus: { path: [0, 0], offset: 3 },
-    },
-  })
+  Editor.addMarks(
+    editor,
+    { key: 'a' },
+    {
+      at: {
+        anchor: { path: [0, 0], offset: 1 },
+        focus: { path: [0, 0], offset: 3 },
+      },
+    }
+  )
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/block-across-edge-existing.js
+++ b/packages/slate/test/transforms/addMarks/selection/block-across-edge-existing.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/block-across-existing.js
+++ b/packages/slate/test/transforms/addMarks/selection/block-across-existing.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/block-across.js
+++ b/packages/slate/test/transforms/addMarks/selection/block-across.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/existing.js
+++ b/packages/slate/test/transforms/addMarks/selection/existing.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/first-character.js
+++ b/packages/slate/test/transforms/addMarks/selection/first-character.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/inline-across.js
+++ b/packages/slate/test/transforms/addMarks/selection/inline-across.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/last-character.js
+++ b/packages/slate/test/transforms/addMarks/selection/last-character.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/middle-character.js
+++ b/packages/slate/test/transforms/addMarks/selection/middle-character.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/addMarks/selection/word.js
+++ b/packages/slate/test/transforms/addMarks/selection/word.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/path/basic.js
+++ b/packages/slate/test/transforms/removeMarks/path/basic.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }], { at: [0, 0] })
+  Editor.removeMarks(editor, { key: 'a' }, { at: [0, 0] })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/range/basic.js
+++ b/packages/slate/test/transforms/removeMarks/range/basic.js
@@ -4,12 +4,16 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }], {
-    at: {
-      anchor: { path: [0, 1], offset: 0 },
-      focus: { path: [0, 1], offset: 2 },
-    },
-  })
+  Editor.removeMarks(
+    editor,
+    { key: 'a' },
+    {
+      at: {
+        anchor: { path: [0, 1], offset: 0 },
+        focus: { path: [0, 1], offset: 2 },
+      },
+    }
+  )
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/across-blocks.js
+++ b/packages/slate/test/transforms/removeMarks/selection/across-blocks.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/across-inlines.js
+++ b/packages/slate/test/transforms/removeMarks/selection/across-inlines.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/collapsed-selection.js
+++ b/packages/slate/test/transforms/removeMarks/selection/collapsed-selection.js
@@ -4,8 +4,8 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.addMarks(editor, [{ key: 'a' }])
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.addMarks(editor, { key: 'a' })
+  Editor.removeMarks(editor, { key: 'a' })
   Editor.insertText(editor, 'a')
 }
 

--- a/packages/slate/test/transforms/removeMarks/selection/existing-marks.js
+++ b/packages/slate/test/transforms/removeMarks/selection/existing-marks.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/first-character.js
+++ b/packages/slate/test/transforms/removeMarks/selection/first-character.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/last-character.js
+++ b/packages/slate/test/transforms/removeMarks/selection/last-character.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/middle-character.js
+++ b/packages/slate/test/transforms/removeMarks/selection/middle-character.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/part-of-mark-backward.js
+++ b/packages/slate/test/transforms/removeMarks/selection/part-of-mark-backward.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/part-of-mark.js
+++ b/packages/slate/test/transforms/removeMarks/selection/part-of-mark.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/removeMarks/selection/whole-word.js
+++ b/packages/slate/test/transforms/removeMarks/selection/whole-word.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.removeMarks(editor, [{ key: 'a' }])
+  Editor.removeMarks(editor, { key: 'a' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/setMarks/path/basic.js
+++ b/packages/slate/test/transforms/setMarks/path/basic.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.setMarks(editor, [{ existing: true }], { key: true }, { at: [0, 0] })
+  Editor.setMarks(editor, { existing: true }, { key: true }, { at: [0, 0] })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/setMarks/range/basic.js
+++ b/packages/slate/test/transforms/setMarks/range/basic.js
@@ -6,7 +6,7 @@ import { jsx } from '../../..'
 export const run = editor => {
   Editor.setMarks(
     editor,
-    [{ key: 'a' }],
+    { key: 'a' },
     { thing: true },
     {
       at: {

--- a/packages/slate/test/transforms/setMarks/selection/basic.js
+++ b/packages/slate/test/transforms/setMarks/selection/basic.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.setMarks(editor, [{ key: 'a' }], { thing: true })
+  Editor.setMarks(editor, { key: 'a' }, { thing: true })
 }
 
 export const input = (


### PR DESCRIPTION
…175)

#### Is this adding or improving a _feature_ or fixing a _bug_?
improving a feature
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

MarkTransforms's methods: `addMarks`, `removeMarks`, `setMarks` can take a single mark now.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3175
Reviewers: @
