### PR TITLE
Bug fix: By default checklist item should be unchecked

### DIFF
--- a/site/examples/check-lists.js
+++ b/site/examples/check-lists.js
@@ -58,25 +58,24 @@ const withChecklists = editor => {
         const after = Editor.after(editor, start, { unit: 'line' })
         const afterRange = Editor.range(editor, start, after)
         const afterText = Editor.string(editor, afterRange)
+        const checklist = {
+          type: 'check-list-item',
+          checked: false,
+          children: [{ text: afterText }],
+        }
         if (afterText.length > 0) {
-          const checklist = {
-            type: 'check-list-item',
-            checked: false,
-            children: [{ text: afterText }],
-          }
           if (selection.anchor.offset === 0) {
             Transforms.delete(editor, { unit: 'line' })
             Transforms.insertNodes(editor, checklist)
+            Transforms.setSelection(editor, {
+              anchor: { path: editor.selection.anchor.path, offset: 0 },
+              focus: { path: editor.selection.anchor.path, offset: 0 },
+            })
             return
           }
           Transforms.splitNodes(editor)
           Transforms.setNodes(editor, checklist)
         } else {
-          const checklist = {
-            type: 'check-list-item',
-            checked: false,
-            children: [{ text: '' }],
-          }
           Transforms.insertNodes(editor, checklist)
         }
         return

--- a/site/examples/check-lists.js
+++ b/site/examples/check-lists.js
@@ -41,27 +41,39 @@ const withChecklists = editor => {
     })
     if (match) {
       const [matchingNode] = match
-      if (matchingNode.type !== 'paragraph') {
-        if (
-          matchingNode.children[matchingNode.children.length - 1].text
-            .length === 0
-        ) {
-          Transforms.delete(editor)
-          Transforms.insertNodes(editor, {
-            type: 'paragraph',
-            children: [{ text: '' }],
-          })
-          return
-        }
-        if (matchingNode.type === 'check-list-item') {
+      if (
+        matchingNode.children[matchingNode.children.length - 1].text.length ===
+        0
+      ) {
+        Transforms.delete(editor)
+        Transforms.insertNodes(editor, {
+          type: 'paragraph',
+          children: [{ text: '' }],
+        })
+        return
+      }
+      if (matchingNode.type === 'check-list-item') {
+        const [start] = Range.edges(editor.selection)
+        const after = Editor.after(editor, start, { unit: 'word' })
+        const afterRange = Editor.range(editor, start, after)
+        const afterText = Editor.string(editor, afterRange)
+        if (afterText.length > 0) {
+          const checklist = {
+            type: 'check-list-item',
+            checked: false,
+            children: [{ text: afterText }],
+          }
+          Transforms.splitNodes(editor)
+          Transforms.setNodes(editor, checklist)
+        } else {
           const checklist = {
             type: 'check-list-item',
             checked: false,
             children: [{ text: '' }],
           }
           Transforms.insertNodes(editor, checklist)
-          return
         }
+        return
       }
     }
     insertBreak()

--- a/site/examples/check-lists.js
+++ b/site/examples/check-lists.js
@@ -53,8 +53,9 @@ const withChecklists = editor => {
         return
       }
       if (matchingNode.type === 'check-list-item') {
-        const [start] = Range.edges(editor.selection)
-        const after = Editor.after(editor, start, { unit: 'word' })
+        const { selection } = editor
+        const [start] = Range.edges(selection)
+        const after = Editor.after(editor, start, { unit: 'line' })
         const afterRange = Editor.range(editor, start, after)
         const afterText = Editor.string(editor, afterRange)
         if (afterText.length > 0) {
@@ -62,6 +63,11 @@ const withChecklists = editor => {
             type: 'check-list-item',
             checked: false,
             children: [{ text: afterText }],
+          }
+          if (selection.anchor.offset === 0) {
+            Transforms.delete(editor, { unit: 'line' })
+            Transforms.insertNodes(editor, checklist)
+            return
           }
           Transforms.splitNodes(editor)
           Transforms.setNodes(editor, checklist)

--- a/site/examples/check-lists.js
+++ b/site/examples/check-lists.js
@@ -47,14 +47,9 @@ const withChecklists = editor => {
             .length === 0
         ) {
           Transforms.delete(editor)
-          const paragraph = {
+          Transforms.insertNodes(editor, {
             type: 'paragraph',
             children: [{ text: '' }],
-          }
-          Transforms.insertNodes(editor, paragraph)
-          Transforms.unwrapNodes(editor, {
-            match: n => n.type === 'check-list-item',
-            split: true,
           })
           return
         }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug Fix

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
As shown in the gif below:
- If the last item is checked and user presses enter then the new checklist item by default will remain unchecked
- The line-through on text is shown for the checked item and not for unchecked item
- Pressing enter on an empty checklist replaces it with a new paragraph now.

![chrome-capture-solved](https://user-images.githubusercontent.com/13781801/71413472-5ad41180-2678-11ea-8f56-62b20ff92140.gif)

[Code Sample showing new behavior](https://codesandbox.io/s/blissful-cache-qy97g)
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

<!--
Please run through this checklist for your pull request:
-->

#### Does this fix any issues or need any specific reviewers?

Fixes: #3384 

Reviewers: @ianstormtaylor 
