### PR TITLE
rename `Node.text` to `Node.string`

### DIFF
--- a/docs/concepts/01-interfaces.md
+++ b/docs/concepts/01-interfaces.md
@@ -60,8 +60,8 @@ For example, when working with nodes:
 ```js
 import { Node } from 'slate'
 
-// Get the text content of an element node.
-const text = Node.text(element)
+// Get the string content of an element node.
+const string = Node.string(element)
 
 // Get the node at a specific path inside a root node.
 const descendant = Node.get(value, path)

--- a/docs/concepts/09-serializing.md
+++ b/docs/concepts/09-serializing.md
@@ -12,7 +12,7 @@ For example, taking the value of an editor and returning plaintext:
 import { Node } from 'slate'
 
 const serialize = nodes => {
-  return nodes.map(n => Node.text(n)).join('\n')
+  return nodes.map(n => Node.string(n)).join('\n')
 }
 ```
 

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -116,8 +116,8 @@ import { Node } from 'slate'
 const serialize = value => {
   return (
     value
-      // Return the text content of each paragraph in the value's children.
-      .map(n => Node.text(n))
+      // Return the string content of each paragraph in the value's children.
+      .map(n => Node.string(n))
       // Join them all with line breaks denoting paragraphs.
       .join('\n')
   )

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -393,7 +393,7 @@ export const Editable = (props: EditableProps) => {
     placeholder &&
     editor.children.length === 1 &&
     Array.from(Node.texts(editor)).length === 1 &&
-    Node.text(editor) === ''
+    Node.string(editor) === ''
   ) {
     const start = Editor.start(editor, [])
     decorations.push({

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -74,7 +74,7 @@ const Element = (props: {
   // If it's a block node with inline children, add the proper `dir` attribute
   // for text direction.
   if (!isInline && Editor.hasInlines(editor, element)) {
-    const text = Node.text(element)
+    const text = Node.string(element)
     const dir = getDirection(text)
 
     if (dir === 'rtl') {

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -21,7 +21,7 @@ const String = (props: {
   // COMPAT: Render text inside void nodes with a zero-width space.
   // So the node can contain selection but the text is not visible.
   if (editor.isVoid(parent)) {
-    return <ZeroWidthString length={Node.text(parent).length} />
+    return <ZeroWidthString length={Node.string(parent).length} />
   }
 
   // COMPAT: If this is the last text node in an empty block, render a zero-
@@ -31,7 +31,7 @@ const String = (props: {
     leaf.text === '' &&
     parent.children[parent.children.length - 1] === text &&
     !editor.isInline(parent) &&
-    Editor.text(editor, parentPath) === ''
+    Editor.string(editor, parentPath) === ''
   ) {
     return <ZeroWidthString isLineBreak />
   }

--- a/packages/slate/src/interfaces/editor/queries/location.ts
+++ b/packages/slate/src/interfaces/editor/queries/location.ts
@@ -620,7 +620,7 @@ export const LocationQueries = {
             ? start
             : Editor.start(editor, path)
 
-          const text = Editor.text(editor, { anchor: s, focus: e })
+          const text = Editor.string(editor, { anchor: s, focus: e })
           string = reverse ? reverseText(text) : text
           isNewBlock = true
         }
@@ -733,13 +733,13 @@ export const LocationQueries = {
   },
 
   /**
-   * Get the text content of a location.
+   * Get the text string content of a location.
    *
    * Note: the text of void nodes is presumed to be an empty string, regardless
    * of what their actual content is.
    */
 
-  text(editor: Editor, at: Location): string {
+  string(editor: Editor, at: Location): string {
     const range = Editor.range(editor, at)
     const [start, end] = Range.edges(range)
     let text = ''

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -464,11 +464,11 @@ export const Node = {
    * computations for a node.
    */
 
-  text(node: Node): string {
+  string(node: Node): string {
     if (Text.isText(node)) {
       return node.text
     } else {
-      return node.children.map(Node.text).join('')
+      return node.children.map(Node.string).join('')
     }
   },
 

--- a/packages/slate/test/interfaces/Node/string/across-elements.js
+++ b/packages/slate/test/interfaces/Node/string/across-elements.js
@@ -17,7 +17,7 @@ export const input = (
 )
 
 export const test = value => {
-  return Node.text(value)
+  return Node.string(value)
 }
 
 export const output = `onetwothreefour`

--- a/packages/slate/test/interfaces/Node/string/element.js
+++ b/packages/slate/test/interfaces/Node/string/element.js
@@ -11,7 +11,7 @@ export const input = (
 )
 
 export const test = value => {
-  return Node.text(value, [1])
+  return Node.string(value, [1])
 }
 
 export const output = `onetwo`

--- a/packages/slate/test/interfaces/Node/string/text.js
+++ b/packages/slate/test/interfaces/Node/string/text.js
@@ -6,7 +6,7 @@ import { jsx } from 'slate-hyperscript'
 export const input = <text>one</text>
 
 export const test = value => {
-  return Node.text(value)
+  return Node.string(value)
 }
 
 export const output = `one`

--- a/packages/slate/test/queries/string/block-across.js
+++ b/packages/slate/test/queries/string/block-across.js
@@ -17,7 +17,7 @@ export const input = (
 )
 
 export const run = editor => {
-  return Editor.text(editor, [0])
+  return Editor.string(editor, [])
 }
 
-export const output = `onetwo`
+export const output = `onetwothreefour`

--- a/packages/slate/test/queries/string/block-void.js
+++ b/packages/slate/test/queries/string/block-void.js
@@ -13,7 +13,7 @@ export const input = (
 )
 
 export const run = editor => {
-  return Editor.text(editor, [0])
+  return Editor.string(editor, [0])
 }
 
 export const output = ``

--- a/packages/slate/test/queries/string/block.js
+++ b/packages/slate/test/queries/string/block.js
@@ -17,7 +17,7 @@ export const input = (
 )
 
 export const run = editor => {
-  return Editor.text(editor, [])
+  return Editor.string(editor, [0])
 }
 
-export const output = `onetwothreefour`
+export const output = `onetwo`

--- a/packages/slate/test/queries/string/inline.js
+++ b/packages/slate/test/queries/string/inline.js
@@ -6,14 +6,13 @@ import { jsx } from '../..'
 export const input = (
   <editor>
     <block>
-      <text>one</text>
-      <text>two</text>
+      one<inline>two</inline>three
     </block>
   </editor>
 )
 
 export const run = editor => {
-  return Editor.text(editor, [0, 0])
+  return Editor.string(editor, [0, 1])
 }
 
-export const output = `one`
+export const output = `two`

--- a/packages/slate/test/queries/string/text.js
+++ b/packages/slate/test/queries/string/text.js
@@ -6,13 +6,14 @@ import { jsx } from '../..'
 export const input = (
   <editor>
     <block>
-      one<inline>two</inline>three
+      <text>one</text>
+      <text>two</text>
     </block>
   </editor>
 )
 
 export const run = editor => {
-  return Editor.text(editor, [0, 1])
+  return Editor.string(editor, [0, 0])
 }
 
-export const output = `two`
+export const output = `one`

--- a/site/examples/hovering-toolbar.js
+++ b/site/examples/hovering-toolbar.js
@@ -104,7 +104,7 @@ const HoveringToolbar = () => {
       !selection ||
       !ReactEditor.isFocused(editor) ||
       Range.isCollapsed(selection) ||
-      Editor.text(editor, selection) === ''
+      Editor.string(editor, selection) === ''
     ) {
       el.removeAttribute('style')
       return

--- a/site/examples/markdown-shortcuts.js
+++ b/site/examples/markdown-shortcuts.js
@@ -54,7 +54,7 @@ const withShortcuts = editor => {
       const path = block ? block[1] : []
       const start = Editor.start(editor, path)
       const range = { anchor, focus: start }
-      const beforeText = Editor.text(editor, range)
+      const beforeText = Editor.string(editor, range)
       const type = SHORTCUTS[beforeText]
 
       if (type) {

--- a/site/examples/mentions.js
+++ b/site/examples/mentions.js
@@ -81,11 +81,11 @@ const MentionExample = () => {
           const wordBefore = Editor.before(editor, start, { unit: 'word' })
           const before = wordBefore && Editor.before(editor, wordBefore)
           const beforeRange = before && Editor.range(editor, before, start)
-          const beforeText = beforeRange && Editor.text(editor, beforeRange)
+          const beforeText = beforeRange && Editor.string(editor, beforeRange)
           const beforeMatch = beforeText && beforeText.match(/^@(\w+)$/)
           const after = Editor.after(editor, start)
           const afterRange = Editor.range(editor, start, after)
-          const afterText = Editor.text(editor, afterRange)
+          const afterText = Editor.string(editor, afterRange)
           const afterMatch = afterText.match(/^(\s|$)/)
 
           if (beforeMatch && afterMatch) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.

#### What's the new behavior?

Renames `Node.text` to `Node.string` to reduce confusion with "text" nodes, since it just returns the string content of the node.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/3276