### PR TITLE
Use lodash throttle instead of debounce for updating selection change

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -14,9 +14,8 @@
     "dist/"
   ],
   "dependencies": {
-    "@types/debounce": "^1.2.0",
     "@types/is-hotkey": "^0.1.1",
-    "debounce": "^1.2.0",
+    "@types/lodash": "^4.14.149",
     "direction": "^1.0.3",
     "is-hotkey": "^0.1.6",
     "is-plain-object": "^3.0.0",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -20,6 +20,7 @@
     "direction": "^1.0.3",
     "is-hotkey": "^0.1.6",
     "is-plain-object": "^3.0.0",
+    "lodash": "^4.17.4",
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "devDependencies": {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   Transforms,
 } from 'slate'
-import debounce from 'debounce'
+import throttle from 'lodash/throttle'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
 import Children from './children'
@@ -363,7 +363,7 @@ export const Editable = (props: EditableProps) => {
   // released. This causes issues in situations where another change happens
   // while a selection is being dragged.
   const onDOMSelectionChange = useCallback(
-    debounce(() => {
+    throttle(() => {
       if (!readOnly && !state.isComposing && !state.isUpdatingSelection) {
         const { activeElement } = window.document
         const el = ReactEditor.toDOMNode(editor, editor)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,11 +2472,6 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@types/debounce@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
-  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
-
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -4258,11 +4253,6 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
-
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Switched slate to use `lodash/throttle` instead of `debounce` package for selection changes in slate.

#### How does this change work?

I just switched the method but the main change is the throttle will execute on the leading and trailing edge of the call while debounce only executed on the trailing edge. This means that the initial change was not reflected immediately causing some bugs when we grab the selection.

NOTE: I'm not experienced with typescript. I added `@types/lodash` package but am not sure if I did this properly, whether I grabbed the right version, or whether it's necessary at all.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3338 
Reviewers: @ianstormtaylor 
