### PR TITLE
Fix child_min_invalid checks

### DIFF
--- a/packages/slate-schema/src/checkers.ts
+++ b/packages/slate-schema/src/checkers.ts
@@ -130,7 +130,6 @@ export const checkAncestor = (
   let g = 0
 
   while (true) {
-    count++
     const group = groups[g] as ChildValidation | undefined
     const child = parent.children[index] as Descendant | undefined
     const childPath = parentPath.concat(index)
@@ -172,6 +171,12 @@ export const checkAncestor = (
       continue
     }
 
+    if (
+      child &&
+      Editor.isMatch(editor, [child, childPath], group.match || {})
+    ) {
+      count++
+    }
     // Since we want to report overflow on last matching child we don't
     // immediately v for count > max, but instead do so once we find
     // a child that doesn't match.
@@ -197,7 +202,7 @@ export const checkAncestor = (
     // If there's no child, we're either done, we're in an optional group, or
     // we're missing a child in a group with a mininmum set.
     if (!child) {
-      if (group.min != null && count <= group.min) {
+      if (group.min != null && count < group.min) {
         return [
           rule,
           {

--- a/packages/slate-schema/test/validations/children/min/invalid-second-with-match.js
+++ b/packages/slate-schema/test/validations/children/min/invalid-second-with-match.js
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+
+import { jsx } from 'slate-hyperscript'
+
+export const schema = [
+  {
+    for: 'node',
+    match: { a: true },
+    validate: {
+      children: [
+        { match: { b: true }, min: 1 },
+        { match: { c: true }, min: 0 },
+      ],
+    },
+  },
+]
+
+export const input = (
+  <editor>
+    <element a>
+      <element c>one</element>
+    </element>
+  </editor>
+)
+
+export const output = <editor />

--- a/site/examples/forced-layout.js
+++ b/site/examples/forced-layout.js
@@ -15,7 +15,8 @@ const schema = [
       ],
     },
     normalize: (editor, error) => {
-      const { code, path, index } = error
+      const { code, path } = error
+      const [index] = path
       const type = index === 0 ? 'title' : 'paragraph'
 
       switch (code) {
@@ -25,11 +26,11 @@ const schema = [
         }
         case 'child_min_invalid': {
           const block = { type, children: [{ text: '', marks: [] }] }
-          Editor.insertNodes(editor, block, { at: path.concat(index) })
+          Editor.insertNodes(editor, block, { at: path })
           break
         }
         case 'child_max_invalid': {
-          Editor.setNodes(editor, { type }, { at: path.concat(index) })
+          Editor.setNodes(editor, { type }, { at: path })
           break
         }
       }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

In some situations, a `child_min_invalid` wasn't being thrown when necessary, often involving `match` arguments in the `children` rules. This was causing the Forced Layout example to not work correctly (if you highlighted everything and deleted it, you were left with a single paragraph instead of a title and a paragraph).

#### How does this change work?

- When checking child nodes, the count is now only incremented when the child node matches the `match` property (or the default empty match of `{}`)
- The Forced Layout code was expecting an `index` property in the returned error, but the `checkers.ts` file never adds an index. Instead, it looks like it sends back the full expected path of the missing node. So I updated the forced layout example to just use the full returned path instead.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3182 
Fixes: #3165 
