### PR TITLE
allow to get ref on the contentEditable div

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -76,6 +76,7 @@ export type EditableProps = {
   readOnly?: boolean
   role?: string
   style?: React.CSSProperties
+  innerRef?: React.Ref<HTMLDivElement>
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   as?: React.ElementType
@@ -95,11 +96,12 @@ export const Editable = (props: EditableProps) => {
     renderElement,
     renderLeaf,
     style = {},
+    innerRef,
     as: Component = 'div',
     ...attributes
   } = props
   const editor = useSlate()
-  const ref = useRef<HTMLDivElement>(null)
+  const ref = innerRef || useRef<HTMLDivElement>(null)
 
   // Update internal state on each render.
   IS_READ_ONLY.set(editor, readOnly)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

It is now possible to pass a `innerRef` prop to the `<Editable>` component, so the parent can e.g. programmatically call `ref.current.focus()` to focus the editor

#### How does this change work?

The editable component uses the passed innerRef or, if none, its own like in the previous version

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3360
Reviewers: @ianstormtaylor 

NB @ianstormtaylor I've never used typescript, so please check that my changes are indeed correct (lint passes though...). There's also a little catch: to make the focus work as in slate 0.4x I have to save the selection before putting the editor in read-only mode and then restore it before calling `focus()`. this is because I click on a custom element inside the document, no idea if it happens in other circumstances, so I wonder is it could be useful to save/restore selection automatically when switching the `readOnly` prop




