### PR TITLE
fix schema properties to be exhaustive, add leaves

### DIFF
--- a/packages/slate-schema/src/errors.ts
+++ b/packages/slate-schema/src/errors.ts
@@ -42,6 +42,13 @@ export interface NextSiblingInvalidError {
   path: Path
 }
 
+export interface NodeLeafInvalidError {
+  code: 'node_leaf_invalid'
+  node: Node
+  path: Path
+  property: string
+}
+
 export interface NodePropertyInvalidError {
   code: 'node_property_invalid'
   node: Node
@@ -76,6 +83,7 @@ export type NodeError =
   | FirstChildInvalidError
   | LastChildInvalidError
   | NextSiblingInvalidError
+  | NodeLeafInvalidError
   | NodePropertyInvalidError
   | NodeTextInvalidError
   | ParentInvalidError

--- a/packages/slate-schema/src/rules.ts
+++ b/packages/slate-schema/src/rules.ts
@@ -11,6 +11,7 @@ export interface NodeValidation {
   children?: ChildValidation[]
   first?: NodeMatch
   last?: NodeMatch
+  leaves?: Record<string, any>
   next?: NodeMatch
   parent?: NodeMatch
   previous?: NodeMatch

--- a/packages/slate-schema/src/with-schema.ts
+++ b/packages/slate-schema/src/with-schema.ts
@@ -121,6 +121,7 @@ export const withSchema = (
 
       case 'child_invalid':
       case 'next_sibling_invalid':
+      case 'node_leaf_invalid':
       case 'node_property_invalid':
       case 'node_text_invalid':
       case 'previous_sibling_invalid': {

--- a/packages/slate-schema/test/validations/leaves/invalid-unknown.js
+++ b/packages/slate-schema/test/validations/leaves/invalid-unknown.js
@@ -7,9 +7,8 @@ export const schema = [
     for: 'node',
     match: { a: true },
     validate: {
-      properties: {
-        a: true,
-        thing: v => v == null || v === 'valid',
+      leaves: {
+        bold: v => v === true || v === undefined,
       },
     },
   },
@@ -17,10 +16,16 @@ export const schema = [
 
 export const input = (
   <editor>
-    <element a thing="valid">
-      word
+    <element a>
+      <text unknown>word</text>
     </element>
   </editor>
 )
 
-export const output = input
+export const output = (
+  <editor>
+    <element a>
+      <text />
+    </element>
+  </editor>
+)

--- a/packages/slate-schema/test/validations/leaves/invalid-value.js
+++ b/packages/slate-schema/test/validations/leaves/invalid-value.js
@@ -7,9 +7,8 @@ export const schema = [
     for: 'node',
     match: { a: true },
     validate: {
-      properties: {
-        a: true,
-        thing: v => v == null || v === 'valid',
+      leaves: {
+        bold: v => v === true || v === undefined,
       },
     },
   },
@@ -17,10 +16,16 @@ export const schema = [
 
 export const input = (
   <editor>
-    <element a thing="valid">
-      word
+    <element a>
+      <text bold="invalid">word</text>
     </element>
   </editor>
 )
 
-export const output = input
+export const output = (
+  <editor>
+    <element a>
+      <text />
+    </element>
+  </editor>
+)

--- a/packages/slate-schema/test/validations/leaves/valid.js
+++ b/packages/slate-schema/test/validations/leaves/valid.js
@@ -7,9 +7,8 @@ export const schema = [
     for: 'node',
     match: { a: true },
     validate: {
-      properties: {
-        a: true,
-        thing: v => v == null || v === 'valid',
+      leaves: {
+        bold: v => v === true || v === undefined,
       },
     },
   },
@@ -17,10 +16,16 @@ export const schema = [
 
 export const input = (
   <editor>
-    <element a thing="valid">
-      word
+    <element a>
+      <text bold>word</text>
     </element>
   </editor>
 )
 
-export const output = input
+export const output = (
+  <editor>
+    <element a>
+      <text bold>word</text>
+    </element>
+  </editor>
+)

--- a/packages/slate-schema/test/validations/properties/invalid-unknown.js
+++ b/packages/slate-schema/test/validations/properties/invalid-unknown.js
@@ -8,7 +8,7 @@ export const schema = [
     match: { a: true },
     validate: {
       properties: {
-        thing: v => v == null || v === 'valid',
+        a: true,
       },
     },
   },
@@ -16,7 +16,7 @@ export const schema = [
 
 export const input = (
   <editor>
-    <element a thing="invalid">
+    <element a thing="unknown">
       word
     </element>
   </editor>

--- a/packages/slate-schema/test/validations/properties/invalid-value.js
+++ b/packages/slate-schema/test/validations/properties/invalid-value.js
@@ -17,10 +17,10 @@ export const schema = [
 
 export const input = (
   <editor>
-    <element a thing="valid">
+    <element a thing="invalid">
       word
     </element>
   </editor>
 )
 
-export const output = input
+export const output = <editor />


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

#### What's the new behavior?

Changes the `properties` validation to be exhaustive, and adds a `leaves` validation for the properties of the leaf text nodes.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/3250
Fixes: https://github.com/ianstormtaylor/slate/issues/3249