### PR TITLE
`lowest` mode to Editor.nodes

### DIFF
--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -425,10 +425,11 @@ export const LocationQueries = {
     if (mode === 'lowest') {
       const lowEntries = []
       for (const entry of iterable) {
-        if(match) {
+        if (match) {
           if (!Editor.isMatch(editor, entry, match)) {
             continue
           }
+          
           if (prev && Path.isChild(entry[1], prev[1])) // If entry is a child of prev, exchange the match
             lowEntries[lowEntries.length - 1] = entry
           else lowEntries.push(entry)
@@ -436,8 +437,7 @@ export const LocationQueries = {
         }
       }
       for (const lowEntry of lowEntries) yield lowEntry
-    }
-    else {
+    } else {
       for (const entry of iterable) {
         if (match) {
           if (

--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -422,21 +422,20 @@ export const LocationQueries = {
 
     let prev: NodeEntry | undefined
     
-    if(mode === 'lowest') {
-      const lowEntries = [];
-      for(const entry of iterable) {
+    if (mode === 'lowest') {
+      const lowEntries = []
+      for (const entry of iterable) {
         if(match) {
           if (!Editor.isMatch(editor, entry, match)) {
             continue
           }
-          if(prev && Path.isChild(entry[1], prev[1])) // If entry is a child of prev, exchange the match
-            lowEntries[lowEntries.length-1] = entry;
-          else
-            lowEntries.push(entry);
-          prev = entry;
+          if (prev && Path.isChild(entry[1], prev[1])) // If entry is a child of prev, exchange the match
+            lowEntries[lowEntries.length - 1] = entry
+          else lowEntries.push(entry)
+          prev = entry
         }
       }
-      for(const lowEntry of lowEntries) yield lowEntry;
+      for (const lowEntry of lowEntries) yield lowEntry
     }
     else {
       for (const entry of iterable) {

--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -423,18 +423,20 @@ export const LocationQueries = {
     let prev: NodeEntry | undefined
     
     if(mode === 'lowest') {
-      const matches = [];
+      const lowEntries = [];
       for(const entry of iterable) {
-        if (!Editor.isMatch(editor, entry, match)) {
-          continue
+        if(match) {
+          if (!Editor.isMatch(editor, entry, match)) {
+            continue
+          }
+          if(prev && Path.isChild(entry[1], prev[1])) // If entry is a child of prev, exchange the match
+            lowEntries[lowEntries.length-1] = entry;
+          else
+            lowEntries.push(entry);
+          prev = entry;
         }
-        if(prev && Path.isChild(entry[1], prev[1])) // If entry is a child of prev, exchange the match
-          matches[matches.length-1] = entry;
-        else
-          matches.push(entry);
-        prev = entry;
       }
-      for(const entry of matches) yield entry;
+      for(const lowEntry of lowEntries) yield lowEntry;
     }
     else {
       for (const entry of iterable) {

--- a/packages/slate/src/interfaces/editor/transforms/node.ts
+++ b/packages/slate/src/interfaces/editor/transforms/node.ts
@@ -640,7 +640,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
     }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
_feature_

#### What's the new behavior?

Allow the Editor.nodes to take `lowest` as mode. Also allowing unwrapNodes to specify the mode `lowest`.

#### How does this change work?

If the lowest mode is specified, Editor.nodes iterates through all matches and removes any parent match if a child also matches. 

#### Have you checked that...?


- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`. [Do not currently have access to test utils]
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.) [Do not currently have access to test utils]
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3227 #3184 
Reviewers: @
