### PR TITLE
add previous/next sibling query support

### DIFF
--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -343,7 +343,7 @@ export const LocationQueries = {
   next(
     editor: Editor,
     at: Location,
-    match: NodeMatch,
+    match?: NodeMatch,
     options: {
       mode?: 'all' | 'highest'
       voids?: boolean
@@ -353,6 +353,20 @@ export const LocationQueries = {
     const [, from] = Editor.last(editor, at)
     const [, to] = Editor.last(editor, [])
     const span: Span = [from, to]
+
+    if (Path.isPath(at) && at.length === 0) {
+      throw new Error(`Cannot get the next node from the root node!`)
+    }
+
+    if (match == null) {
+      if (Path.isPath(at)) {
+        const [parent] = Editor.parent(editor, at)
+        match = ([n]) => parent.children.includes(n)
+      } else {
+        match = () => true
+      }
+    }
+
     const [, next] = Editor.nodes(editor, { at: span, match, mode, voids })
     return next
   },
@@ -678,7 +692,7 @@ export const LocationQueries = {
   previous(
     editor: Editor,
     at: Location,
-    match: NodeMatch,
+    match?: NodeMatch,
     options: {
       mode?: 'all' | 'highest'
       voids?: boolean
@@ -688,6 +702,20 @@ export const LocationQueries = {
     const [, from] = Editor.first(editor, at)
     const [, to] = Editor.first(editor, [])
     const span: Span = [from, to]
+
+    if (Path.isPath(at) && at.length === 0) {
+      throw new Error(`Cannot get the previous node from the root node!`)
+    }
+
+    if (match == null) {
+      if (Path.isPath(at)) {
+        const [parent] = Editor.parent(editor, at)
+        match = ([n]) => parent.children.includes(n)
+      } else {
+        match = () => true
+      }
+    }
+
     const [, previous] = Editor.nodes(editor, {
       reverse: true,
       at: span,

--- a/packages/slate/test/queries/next/default.js
+++ b/packages/slate/test/queries/next/default.js
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+
+export const run = editor => {
+  return Editor.next(editor, [0])
+}
+
+export const output = [<block>two</block>, [1]]

--- a/packages/slate/test/queries/previous/default.js
+++ b/packages/slate/test/queries/previous/default.js
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+
+export const run = editor => {
+  return Editor.previous(editor, [1])
+}
+
+export const output = [<block>one</block>, [0]]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

#### What's the new behavior?

This makes the `match` argument optional to `Editor.previous` and `Editor.next`, which makes the common use case of getting the previous/next sibling easy.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
