### PR TITLE
Firefox: fix wrong selection with double click

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -516,10 +516,15 @@ export const ReactEditor = {
       const isStart = Editor.isStart(editor, focus, focus.path)
 
       if (isEnd) {
-        anchor = Editor.after(editor, anchor)
+        const after = Editor.after(editor, anchor)
+
+        // Editor.after() might return undefined
+        anchor = after || anchor
       }
       if (isStart) {
-        focus = Editor.before(editor, focus)
+        const before = Editor.before(editor, focus)
+
+        focus = before || focus
       }
     }
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -492,9 +492,9 @@ export const ReactEditor = {
      *
      * { type: 'paragraph',
      *   children: [
-     *     { text: 'foo' },
+     *     { text: 'foo ' },
      *     { text: 'bar' },
-     *     { text: 'baz' }
+     *     { text: ' baz' }
      *   ]
      * }
      *
@@ -505,7 +505,7 @@ export const ReactEditor = {
      *
      * while on firefox will create this range:
      *
-     * anchor -> [0,0] offset 3
+     * anchor -> [0,0] offset 4
      * focus  -> [0,2] offset 0
      *
      * let's try to fix it...


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bugfix

#### What's the new behavior?

on firefox, when double clicking on a word which is a whole node, the selection is adjusted so that an inline style can be applied correctly

#### How does this change work?

on firefox, when the selection isn't collapsed, the range is adjusted so that:
1) if the anchor is on the end edge of a node, it is moved to the start edge of the next node
2) if the focux is on the start edge of a node, it is moved to the end edge of the previous node

this makes the range match what happens on chrome and avoid applying inline styles to unselected text

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3336
Reviewers: @ianstormtaylor 
