### PR TITLE
fix rich text example

### DIFF
--- a/site/examples/rich-text.js
+++ b/site/examples/rich-text.js
@@ -100,7 +100,7 @@ const withRichText = editor => {
 }
 
 const isMarkActive = (editor, type) => {
-  const [mark] = Editor.marks(editor, { match: { type }, mode: 'universal' })
+  const [mark] = Editor.marks(editor, { match: { type } })
   return !!mark
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Resolving a bug in the examples where all marks show as active when only one was.

#### What's the new behavior?

The marks were matching even when they weren't active. Removing universal mode fixed the issue. 