### PR TITLE
Custom Format docs typo fix: leaf -> props

### DIFF
--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -108,7 +108,7 @@ const Leaf = props => {
   return (
     <span
       {...props.attributes}
-      style={{ fontWeight: props.bold ? 'bold' : 'normal' }}
+      style={{ fontWeight: props.leaf.bold ? 'bold' : 'normal' }}
     >
       {props.children}
     </span>
@@ -181,7 +181,7 @@ const Leaf = props => {
   return (
     <span
       {...props.attributes}
-      style={{ fontWeight: props.bold ? 'bold' : 'normal' }}
+      style={{ fontWeight: props.leaf.bold ? 'bold' : 'normal' }}
     >
       {props.children}
     </span>

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -108,7 +108,7 @@ const Leaf = props => {
   return (
     <span
       {...props.attributes}
-      style={{ fontWeight: leaf.bold ? 'bold' : 'normal' }}
+      style={{ fontWeight: props.bold ? 'bold' : 'normal' }}
     >
       {props.children}
     </span>
@@ -181,7 +181,7 @@ const Leaf = props => {
   return (
     <span
       {...props.attributes}
-      style={{ fontWeight: leaf.bold ? 'bold' : 'normal' }}
+      style={{ fontWeight: props.bold ? 'bold' : 'normal' }}
     >
       {props.children}
     </span>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Doc typo

#### What's the new behavior?

No change.

#### How does this change work?

N/a

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?
