### PR TITLE
Force a zero offset when inside a void node

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -197,6 +197,13 @@ export const ReactEditor = {
     const el = ReactEditor.toDOMNode(editor, node)
     let domPoint: DOMPoint | undefined
 
+    // If we're inside a void node, force the offset to 0, otherwise the zero
+    // width spacing character will result in an incorrect offset of 1
+    const [match] = Editor.nodes(editor, { at: point, match: 'void' })
+    if (match) {
+      point = { path: point.path, offset: 0 }
+    }
+
     // For each leaf, we need to isolate its content, which means filtering
     // to its direct text and zero-width spans. (We have to filter out any
     // other siblings that may have been rendered alongside them.)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Selecting a void node no longer crashes.

#### How does this change work?

`ReactEditor.toDOMPoint` forces an offset of 0 if the point is inside a void node.

I have no idea how to add tests for this, but can include some with a little guidance. 

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3239 
