### PR TITLE
fix: <input /> onChange is not triggered in Firefox #3500

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -446,7 +446,7 @@ export const Editable = (props: EditableProps) => {
             // COMPAT: Firefox doesn't support the `beforeinput` event, so we
             // fall back to React's leaky polyfill instead just for it. It
             // only works for the `insertText` input type.
-            if (IS_FIREFOX && !readOnly) {
+            if (IS_FIREFOX && !readOnly && ReactEditor.isFocused(editor)) {
               event.preventDefault()
               const text = (event as any).data as string
               Editor.insertText(editor, text)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug.

#### How does this change work?
Now Editable.onBeforeInput only calls event.preventDefault() when the editor is focused.