### PR TITLE
split `format_text` into two commands

### DIFF
--- a/packages/slate/src/interfaces/command.ts
+++ b/packages/slate/src/interfaces/command.ts
@@ -22,6 +22,16 @@ export const Command = {
 }
 
 /**
+ * The `AddMarkCommand` adds properties to the text nodes in the selection.
+ */
+
+export interface AddMarkCommand {
+  type: 'add_mark'
+  key: string
+  value: any
+}
+
+/**
  * The `DeleteBackwardCommand` delete's content backward, meaning before the
  * current selection, by a specific `unit` of distance.
  */
@@ -47,15 +57,6 @@ export interface DeleteForwardCommand {
 
 export interface DeleteFragmentCommand {
   type: 'delete_fragment'
-}
-
-/**
- * The `FormatTextCommand` adds properties to the text nodes in the selection.
- */
-
-export interface FormatTextCommand {
-  type: 'format_text'
-  properties: Record<string, any>
 }
 
 /**
@@ -94,19 +95,29 @@ export interface InsertTextCommand {
 }
 
 /**
+ * The `RemoveMarkCommand` removes properties from text nodes in the selection.
+ */
+
+export interface RemoveMarkCommand {
+  type: 'remove_mark'
+  key: string
+}
+
+/**
  * The `CoreCommand` union is a set of all of the commands that are recognized
  * by Slate's "core" out of the box.
  */
 
 export type CoreCommand =
+  | AddMarkCommand
   | DeleteBackwardCommand
   | DeleteForwardCommand
   | DeleteFragmentCommand
-  | FormatTextCommand
   | InsertBreakCommand
   | InsertFragmentCommand
   | InsertNodeCommand
   | InsertTextCommand
+  | RemoveMarkCommand
 
 export const CoreCommand = {
   /**
@@ -116,14 +127,14 @@ export const CoreCommand = {
   isCoreCommand(value: any): value is CoreCommand {
     if (Command.isCommand(value)) {
       switch (value.type) {
+        case 'add_mark':
+          return typeof value.key === 'string' && typeof value.value != null
         case 'delete_backward':
           return typeof value.unit === 'string'
         case 'delete_forward':
           return typeof value.unit === 'string'
         case 'delete_fragment':
           return true
-        case 'format_text':
-          return isPlainObject(value.properties)
         case 'insert_break':
           return true
         case 'insert_fragment':
@@ -132,6 +143,8 @@ export const CoreCommand = {
           return Node.isNode(value.node)
         case 'insert_text':
           return typeof value.text === 'string'
+        case 'remove_mark':
+          return typeof value.key === 'string'
       }
     }
 

--- a/packages/slate/src/interfaces/command.ts
+++ b/packages/slate/src/interfaces/command.ts
@@ -128,7 +128,7 @@ export const CoreCommand = {
     if (Command.isCommand(value)) {
       switch (value.type) {
         case 'add_mark':
-          return typeof value.key === 'string' && typeof value.value != null
+          return typeof value.key === 'string' && value.value != null
         case 'delete_backward':
           return typeof value.unit === 'string'
         case 'delete_forward':


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

#### What's the new behavior?

This splits the `format_text` command into two commands: `add_mark` and `remove_mark`.

> Note: there's still no `Mark` interface, or any of its baggage. But "mark" is a useful term that tends to mean text-level formatting (eg. the `<mark>` tag in HTML) and we're using it going forward to have a way to refer to text-level custom formatting properties.

#### How does this change work?

It adds two new commands that replace what `format_text` did before.

This was necessary to allow people to easily be able to write logic that **always** adds or **always** removes marks. Otherwise, with the `format_text` command you'd have to know whether it was active or not to ensure you weren't toggling it off.

This has the benefit of leaving the "active" definition for toggling up to userland, since Slate's core no longer cares how you define whether a specific mark is active.

I always prefer to keep the number of core commands to a minimum, which is why I originally tried to combine them. But in this case it made for an awkward API tradeoff.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
