### PR TITLE
Fix trailing new line in blocks

### DIFF
--- a/packages/slate-react/src/components/children.tsx
+++ b/packages/slate-react/src/components/children.tsx
@@ -69,7 +69,7 @@ const Children = (props: {
         <TextComponent
           decorations={ds}
           key={key.id}
-          isLast={isLeafBlock && i === node.children.length}
+          isLast={isLeafBlock && i === node.children.length - 1}
           parent={node}
           renderLeaf={renderLeaf}
           text={n}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing bug

#### What's the new behavior?

`String` inserts trailing new line when block `isLast`

#### How does this change work?

A bad comparison with `node.children.length` was preventing `String` from inserting a trailing new line at the end of a block.

For instance:
```javascript
if (command.type === 'insert_break' && command.soft) {
  Editor.insertText(editor, '\n')
}
...
editor.exec({ type: 'insert_break', soft: true }) // <shift><enter>
```
Previously, if soft break was inserted at the end of the block, you'd need to insert it twice to see a new line because `isLast` was never going to be `true` 😜 

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: 0.52.5
Reviewers: @ianstormtaylor 
