### PR TITLE
fix: typo

### DIFF
--- a/site/examples/links.js
+++ b/site/examples/links.js
@@ -51,7 +51,7 @@ const withLinks = editor => {
     }
 
     if (text && isUrl(text)) {
-      wrapLink(editor, url)
+      wrapLink(editor, text)
     } else {
       exec(command)
     }


### PR DESCRIPTION
url is not defined

#### Is this adding or improving a _feature_ or fixing a _bug_?

bug

#### How does this change work?

replace `url` by `text`

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
