### PR TITLE
Change lernajs to correct URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,7 @@ If you're maintaining a translation, feel free to pull request it here!
 
 ### Packages
 
-Slate's codebase is monorepo managed with [Lerna](https://lernajs.io/). It consists of a handful of packages—although you won't always use all of them. They are:
+Slate's codebase is monorepo managed with [Lerna](https://lerna.js.org/). It consists of a handful of packages—although you won't always use all of them. They are:
 
 | **Package**                                         | **Version**                                                                                                                         | **Size**                                                                                                                                                                                        | **Description**                                  |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |


### PR DESCRIPTION

#### How does this change work?
The URL to the lerna website in README.md is not working, I noticed they changed it to a new one and updated the readme