### PR TITLE
Fix the stealing focus problem when multi instances are present

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -191,7 +191,7 @@ export const Editable = (props: EditableProps) => {
         ) {
           return
         }
-      } catch {
+      } catch (e) {
         return
       }
     }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -175,11 +175,12 @@ export const Editable = (props: EditableProps) => {
       return
     }
 
-    const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
+    let newDomRange: DOMRange | null = null
+    try {
+      newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
 
-    // If the DOM selection is already correct, we're done.
-    if (hasDomSelection) {
-      try {
+      // If the DOM selection is already correct, we're done.
+      if (hasDomSelection) {
         const newEditorRange = ReactEditor.toSlateRange(
           editor,
           domSelection.getRangeAt(0)
@@ -191,9 +192,9 @@ export const Editable = (props: EditableProps) => {
         ) {
           return
         }
-      } catch (e) {
-        return
       }
+    } catch (e) {
+      return
     }
 
     // Otherwise the DOM selection is out of sync, so update it.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -178,12 +178,22 @@ export const Editable = (props: EditableProps) => {
     const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
 
     // If the DOM selection is already correct, we're done.
-    if (
-      hasDomSelection &&
-      newDomRange &&
-      isRangeEqual(domSelection.getRangeAt(0), newDomRange)
-    ) {
-      return
+    if (hasDomSelection) {
+      try {
+        const newEditorRange = ReactEditor.toSlateRange(
+          editor,
+          domSelection.getRangeAt(0)
+        )
+        if (
+          selection &&
+          newEditorRange &&
+          Range.equals(selection, newEditorRange)
+        ) {
+          return
+        }
+      } catch {
+        return
+      }
     }
 
     // Otherwise the DOM selection is out of sync, so update it.
@@ -919,23 +929,6 @@ export const Editable = (props: EditableProps) => {
  */
 
 const defaultDecorate = () => []
-
-/**
- * Check if two DOM range objects are equal.
- */
-
-const isRangeEqual = (a: DOMRange, b: DOMRange) => {
-  return (
-    (a.startContainer === b.startContainer &&
-      a.startOffset === b.startOffset &&
-      a.endContainer === b.endContainer &&
-      a.endOffset === b.endOffset) ||
-    (a.startContainer === b.endContainer &&
-      a.startOffset === b.endOffset &&
-      a.endContainer === b.startContainer &&
-      a.endOffset === b.startOffset)
-  )
-}
 
 /**
  * Check if the target is in the editor.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Fixes: #3380 
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
The 'isRangeEqual' method does not work correctly and returns false most of the time. This causes the editor to remove and add all the selection ranges again on every render of the Editable component. 

Also, the above behavior causes some problems when multiple instances are present and the last instance steals focus.

**Before:**
![before-bugfix-optimized](https://user-images.githubusercontent.com/573937/74655760-24ab9d80-51a2-11ea-9db2-d256dd2b132b.gif)

**After:**
![after-bugfix-optimized](https://user-images.githubusercontent.com/573937/74655786-33925000-51a2-11ea-8f9d-e7bafe7d2737.gif)

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3380 
