### PR TITLE
fix: ts

### DIFF
--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -28,7 +28,7 @@ export const SlateContext = createContext<[Editor] | null>(null)
 
 export const Slate = (props: {
   editor: Editor
-  children: JSX.Element | JSX.Element[]
+  children: React.ReactNode
   defaultValue?: Node[]
   onChange?: (children: Node[], operations: Operation[]) => void
 }) => {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### How does this change work?

`JSX.Element` does not accept null, undefined or boolean, so conditional rendering is not allowed.
`React.ReactNode` seems to be the default for `children`

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
