### PR TITLE
[WIP] Use Generics for top-level functions 

### DIFF
--- a/docs/concepts/01-interfaces.md
+++ b/docs/concepts/01-interfaces.md
@@ -5,7 +5,6 @@ Slate works with pure JSON objects. All it requires is that those JSON objects c
 ```ts
 interface Text {
   text: string
-  [key: string]: any
 }
 ```
 
@@ -22,7 +21,6 @@ To take another example, the `Element` node interface in Slate is:
 ```ts
 interface Element {
   children: Node[]
-  [key: string]: any
 }
 ```
 

--- a/docs/concepts/02-nodes.md
+++ b/docs/concepts/02-nodes.md
@@ -55,7 +55,6 @@ Elements make up the middle layers of a richtext document. They are the nodes th
 ```ts
 interface Element {
   children: Node[]
-  [key: string]: any
 }
 ```
 
@@ -126,7 +125,6 @@ Text nodes are the lowest-level nodes in the tree, containing the text content o
 ```ts
 interface Text {
   text: string
-  [key: string]: any
 }
 ```
 

--- a/docs/concepts/03-locations.md
+++ b/docs/concepts/03-locations.md
@@ -37,7 +37,6 @@ Points are slightly more specific than paths, and contain an `offset` into a spe
 interface Point {
   path: Path
   offset: number
-  [key: string]: any
 }
 ```
 
@@ -71,7 +70,6 @@ Ranges are a way to refer not just to a single point in the document, but to a w
 interface Range {
   anchor: Point
   focus: Point
-  [key: string]: any
 }
 ```
 

