### PR TITLE
use native character insertion to fix browser/OS text features.

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -36,6 +36,7 @@ import {
   IS_FOCUSED,
   PLACEHOLDER_SYMBOL,
 } from '../utils/weak-maps'
+import { asNative, flushNativeEvents } from '../utils/native'
 
 // COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
 const HAS_BEFORE_INPUT_SUPPORT = !(IS_FIREFOX || IS_EDGE_LEGACY)
@@ -229,7 +230,47 @@ export const Editable = (props: EditableProps) => {
           return
         }
 
-        event.preventDefault()
+        let native = false
+        if (
+          type === 'insertText' &&
+          selection &&
+          Range.isCollapsed(selection) &&
+          // Only do it for single character events, for the simplest scenario,
+          // for now.
+          event.data &&
+          event.data.length === 1 &&
+          // Chrome seems to have issues correctly editing the start of nodes.
+          // I see this when there is an inline element, like a link, and you select
+          // right after it (the start of the next node).
+          selection.anchor.offset !== 0
+        ) {
+          native = true
+
+          // Skip native if there are marks, as that means
+          // `insertText` will insert a node, not just text.
+          if (editor.marks) {
+            native = false
+          }
+
+          // and because of the selection moving in `insertText` (create-editor.tx).
+          const { anchor } = selection
+          const inline = Editor.above(editor, {
+            at: anchor,
+            match: n => Editor.isInline(editor, n),
+            mode: 'highest',
+          })
+          if (inline) {
+            const [, inlinePath] = inline
+
+            if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
+              native = false
+            }
+          }
+        }
+
+        if (!native) {
+          event.preventDefault()
+        }
 
         // COMPAT: For the deleting forward/backward input types we don't want
         // to change the selection because it is the range that will be deleted,
@@ -327,7 +368,13 @@ export const Editable = (props: EditableProps) => {
             if (data instanceof DataTransfer) {
               ReactEditor.insertData(editor, data)
             } else if (typeof data === 'string') {
-              Editor.insertText(editor, data)
+              // Only insertText operations use the native functionality, for now.
+              // Potentially expand to single character deletes, as well.
+              if (native) {
+                asNative(editor, () => Editor.insertText(editor, data))
+              } else {
+                Editor.insertText(editor, data)
+              }
             }
 
             break
@@ -486,6 +533,13 @@ export const Editable = (props: EditableProps) => {
           },
           [readOnly]
         )}
