### PR TITLE
Fix IME input bug (#3292)

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -539,13 +539,24 @@ export const Editable = (props: EditableProps) => {
           },
           [attributes.onCompositionEnd]
         )}
+        onCompositionUpdate={useCallback(
+          (event: React.CompositionEvent<HTMLDivElement>) => {
+            if (
+              hasEditableTarget(editor, event.target) &&
+              !isEventHandled(event, attributes.onCompositionUpdate)
+            ) {
+              state.isComposing = true
+            }
+          },
+          [attributes.onCompositionUpdate]
+        )}
         onCompositionStart={useCallback(
           (event: React.CompositionEvent<HTMLDivElement>) => {
             if (
               hasEditableTarget(editor, event.target) &&
               !isEventHandled(event, attributes.onCompositionStart)
             ) {
-              state.isComposing = true
+              editor.exec({ type: 'delete_fragment' })
             }
           },
           [attributes.onCompositionStart]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
bug #3292
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Error doesn't happen after IME input.

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
The error happens because React tries to remove DOM nodes which is already deleted when IME input started. So I added deletion of DOM nodes on compositionstart event.
And I moved `state.isComposing = true`  to the listener for compositionupdate event, this is because cursor doesn't work well properly if it is left in compositionstart event.

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes:  #3292
Reviewers: @ianstormtaylor
