### PR TITLE
Fix mention and images examples

### DIFF
--- a/site/examples/images.js
+++ b/site/examples/images.js
@@ -72,7 +72,7 @@ const withImages = editor => {
 
       case 'insert_image': {
         const { url } = command
-        const text = { text: '', marks: [] }
+        const text = { text: 'NOTEMPTY', marks: [] }
         const image = { type: 'image', url, children: [text] }
         Editor.insertNodes(editor, image)
         break
@@ -159,7 +159,7 @@ const initialValue = [
     url: 'https://source.unsplash.com/kFrdX5IeQzI',
     children: [
       {
-        text: '',
+        text: 'NOTEMPTY',
         marks: [],
       },
     ],

--- a/site/examples/mentions.js
+++ b/site/examples/mentions.js
@@ -154,7 +154,7 @@ const withMentions = editor => {
       const mention = {
         type: 'mention',
         character: command.character,
-        children: [{ text: '', marks: [] }],
+        children: [{ text: 'NOTEMPTY', marks: [] }],
       }
 
       Editor.insertNodes(editor, mention)
@@ -220,7 +220,7 @@ const initialValue = [
       {
         type: 'mention',
         character: 'R2-D2',
-        children: [{ text: '', marks: [] }],
+        children: [{ text: 'NOTEMPTY', marks: [] }],
       },
       {
         text: ' or ',
@@ -229,7 +229,7 @@ const initialValue = [
       {
         type: 'mention',
         character: 'Mace Windu',
-        children: [{ text: '', marks: [] }],
+        children: [{ text: 'NOTEMPTY', marks: [] }],
       },
       {
         text: '!',


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug where Slate was crashing in mentions and images examples when clicking on a mention or image respectively.

#### What's the new behavior?

Those examples don't crash anymore.

#### How does this change work?

Add content to the text of the elements.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3145
Reviewers: @ianstormtaylor 