+        onInput={useCallback((event: React.SyntheticEvent) => {
+          // Flush native operations, as native events will have propogated
+          // and we can correctly compare DOM text values in components
+          // to stop rendering, so that browsers functions like autocorrect
+          // and spellcheck work as expected.
+          flushNativeEvents(editor)
+        }, [])}
         onBlur={useCallback(
           (event: React.FocusEvent<HTMLDivElement>) => {
             if (

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -235,10 +235,12 @@ export const Editable = (props: EditableProps) => {
           type === 'insertText' &&
           selection &&
           Range.isCollapsed(selection) &&
-          // Only do it for single character events, for the simplest scenario,
-          // for now.
+          // Only do it for single character a-z or space for now.
+          // Long-press events (hold a + press 4 = ä) to choose a special character otherwise
+          // causes duplicate inserts.
           event.data &&
           event.data.length === 1 &&
+          /[a-z ]/i.test(event.data) &&
           // Chrome seems to have issues correctly editing the start of nodes.
           // I see this when there is an inline element, like a link, and you select
           // right after it (the start of the next node).

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -55,15 +55,42 @@ const String = (props: {
 /**
  * Leaf strings with text in them.
  */
+type TextStringProps = { text: string; isTrailing?: boolean }
+class TextString extends React.Component<TextStringProps> {
+  ref: { current: HTMLSpanElement | null } = React.createRef()
 
-const TextString = (props: { text: string; isTrailing?: boolean }) => {
-  const { text, isTrailing = false } = props
-  return (
-    <span data-slate-string>
-      {text}
-      {isTrailing ? '\n' : null}
-    </span>
-  )
+  // This component may have skipped rendering due to native operations being
+  // applied. If an undo is performed React will see the old and new shadow DOM
+  // match and not apply an update. Forces each render to actually reconcile.
+  forceUpdateFlag = false
+
+  shouldComponentUpdate(nextProps: TextStringProps) {
+    return this.ref.current
+      ? this.ref.current.textContent !== nextProps.text
+      : true
+  }
+
+  componentDidMount() {
+    this.forceUpdateFlag = !this.forceUpdateFlag
+  }
+
+  componentDidUpdate() {
+    this.forceUpdateFlag = !this.forceUpdateFlag
+  }
+
+  render() {
+    const { text, isTrailing = false } = this.props
+    return (
+      <span
+        data-slate-string
+        ref={this.ref}
+        key={this.forceUpdateFlag ? 'A' : 'B'}
+      >
+        {text}
+        {isTrailing ? '\n' : null}
+      </span>
+    )
+  }
 }
 
 /**

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -4,6 +4,11 @@ import { Editor, Node, Path, Operation, Transforms, Range } from 'slate'
 import { ReactEditor } from './react-editor'
 import { Key } from '../utils/key'
 import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/weak-maps'
+import {
+  AS_NATIVE,
+  NATIVE_OPERATIONS,
+  flushNativeEvents,
+} from '../utils/native'
 import { isDOMText, getPlainText } from '../utils/dom'
 
 /**
@@ -15,6 +20,31 @@ export const withReact = <T extends Editor>(editor: T) => {
   const { apply, onChange } = e
 
   e.apply = (op: Operation) => {
+    // if we're NOT an insert_text and there's a queue
+    // of native events, bail out and flush the queue.
+    // otherwise transforms as part of this cycle will
+    // be incorrect.
+    //
+    // This is needed as overriden operations (e.g. `insertText`)
+    // can call additional transforms, which will need accurate
+    // content, and will be called _before_ `onInput` is fired.
+    if (op.type !== 'insert_text') {
+      AS_NATIVE.set(editor, false)
+      flushNativeEvents(editor)
+    }
+
+    // If we're in native mode, queue the operation
+    // and it will be applied later.
+    if (AS_NATIVE.get(editor)) {
+      const nativeOps = NATIVE_OPERATIONS.get(editor)
+      if (nativeOps) {
+        nativeOps.push(op)
+      } else {
+        NATIVE_OPERATIONS.set(editor, [op])
+      }
+      return
+    }
+
     const matches: [Path, Key][] = []
 
     switch (op.type) {

--- a/packages/slate-react/src/utils/native.ts
+++ b/packages/slate-react/src/utils/native.ts
@@ -1,0 +1,35 @@
+import { Editor, Operation } from 'slate'
+
+export const AS_NATIVE: WeakMap<Editor, boolean> = new WeakMap()
+export const NATIVE_OPERATIONS: WeakMap<Editor, Operation[]> = new WeakMap()
+
+/**
+ * `asNative` queues operations as native, meaning native browser events will
+ * not have been prevented, and we need to flush the operations
+ * after the native events have propogated to the DOM.
+ * @param {Editor} editor - Editor on which the operations are being applied
+ * @param {callback} fn - Function containing .exec calls which will be queued as native
+ */
+export const asNative = (editor: Editor, fn: () => void) => {
+  AS_NATIVE.set(editor, true)
+  fn()
+  AS_NATIVE.set(editor, false)
+}
+
+/**
+ * `flushNativeEvents` applies any queued native events.
+ * @param {Editor} editor - Editor on which the operations are being applied
+ */
+export const flushNativeEvents = (editor: Editor) => {
+  const nativeOps = NATIVE_OPERATIONS.get(editor)
+
+  // Clear list _before_ applying, as we might flush
+  // events in each op, as well.
+  NATIVE_OPERATIONS.set(editor, [])
+
+  if (nativeOps) {
+    nativeOps.forEach(op => {
+      editor.apply(op)
+    })
+  }
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a bug

#### What's the new behavior?

Fixes spellcheck, text replacement, autocorrect and makes it so spellcheck squiggles dont blink in and out as you type.

This is a port of #3076 to 50+. It's fixing the same bug(s), with the same technique and comments from @ryanmitts.

Current behavior:
![current](https://user-images.githubusercontent.com/60460/70583017-4ae50980-1b71-11ea-8edb-c9c40958b223.gif)

Fixed:
![fixed](https://user-images.githubusercontent.com/60460/70583028-51738100-1b71-11ea-8231-4a452eec6a5e.gif)

#### How does this change work?

Single character insert events are not cancelled, as browser features like spellcheck only fires on user events and are removed on DOM updates. Native events are allowed to pass through, and <TextString /> will cancel its render if the effective text value hasn't changed.

Native Operations are queued and applied `onInput`, as for the <TextString /> check to work the native events need to propagate.

As #3076, this is pretty narrow and is only applied for `insertText` onBeforeInput events, with no selection, not at the end of inline nodes (as the selection is moved on `insert_text` elsewhere) or at the very beginning of a selection.

#3076 has more details.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2061 (and some of #2051?)
Reviewers: @ianstormtaylor
