### PR TITLE
Fixed incorrect editor usage in Embed example

### DIFF
--- a/site/examples/embeds.js
+++ b/site/examples/embeds.js
@@ -5,6 +5,7 @@ import {
   Editable,
   withReact,
   useEditor,
+  ReactEditor,
   useFocused,
   useSelected,
 } from 'slate-react'
@@ -91,7 +92,7 @@ const VideoElement = ({ attributes, children, element }) => {
               boxSizing: 'border-box',
             }}
             onChange={value => {
-              const path = editor.findPath(element)
+              const path = ReactEditor.findPath(editor, element)
               Transforms.setNodes(editor, { url: value }, { at: path })
             }}
           />


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Using the correct updated API to find Paths.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Replacing editor.findPath(element) with ReactEditor.findPath(editor, element)
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3392
Reviewers: @thesunny
