### PR TITLE
fix: check isContentEditable of target element in ReactEditor.hasDOMNode

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -149,15 +149,15 @@ export const ReactEditor = {
     options: { editable?: boolean } = {}
   ): boolean {
     const { editable = false } = options
-    const el = ReactEditor.toDOMNode(editor, editor)
-    let element
+    const editorEl = ReactEditor.toDOMNode(editor, editor)
+    let targetEl
 
     // COMPAT: In Firefox, reading `target.nodeType` will throw an error if
     // target is originating from an internal "restricted" element (e.g. a
     // stepper arrow on a number input). (2018/05/04)
     // https://github.com/ianstormtaylor/slate/issues/1819
     try {
-      element = (isDOMElement(target)
+      targetEl = (isDOMElement(target)
         ? target
         : target.parentElement) as HTMLElement
     } catch (err) {
@@ -168,13 +168,13 @@ export const ReactEditor = {
       }
     }
 
-    if (!element) {
+    if (!targetEl) {
       return false
     }
 
     return (
-      element.closest(`[data-slate-editor]`) === el &&
-      (!editable || element.isContentEditable)
+      targetEl.closest(`[data-slate-editor]`) === editorEl &&
+      (!editable || targetEl.isContentEditable)
     )
   },
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -157,7 +157,9 @@ export const ReactEditor = {
     // stepper arrow on a number input). (2018/05/04)
     // https://github.com/ianstormtaylor/slate/issues/1819
     try {
-      element = isDOMElement(target) ? target : target.parentElement
+      element = (isDOMElement(target)
+        ? target
+        : target.parentElement) as HTMLElement
     } catch (err) {
       if (
         !err.message.includes('Permission denied to access property "nodeType"')
@@ -172,7 +174,7 @@ export const ReactEditor = {
 
     return (
       element.closest(`[data-slate-editor]`) === el &&
-      (!editable || el.isContentEditable)
+      (!editable || element.isContentEditable)
     )
   },
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a _bug_:
```ReactEditor.hasDOMNode``` checks ```isContentEditable``` of editor element. When element with ```contentEditable={false}```, which is not exists in editor value (e.g., some helper element), get selection, ```onDOMSelectionChange``` [checks](https://github.com/ianstormtaylor/slate/blob/22d9095c39a0e201878e1df04ef5e35d4d86a596/packages/slate-react/src/components/editable.tsx#L385-L386) work incorrectly.

demo: 
- https://codesandbox.io/s/slate-reproductions-lblhy
- on official [check-lists demo](https://www.slatejs.org/examples/check-lists) page (click near the left of the checkbox):
![Kapture 2019-12-26 at 12 31 36](https://user-images.githubusercontent.com/6900732/71470331-df3fa500-27dc-11ea-9999-a48688bcd5a5.gif)


#### What's the new behavior?
```ReactEditor.hasDOMNode``` now checks ```isContentEditable``` prop of target element instead of editor element.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
