### PR TITLE
remove `editor.exec` from example code

### DIFF
--- a/docs/walkthroughs/02-adding-event-handlers.md
+++ b/docs/walkthroughs/02-adding-event-handlers.md
@@ -75,7 +75,7 @@ const App = () => {
             // Prevent the ampersand character from being inserted.
             event.preventDefault()
             // Execute a command to insert text when the event occurs.
-            editor.exec({ type: 'insert_text', text: 'and' })
+            Editor.insertText(editor, 'and')
           }
         }}
       />


### PR DESCRIPTION
replace the `editor.exec` call with the new command method.

#### Is this adding or improving a _feature_ or fixing a _bug_?
bugfix? - updating the documentation.


