### PR TITLE
Moved decorator calls for Elements to inside the memoized Element

### DIFF
--- a/packages/slate-react/src/components/children.tsx
+++ b/packages/slate-react/src/components/children.tsx
@@ -41,23 +41,16 @@ const Children = (props: {
     const n = node.children[i] as Descendant
     const key = ReactEditor.findKey(editor, n)
     const range = Editor.range(editor, p)
+
     const sel = selection && Range.intersection(range, selection)
-    const ds = decorate([n, p])
-
-    for (const dec of decorations) {
-      const d = Range.intersection(dec, range)
-
-      if (d) {
-        ds.push(d)
-      }
-    }
 
     if (Element.isElement(n)) {
       children.push(
         <ElementComponent
           decorate={decorate}
-          decorations={ds}
+          decorations={decorations}
           element={n}
+          path={p}
           key={key.id}
           renderElement={renderElement}
           renderLeaf={renderLeaf}
@@ -65,6 +58,15 @@ const Children = (props: {
         />
       )
     } else {
+      const ds = decorate([n, p])
+
+      for (const dec of decorations) {
+        const d = Range.intersection(dec, range)
+
+        if (d) {
+          ds.push(d)
+        }
+      }
       children.push(
         <TextComponent
           decorations={ds}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Feature

#### What's the new behavior?
The need for Element-level decorators is demonstrated by the GIF below, where a search term is highlighted across multiple children of an Element. 
![element-decorator](https://user-images.githubusercontent.com/59033338/71297777-2e24af00-2385-11ea-8ffc-6008a26d98f4.gif)

In the original example this was also possible, but it would not scale, as the Element-level decorator would be called on any change.

#### How does this change work?
Decorator calls used to be called regardless of whether an Element had changed. This change moves the decorator call to inside the memoized Element. This makes it more efficient to implement Element-level decorators.

An important side-effect is that render useCallback hooks (such as those used for renderLeaf) require the decorators as callback dependencies.

#### Have you checked that...?

- [ ] The new code matches the existing patterns and styles. **Not sure about the typing at slate-react/src/components/element.tsx:50 , advice is welcome**
- [X ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3352 , though it's still not possible to decorate siblings, the need for this might gone, as we can efficiently decorate Elements and their children.
Reviewers: @ianstormtaylor 
