### PR TITLE
Make Editable accept 'as' prop

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -57,22 +57,23 @@ export interface RenderLeafProps {
   }
 }
 
+export type EditableProps = {
+  decorate?: (entry: NodeEntry) => Range[]
+  onDOMBeforeInput?: (event: Event) => void
+  placeholder?: string
+  readOnly?: boolean
+  role?: string
+  style?: React.CSSProperties
+  renderElement?: (props: RenderElementProps) => JSX.Element
+  renderLeaf?: (props: RenderLeafProps) => JSX.Element
+  as?: React.ElementType
+} & React.TextareaHTMLAttributes<HTMLDivElement>
+
 /**
  * Editable.
  */
 
-export const Editable = (
-  props: {
-    decorate?: (entry: NodeEntry) => Range[]
-    onDOMBeforeInput?: (event: Event) => void
-    placeholder?: string
-    readOnly?: boolean
-    role?: string
-    style?: React.CSSProperties
-    renderElement?: (props: RenderElementProps) => JSX.Element
-    renderLeaf?: (props: RenderLeafProps) => JSX.Element
-  } & React.TextareaHTMLAttributes<HTMLDivElement>
-) => {
+export const Editable = (props: EditableProps) => {
   const {
     autoFocus,
     decorate = defaultDecorate,
@@ -82,6 +83,7 @@ export const Editable = (
     renderElement,
     renderLeaf,
     style = {},
+    as: Component = 'div',
     ...attributes
   } = props
   const editor = useSlate()
@@ -400,7 +402,7 @@ export const Editable = (
 
   return (
     <ReadOnlyContext.Provider value={readOnly}>
-      <div
+      <Component
         // COMPAT: The Grammarly Chrome extension works by changing the DOM
         // out from under `contenteditable` elements, which leads to weird
         // behaviors so we have to disable it like editor. (2017/04/24)
@@ -887,7 +889,7 @@ export const Editable = (
           renderLeaf={renderLeaf}
           selection={editor.selection}
         />
-      </div>
+      </Component>
     </ReadOnlyContext.Provider>
   )
 }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -57,6 +57,10 @@ export interface RenderLeafProps {
   }
 }
 
+/**
+ * `EditableProps` are passed to the `<Editable>` component.
+ */
+
 export type EditableProps = {
   decorate?: (entry: NodeEntry) => Range[]
   onDOMBeforeInput?: (event: Event) => void


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### What's the new behavior?

`Editable` is able to accept an optional `as` prop which can be an intrinsic element or a component (Class or Functional).

#### How does this change work?

Example:
```typescript
<Editable as="section" /> // intrinsic element "section"
<Editable as={Component} /> // functional/class component
```
If a component is passed, it must forward refs. Added an example which shows how it should be done.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @ianstormtaylor 
