### PR TITLE
feat: delete current line when deleting backward with line unit

### DIFF
--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -15,14 +15,14 @@ export const withReact = <T extends Editor>(editor: T) => {
   const e = editor as T & ReactEditor
   const { apply, onChange, deleteBackward } = e
 
-  e.deleteBackward = (unit) => {
+  e.deleteBackward = unit => {
     if (unit !== 'line') {
       return deleteBackward(unit)
     }
 
     if (editor.selection && Range.isCollapsed(editor.selection)) {
       const parentBlockEntry = Editor.above(editor, {
-        match: (n) => Editor.isBlock(editor, n),
+        match: n => Editor.isBlock(editor, n),
         at: editor.selection,
       })
 
@@ -108,7 +108,7 @@ export const withReact = <T extends Editor>(editor: T) => {
     let attach = contents.childNodes[0] as HTMLElement
 
     // Make sure attach is non-empty, since empty nodes will not get copied.
-    contents.childNodes.forEach((node) => {
+    contents.childNodes.forEach(node => {
       if (node.textContent && node.textContent.trim() !== '') {
         attach = node as HTMLElement
       }
@@ -136,7 +136,7 @@ export const withReact = <T extends Editor>(editor: T) => {
     // Remove any zero-width space spans from the cloned DOM so that they don't
     // show up elsewhere when pasted.
     Array.from(contents.querySelectorAll('[data-slate-zero-width]')).forEach(
-      (zw) => {
+      zw => {
         const isNewline = zw.getAttribute('data-slate-zero-width') === 'n'
         zw.textContent = isNewline ? '\n' : ''
       }

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -21,16 +21,17 @@ export const withReact = <T extends Editor>(editor: T) => {
     }
 
     if (editor.selection && Range.isCollapsed(editor.selection)) {
-      const parentBlockElement = Editor.above(editor, {
+      const parentBlockEntry = Editor.above(editor, {
         match: (n) => Editor.isBlock(editor, n),
         at: editor.selection,
       })
 
-      if (parentBlockElement) {
+      if (parentBlockEntry) {
+        const [, parentBlockPath] = parentBlockEntry
         const parentElementRange = Editor.range(
           editor,
-          parentBlockElement[1],
-          editor.selection
+          parentBlockPath,
+          editor.selection.anchor
         )
 
         const currentLineRange = findCurrentLineRange(e, parentElementRange)

--- a/packages/slate-react/src/utils/lines.ts
+++ b/packages/slate-react/src/utils/lines.ts
@@ -2,7 +2,7 @@
  * Utilities for single-line deletion
  */
 
-import { Range, Transforms, Editor } from 'slate'
+import { Range, Editor } from 'slate'
 import { ReactEditor } from '..'
 
 const doRectsIntersect = (rect: DOMRect, compareRect: DOMRect) => {

--- a/packages/slate-react/src/utils/lines.ts
+++ b/packages/slate-react/src/utils/lines.ts
@@ -1,0 +1,79 @@
+/**
+ * Utilities for single-line deletion
+ */
+
+import { Range, Transforms, Editor } from 'slate'
+import { ReactEditor } from '..'
+
+const doRectsIntersect = (rect: DOMRect, compareRect: DOMRect) => {
+  const middle = (compareRect.top + compareRect.bottom) / 2
+
+  return rect.top <= middle && rect.bottom >= middle
+}
+
+const areRangesSameLine = (
+  editor: ReactEditor,
+  range1: Range,
+  range2: Range
+) => {
+  const rect1 = ReactEditor.toDOMRange(editor, range1).getBoundingClientRect()
+  const rect2 = ReactEditor.toDOMRange(editor, range2).getBoundingClientRect()
+
+  return doRectsIntersect(rect1, rect2) && doRectsIntersect(rect2, rect1)
+}
+
+/**
+ * A helper utility that returns the end portion of a `Range`
+ * which is located on a single line.
+ *
+ * @param {Editor} editor The editor object to compare against
+ * @param {Range} parentRange The parent range to compare against
+ * @returns {Range} A valid portion of the parentRange which is one a single line
+ */
+export const findCurrentLineRange = (
+  editor: ReactEditor,
+  parentRange: Range
+): Range => {
+  const parentRangeBoundary = Editor.range(editor, Range.end(parentRange))
+  const positions = Array.from(Editor.positions(editor, { at: parentRange }))
+
+  let left = 0
+  let right = positions.length
+  let middle = Math.floor(right / 2)
+
+  if (
+    areRangesSameLine(
+      editor,
+      Editor.range(editor, positions[left]),
+      parentRangeBoundary
+    )
+  ) {
+    return Editor.range(editor, positions[left], parentRangeBoundary)
+  }
+
+  if (positions.length < 2) {
+    return Editor.range(
+      editor,
+      positions[positions.length - 1],
+      parentRangeBoundary
+    )
+  }
+
+  while (middle !== positions.length && middle !== left) {
+    if (
+      areRangesSameLine(
+        editor,
+        Editor.range(editor, positions[middle]),
+        parentRangeBoundary
+      )
+    ) {
+      right = middle
+    } else {
+      left = middle
+    }
+
+    middle = Math.floor((left + right) / 2)
+  }
+
+  return Editor.range(editor, positions[right], parentRangeBoundary)
+}


### PR DESCRIPTION
#### New Feature

This PR resolves #1623 and allows a `deleteBackward({ unit: 'line' })` to delete the current line.

#### What's the new behavior?

This PR mimics native text editor functionality and allows the `CMD + BACKSPACE` or (`deleteBackward({ unit: 'line' })` command) to delete the current line where the selection lives.

##### Before

![before](https://user-images.githubusercontent.com/4030377/71205122-9f197900-2256-11ea-8709-e71d44a5b405.gif)

##### After

![delete_backward](https://user-images.githubusercontent.com/4030377/71205130-a17bd300-2256-11ea-8384-4674c0b2557a.gif)

#### How does this change work?

A quick highlight of the logic for this addition:

1. Runs during the `deleteBackward` command is ran with `unit='line'`
2. The editor must have a selection value that is collapsed
3. It then finds a parent block element
4. If a parent element exists it will determine a `Range` for the current line
  - This range is found by getting an array of valid positions within the parent element
  - We then compare the `BoundingClientRect` of positions against the current selection to find the maximum range which is on the same line
  - This uses binary search to make this reasonably efficient
5. If that range is not collapsed (i.e. selection is at beginning of line) it will delete the range

The plugin API has changed a few times since I've started this PR 😄so if there are any better ways to gather positions, ranges, etc. please let me know!

#### Testing

There are currently no tests for `slate-react` and this logic requires a DOM environment to validate so I'm not sure if this can be tested fully.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

N/A

Fixes: #1623
