### PR TITLE
Add `lowest` mode to Editor.nodes

### DIFF
--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -372,7 +372,7 @@ export const LocationQueries = {
     options: {
       at?: Location | Span
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       reverse?: boolean
       voids?: boolean
     } = {}
@@ -411,24 +411,41 @@ export const LocationQueries = {
 
     let prev: NodeEntry | undefined
 
-    for (const entry of iterable) {
-      if (match) {
-        if (
-          mode === 'highest' &&
-          prev &&
-          Path.compare(entry[1], prev[1]) === 0
-        ) {
-          continue
-        }
+    if (mode === 'lowest') {
+      const lowEntries = []
+      for (const entry of iterable) {
+        if (match) {
+          if (!Editor.isMatch(editor, entry[0], match)) {
+            continue
+          }
 
-        if (!Editor.isMatch(editor, entry[0], match)) {
-          continue
+          if (prev && Path.isChild(entry[1], prev[1]))
+            lowEntries[lowEntries.length - 1] = entry
+          else lowEntries.push(entry)
+          prev = entry
         }
-
-        prev = entry
       }
+      for (const lowEntry of lowEntries) yield lowEntry
+    } else {
+      for (const entry of iterable) {
+        if (match) {
+          if (
+            mode === 'highest' &&
+            prev &&
+            Path.compare(entry[1], prev[1]) === 0
+          ) {
+            continue
+          }
 
-      yield entry
+          if (!Editor.isMatch(editor, entry[0], match)) {
+            continue
+          }
+
+          prev = entry
+        }
+
+        yield entry
+      }
     }
   },
 

--- a/packages/slate/src/interfaces/editor/transforms/node.ts
+++ b/packages/slate/src/interfaces/editor/transforms/node.ts
@@ -123,7 +123,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       voids?: boolean
     } = {}
   ) {
@@ -322,7 +322,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       to: Path
       voids?: boolean
     }
@@ -370,7 +370,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       hanging?: boolean
       voids?: boolean
     } = {}
@@ -419,7 +419,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       hanging?: boolean
       split?: boolean
       voids?: boolean
@@ -637,7 +637,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
     } = {}
@@ -665,7 +665,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
     }
@@ -719,7 +719,7 @@ export const NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch
-      mode?: 'all' | 'highest'
+      mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
     } = {}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
_feature_

#### What's the new behavior?

Allow the Editor.nodes to take `lowest` as mode. Also allowing unwrapNodes to specify the mode `lowest`.

#### How does this change work?

If the lowest mode is specified, Editor.nodes iterates through all matches and removes any parent match if a child also matches. 

#### Have you checked that...?


- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`. 
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.) 
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3227 #3184 
Reviewers: @