### PR TITLE
Change withSchema to allow currying (#3181)

### DIFF
--- a/packages/slate-schema/src/with-schema.ts
+++ b/packages/slate-schema/src/with-schema.ts
@@ -7,10 +7,10 @@ import { checkNode, checkAncestor } from './checkers'
 /**
  * The `withSchema` plugin augments an editor to ensure that its content is
  * normalized to always obey a schema after operations are applied.
- * 
+ *
  * The parameters are curried so that it can easily be composed with other plugins.
  * For example (using flowRight from lodash):
- * 
+ *
  * editor = _.flowRight(
  *    withHistory,
  *    withSchema(rules),
@@ -18,12 +18,17 @@ import { checkNode, checkAncestor } from './checkers'
  */
 
 type IWithSchema = {
-  (rules: SchemaRule[]): (editor: Editor) => Editor;
-  (rules: SchemaRule[], editor: Editor): Editor;
+  (rules: SchemaRule[]): (editor: Editor) => Editor
+  (rules: SchemaRule[], editor: Editor): Editor
 }
 
-export const withSchema: IWithSchema = (rules: SchemaRule[] = [], editor?: Editor): any => {
-  if (editor === undefined) { return (editor: Editor) => withSchema(rules, editor); }
+export const withSchema: IWithSchema = (
+  rules: SchemaRule[] = [],
+  editor?: Editor
+): any => {
+  if (editor === undefined) {
+    return (editor: Editor) => withSchema(rules, editor)
+  }
 
   const { normalizeNode } = editor
   const markRules: MarkRule[] = []

--- a/packages/slate-schema/src/with-schema.ts
+++ b/packages/slate-schema/src/with-schema.ts
@@ -7,12 +7,24 @@ import { checkNode, checkAncestor } from './checkers'
 /**
  * The `withSchema` plugin augments an editor to ensure that its content is
  * normalized to always obey a schema after operations are applied.
+ * 
+ * The parameters are curried so that it can easily be composed with other plugins.
+ * For example (using flowRight from lodash):
+ * 
+ * editor = _.flowRight(
+ *    withHistory,
+ *    withSchema(rules),
+ * )(editor);
  */
 
-export const withSchema = (
-  editor: Editor,
-  rules: SchemaRule[] = []
-): Editor => {
+type IWithSchema = {
+  (rules: SchemaRule[]): (editor: Editor) => Editor;
+  (rules: SchemaRule[], editor: Editor): Editor;
+}
+
+export const withSchema: IWithSchema = (rules: SchemaRule[] = [], editor?: Editor): any => {
+  if (editor === undefined) { return (editor: Editor) => withSchema(rules, editor); }
+
   const { normalizeNode } = editor
   const markRules: MarkRule[] = []
   const nodeRules: NodeRule[] = []

--- a/packages/slate-schema/test/index.js
+++ b/packages/slate-schema/test/index.js
@@ -6,7 +6,7 @@ import { withSchema } from '..'
 describe('slate-schema', () => {
   fixtures(__dirname, 'validations', ({ module }) => {
     const { input, schema, output } = module
-    const editor = withSchema(input, schema)
+    const editor = withSchema(schema, input)
     Editor.normalize(editor, { force: true })
     assert.deepEqual(editor.children, output.children)
   })

--- a/site/examples/forced-layout.js
+++ b/site/examples/forced-layout.js
@@ -40,7 +40,7 @@ const schema = [
 const ForcedLayoutExample = () => {
   const renderElement = useCallback(props => <Element {...props} />, [])
   const editor = useMemo(
-    () => withSchema(withHistory(withReact(createEditor())), schema),
+    () => withSchema(schema, withHistory(withReact(createEditor()))),
     []
   )
   return (


### PR DESCRIPTION
I've reversed the order of the parameters so the rules come first.
The function is curried so that it can be called in two ways:

withSchema(rules, editor)
withSchema(rules)(editor)

Addresses #3181