### PR TITLE
Fix links in slate-react readme

### DIFF
--- a/packages/slate-react/Readme.md
+++ b/packages/slate-react/Readme.md
@@ -1,8 +1,8 @@
 This package contains the React-specific logic for Slate. It's separated further into a series of directories:
 
 - [**Components**](./src/components) — containing the React components for rendering Slate editors.
-- [**Constants**](./src/constants) — containing a few private constants modules.
-- [**Plugins**](./src/plugins) — containing the React-specific plugins for Slate editors.
+- [**Hooks**](./src/hooks) — containing a few React hooks for Slate editors.
+- [**Plugins**](./src/plugin) — containing the React-specific plugins for Slate editors.
 - [**Utils**](./src/utils) — containing a few private convenience modules.
 
 Feel free to poke around in each of them to learn more!


### PR DESCRIPTION
Fixed the "Plugins" link and changed the "Constants" link (a folder which no longer exists) to a "Hooks" link.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving docs

#### What's the new behavior?

The links don't 404

#### How does this change work?
...
#### Have you checked that...?

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
