### PR TITLE
fix: Slate editor props

### DIFF
--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -7,7 +7,7 @@ import { HistoryEditor } from './history-editor'
  * editor as operations are applied to it, using undo and redo stacks.
  */
 
-export const withHistory = <T>(editor: T): T & HistoryEditor => {
+export const withHistory = <T extends Editor>(editor: T): T & HistoryEditor => {
   const e = editor as HistoryEditor
   const { apply } = e
   e.history = { undos: [], redos: [] }

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -7,8 +7,8 @@ import { HistoryEditor } from './history-editor'
  * editor as operations are applied to it, using undo and redo stacks.
  */
 
-export const withHistory = <T extends Editor>(editor: T): T & HistoryEditor => {
-  const e = editor as HistoryEditor
+export const withHistory = <T extends Editor>(editor: T) => {
+  const e = editor as T & HistoryEditor
   const { apply } = e
   e.history = { undos: [], redos: [] }
 

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -7,7 +7,7 @@ import { HistoryEditor } from './history-editor'
  * editor as operations are applied to it, using undo and redo stacks.
  */
 
-export const withHistory = (editor: Editor): HistoryEditor => {
+export const withHistory = <T>(editor: T): T & HistoryEditor => {
   const e = editor as HistoryEditor
   const { apply } = e
   e.history = { undos: [], redos: [] }

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import { Node } from 'slate'
+import { Editor, Node } from 'slate'
 
 import { ReactEditor } from '../plugin/react-editor'
 import { FocusedContext } from '../hooks/use-focused'
@@ -13,7 +13,7 @@ import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
  */
 
 export const Slate = (props: {
-  editor: ReactEditor
+  editor: Editor
   value: Node[]
   children: React.ReactNode
   onChange: (value: Node[]) => void

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import { Editor, Node } from 'slate'
+import { Node } from 'slate'
 
 import { ReactEditor } from '../plugin/react-editor'
 import { FocusedContext } from '../hooks/use-focused'
@@ -13,7 +13,7 @@ import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
  */
 
 export const Slate = (props: {
-  editor: Editor
+  editor: ReactEditor
   value: Node[]
   children: React.ReactNode
   onChange: (value: Node[]) => void

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -9,7 +9,7 @@ import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/weak-maps'
  * `withReact` adds React and DOM specific behaviors to the editor.
  */
 
-export const withReact = <T>(editor: T): T & ReactEditor => {
+export const withReact = <T extends Editor>(editor: T): T & ReactEditor => {
   const e = editor as ReactEditor
   const { apply, onChange } = e
 

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -9,8 +9,8 @@ import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/weak-maps'
  * `withReact` adds React and DOM specific behaviors to the editor.
  */
 
-export const withReact = <T extends Editor>(editor: T): T & ReactEditor => {
-  const e = editor as ReactEditor
+export const withReact = <T extends Editor>(editor: T) => {
+  const e = editor as T & ReactEditor
   const { apply, onChange } = e
 
   e.apply = (op: Operation) => {

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -9,7 +9,7 @@ import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/weak-maps'
  * `withReact` adds React and DOM specific behaviors to the editor.
  */
 
-export const withReact = (editor: Editor): ReactEditor => {
+export const withReact = <T>(editor: T): T & ReactEditor => {
   const e = editor as ReactEditor
   const { apply, onChange } = e
 


### PR DESCRIPTION

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

 TS2322: Type 'Editor' is not assignable to type 'ReactEditor'.