### PR TITLE
Improved merging of blocks when deleting text

### DIFF
--- a/packages/slate/test/transforms/delete/selection/block-inline-over.js
+++ b/packages/slate/test/transforms/delete/selection/block-inline-over.js
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Editor.delete(editor)
+}
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      t<anchor />
+      wo<inline>three</inline>fou
+      <focus />r
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>one</block>
+    <block>
+      t<cursor />r
+    </block>
+  </editor>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Deleting across inlines/text nodes within a single block no longer merges the parent block with the previous block.

#### How does this change work?

Instead of using `isBlockAncestor`, I hoisted the block matching from the `startVoid`/`endVoid` checks and compared the paths of the starting/ending blocks to see if the selection was across multiple blocks.

I'm not 100% confident this is the right approach (not familiar enough with Slate's internals) but all tests are passing, along with the new test I added. Also, the Rich Text example now functions as expected when backspacing into the bolded text (it no longer merges the paragraph with the one above).


#### Have you checked that...?


- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3255

