### PR TITLE
Fix Getting Started links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,9 +118,9 @@ If you have an idea for an example that shows a common use case, pull request it
 
 ### Documentation
 
-If you're using Slate for the first time, check out the [Getting Started](http://docs.slatejs.org/walkthroughs/installing-slate) walkthroughs and the [Concepts](http://docs.slatejs.org/concepts) to familiarize yourself with Slate's architecture and mental models.
+If you're using Slate for the first time, check out the [Getting Started](http://docs.slatejs.org/walkthroughs) walkthroughs and the [Concepts](http://docs.slatejs.org/concepts) to familiarize yourself with Slate's architecture and mental models.
 
-- [**Walkthroughs**](http://docs.slatejs.org/walkthroughs/installing-slate)
+- [**Walkthroughs**](http://docs.slatejs.org/walkthroughs)
 - [**Concepts**](http://docs.slatejs.org/concepts)
 - [**FAQ**](http://docs.slatejs.org/general/faq)
 - [**Resources**](http://docs.slatejs.org/general/resources)


### PR DESCRIPTION
The Getting Started and Walkthroughs links both currently lead to a 404 page. The modification in this change should fix them to link to the correct location.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a documentation bug

#### What's the new behavior?

The Getting Started and Walkthroughs links on the Readme page should now correctly link to the walkthroughs

#### How does this change work?

Removed the part at the end of the URLs that probably worked at one point but does not because the URL formats have apparently changed. Linking to /walkthroughs seems to auto-redirect to the first walkthrough.

#### Have you checked that...?

- [N/A] The new code matches the existing patterns and styles.
- [N/A] The tests pass with `yarn test`.
- [N/A] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [N/A] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
