### PR TITLE
Enable processing of tsx files with babel in rollup.config.js

### DIFF
--- a/config/rollup/rollup.config.js
+++ b/config/rollup/rollup.config.js
@@ -89,7 +89,7 @@ function configure(pkg, env, target) {
     babel({
       runtimeHelpers: true,
       include: [`packages/${pkg.name}/src/**`],
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.ts', '.tsx'],
       presets: [
         '@babel/preset-typescript',
         [


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixes https://github.com/ianstormtaylor/slate/issues/3471
Fixes https://github.com/ianstormtaylor/slate/issues/3400

#### What's the new behavior?

No new behavior. This is a fix in babel setup in `rollup.config.js`.

#### How does this change work?

[Experimental JS "Rest in objects" feature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) in `packages/slate-react/dist/index.es.js` & `packages/slate-react/dist/index.js` becomes a valid JS that works in older browsers.

Example:

```js
    const { autoFocus, decorate = defaultDecorate, onDOMBeforeInput: propsOnDOMBeforeInput, placeholder, readOnly = false, renderElement, renderLeaf, style = {}, as: Component = 'div', ...attributes } = props;
```

becomes:
```js
var {
    autoFocus,
    decorate = defaultDecorate,
    onDOMBeforeInput: propsOnDOMBeforeInput,
    placeholder,
    readOnly = false,
    renderElement,
    renderLeaf,
    style = {},
    as: Component = 'div'
  } = props,
      attributes = _objectWithoutProperties(props, ["autoFocus", "decorate", "onDOMBeforeInput", "placeholder", "readOnly", "renderElement", "renderLeaf", "style", "as"]);
```

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

I have also checked it in MS Edge 18 :heavy_check_mark: 

Unfortunately IE 11 still does not work. I'm getting a syntax error (arrow function).
**Is there a plan to support IE 11?**

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/ianstormtaylor/slate/issues/3471, https://github.com/ianstormtaylor/slate/issues/3400
Reviewers: @ianstormtaylor 
