### PR TITLE
On paste

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -886,16 +886,17 @@ export const Editable = (props: EditableProps) => {
         )}
         onPaste={useCallback(
           (event: React.ClipboardEvent<HTMLDivElement>) => {
-            // COMPAT: Firefox doesn't support the `beforeinput` event, so we
-            // fall back to React's `onPaste` here instead.
             if (
-              IS_FIREFOX &&
               !readOnly &&
               hasEditableTarget(editor, event.target) &&
               !isEventHandled(event, attributes.onPaste)
             ) {
-              event.preventDefault()
-              ReactEditor.insertData(editor, event.clipboardData)
+              // COMPAT: Firefox doesn't support the `beforeinput` event, so we
+              // fall back to React's `onPaste` here instead.
+              if (IS_FIREFOX) {
+                event.preventDefault()
+                ReactEditor.insertData(editor, event.clipboardData)
+              }
             }
           },
           [readOnly, attributes.onPaste]

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -354,7 +354,7 @@ export const Editable = (props: EditableProps) => {
         }
       }
     },
-    []
+    [readOnly, propsOnDOMBeforeInput]
   )
 
   // Listen on the native `selectionchange` event to be able to update any time


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

bigfix

#### What's the new behavior?

if the user specify the `onPaste` props it is now called on every browser and not just Firefox

#### How does this change work?

it calls the `onPaste` handler on every browser and not just Firefox

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3394
Reviewers: @ianstormtaylor 
