### PR TITLE
Fix paste example: nested formatting

### DIFF
--- a/site/examples/paste-html.js
+++ b/site/examples/paste-html.js
@@ -59,7 +59,9 @@ export const deserialize = el => {
     parent = el.childNodes[0]
   }
 
-  const children = Array.from(parent.childNodes).map(deserialize)
+  const children = Array.from(parent.childNodes)
+    .map(deserialize)
+    .flat()
 
   if (el.nodeName === 'BODY') {
     return jsx('fragment', {}, children)
@@ -72,7 +74,7 @@ export const deserialize = el => {
 
   if (TEXT_TAGS[nodeName]) {
     const attrs = TEXT_TAGS[nodeName](el)
-    return jsx('text', attrs, children)
+    return children.map(child => jsx('text', attrs, child))
   }
 
   return children


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

Pasting nested formatting, such as `<em>One <u>Two</u></em>` works instead of crashing.

#### How does this change work?

Instead of a single `jsx("text", attrs, children)` call, the children are iterated over and return their own text nodes, which seems to handle multiple nested formats. I'm not sure if this ends up creating an excessive amount of text nodes, but it seems that `Editor.insertFragment` is smart enough to merge text nodes with identical attributes.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3188 
