### PR TITLE
Auto focus after mounting

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1,4 +1,10 @@
-import React, { useLayoutEffect, useRef, useMemo, useCallback } from 'react'
+import React, {
+  useLayoutEffect,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+} from 'react'
 import { Editor, Element, NodeEntry, Node, Range, Text, Mark } from 'slate'
 import debounce from 'debounce'
 import scrollIntoView from 'scroll-into-view-if-needed'
@@ -96,6 +102,7 @@ export const Editable = (
     renderDecoration,
     renderElement,
     renderMark,
+    autoFocus,
     style = {},
     onDOMBeforeInput: propsOnDOMBeforeInput,
     ...attributes
@@ -209,6 +216,14 @@ export const Editable = (
       state.isUpdatingSelection = false
     })
   })
+
+  // The autoFocus TextareaHTMLAttribute doesn't do anything on a div, so it
+  // needs to be manually focused.
+  useEffect(() => {
+    if (ref.current && autoFocus) {
+      ref.current.focus()
+    }
+  }, [autoFocus])
 
   // Listen on the native `beforeinput` event to get real "Level 2" events. This
   // is required because React's `beforeinput` is fake and never really attaches


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

`<Editable autoFocus ... />` now focuses after mounting.

#### How does this change work?

Editable props include `TextareaHTMLAttributes<HTMLDivElement>`, which includes an `autoFocus` props. `autoFocus` does nothing on a div element, so auto focus needs to be handled manually in a useEffect hook.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

