### PR TITLE
Fix paste-html heading problem. (#3320)

### DIFF
--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -262,13 +262,17 @@ export const TextTransforms = {
       const [, blockPath] = blockMatch
       const isBlockStart = Editor.isStart(editor, at, blockPath)
       const isBlockEnd = Editor.isEnd(editor, at, blockPath)
-      const mergeStart = !isBlockStart || (isBlockStart && isBlockEnd)
+      const mergeStart = !isBlockStart
       const mergeEnd = !isBlockEnd
       const [, firstPath] = Node.first({ children: fragment }, [])
       const [, lastPath] = Node.last({ children: fragment }, [])
 
       const matches: NodeEntry[] = []
       const matcher = ([n, p]: NodeEntry) => {
+        if (!p.length) {
+          return false
+        }
+
         if (
           mergeStart &&
           Path.isAncestor(p, firstPath) &&
@@ -349,6 +353,14 @@ export const TextTransforms = {
         mode: hasBlocks ? 'lowest' : 'highest',
         voids,
       })
+
+      if (isBlockStart && isBlockEnd) {
+        const [, emptyBlockPath] = Editor.parent(editor, at.path)
+        Transforms.delete(editor, {
+          at: emptyBlockPath,
+          unit: 'block',
+        })
+      }
 
       const startRef = Editor.pathRef(
         editor,

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -354,7 +354,14 @@ export const TextTransforms = {
         voids,
       })
 
-      if (isBlockStart && isBlockEnd) {
+      const [firstMatch] = matches
+      let firstMatchBlock
+
+      if (firstMatch) {
+        ;[firstMatchBlock] = firstMatch
+      }
+
+      if (isBlockStart && isBlockEnd && Element.isElement(firstMatchBlock)) {
         const [, emptyBlockPath] = Editor.parent(editor, at.path)
         Transforms.delete(editor, {
           at: emptyBlockPath,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fix paste-html heading problem. (#3320)

#### What's the new behavior?

[Preview Link](https://imgur.com/a/Bhiez7Y)
![Preview](http://g.recordit.co/lhgQ6TIof8.gif)

#### How does this change work?

If the pasted line is empty, it deletes the current line and pastes the value in the clipboard. If the pasted line is not empty, combines the value in the clipboard with the current line.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3320
