### PR TITLE
Allow zero as offset on <anchor> and <focus> inside <selection>

### DIFF
--- a/packages/slate-hyperscript/src/creators.ts
+++ b/packages/slate-hyperscript/src/creators.ts
@@ -152,13 +152,13 @@ export function createSelection(
   const anchor: AnchorToken = children.find(c => c instanceof AnchorToken)
   const focus: FocusToken = children.find(c => c instanceof FocusToken)
 
-  if (!anchor || !anchor.offset || !anchor.path) {
+  if (!anchor || (!anchor.offset && anchor.offset !== 0) || !anchor.path) {
     throw new Error(
       `The <selection> hyperscript tag must have an <anchor> tag as a child with \`path\` and \`offset\` attributes defined.`
     )
   }
 
-  if (!focus || !focus.offset || !focus.path) {
+  if (!focus || (!focus.offset && focus.offset !== 0) || !focus.path) {
     throw new Error(
       `The <selection> hyperscript tag must have a <focus> tag as a child with \`path\` and \`offset\` attributes defined.`
     )

--- a/packages/slate-hyperscript/src/creators.ts
+++ b/packages/slate-hyperscript/src/creators.ts
@@ -152,13 +152,13 @@ export function createSelection(
   const anchor: AnchorToken = children.find(c => c instanceof AnchorToken)
   const focus: FocusToken = children.find(c => c instanceof FocusToken)
 
-  if (!anchor || (!anchor.offset && anchor.offset !== 0) || !anchor.path) {
+  if (!anchor || anchor.offset == null || anchor.path == null) {
     throw new Error(
       `The <selection> hyperscript tag must have an <anchor> tag as a child with \`path\` and \`offset\` attributes defined.`
     )
   }
 
-  if (!focus || (!focus.offset && focus.offset !== 0) || !focus.path) {
+  if (!focus || focus.offset == null || focus.path == null) {
     throw new Error(
       `The <selection> hyperscript tag must have a <focus> tag as a child with \`path\` and \`offset\` attributes defined.`
     )

--- a/packages/slate-hyperscript/test/fixtures/selection-offset-start.js
+++ b/packages/slate-hyperscript/test/fixtures/selection-offset-start.js
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>word</element>
+    <selection>
+      <anchor path={[0, 0]} offset={0} />
+      <focus path={[0, 0]} offset={0} />
+    </selection>
+  </editor>
+)
+
+export const output = {
+  children: [
+    {
+      children: [
+        {
+          text: 'word',
+        },
+      ],
+    },
+  ],
+  selection: {
+    anchor: {
+      path: [0, 0],
+      offset: 0,
+    },
+    focus: {
+      path: [0, 0],
+      offset: 0,
+    },
+  },
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

This currently fails on `master`:

```jsx
<selection>
  <anchor offset={0} path={[0]} />
  <focus offset={0} path={[0]} />
</selection>
```

The reason is because the guards for checking the truthiness of offset in `createSelection` look like this:

```js
if (!anchor || !anchor.offset || !anchor.path) {
```

This won't work for zero, since that's falsy in JavaScript. This PR fixes this.

#### How does this change work?

I check if the offset if falsy and explicitly not zero. I wanted to use something like `Number.isFinite` instead, but unfortunately that doesn't work for a `number | undefined` union.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)