### PR TITLE
fix: update incorrect link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,7 +118,7 @@ If you have an idea for an example that shows a common use case, pull request it
 
 ### Documentation
 
-If you're using Slate for the first time, check out the [Getting Started](http://docs.slatejs.org/walkthroughs/installing-slate) walkthroughs and the [Concepts](http://docs.slatejs.org/concepts) to familiarize yourself with Slate's architecture and mental models.
+If you're using Slate for the first time, check out the [Getting Started](https://docs.slatejs.org/walkthroughs/01-installing-slate) walkthroughs and the [Concepts](http://docs.slatejs.org/concepts) to familiarize yourself with Slate's architecture and mental models.
 
 - [**Walkthroughs**](http://docs.slatejs.org/walkthroughs/installing-slate)
 - [**Concepts**](http://docs.slatejs.org/concepts)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug in the readme (incorrect link)

#### Have you checked that...?

- [*] The new code matches the existing patterns and styles.
- [*] The tests pass with `yarn test`.
- [*] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [*] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #incorrect link to docs in the readme
Reviewers: @ianstormtaylor 
