### PR TITLE
simplifies code contributions by automating the dev setup with gitpod.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn start
+ports:
+  - port: 3000
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - esbenp.prettier-vscode@5.7.2:uyRGbFR3U94Ki5fjjZ7aoQ==

--- a/Contributing.md
+++ b/Contributing.md
@@ -50,6 +50,18 @@ yarn install
 yarn build
 ```
 
+### Online one-click setup
+
+You can use Gitpod (an online IDE which is free for Open Source) for contributing. With a single click, it will launch a workspace and automatically: 
+
+- clone the slate repo.
+- install the dependencies.
+- run `yarn build && yarn start`.
+
+So that you can start straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/ianstormtaylor/slate/)
+
 ## Running Examples
 
 To run the examples, start by building the monorepo as described in the [Repository Setup](#repository-setup) section.

--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,9 @@
   <a href="./packages/slate/package.json">
     <img src="https://img.shields.io/npm/v/slate.svg?maxAge=3600&label=version&colorB=007ec6">
   </a>
+  <a href="https://gitpod.io#https://github.com/ianstormtaylor/slate/">
+    <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod">
+  </a>
 </p>
 <br/>
 


### PR DESCRIPTION
Hi! there :slightly_smiling_face:

This PR simplifies code contributions by adding configuration for Gitpod (A Free online VS Code like IDE). With a single click, it will launch a workspace and automatically: 

- clone the slate repo.
- install the dependencies.
- run `yarn build && yarn start`.

You can give it a try on My Fork of the repo:

https://gitpod.io/#https://github.com/nisarhassan12/slate

![image](https://user-images.githubusercontent.com/46004116/71973908-f8f7d800-3231-11ea-9438-6750afc0d1b1.png)