--- a/docs/concepts/06-editor.md
+++ b/docs/concepts/06-editor.md
@@ -8,7 +8,6 @@ interface Editor {
   selection: Range | null
   operations: Operation[]
   marks: Record<string, any> | null
-  [key: string]: any
 
   // Schema-specific node behaviors.
   isInline: (element: Element) => boolean

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -58,13 +58,15 @@ export interface Editor {
   removeMark: (key: string) => void
 }
 
+interface EditorLike extends Editor {}
+
 export const Editor = {
   /**
    * Get the ancestor above a location in the document.
    */
 
-  above<T extends Ancestor>(
-    editor: Editor,
+  above<A extends Ancestor>(
+    editor: EditorLike,
     options: {
       at?: Location
       match?: NodeMatch<T>
@@ -105,7 +107,7 @@ export const Editor = {
    * `editor.marks` property instead, and applied when text is inserted next.
    */
 
-  addMark(editor: Editor, key: string, value: any): void {
+  addMark<E extends Editor, El extends Element>(editor: Editor, key: string, value: any): void {
     editor.addMark(key, value)
   },
 
@@ -113,7 +115,7 @@ export const Editor = {
    * Get the point after a location.
    */
 
-  after(
+  after<E extends Editor, El extends Element>(
     editor: Editor,
     at: Location,
     options: {
@@ -147,7 +149,7 @@ export const Editor = {
    * Get the point before a location.
    */
 
-  before(
+  before<E extends Editor, El extends Element>(
     editor: Editor,
     at: Location,
     options: {
@@ -185,7 +187,7 @@ export const Editor = {
    * Delete content in the editor backward from the current selection.
    */
 
-  deleteBackward(
+  deleteBackward<E extends Editor, El extends Element>(
     editor: Editor,
     options: {
       unit?: 'character' | 'word' | 'line' | 'block'
@@ -199,7 +201,7 @@ export const Editor = {
    * Delete content in the editor forward from the current selection.
    */
 
-  deleteForward(
+  deleteForward<E extends Editor, El extends Element>(
     editor: Editor,
     options: {
       unit?: 'character' | 'word' | 'line' | 'block'
@@ -213,7 +215,7 @@ export const Editor = {
    * Delete the content in the current selection.
    */
 
-  deleteFragment(editor: Editor): void {
+  deleteFragment<E extends Editor, El extends Element>(editor: Editor): void {
     editor.deleteFragment()
   },
 
@@ -221,7 +223,7 @@ export const Editor = {
    * Get the start and end points of a location.
    */
 
-  edges(editor: Editor, at: Location): [Point, Point] {
+  edges<E extends Editor, El extends Element>(editor: Editor, at: Location): [Point, Point] {
     return [Editor.start(editor, at), Editor.end(editor, at)]
   },
 
@@ -229,7 +231,7 @@ export const Editor = {
    * Get the end point of a location.
    */
 
-  end(editor: Editor, at: Location): Point {
+  end<E extends Editor, El extends Element>(editor: Editor, at: Location): Point {
     return Editor.point(editor, at, { edge: 'end' })
   },
 
@@ -237,7 +239,7 @@ export const Editor = {
    * Get the first node at a location.
    */
 
-  first(editor: Editor, at: Location): NodeEntry {
+  first<E extends Editor>(editor: E, at: Location): NodeEntry {
     const path = Editor.path(editor, at, { edge: 'start' })
     return Editor.node(editor, path)
   },
@@ -246,7 +248,7 @@ export const Editor = {
    * Get the fragment at a location.
    */
 
-  fragment(editor: Editor, at: Location): Descendant[] {
+  fragment<E extends Editor>(editor: E, at: Location): Descendant[] {
     const range = Editor.range(editor, at)
     const fragment = Node.fragment(editor, range)
     return fragment
@@ -255,7 +257,7 @@ export const Editor = {
    * Check if a node has block children.
    */
 
-  hasBlocks(editor: Editor, element: Element): boolean {
+  hasBlocks<E extends Editor, El extends Element>(editor: E, element: El): boolean {
     return element.children.some(n => Editor.isBlock(editor, n))
   },
 
@@ -263,7 +265,7 @@ export const Editor = {
    * Check if a node has inline and text children.
    */
 
-  hasInlines(editor: Editor, element: Element): boolean {
+  hasInlines<E extends Editor, El extends Element>(editor: E, element: El): boolean {
     return element.children.some(
       n => Text.isText(n) || Editor.isInline(editor, n)
     )
@@ -273,7 +275,7 @@ export const Editor = {
    * Check if a node has text children.
    */
 
-  hasTexts(editor: Editor, element: Element): boolean {
+  hasTexts<E extends Editor, El extends Element>(editor: E, element: El): boolean {
     return element.children.every(n => Text.isText(n))
   },
 
@@ -283,7 +285,7 @@ export const Editor = {
    * If the selection is currently expanded, it will be deleted first.
    */
 
-  insertBreak(editor: Editor): void {
+  insertBreak<E extends Editor>(editor: E): void {
     editor.insertBreak()
   },
 
@@ -293,7 +295,7 @@ export const Editor = {
    * If the selection is currently expanded, it will be deleted first.
    */
 
-  insertFragment(editor: Editor, fragment: Node[]): void {
+  insertFragment<E extends Editor>(editor: E, fragment: Node[]): void {
     editor.insertFragment(fragment)
   },
 
@@ -303,7 +305,7 @@ export const Editor = {
    * If the selection is currently expanded, it will be deleted first.
    */
 
-  insertNode(editor: Editor, node: Node): void {
+  insertNode<E extends Editor>(editor: E, node: Node): void {
     editor.insertNode(node)
   },
 
@@ -313,7 +315,7 @@ export const Editor = {
    * If the selection is currently expanded, it will be deleted first.
    */
 
-  insertText(editor: Editor, text: string): void {
+  insertText<E extends Editor>(editor: E, text: string): void {
     editor.insertText(text)
   },
 
@@ -321,7 +323,7 @@ export const Editor = {
    * Check if a value is a block `Element` object.
    */
 
-  isBlock(editor: Editor, value: any): value is Element {
+  isBlock<E extends Editor, El extends Element>(editor: E, value: any): value is Element {
     return Element.isElement(value) && !editor.isInline(value)
   },
 
@@ -1330,7 +1332,7 @@ export const Editor = {
         // the operation was applied.
         parent.children.splice(index, 1)
         const truePath = Path.transform(path, op)!
-        const newParent: Ancestor = Node.get(editor, Path.parent(truePath))
+        const newParent = Node.get(editor, Path.parent(truePath)) as Ancestor
         const newIndex = truePath[truePath.length - 1]
 
         newParent.children.splice(newIndex, 0, node)

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1244,7 +1244,7 @@ export const Editor = {
    * Transform the editor by an operation.
    */
 
-  transform(editor: Editor, op: Operation) {
+  transform<E extends Editor>(editor: E, op: Operation): void {
     editor.children = createDraft(editor.children)
     let selection = editor.selection && createDraft(editor.selection)
 
@@ -1330,7 +1330,7 @@ export const Editor = {
         // the operation was applied.
         parent.children.splice(index, 1)
         const truePath = Path.transform(path, op)!
-        const newParent = Node.get(editor, Path.parent(truePath))
+        const newParent: Ancestor = Node.get(editor, Path.parent(truePath))
         const newIndex = truePath[truePath.length - 1]
 
         newParent.children.splice(newIndex, 0, node)

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -38,7 +38,6 @@ export interface Editor {
   selection: Range | null
   operations: Operation[]
   marks: Record<string, any> | null
-  [key: string]: any
 
   // Schema-specific node behaviors.
   isInline: (element: Element) => boolean

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -9,7 +9,6 @@ import { Editor, Node, Path } from '..'
 
 export interface Element {
   children: Node[]
-  [key: string]: any
 }
 
 export const Element = {

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -16,7 +16,7 @@ export const Element = {
    * Check if a value implements the `Element` interface.
    */
 
-  isElement(value: any): value is Element {
+  isElement<E extends Element>(value: any): value is E {
     return (
       isPlainObject(value) &&
       Node.isNodeList(value.children) &&
@@ -28,7 +28,7 @@ export const Element = {
    * Check if a value is an array of `Element` objects.
    */
 
-  isElementList(value: any): value is Element[] {
+  isElementList<E extends Element>(value: any): value is E[] {
     return (
       Array.isArray(value) &&
       (value.length === 0 || Element.isElement(value[0]))

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -42,7 +42,7 @@ export const Element = {
    * children are equivalent.
    */
 
-  matches(element: Element, props: Partial<Element>): boolean {
+  matches<E extends Element>(element: E, props: Partial<E>): boolean {
     for (const key in props) {
       if (key === 'children') {
         continue

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -125,7 +125,7 @@ export const Node = {
    */
 
   *descendants<N extends Node>(
-    root: Node,
+    root: N,
     options: {
       from?: Path
       to?: Path
@@ -279,7 +279,7 @@ export const Node = {
    * Check if a value implements the `Node` interface.
    */
 
-  isNode(value: any): value is Node {
+  isNode<N extends Node>(value: any): value is N {
     return (
       Text.isText(value) || Element.isElement(value) || Editor.isEditor(value)
     )
@@ -289,7 +289,7 @@ export const Node = {
    * Check if a value is a list of `Node` objects.
    */
 
-  isNodeList(value: any): value is Node[] {
+  isNodeList<N extends Node>(value: any): value is N[] {
     return Array.isArray(value) && (value.length === 0 || Node.isNode(value[0]))
   },
 

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -5,7 +5,6 @@ export type InsertNodeOperation = {
   type: 'insert_node'
   path: Path
   node: Node
-  [key: string]: any
 }
 
 export type InsertTextOperation = {
@@ -13,7 +12,6 @@ export type InsertTextOperation = {
   path: Path
   offset: number
   text: string
-  [key: string]: any
 }
 
 export type MergeNodeOperation = {
@@ -22,21 +20,18 @@ export type MergeNodeOperation = {
   position: number
   target: number | null
   properties: Partial<Node>
-  [key: string]: any
 }
 
 export type MoveNodeOperation = {
   type: 'move_node'
   path: Path
   newPath: Path
-  [key: string]: any
 }
 
 export type RemoveNodeOperation = {
   type: 'remove_node'
   path: Path
   node: Node
-  [key: string]: any
 }
 
 export type RemoveTextOperation = {
@@ -44,7 +39,6 @@ export type RemoveTextOperation = {
   path: Path
   offset: number
   text: string
-  [key: string]: any
 }
 
 export type SetNodeOperation = {
@@ -52,25 +46,21 @@ export type SetNodeOperation = {
   path: Path
   properties: Partial<Node>
   newProperties: Partial<Node>
-  [key: string]: any
 }
 
 export type SetSelectionOperation =
   | {
       type: 'set_selection'
-      [key: string]: any
       properties: null
       newProperties: Range
     }
   | {
       type: 'set_selection'
-      [key: string]: any
       properties: Partial<Range>
       newProperties: Partial<Range>
     }
   | {
       type: 'set_selection'
-      [key: string]: any
       properties: Range
       newProperties: null
     }
@@ -81,7 +71,6 @@ export type SplitNodeOperation = {
   position: number
   target: number | null
   properties: Partial<Node>
-  [key: string]: any
 }
 
 export type NodeOperation =

--- a/packages/slate/src/interfaces/point.ts
+++ b/packages/slate/src/interfaces/point.ts
@@ -12,7 +12,6 @@ import { Operation, Path } from '..'
 export interface Point {
   path: Path
   offset: number
-  [key: string]: any
 }
 
 export const Point = {

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -11,7 +11,6 @@ import { Operation, Path, Point, PointEntry } from '..'
 export interface Range {
   anchor: Point
   focus: Point
-  [key: string]: any
 }
 
 export const Range = {

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -19,8 +19,8 @@ export const Range = {
    * in the document.
    */
 
-  edges(
-    range: Range,
+  edges<R extends Range>(
+    range: R,
     options: {
       reverse?: boolean
     } = {}

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -9,7 +9,6 @@ import { Range } from '..'
 
 export interface Text {
   text: string
-  [key: string]: any
 }
 
 export const Text = {

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -16,9 +16,9 @@ export const Text = {
    * Check if two text nodes are equal.
    */
 
-  equals(
-    text: Text,
-    another: Text,
+  equals<T extends Text>(
+    text: T,
+    another: T,
     options: { loose?: boolean } = {}
   ): boolean {
     const { loose = false } = options
@@ -69,7 +69,7 @@ export const Text = {
    * the `text` property are two nodes equal.
    */
 
-  matches(text: Text, props: Partial<Text>): boolean {
+  matches<T extends Text>(text: T, props: Partial<T>): boolean {
     for (const key in props) {
       if (key === 'text') {
         continue
@@ -87,8 +87,8 @@ export const Text = {
    * Get the leaves for a text node given decorations.
    */
 
-  decorations(node: Text, decorations: Range[]): Text[] {
-    let leaves: Text[] = [{ ...node }]
+  decorations<T extends Text>(node: T, decorations: Range[]): T[] {
+    let leaves: T[] = [{ ...node }]
 
     for (const dec of decorations) {
       const { anchor, focus, ...rest } = dec

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -18,7 +18,7 @@ export const GeneralTransforms = {
    * Transform the editor by an operation.
    */
 
-  transform(editor: Editor, op: Operation) {
+  transform<E extends Editor>(editor: E, op: Operation) {
     editor.children = createDraft(editor.children)
     let selection = editor.selection && createDraft(editor.selection)
 
@@ -104,7 +104,7 @@ export const GeneralTransforms = {
         // the operation was applied.
         parent.children.splice(index, 1)
         const truePath = Path.transform(path, op)!
-        const newParent = Node.get(editor, Path.parent(truePath))
+        const newParent = Node.get(editor, Path.parent(truePath)) as Element
         const newIndex = truePath[truePath.length - 1]
 
         newParent.children.splice(newIndex, 0, node)

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -1,4 +1,5 @@
 import {
+  Ancestor,
   Editor,
   Element,
   Location,
@@ -26,7 +27,7 @@ export const NodeTransforms = {
       select?: boolean
       voids?: boolean
     } = {}
-  ) {
+  ): void {
     Editor.withoutNormalizing(editor, () => {
       const { hanging = false, voids = false, mode = 'lowest' } = options
       let { at, match, select } = options
@@ -133,8 +134,8 @@ export const NodeTransforms = {
    * their parent in two if necessary.
    */
 
-  liftNodes(
-    editor: Editor,
+  liftNodes<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -196,8 +197,8 @@ export const NodeTransforms = {
    * removing any empty containing nodes after the merge if necessary.
    */
 
-  mergeNodes(
-    editor: Editor,
+  mergeNodes<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -335,8 +336,8 @@ export const NodeTransforms = {
    * Move the nodes at a location to a new location.
    */
 
-  moveNodes(
-    editor: Editor,
+  moveNodes<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -344,7 +345,7 @@ export const NodeTransforms = {
       to: Path
       voids?: boolean
     }
-  ) {
+  ): void {
     Editor.withoutNormalizing(editor, () => {
       const {
         to,
@@ -385,8 +386,8 @@ export const NodeTransforms = {
    * Remove the nodes at a specific location in the document.
    */
 
-  removeNodes(
-    editor: Editor,
+  removeNodes<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -394,7 +395,7 @@ export const NodeTransforms = {
       hanging?: boolean
       voids?: boolean
     } = {}
-  ) {
+  ): void {
     Editor.withoutNormalizing(editor, () => {
       const { hanging = false, voids = false, mode = 'lowest' } = options
       let { at = editor.selection, match } = options
@@ -431,9 +432,9 @@ export const NodeTransforms = {
    * Set new properties on the nodes at a location.
    */
 
-  setNodes(
-    editor: Editor,
-    props: Partial<Node>,
+  setNodes<E extends Editor, N extends Node>(
+    editor: E,
+    props: Partial<N>,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -530,8 +531,8 @@ export const NodeTransforms = {
    * Split the nodes at a specific location.
    */
 
-  splitNodes(
-    editor: Editor,
+  splitNodes<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -658,8 +659,8 @@ export const NodeTransforms = {
    * Unset properties on the nodes at a location.
    */
 
-  unsetNodes(
-    editor: Editor,
+  unsetNodes<E extends Editor>(
+    editor: E,
     props: string | string[],
     options: {
       at?: Location
@@ -687,8 +688,8 @@ export const NodeTransforms = {
    * necessary to ensure that only the content in the range is unwrapped.
    */
 
-  unwrapNodes(
-    editor: Editor,
+  unwrapNodes<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -746,9 +747,9 @@ export const NodeTransforms = {
    * of the range first to ensure that only the content in the range is wrapped.
    */
 
-  wrapNodes(
-    editor: Editor,
-    element: Element,
+  wrapNodes<E extends Editor, El extends Element>(
+    editor: E,
+    element: El,
     options: {
       at?: Location
       match?: (node: Node) => boolean
@@ -823,7 +824,7 @@ export const NodeTransforms = {
             : Path.common(firstPath, lastPath)
 
           const range = Editor.range(editor, firstPath, lastPath)
-          const [commonNode] = Editor.node(editor, commonPath)
+          const [commonNode] = Editor.node(editor, commonPath) as Ancestor[]
           const depth = commonPath.length + 1
           const wrapperPath = Path.next(lastPath.slice(0, depth))
           const wrapper = { ...element, children: [] }
@@ -845,7 +846,7 @@ export const NodeTransforms = {
  * Convert a range into a point by deleting it's content.
  */
 
-const deleteRange = (editor: Editor, range: Range): Point | null => {
+const deleteRange = <E extends Editor>(editor: E, range: Range): Point | null => {
   if (Range.isCollapsed(range)) {
     return range.anchor
   } else {
@@ -856,7 +857,7 @@ const deleteRange = (editor: Editor, range: Range): Point | null => {
   }
 }
 
-const matchPath = (editor: Editor, path: Path): ((node: Node) => boolean) => {
+const matchPath = <E extends Editor>(editor: E, path: Path): ((node: Node) => boolean) => {
   const [node] = Editor.node(editor, path)
   return n => n === node
 }

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -15,12 +15,12 @@ export const NodeTransforms = {
    * Insert nodes at a specific location in the Editor.
    */
 
-  insertNodes(
-    editor: Editor,
-    nodes: Node | Node[],
+  insertNodes<E extends Editor, N extends Node>(
+    editor: E,
+    nodes: N | N[],
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: (node: N) => boolean
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       select?: boolean
@@ -86,7 +86,7 @@ export const NodeTransforms = {
           }
         }
 
-        const [entry] = Editor.nodes(editor, {
+        const [entry] = Editor.nodes(editor as Editor, {
           at: at.path,
           match,
           mode,

--- a/packages/slate/src/transforms/selection.ts
+++ b/packages/slate/src/transforms/selection.ts
@@ -5,12 +5,12 @@ export const SelectionTransforms = {
    * Collapse the selection.
    */
 
-  collapse(
-    editor: Editor,
+  collapse<E extends Editor>(
+    editor: E,
     options: {
       edge?: 'anchor' | 'focus' | 'start' | 'end'
     } = {}
-  ) {
+  ): void {
     const { edge = 'anchor' } = options
     const { selection } = editor
 
@@ -33,7 +33,7 @@ export const SelectionTransforms = {
    * Unset the selection.
    */
 
-  deselect(editor: Editor) {
+  deselect<E extends Editor>(editor: E): void {
     const { selection } = editor
 
     if (selection) {
@@ -49,15 +49,15 @@ export const SelectionTransforms = {
    * Move the selection's point forward or backward.
    */
 
-  move(
-    editor: Editor,
+  move<E extends Editor>(
+    editor: E,
     options: {
       distance?: number
       unit?: 'offset' | 'character' | 'word' | 'line'
       reverse?: boolean
       edge?: 'anchor' | 'focus' | 'start' | 'end'
     } = {}
-  ) {
+  ): void {
     const { selection } = editor
     const { distance = 1, unit = 'character', reverse = false } = options
     let { edge = null } = options
@@ -105,7 +105,7 @@ export const SelectionTransforms = {
    * Set the selection to a new value.
    */
 
-  select(editor: Editor, target: Location) {
+  select<E extends Editor>(editor: E, target: Location): void {
     const { selection } = editor
     target = Editor.range(editor, target)
 
@@ -133,13 +133,13 @@ export const SelectionTransforms = {
    * Set new properties on one of the selection's points.
    */
 
-  setPoint(
-    editor: Editor,
-    props: Partial<Point>,
+  setPoint<E extends Editor, P extends Point>(
+    editor: E,
+    props: Partial<P>,
     options: {
       edge?: 'anchor' | 'focus' | 'start' | 'end'
     }
-  ) {
+  ): void {
     const { selection } = editor
     let { edge = 'both' } = options
 
@@ -170,7 +170,7 @@ export const SelectionTransforms = {
    * Set new properties on the selection.
    */
 
-  setSelection(editor: Editor, props: Partial<Range>) {
+  setSelection<E extends Editor>(editor: E, props: Partial<Range>): void {
     const { selection } = editor
     const oldProps: Partial<Range> | null = {}
     const newProps: Partial<Range> = {}

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -16,8 +16,8 @@ export const TextTransforms = {
    * Delete content in the editor.
    */
 
-  delete(
-    editor: Editor,
+  delete<E extends Editor>(
+    editor: E,
     options: {
       at?: Location
       distance?: number
@@ -26,7 +26,7 @@ export const TextTransforms = {
       hanging?: boolean
       voids?: boolean
     } = {}
-  ) {
+  ): void {
     Editor.withoutNormalizing(editor, () => {
       const {
         reverse = false,
@@ -188,15 +188,15 @@ export const TextTransforms = {
    * Insert a fragment at a specific location in the editor.
    */
 
-  insertFragment(
-    editor: Editor,
-    fragment: Node[],
+  insertFragment<E extends Editor, N extends Node>(
+    editor: E,
+    fragment: N[],
     options: {
       at?: Location
       hanging?: boolean
       voids?: boolean
     } = {}
-  ) {
+  ): void {
     Editor.withoutNormalizing(editor, () => {
       const { hanging = false, voids = false } = options
       let { at = editor.selection } = options
@@ -403,14 +403,14 @@ export const TextTransforms = {
    * Insert a string of text in the Editor.
    */
 
-  insertText(
-    editor: Editor,
+  insertText<E extends Editor>(
+    editor: E,
     text: string,
     options: {
       at?: Location
       voids?: boolean
     } = {}
-  ) {
+  ): void {
     Editor.withoutNormalizing(editor, () => {
       const { voids = false } = options
       let { at = editor.selection } = options


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement

#### What's the new behavior?

No behavior change, other than that TypeScript consumers of the library should be able to use their own extensions of top-level interfaces (eg `interface MyEditor extends Editor {...}`)

#### Have you checked that...?

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3416
