### PR TITLE
Fix Paste without Formatting / Paste and Match Style producing uneditable text nodes.

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -231,7 +231,6 @@ export const Editable = (props: EditableProps) => {
         isComposing: boolean
       }
     ) => {
-      console.log('onDOMBeforeInput', event)
       if (
         !readOnly &&
         hasEditableTarget(editor, event.target) &&
@@ -888,20 +887,13 @@ export const Editable = (props: EditableProps) => {
         )}
         onPaste={useCallback(
           (event: React.ClipboardEvent<HTMLDivElement>) => {
+            // COMPAT: Firefox doesn't support the `beforeinput` event, so we
+            // fall back to React's `onPaste` here instead.
             // COMPAT: Firefox, Chrome and Safari are not emitting `beforeinput` events
             // when "paste without formatting" option is used.
             // This unfortunately needs to be handled with paste events instead.
-            if (isPlainTextOnlyPaste(event.nativeEvent) && !readOnly) {
-              event.preventDefault()
-              ReactEditor.insertData(editor, event.clipboardData)
-
-              return
-            }
-
-            // COMPAT: Firefox doesn't support the `beforeinput` event, so we
-            // fall back to React's `onPaste` here instead.
             if (
-              IS_FIREFOX &&
+              (IS_FIREFOX || isPlainTextOnlyPaste(event.nativeEvent)) &&
               !readOnly &&
               hasEditableTarget(editor, event.target) &&
               !isEventHandled(event, attributes.onPaste)

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -57,6 +57,18 @@ export const isDOMText = (value: any): value is DOMText => {
 }
 
 /**
+ * Checks whether a paste event is a plaintext-only event.
+ */
+
+export const isPlainTextOnlyPaste = (event: ClipboardEvent) => {
+  return (
+    event.clipboardData &&
+    event.clipboardData.getData('text/plain') !== '' &&
+    event.clipboardData.types.length === 1
+  )
+}
+
+/**
  * Normalize a DOM point so that it always refers to a text node.
  */
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

This fixes https://github.com/ianstormtaylor/slate/issues/3414. Basically right now Paste and Match Style type of pasting from Chrome is working properly - as well as `mod+shift+v` shortcut from other browsers.

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

Since these types of pastes are not emitting `beforeinput` events, I handle them in `paste` event handler. After that it's just a matter of simply passing them to `insertData` of `ReactEditor`. I want to minimize the surface area of change, so this behavior is triggered only for pastes having exclusively `text/plain` ClipboardData in them.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/3414
Reviewers: @
