### PR TITLE
Allow links to be pasted without a selection

### DIFF
--- a/site/examples/links.js
+++ b/site/examples/links.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react'
 import isUrl from 'is-url'
 import { Slate, Editable, withReact, useSlate } from 'slate-react'
-import { Editor, createEditor } from 'slate'
+import { Editor, Range, createEditor } from 'slate'
 import { withHistory } from 'slate-history'
 
 import { Button, Icon, Toolbar } from '../components'
@@ -85,12 +85,20 @@ const wrapLink = (editor, url) => {
     unwrapLink(editor)
   }
 
-  const link = { type: 'link', url, children: [] }
-  if (Point.equals(editor.selection.anchor, editor.selection.focus)) {
-    Editor.insertText(editor, url)
+  const { selection } = editor
+  const isCollapsed = Range.isCollapsed(selection)
+  const link = {
+    type: 'link',
+    url,
+    children: isCollapsed ? [{ text: url }] : [],
   }
-  Editor.wrapNodes(editor, link, { split: true })
-  Editor.collapse(editor, { edge: 'end' })
+
+  if (isCollapsed) {
+    Editor.insertNodes(editor, link)
+  } else {
+    Editor.wrapNodes(editor, link, { split: true })
+    Editor.collapse(editor, { edge: 'end' })
+  }
 }
 
 const Element = ({ attributes, children, element }) => {

--- a/site/examples/links.js
+++ b/site/examples/links.js
@@ -86,6 +86,9 @@ const wrapLink = (editor, url) => {
   }
 
   const link = { type: 'link', url, children: [] }
+  if (Point.equals(editor.selection.anchor, editor.selection.focus)) {
+    Editor.insertText(editor, url)
+  }
   Editor.wrapNodes(editor, link, { split: true })
   Editor.collapse(editor, { edge: 'end' })
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Improving a feature
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
For the Links example, allows links to be pasted even when there is no text selected.

![Dec-11-2019 09-31-27](https://user-images.githubusercontent.com/103864/70645047-0a30d300-1bf9-11ea-973c-77621404f7e5.gif)

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

It checks if the current selection's anchor == focus, and if so that means that there is no selection, and it should insert text before wrapping the link.
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor 
