### PR TITLE
onCompositionEnd not need to insert text in firfox

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -534,7 +534,7 @@ export const Editable = (
               // aren't correct and never fire the "insertFromComposition"
               // type that we need. So instead, insert whenever a composition
               // ends since it will already have been committed to the DOM.
-              if (!IS_SAFARI && event.data) {
+              if (!IS_SAFARI && !IS_FIREFOX && event.data) {
                 editor.exec({ type: 'insert_text', text: event.data })
               }
             }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing bug

![Dec-03-2019 13-54-05](https://user-images.githubusercontent.com/2088642/70024179-7ea1bb80-15d4-11ea-9b9f-af56be9f52b5.gif)


#### What's the new behavior?

Firefox composition input work fine

#### How does this change work?

Slate use React `onBeforeUpdate` event to insert text, compositionend also trigger `onBeforeUpdate` so no need to insert text in compositionend

#### Have you checked that...?

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
