### PR TITLE
fix onBeforeInput memoization

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -442,7 +442,7 @@ export const Editable = (props: EditableProps) => {
             const text = (event as any).data as string
             editor.exec({ type: 'insert_text', text })
           }
-        }, [])}
+        }, [readOnly])}
         onBlur={useCallback(
           (event: React.FocusEvent<HTMLDivElement>) => {
             if (

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -501,7 +501,7 @@ export const Editable = (props: EditableProps) => {
 
             IS_FOCUSED.delete(editor)
           },
-          [attributes.onBlur]
+          [readOnly, attributes.onBlur]
         )}
         onClick={useCallback(
           (event: React.MouseEvent<HTMLDivElement>) => {
@@ -521,7 +521,7 @@ export const Editable = (props: EditableProps) => {
               }
             }
           },
-          [attributes.onClick]
+          [readOnly, attributes.onClick]
         )}
         onCompositionEnd={useCallback(
           (event: React.CompositionEvent<HTMLDivElement>) => {
@@ -581,7 +581,7 @@ export const Editable = (props: EditableProps) => {
               }
             }
           },
-          [attributes.onCut]
+          [readOnly, attributes.onCut]
         )}
         onDragOver={useCallback(
           (event: React.DragEvent<HTMLDivElement>) => {
@@ -646,7 +646,7 @@ export const Editable = (props: EditableProps) => {
               }
             }
           },
-          [attributes.onDrop]
+          [readOnly, attributes.onDrop]
         )}
         onFocus={useCallback(
           (event: React.FocusEvent<HTMLDivElement>) => {
@@ -670,7 +670,7 @@ export const Editable = (props: EditableProps) => {
               IS_FOCUSED.set(editor, true)
             }
           },
-          [attributes.onFocus]
+          [readOnly, attributes.onFocus]
         )}
         onKeyDown={useCallback(
           (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -866,7 +866,7 @@ export const Editable = (props: EditableProps) => {
               }
             }
           },
-          [attributes.onKeyDown]
+          [readOnly, attributes.onKeyDown]
         )}
         onPaste={useCallback(
           (event: React.ClipboardEvent<HTMLDivElement>) => {
@@ -885,7 +885,7 @@ export const Editable = (props: EditableProps) => {
               })
             }
           },
-          [attributes.onPaste]
+          [readOnly, attributes.onPaste]
         )}
       >
         <Children

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -433,16 +433,19 @@ export const Editable = (props: EditableProps) => {
           // Allow for passed-in styles to override anything.
           ...style,
         }}
-        onBeforeInput={useCallback((event: React.SyntheticEvent) => {
-          // COMPAT: Firefox doesn't support the `beforeinput` event, so we
-          // fall back to React's leaky polyfill instead just for it. It
-          // only works for the `insertText` input type.
-          if (IS_FIREFOX && !readOnly) {
-            event.preventDefault()
-            const text = (event as any).data as string
-            editor.exec({ type: 'insert_text', text })
-          }
-        }, [readOnly])}
+        onBeforeInput={useCallback(
+          (event: React.SyntheticEvent) => {
+            // COMPAT: Firefox doesn't support the `beforeinput` event, so we
+            // fall back to React's leaky polyfill instead just for it. It
+            // only works for the `insertText` input type.
+            if (IS_FIREFOX && !readOnly) {
+              event.preventDefault()
+              const text = (event as any).data as string
+              editor.exec({ type: 'insert_text', text })
+            }
+          },
+          [readOnly]
+        )}
         onBlur={useCallback(
           (event: React.FocusEvent<HTMLDivElement>) => {
             if (


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bugfix

#### What's the new behavior?

the onBeforeInput callback is created on first render and then never changed, this means that if the user renders `<Editable>` with a different value of the `readOnly` prop, the callback will never see the updated value.

#### How does this change work?

it correctly memoizes the callback passing `[readOnly]` in the dependencies

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3345
Reviewers: @
