### PR TITLE
Fix test folders name swap for interfaces/Editor/nodes

### DIFF
--- a/packages/slate/test/interfaces/Editor/nodes/mode-all/block.js
+++ b/packages/slate/test/interfaces/Editor/nodes/mode-all/block.js
@@ -16,7 +16,7 @@ export const input = (
 
 export const test = editor => {
   return Array.from(
-    Editor.nodes(editor, { at: [], match: n => n.a, mode: 'highest' })
+    Editor.nodes(editor, { at: [], match: n => n.a, mode: 'all' })
   )
 }
 
@@ -27,10 +27,12 @@ export const output = [
     </block>,
     [0],
   ],
+  [<block a>one</block>, [0, 0]],
   [
     <block a>
       <block a>two</block>
     </block>,
     [1],
   ],
+  [<block a>two</block>, [1, 0]],
 ]

--- a/packages/slate/test/interfaces/Editor/nodes/mode-highest/block.js
+++ b/packages/slate/test/interfaces/Editor/nodes/mode-highest/block.js
@@ -16,7 +16,7 @@ export const input = (
 
 export const test = editor => {
   return Array.from(
-    Editor.nodes(editor, { at: [], match: n => n.a, mode: 'all' })
+    Editor.nodes(editor, { at: [], match: n => n.a, mode: 'highest' })
   )
 }
 
@@ -27,12 +27,10 @@ export const output = [
     </block>,
     [0],
   ],
-  [<block a>one</block>, [0, 0]],
   [
     <block a>
       <block a>two</block>
     </block>,
     [1],
   ],
-  [<block a>two</block>, [1, 0]],
 ]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

I realized the folder names for the tests in `interfaces/Editor/nodes/mode-all` and `interfaces/Editor/nodes/mode-highest` were swapped (ie. tests for mode-all was in mode-highest and vice versa). So I fixed that.

#### What's the new behavior?

N/A

#### How does this change work?

N/A

#### Have you checked that...?

N/A

#### Does this fix any issues or need any specific reviewers?

N/A
