### PR TITLE
Remove unsetNodes method

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -277,10 +277,14 @@ export const createEditor = (): Editor => {
 
       if (selection) {
         if (Range.isExpanded(selection)) {
-          Transforms.unsetNodes(editor, key, {
-            match: Text.isText,
-            split: true,
-          })
+          Transforms.setNodes(
+            editor,
+            { [key]: null },
+            {
+              match: Text.isText,
+              split: true,
+            }
+          )
         } else {
           const marks = { ...(Editor.marks(editor) || {}) }
           delete marks[key]

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -655,34 +655,6 @@ export const NodeTransforms = {
   },
 
   /**
-   * Unset properties on the nodes at a location.
-   */
-
-  unsetNodes(
-    editor: Editor,
-    props: string | string[],
-    options: {
-      at?: Location
-      match?: (node: Node) => boolean
-      mode?: 'all' | 'highest' | 'lowest'
-      split?: boolean
-      voids?: boolean
-    } = {}
-  ) {
-    if (!Array.isArray(props)) {
-      props = [props]
-    }
-
-    const obj = {}
-
-    for (const key of props) {
-      obj[key] = null
-    }
-
-    Transforms.setNodes(editor, obj, options)
-  },
-
-  /**
    * Unwrap the nodes at a location from a parent node, splitting the parent if
    * necessary to ensure that only the content in the range is unwrapped.
    */

--- a/packages/slate/test/transforms/unsetNodes/text/text.js
+++ b/packages/slate/test/transforms/unsetNodes/text/text.js
@@ -1,10 +1,10 @@
 /** @jsx jsx */
 
-import { Transforms, Text } from 'slate'
+import { Text, Transforms } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.unsetNodes(editor, 'key', { match: Text.isText })
+  Transforms.setNodes(editor, { key: null }, { match: Text.isText })
 }
 
 export const input = (


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Simplifying the API

#### What's the new behavior?

Removes the method `unsetNodes` because the same functionality is available using `setNodes` with a `null` value

#### How does this change work?

Removes the method and changes any uses of the method to use the `setNodes` method instead

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3343 
Reviewers: @ianstormtaylor 
