### PR TITLE
if work with withimages need return child type

### DIFF
--- a/site/examples/forced-layout.js
+++ b/site/examples/forced-layout.js
@@ -19,7 +19,7 @@ const withLayout = editor => {
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
-        const type = childPath[0] === 0 ? 'title' : 'paragraph'
+        const type = childPath[0] === 0 ? 'title' : child.type
 
         if (child.type !== type) {
           Transforms.setNodes(editor, { type }, { at: childPath })


### PR DESCRIPTION
if not return child type ,image will as paragraph

#### Is this adding or improving a _feature_ or fixing a _bug_?
no

#### What's the new behavior?

no

#### How does this change work?

no

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
