### PR TITLE
Fix pasting plain text with newlines

### DIFF
--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -69,12 +69,12 @@ export const withReact = <T extends Editor>(editor: T) => {
     const text = data.getData('text/plain')
 
     if (text) {
-      const lines = text.split('\n')
+      const lines = text.split(/\r\n|\r|\n/)
       let split = false
 
       for (const line of lines) {
         if (split) {
-          Transforms.splitNodes(e)
+          Transforms.splitNodes(e, { always: true })
         }
 
         Transforms.insertText(e, line)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

Fixes https://github.com/ianstormtaylor/slate/issues/1681

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->
Before:
![slate_before](https://user-images.githubusercontent.com/1505923/73381485-d5093e80-4293-11ea-9f8f-91b7b350ecba.gif)

After:
![slate_after](https://user-images.githubusercontent.com/1505923/73381494-d9cdf280-4293-11ea-98f8-58ececbadcbd.gif)

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->
This PR fixes two issues:

1. The issue described in #1681. Plain text with `\r` or `\r\n` newlines would not be pasted into slate with newlines properly.
2. Pasting plain text content with normal `\n` newlines was also not working. This was because `Transform.splitNodes` was not splitting the paragraph after each newline. Adding `{ always: true }` fixes this.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
