### PR TITLE
Fix check list example

### DIFF
--- a/site/examples/check-lists.js
+++ b/site/examples/check-lists.js
@@ -1,5 +1,12 @@
 import React, { useMemo, useCallback } from 'react'
-import { Slate, Editable, withReact, useEditor, useReadOnly, ReactEditor } from 'slate-react'
+import {
+  Slate,
+  Editable,
+  withReact,
+  useEditor,
+  useReadOnly,
+  ReactEditor,
+} from 'slate-react'
 import { Editor, Range, Point, createEditor } from 'slate'
 import { css } from 'emotion'
 import { withHistory } from 'slate-history'
@@ -97,7 +104,11 @@ const CheckListItemElement = ({ attributes, children, element }) => {
           checked={checked}
           onChange={event => {
             const path = ReactEditor.findPath(editor, element)
-            Editor.setNodes(editor, { checked: event.target.checked }, { at: path })
+            Editor.setNodes(
+              editor,
+              { checked: event.target.checked },
+              { at: path }
+            )
           }}
         />
       </span>

--- a/site/examples/check-lists.js
+++ b/site/examples/check-lists.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react'
-import { Slate, Editable, withReact, useEditor, useReadOnly } from 'slate-react'
+import { Slate, Editable, withReact, useEditor, useReadOnly, ReactEditor } from 'slate-react'
 import { Editor, Range, Point, createEditor } from 'slate'
 import { css } from 'emotion'
 import { withHistory } from 'slate-history'
@@ -96,8 +96,8 @@ const CheckListItemElement = ({ attributes, children, element }) => {
           type="checkbox"
           checked={checked}
           onChange={event => {
-            const path = editor.findPath(element)
-            editor.setNodes({ checked: event.target.checked }, { at: path })
+            const path = ReactEditor.findPath(editor, element)
+            Editor.setNodes(editor, { checked: event.target.checked }, { at: path })
           }}
         />
       </span>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug.

#### What's the new behavior?

The check list example uses `ReactEditor.findPath(editor, ...)` instead of `editor.findPath()`. This allows to uncheck and check the checkboxes again.