### PR TITLE
Load with correct starting example

### DIFF
--- a/site/pages/examples/[example].js
+++ b/site/pages/examples/[example].js
@@ -234,7 +234,7 @@ const ExamplePage = () => {
   const [stacktrace, setStacktrace] = useState()
   const [showTabs, setShowTabs] = useState()
   const router = useRouter()
-  const { example = 'rich-text' } = router.query
+  const { example = router.asPath.replace('/examples/', '') } = router.query
   const EXAMPLE = EXAMPLES.find(e => e[2] === example)
   const [name, Component, path] = EXAMPLE
   return (


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Reloading the page on one of the examples now stays on that example.

#### How does this change work?

Seems like next.js only populates `router.query` after it pushes a route itself. There may be a cleaner solution, but parsing the starting example out of the `asPath` parameter seems to work fine for both initial load and navigating between pages and gets it fixed for now.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3211 
