### PR TITLE
Fix element memoization checks. Allows placeholder to change dynamically based on the props. Allows renderLeaf to be memoized.

### DIFF
--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -14,6 +14,7 @@ import {
   NODE_TO_INDEX,
   KEY_TO_ELEMENT,
 } from '../utils/weak-maps'
+import { isDecoratorRangeListEqual } from '../utils/range-list'
 import { RenderElementProps, RenderLeafProps } from './editable'
 
 /**
@@ -136,7 +137,7 @@ const MemoizedElement = React.memo(Element, (prev, next) => {
     prev.element === next.element &&
     prev.renderElement === next.renderElement &&
     prev.renderLeaf === next.renderLeaf &&
-    isRangeListEqual(prev.decorations, next.decorations) &&
+    isDecoratorRangeListEqual(prev.decorations, next.decorations) &&
     (prev.selection === next.selection ||
       (!!prev.selection &&
         !!next.selection &&
@@ -157,31 +158,6 @@ export const DefaultElement = (props: RenderElementProps) => {
       {children}
     </Tag>
   )
-}
-
-/**
- * Check if a list of ranges is equal to another.
- *
- * PERF: this requires the two lists to also have the ranges inside them in the
- * same order, but this is an okay constraint for us since decorations are
- * kept in order, and the odd case where they aren't is okay to re-render for.
- */
-
-const isRangeListEqual = (list: Range[], another: Range[]): boolean => {
-  if (list.length !== another.length) {
-    return false
-  }
-
-  for (let i = 0; i < list.length; i++) {
-    const range = list[i]
-    const other = another[i]
-
-    if (!Range.equals(range, other)) {
-      return false
-    }
-  }
-
-  return true
 }
 
 export default MemoizedElement

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -68,7 +68,9 @@ const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
     next.text === prev.text &&
-    Text.matches(next.leaf, prev.leaf)
+    next.leaf.text === prev.leaf.text &&
+    Text.matches(next.leaf, prev.leaf) &&
+    next.leaf[PLACEHOLDER_SYMBOL] === prev.leaf[PLACEHOLDER_SYMBOL]
   )
 })
 

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -10,6 +10,7 @@ import {
   NODE_TO_ELEMENT,
   ELEMENT_TO_NODE,
 } from '../utils/weak-maps'
+import { isDecoratorRangeListEqual } from '../utils/range-list'
 
 /**
  * Text.
@@ -68,7 +69,8 @@ const MemoizedText = React.memo(Text, (prev, next) => {
     next.parent === prev.parent &&
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
-    next.text === prev.text
+    next.text === prev.text &&
+    isDecoratorRangeListEqual(next.decorations, prev.decorations)
   )
 })
 

--- a/packages/slate-react/src/utils/range-list.ts
+++ b/packages/slate-react/src/utils/range-list.ts
@@ -1,0 +1,43 @@
+import { Range } from 'slate'
+import { PLACEHOLDER_SYMBOL } from './weak-maps'
+
+export const shallowCompare = (obj1: {}, obj2: {}) =>
+  Object.keys(obj1).length === Object.keys(obj2).length &&
+  Object.keys(obj1).every(
+    key => obj2.hasOwnProperty(key) && obj1[key] === obj2[key]
+  )
+
+/**
+ * Check if a list of decorator ranges are equal to another.
+ *
+ * PERF: this requires the two lists to also have the ranges inside them in the
+ * same order, but this is an okay constraint for us since decorations are
+ * kept in order, and the odd case where they aren't is okay to re-render for.
+ */
+
+export const isDecoratorRangeListEqual = (
+  list: Range[],
+  another: Range[]
+): boolean => {
+  if (list.length !== another.length) {
+    return false
+  }
+
+  for (let i = 0; i < list.length; i++) {
+    const range = list[i]
+    const other = another[i]
+
+    const { anchor: rangeAnchor, focus: rangeFocus, ...rangeOwnProps } = range
+    const { anchor: otherAnchor, focus: otherFocus, ...otherOwnProps } = other
+
+    if (
+      !Range.equals(range, other) ||
+      range[PLACEHOLDER_SYMBOL] !== other[PLACEHOLDER_SYMBOL] ||
+      !shallowCompare(rangeOwnProps, otherOwnProps)
+    ) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -76,7 +76,7 @@ export const Text = {
         continue
       }
 
-      if (text[key] !== props[key]) {
+      if (!text.hasOwnProperty(key) || text[key] !== props[key]) {
         return false
       }
     }

--- a/packages/slate/test/interfaces/Text/matches/undefined-false.js
+++ b/packages/slate/test/interfaces/Text/matches/undefined-false.js
@@ -1,0 +1,12 @@
+import { Text } from 'slate'
+
+export const input = {
+  text: { foo: undefined },
+  props: { bar: undefined },
+}
+
+export const test = ({ text, props }) => {
+  return Text.matches(text, props)
+}
+
+export const output = false

--- a/packages/slate/test/interfaces/Text/matches/undefined-true.js
+++ b/packages/slate/test/interfaces/Text/matches/undefined-true.js
@@ -1,0 +1,12 @@
+import { Text } from 'slate'
+
+export const input = {
+  text: { foo: undefined },
+  props: { foo: undefined },
+}
+
+export const test = ({ text, props }) => {
+  return Text.matches(text, props)
+}
+
+export const output = true


### PR DESCRIPTION
There are bugs with the memoization checks in the element, text, and leaf components.

The `renderLeaf` function to the Editable cannot be memoized as if it is, the rendering of leaves are not reconciled correctly on the DOM as the old node is allowed to stay despite the leaf being different. This is because the leaf element does not actually check it's text content in the memoization check.

The placeholder decorator is not re-rendered when the placeholder text is changed, this is because the element, leaf and text components do not check the decorator properties.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug.

#### What's the new behavior?

The appropriate components check in the memoization comparison if two decorator range list items are placeholders, and if they are, if their text equals.

![Demo](https://media.giphy.com/media/SwJAwvKljEhJUWvgK2/giphy.gif)

You will also be able to memoize the `renderLeaf` function when using decorators.

#### How does this change work?

Checking the decorator props, and the leaf checking it's text is the same in the memoization checks.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3423, #3432, #3447
Reviewers: @
