### PR TITLE
Fix inputs from not being able to be used within void nodes in Firefox

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -442,11 +442,16 @@ export const Editable = (props: EditableProps) => {
           ...style,
         }}
         onBeforeInput={useCallback(
-          (event: React.SyntheticEvent) => {
+          (event: React.FormEvent<HTMLDivElement>) => {
             // COMPAT: Firefox doesn't support the `beforeinput` event, so we
             // fall back to React's leaky polyfill instead just for it. It
             // only works for the `insertText` input type.
-            if (IS_FIREFOX && !readOnly) {
+            if (
+              IS_FIREFOX &&
+              !readOnly &&
+              !isEventHandled(event, attributes.onBeforeInput) &&
+              hasEditableTarget(editor, event.target)
+            ) {
               event.preventDefault()
               const text = (event as any).data as string
               Editor.insertText(editor, text)

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -149,15 +149,17 @@ export const ReactEditor = {
     options: { editable?: boolean } = {}
   ): boolean {
     const { editable = false } = options
-    const el = ReactEditor.toDOMNode(editor, editor)
-    let element
+    const editorEl = ReactEditor.toDOMNode(editor, editor)
+    let targetEl
 
     // COMPAT: In Firefox, reading `target.nodeType` will throw an error if
     // target is originating from an internal "restricted" element (e.g. a
     // stepper arrow on a number input). (2018/05/04)
     // https://github.com/ianstormtaylor/slate/issues/1819
     try {
-      element = isDOMElement(target) ? target : target.parentElement
+      targetEl = (isDOMElement(target)
+        ? target
+        : target.parentElement) as HTMLElement
     } catch (err) {
       if (
         !err.message.includes('Permission denied to access property "nodeType"')
@@ -166,13 +168,13 @@ export const ReactEditor = {
       }
     }
 
-    if (!element) {
+    if (!targetEl) {
       return false
     }
 
     return (
-      element.closest(`[data-slate-editor]`) === el &&
-      (!editable || el.isContentEditable)
+      targetEl.closest(`[data-slate-editor]`) === editorEl &&
+      (!editable || targetEl.isContentEditable)
     )
   },
 

--- a/site/examples/editable-voids.js
+++ b/site/examples/editable-voids.js
@@ -1,0 +1,154 @@
+import React, { useState, useMemo } from 'react'
+import { Transforms, createEditor } from 'slate'
+import { Slate, Editable, useEditor, withReact } from 'slate-react'
+import { withHistory } from 'slate-history'
+import { css } from 'emotion'
+
+import RichTextEditor from './richtext'
+import { Button, Icon, Toolbar } from '../components'
+
+const EditableVoidsExample = () => {
+  const [value, setValue] = useState(initialValue)
+  const editor = useMemo(
+    () => withEditableVoids(withHistory(withReact(createEditor()))),
+    []
+  )
+
+  return (
+    <Slate editor={editor} value={value} onChange={setValue}>
+      <Toolbar>
+        <InsertEditableVoidButton />
+      </Toolbar>
+
+      <Editable
+        renderElement={props => <Element {...props} />}
+        placeholder="Enter some text..."
+      />
+    </Slate>
+  )
+}
+
+const withEditableVoids = editor => {
+  const { isVoid } = editor
+
+  editor.isVoid = element => {
+    return element.type === 'editable-void' ? true : isVoid(element)
+  }
+
+  return editor
+}
+
+const insertEditableVoid = editor => {
+  const text = { text: '' }
+  const voidNode = { type: 'editable-void', children: [text] }
+  Transforms.insertNodes(editor, voidNode)
+}
+
+const Element = props => {
+  const { attributes, children, element } = props
+
+  switch (element.type) {
+    case 'editable-void':
+      return <EditableVoidElement {...props} />
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+const unsetWidthStyle = css`
+  width: unset;
+`
+
+const EditableVoidElement = ({ attributes, children, element }) => {
+  const [inputValue, setInputValue] = useState('')
+
+  return (
+    // Need contentEditable=false or Firefox has issues with certain input types.
+    <div {...attributes} contentEditable={false}>
+      <div
+        className={css`
+          box-shadow: 0 0 0 3px #ddd;
+          padding: 8px;
+        `}
+      >
+        <h4>Name:</h4>
+        <input
+          className={css`
+            margin: 8px 0;
+          `}
+          type="text"
+          value={inputValue}
+          onChange={e => {
+            setInputValue(e.target.value)
+          }}
+        />
+        <h4>Left or right handed:</h4>
+        <input
+          className={unsetWidthStyle}
+          type="radio"
+          name="handedness"
+          value="left"
+        />{' '}
+        Left
+        <br />
+        <input
+          className={unsetWidthStyle}
+          type="radio"
+          name="handedness"
+          value="right"
+        />{' '}
+        Right
+        <h4>Tell us about yourself:</h4>
+        <div
+          className={css`
+            padding: 20px;
+            border: 2px solid #ddd;
+          `}
+        >
+          <RichTextEditor />
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+const InsertEditableVoidButton = () => {
+  const editor = useEditor()
+  return (
+    <Button
+      onMouseDown={event => {
+        event.preventDefault()
+        insertEditableVoid(editor)
+      }}
+    >
+      <Icon>add</Icon>
+    </Button>
+  )
+}
+
+const initialValue = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text:
+          'In addition to nodes that contain editable text, you can insert void nodes, which can also contain editable elements, inputs, or an entire other Slate editor.',
+      },
+    ],
+  },
+  {
+    type: 'editable-void',
+    children: [{ text: '' }],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+]
+
+export default EditableVoidsExample

--- a/site/pages/examples/[example].js
+++ b/site/pages/examples/[example].js
@@ -9,6 +9,7 @@ import ErrorBoundary from 'react-error-boundary'
 import { Icon } from '../../components'
 
 import CheckLists from '../../examples/check-lists'
+import EditableVoids from '../../examples/editable-voids'
 import Embeds from '../../examples/embeds'
 import ForcedLayout from '../../examples/forced-layout'
 import HoveringToolbar from '../../examples/hovering-toolbar'
@@ -27,6 +28,7 @@ import Tables from '../../examples/tables'
 
 const EXAMPLES = [
   ['Checklists', CheckLists, 'check-lists'],
+  ['Editable Voids', EditableVoids, 'editable-voids'],
   ['Embeds', Embeds, 'embeds'],
   ['Forced Layout', ForcedLayout, 'forced-layout'],
   ['Hovering Toolbar', HoveringToolbar, 'hovering-toolbar'],


### PR DESCRIPTION
This change builds on top of PR #3389 (I can rebase when it is merged since I copied into the commit).

That PR allows void nodes to have any kind of element in them and the editor events will not respond to them if the void node renders with `contentEditable={false}`, this will treat all it's children as not editable unless specified otherwise, therefore events within the void node will be treated like they are outside the editor. Currently they cannot have inputs or any other content editable areas or the editor event handlers try to interpret them as part of the main editor document, when if they are in void nodes with `contentEditable` turned off, they should be treated as isolated islands.

This behavior could be achieved with the pre 0.50.x versions, therefore some of our projects will have regressions.

That PR will fix #3425 and #3426.

This PR fixes a bug specific to Firefox where input events within a void nodes prevent inputs from working.

I included an example of having these isolated void nodes in case it's of value for future testing and and to serve as an example.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

See the example. A void node can be made to be completely isolated.

#### How does this change work?

The previous PR would stop all events on the editor from responding to non editable targets. This CR will stop the Firefox specific onBeforeInput event from firing in the same case.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3425, #3426, the other PR (#3389) listed above fixes it mostly, this makes it work in Firefox to resolve the same issues.

Reviewers: @ianstormtaylor 
