### PR TITLE
remove the path from node matching functions

### DIFF
--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -685,7 +685,7 @@ export const LocationQueries = {
     if (match == null) {
       if (Path.isPath(at)) {
         const [parent] = Editor.parent(editor, at)
-        match = ([n]) => parent.children.includes(n)
+        match = n => parent.children.includes(n)
       } else {
         match = () => true
       }

--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -258,7 +258,7 @@ export const LocationQueries = {
     const path = Editor.path(editor, at)
 
     for (const entry of Editor.levels(editor, { at: path, voids })) {
-      if (Editor.isMatch(editor, entry, match)) {
+      if (Editor.isMatch(editor, entry[0], match)) {
         return entry
       }
     }
@@ -290,8 +290,8 @@ export const LocationQueries = {
 
     if (match == null) {
       if (Path.isPath(at)) {
-        const path = at
-        match = ([, p]) => Path.equals(p, path)
+        const [node] = Editor.node(editor, at)
+        match = n => n === node
       } else {
         match = () => true
       }
@@ -304,7 +304,7 @@ export const LocationQueries = {
         continue
       }
 
-      if (Editor.isMatch(editor, [n, p], match)) {
+      if (Editor.isMatch(editor, n, match)) {
         prevPath = p
         yield [n, p]
       }
@@ -336,7 +336,7 @@ export const LocationQueries = {
     if (match == null) {
       if (Path.isPath(at)) {
         const [parent] = Editor.parent(editor, at)
-        match = ([n]) => parent.children.includes(n)
+        match = n => parent.children.includes(n)
       } else {
         match = () => true
       }
@@ -421,7 +421,7 @@ export const LocationQueries = {
           continue
         }
 
-        if (!Editor.isMatch(editor, entry, match)) {
+        if (!Editor.isMatch(editor, entry[0], match)) {
           continue
         }
 

--- a/packages/slate/src/interfaces/editor/queries/node.ts
+++ b/packages/slate/src/interfaces/editor/queries/node.ts
@@ -1,16 +1,14 @@
-import { Editor, Element, Node, NodeEntry, NodeMatch, Text } from '../../..'
+import { Editor, Element, Node, NodeMatch, Text } from '../../..'
 
 export const NodeQueries = {
   /**
    * Check if a node entry is a match.
    */
 
-  isMatch(editor: Editor, entry: NodeEntry, match: NodeMatch): boolean {
+  isMatch(editor: Editor, node: Node, match: NodeMatch): boolean {
     if (Array.isArray(match)) {
-      return match.some(m => Editor.isMatch(editor, entry, m))
+      return match.some(m => Editor.isMatch(editor, node, m))
     }
-
-    const [node] = entry
 
     switch (match) {
       case 'text':
@@ -32,7 +30,7 @@ export const NodeQueries = {
     }
 
     if (typeof match === 'function') {
-      return match(entry)
+      return match(node, editor)
     } else {
       return Node.matches(node, match)
     }

--- a/packages/slate/src/interfaces/editor/transforms/node.ts
+++ b/packages/slate/src/interfaces/editor/transforms/node.ts
@@ -241,17 +241,18 @@ export const NodeTransforms = {
       const newPath = Path.next(prevPath)
       const commonPath = Path.common(path, prevPath)
       const isPreviousSibling = Path.isSibling(path, prevPath)
+      const levels = Array.from(Editor.levels(editor, { at: path }), ([n]) => n)
+        .slice(commonPath.length)
+        .slice(0, -1)
 
       // Determine if the merge will leave an ancestor of the path empty as a
       // result, in which case we'll want to remove it after merging.
-      const emptyAncestor = Editor.match(editor, path, ([n, p]) => {
-        return (
-          Path.isDescendant(p, commonPath) &&
-          Path.isAncestor(p, path) &&
-          Element.isElement(n) &&
-          n.children.length === 1
-        )
-      })
+      const emptyAncestor = Editor.match(
+        editor,
+        path,
+        n =>
+          levels.includes(n) && Element.isElement(n) && n.children.length === 1
+      )
 
       const emptyRef = emptyAncestor && Editor.pathRef(editor, emptyAncestor[1])
       let properties

--- a/packages/slate/src/interfaces/editor/transforms/text.ts
+++ b/packages/slate/src/interfaces/editor/transforms/text.ts
@@ -103,14 +103,27 @@ export const TextTransforms = {
 
       // Get the highest nodes that are completely inside the range, as well as
       // the start and end nodes.
-      const matches = Editor.nodes(editor, {
+      const matches: NodeEntry[] = []
+      let lastPath: Path | undefined
+
+      for (const entry of Editor.nodes(editor, {
         at,
         voids,
-        mode: 'highest',
-        match: ([n, p]) =>
-          (!voids && Element.isElement(n) && editor.isVoid(n)) ||
-          (!Path.isCommon(p, start.path) && !Path.isCommon(p, end.path)),
-      })
+      })) {
+        const [node, path] = entry
+
+        if (lastPath && Path.compare(path, lastPath) === 0) {
+          continue
+        }
+
+        if (
+          (Element.isElement(node) && editor.isVoid(node)) ||
+          (!Path.isCommon(path, start.path) && !Path.isCommon(path, end.path))
+        ) {
+          matches.push(entry)
+          lastPath = path
+        }
+      }
 
       const pathRefs = Array.from(matches, ([, p]) => Editor.pathRef(editor, p))
       const startRef = Editor.pointRef(editor, start)

--- a/packages/slate/src/interfaces/editor/transforms/text.ts
+++ b/packages/slate/src/interfaces/editor/transforms/text.ts
@@ -117,7 +117,7 @@ export const TextTransforms = {
         }
 
         if (
-          (Element.isElement(node) && editor.isVoid(node)) ||
+          (!voids && Element.isElement(node) && editor.isVoid(node)) ||
           (!Path.isCommon(path, start.path) && !Path.isCommon(path, end.path))
         ) {
           matches.push(entry)

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -544,5 +544,5 @@ export type NodeMatch =
   | 'editor'
   | 'void'
   | Partial<Node>
-  | ((entry: NodeEntry) => boolean)
+  | ((node: Node, editor: Editor) => boolean)
   | NodeMatch[]

--- a/packages/slate/test/queries/nodes/match-function/one.js
+++ b/packages/slate/test/queries/nodes/match-function/one.js
@@ -15,14 +15,10 @@ export const run = editor => {
   return Array.from(
     Editor.nodes(editor, {
       at: [],
-      match: ([, p]) => p.length === 1,
+      match: () => true,
       mode: 'highest',
     })
   )
 }
 
-export const output = [
-  [<block>one</block>, [0]],
-  [<block>two</block>, [1]],
-  [<block>three</block>, [2]],
-]
+export const output = [[input, []]]

--- a/packages/slate/test/transforms/liftNodes/selection/block-nested.js
+++ b/packages/slate/test/transforms/liftNodes/selection/block-nested.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.liftNodes(editor, { match: ([, p]) => p.length === 3 })
+  Editor.liftNodes(editor, { match: { c: true } })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/moveNodes/selection/block-nested-after.js
+++ b/packages/slate/test/transforms/moveNodes/selection/block-nested-after.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.moveNodes(editor, { match: ([, p]) => p.length === 2, to: [1] })
+  Editor.moveNodes(editor, { match: 'block', to: [1] })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/moveNodes/selection/block-nested-before.js
+++ b/packages/slate/test/transforms/moveNodes/selection/block-nested-before.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.moveNodes(editor, { match: ([, p]) => p.length === 2, to: [0] })
+  Editor.moveNodes(editor, { match: 'block', to: [0] })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/moveNodes/selection/block.js
+++ b/packages/slate/test/transforms/moveNodes/selection/block.js
@@ -14,7 +14,7 @@ export const input = (
 )
 
 export const run = editor => {
-  Editor.moveNodes(editor, { match: ([, p]) => p.length === 1, to: [1] })
+  Editor.moveNodes(editor, { match: 'block', to: [1] })
 }
 
 export const output = (

--- a/packages/slate/test/transforms/splitNodes/depth/two.js
+++ b/packages/slate/test/transforms/splitNodes/depth/two.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.splitNodes(editor, { match: ([, p]) => p.length === 2 })
+  Editor.splitNodes(editor, { match: 'inline' })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/splitNodes/depth/zero.js
+++ b/packages/slate/test/transforms/splitNodes/depth/zero.js
@@ -4,7 +4,7 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Editor.splitNodes(editor, { match: ([, p]) => p.length === 0 })
+  Editor.splitNodes(editor, { match: () => true })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/splitNodes/point/block.js
+++ b/packages/slate/test/transforms/splitNodes/point/block.js
@@ -6,7 +6,7 @@ import { jsx } from '../../..'
 export const run = editor => {
   Editor.splitNodes(editor, {
     at: { path: [0, 0], offset: 2 },
-    match: ([, p]) => p.length === 1,
+    match: 'block',
   })
 }
 

--- a/packages/slate/test/transforms/splitNodes/point/inline.js
+++ b/packages/slate/test/transforms/splitNodes/point/inline.js
@@ -6,7 +6,7 @@ import { jsx } from '../../..'
 export const run = editor => {
   Editor.splitNodes(editor, {
     at: { path: [0, 1, 0], offset: 2 },
-    match: ([, p]) => p.length === 2,
+    match: 'inline',
   })
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

#### What's the new behavior?

This changes the `NodeMatch` matching function arguments to receive just a `Node` instead of a `NodeEntry`. So before this PR it was:

```js
const match = ([node, path]) => true
```

With this PR it is:

```js
const match = node => true
```

I realized that all of the core use cases (and likely most userland ones) that used the `path` could be implemented with just the `node`. And this simplification makes it easier to use and write matching functions because you can often directly pass in helpers like:

```js
{
  match: isCodeBlock
}
```

Without having to write more awkward `isCodeBlockEntry` helpers.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
