### PR TITLE
fix: incorrect unwrapping list items and quotes in MarkdownShortcuts …

### DIFF
--- a/site/examples/markdown-shortcuts.js
+++ b/site/examples/markdown-shortcuts.js
@@ -91,11 +91,16 @@ const withShortcuts = editor => {
           block.type !== 'paragraph' &&
           Point.equals(selection.anchor, start)
         ) {
-          Transforms.setNodes(editor, { type: 'paragraph' })
+          let type = block.type
+
+          if (path.length <= 2) {
+            type = 'paragraph'
+            Transforms.setNodes(editor, { type })
+          }
 
           if (block.type === 'list-item') {
-            Transforms.unwrapNodes(editor, {
-              match: n => n.type === 'bulleted-list',
+            Transforms.liftNodes(editor, {
+              match: n => n.type === type,
             })
           }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving

#### What's the new behavior?

Currently if in Markdown Shortcut example you remove second list item it will unwrap the whole list (so `<li>` elements will move to the root of the document). If you try to unwrap nested list Slate will change it to paragraph but will leave it inside list which is incorrect.

#### How does this change work?

Now if you try to remove nested list element Slate will unwrap it and if list item is not nested it will change it to paragraph and will lift it to the root of the document.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

