### PR TITLE
fix: type

### DIFF
--- a/packages/slate-schema/src/rules.ts
+++ b/packages/slate-schema/src/rules.ts
@@ -13,7 +13,7 @@ export interface MarkRule {
 }
 
 export interface ChildValidation {
-  match?: NodeMatch[]
+  match?: NodeMatch | NodeMatch[]
   min?: number
   max?: number
 }


### PR DESCRIPTION
forced-layout example is not using an array for `match`

#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### What's the new behavior?

allow non-array match

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
