### PR TITLE
Fix forced layout example

### DIFF
--- a/site/examples/forced-layout.js
+++ b/site/examples/forced-layout.js
@@ -1,12 +1,12 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import { Slate, Editable, withReact } from 'slate-react'
-import { Editor, createEditor } from 'slate'
+import { Editor, createEditor, Node } from 'slate'
 import { withHistory } from 'slate-history'
 
 const withLayout = editor => {
   const { normalizeNode } = editor
 
-  editor.normalizeNode = path => {
+  editor.normalizeNode = ([node, path]) => {
     if (path.length === 0) {
       if (editor.children.length < 1) {
         const title = { type: 'title', children: [{ text: 'Untitled' }] }
@@ -27,7 +27,7 @@ const withLayout = editor => {
       }
     }
 
-    return normalizeNode(path)
+    return normalizeNode([node, path])
   }
 
   return editor


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Forced layout example works. In 0.53.0, it wasn't, due to a couple issues.

#### How does this change work?

- Forced layout example was destructuring the first element of a `[node, path]` array into `[path]`, so `path` wasn't actually a path. And then it was forwarding `[path]` to the next pass, instead of `[node, path]`.
- It called `Node.children` but never imported it.

Note: If the plan is to execute #3275, then this PR should be ignored and `normalizeNode` should instead be changed to only use a path. But in the meantime, the example's broken.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

