### PR TITLE
Add node key override to allow performant immutable controlled updates

### DIFF
--- a/packages/slate-react/src/components/children.tsx
+++ b/packages/slate-react/src/components/children.tsx
@@ -5,7 +5,7 @@ import ElementComponent from './element'
 import TextComponent from './text'
 import { ReactEditor } from '..'
 import { useEditor } from '../hooks/use-editor'
-import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
+import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/maps'
 import { RenderElementProps, RenderLeafProps } from './editable'
 
 /**

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -34,7 +34,7 @@ import {
   NODE_TO_ELEMENT,
   IS_FOCUSED,
   PLACEHOLDER_SYMBOL,
-} from '../utils/weak-maps'
+} from '../utils/maps'
 
 /**
  * `RenderElementProps` are passed to the `renderElement` handler.

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -134,7 +134,8 @@ const MemoizedElement = React.memo(Element, (prev, next) => {
   return (
     prev.decorate === next.decorate &&
     (prev.element === next.element ||
-      (prev.element.key && next.element.key &&
+      (prev.element.key &&
+        next.element.key &&
         prev.element.key.id === next.element.key.id)) &&
     prev.renderElement === next.renderElement &&
     prev.renderLeaf === next.renderLeaf &&

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -13,7 +13,7 @@ import {
   NODE_TO_PARENT,
   NODE_TO_INDEX,
   KEY_TO_ELEMENT,
-} from '../utils/weak-maps'
+} from '../utils/maps'
 import { RenderElementProps, RenderLeafProps } from './editable'
 
 /**
@@ -114,11 +114,11 @@ const Element = (props: {
   // Update element-related weak maps with the DOM element ref.
   useIsomorphicLayoutEffect(() => {
     if (ref.current) {
-      KEY_TO_ELEMENT.set(key, ref.current)
+      KEY_TO_ELEMENT.set(key.id, ref.current)
       NODE_TO_ELEMENT.set(element, ref.current)
       ELEMENT_TO_NODE.set(ref.current, element)
     } else {
-      KEY_TO_ELEMENT.delete(key)
+      KEY_TO_ELEMENT.delete(key.id)
       NODE_TO_ELEMENT.delete(element)
     }
   })

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -133,7 +133,9 @@ const Element = (props: {
 const MemoizedElement = React.memo(Element, (prev, next) => {
   return (
     prev.decorate === next.decorate &&
-    prev.element === next.element &&
+    (prev.element === next.element ||
+      (prev.element.key && next.element.key &&
+        prev.element.key.id === next.element.key.id)) &&
     prev.renderElement === next.renderElement &&
     prev.renderLeaf === next.renderLeaf &&
     isRangeListEqual(prev.decorations, next.decorations) &&

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Text, Element } from 'slate'
 
 import String from './string'
-import { PLACEHOLDER_SYMBOL } from '../utils/weak-maps'
+import { PLACEHOLDER_SYMBOL } from '../utils/maps'
 import { RenderLeafProps } from './editable'
 
 /**

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -5,7 +5,7 @@ import { ReactEditor } from '../plugin/react-editor'
 import { FocusedContext } from '../hooks/use-focused'
 import { EditorContext } from '../hooks/use-editor'
 import { SlateContext } from '../hooks/use-slate'
-import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
+import { EDITOR_TO_ON_CHANGE } from '../utils/maps'
 
 /**
  * A wrapper around the provider to handle `onChange` events, because the editor

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -5,11 +5,7 @@ import Leaf from './leaf'
 import { ReactEditor, useEditor } from '..'
 import { RenderLeafProps } from './editable'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
-import {
-  KEY_TO_ELEMENT,
-  NODE_TO_ELEMENT,
-  ELEMENT_TO_NODE,
-} from '../utils/maps'
+import { KEY_TO_ELEMENT, NODE_TO_ELEMENT, ELEMENT_TO_NODE } from '../utils/maps'
 
 /**
  * Text.

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -9,7 +9,7 @@ import {
   KEY_TO_ELEMENT,
   NODE_TO_ELEMENT,
   ELEMENT_TO_NODE,
-} from '../utils/weak-maps'
+} from '../utils/maps'
 
 /**
  * Text.
@@ -47,11 +47,11 @@ const Text = (props: {
   // Update element-related weak maps with the DOM element ref.
   useIsomorphicLayoutEffect(() => {
     if (ref.current) {
-      KEY_TO_ELEMENT.set(key, ref.current)
+      KEY_TO_ELEMENT.set(key.id, ref.current)
       NODE_TO_ELEMENT.set(text, ref.current)
       ELEMENT_TO_NODE.set(ref.current, text)
     } else {
-      KEY_TO_ELEMENT.delete(key)
+      KEY_TO_ELEMENT.delete(key.id)
       NODE_TO_ELEMENT.delete(text)
     }
   })

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -10,7 +10,7 @@ import {
   NODE_TO_INDEX,
   NODE_TO_KEY,
   NODE_TO_PARENT,
-} from '../utils/weak-maps'
+} from '../utils/maps'
 import {
   DOMElement,
   DOMNode,
@@ -191,7 +191,7 @@ export const ReactEditor = {
   toDOMNode(editor: ReactEditor, node: Node): HTMLElement {
     const domNode = Editor.isEditor(node)
       ? EDITOR_TO_ELEMENT.get(editor)
-      : KEY_TO_ELEMENT.get(ReactEditor.findKey(editor, node))
+      : KEY_TO_ELEMENT.get(ReactEditor.findKey(editor, node).id)
 
     if (!domNode) {
       throw new Error(

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -36,7 +36,7 @@ export const ReactEditor = {
    */
 
   findKey(editor: ReactEditor, node: Node): Key {
-    let key = NODE_TO_KEY.get(node)
+    let key = node.key || NODE_TO_KEY.get(node)
 
     if (!key) {
       key = new Key()

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -3,7 +3,7 @@ import { Editor, Node, Path, Operation, Transforms } from 'slate'
 
 import { ReactEditor } from './react-editor'
 import { Key } from '../utils/key'
-import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/weak-maps'
+import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/maps'
 
 /**
  * `withReact` adds React and DOM specific behaviors to the editor.

--- a/packages/slate-react/src/utils/maps.ts
+++ b/packages/slate-react/src/utils/maps.ts
@@ -11,14 +11,14 @@ export const NODE_TO_INDEX: WeakMap<Node, number> = new WeakMap()
 export const NODE_TO_PARENT: WeakMap<Node, Ancestor> = new WeakMap()
 
 /**
- * Weak maps that allow us to go between Slate nodes and DOM nodes. These
+ * Maps that allow us to go between Slate nodes and DOM nodes. These
  * are used to resolve DOM event-related logic into Slate actions.
  */
 
 export const EDITOR_TO_ELEMENT: WeakMap<Editor, HTMLElement> = new WeakMap()
 export const EDITOR_TO_PLACEHOLDER: WeakMap<Editor, string> = new WeakMap()
 export const ELEMENT_TO_NODE: WeakMap<HTMLElement, Node> = new WeakMap()
-export const KEY_TO_ELEMENT: WeakMap<Key, HTMLElement> = new WeakMap()
+export const KEY_TO_ELEMENT: Map<string, HTMLElement> = new Map()
 export const NODE_TO_ELEMENT: WeakMap<Node, HTMLElement> = new WeakMap()
 export const NODE_TO_KEY: WeakMap<Node, Key> = new WeakMap()
 

--- a/site/examples/controlled-keys.js
+++ b/site/examples/controlled-keys.js
@@ -4,6 +4,7 @@ import React, { useState, useMemo, useCallback } from 'react'
 import faker from 'faker'
 import { createEditor } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
+import { ENETDOWN } from 'constants'
 
 const HEADINGS = 5
 const PARAGRAPHS = 5
@@ -12,6 +13,7 @@ const initialValue = []
 for (let h = 0; h < HEADINGS; h++) {
   initialValue.push({
     type: 'heading',
+    key: { id: `h${h}` },
     children: [
       {
         text: faker.lorem.sentence(),
@@ -22,6 +24,7 @@ for (let h = 0; h < HEADINGS; h++) {
 
   for (let p = 0; p < PARAGRAPHS; p++) {
     initialValue.push({
+      key: { id: `h${h}p${p}` },
       children: [
         {
           text: faker.lorem.paragraph(),
@@ -36,14 +39,29 @@ const ControlledKeyExample = () => {
   const [value, setValue] = useState(initialValue)
   const renderElement = useCallback(props => <Element {...props} />, [])
   const editor = useMemo(() => withReact(createEditor()), [])
+  const [selection, setSelection] = useState(null)
 
   const onKeyDown = event => {
-    console.log(editor.selection.focus)
+    if (event.key.length > 1) {
+      return
+    }
     event.preventDefault()
-    const _value = cloneDeep(value)
-    _value[3].children[0].text += event.key
-    _value[3].key.id += '1'
+    const { path, offset } = editor.selection.focus
+    const _value = JSON.parse(JSON.stringify(value))
+    const _textNode = _value[path[0]].children[0]
+    _textNode.text =
+      _textNode.text.slice(0, offset) + event.key + _textNode.text.slice(offset)
+    _value[path[0]].key.id += '1'
     setValue(_value)
+
+    const _selection = JSON.parse(JSON.stringify(editor.selection))
+    _selection.focus.offset += 1
+    _selection.anchor.offset += 1
+    setSelection(_selection)
+  }
+
+  if (selection) {
+    editor.selection = selection
   }
 
   return (
@@ -68,4 +86,4 @@ const Element = ({ attributes, children, element }) => {
   }
 }
 
-export default HugeDocumentExample
+export default ControlledKeyExample

--- a/site/examples/controlled-keys.js
+++ b/site/examples/controlled-keys.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+
+import React, { useState, useMemo, useCallback } from 'react'
+import faker from 'faker'
+import { createEditor } from 'slate'
+import { Slate, Editable, withReact } from 'slate-react'
+
+const HEADINGS = 5
+const PARAGRAPHS = 5
+const initialValue = []
+
+for (let h = 0; h < HEADINGS; h++) {
+  initialValue.push({
+    type: 'heading',
+    children: [
+      {
+        text: faker.lorem.sentence(),
+        key: { id: `h${h}t` },
+      },
+    ],
+  })
+
+  for (let p = 0; p < PARAGRAPHS; p++) {
+    initialValue.push({
+      children: [
+        {
+          text: faker.lorem.paragraph(),
+          key: { id: `h${h}p${p}t` },
+        },
+      ],
+    })
+  }
+}
+
+const ControlledKeyExample = () => {
+  const [value, setValue] = useState(initialValue)
+  const renderElement = useCallback(props => <Element {...props} />, [])
+  const editor = useMemo(() => withReact(createEditor()), [])
+
+  const onKeyDown = event => {
+    console.log(editor.selection.focus)
+    event.preventDefault()
+    const _value = cloneDeep(value)
+    _value[3].children[0].text += event.key
+    _value[3].key.id += '1'
+    setValue(_value)
+  }
+
+  return (
+    <Slate editor={editor} value={value} onChange={() => null}>
+      <Editable
+        renderElement={renderElement}
+        onKeyDown={onKeyDown}
+        spellCheck={false}
+        autoFocus
+      />
+    </Slate>
+  )
+}
+
+const Element = ({ attributes, children, element }) => {
+  console.log('Element.render')
+  switch (element.type) {
+    case 'heading':
+      return <h1 {...attributes}>{children}</h1>
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+export default HugeDocumentExample

--- a/site/pages/examples/[example].js
+++ b/site/pages/examples/[example].js
@@ -24,6 +24,7 @@ import ReadOnly from '../../examples/read-only'
 import RichText from '../../examples/richtext'
 import SearchHighlighting from '../../examples/search-highlighting'
 import Tables from '../../examples/tables'
+import ControlledKeys from '../../examples/controlled-keys'
 
 const EXAMPLES = [
   ['Checklists', CheckLists, 'check-lists'],
@@ -42,6 +43,7 @@ const EXAMPLES = [
   ['Rich Text', RichText, 'richtext'],
   ['Search Highlighting', SearchHighlighting, 'search-highlighting'],
   ['Tables', Tables, 'tables'],
+  ['Controlled Keys', ControlledKeys, 'controlled-keys'],
 ]
 
 const Header = props => (


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature.

#### What's the new behavior?

We propose that we follow React's pattern for controlling DOM node updates, which allows us to explicitly pass a `key` prop to our components. If we keep this `key` prop constant, React will only update the corresponding DOM node if the component's contents have changed. On the other hand, if we change the `key` prop, React will re-mount our component and force an update on the DOM node.  

So, we could optionally override the `key` prop on our components through the `value`, like so:

```js
const initialValue = [{
  type: 'paragraph',
  key: 0,
  children: [{
    text: `line ${idx}`
   }]
}
```

Keeping that `key` constant would tell Slate to skip this node in the next render, so now it is the controlling application's responsibility to update the `key` whenever the contents of that node change. If the `key` field is left out of a `value` node, Slate generates it based on the current weak map implementation.

The following screencast and snippet are from `site/examples/controlled-keys.js`, a new example that demonstrates the key overriding with controlled `value`s.

![slate-override](https://user-images.githubusercontent.com/2692844/74893439-ad862d00-538c-11ea-848a-3c7592c1e348.gif)

```js
const onKeyDown = event => {
    if (event.key.length > 1) {
      return
    }
    event.preventDefault()
    const { path, offset } = editor.selection.focus
    const _value = JSON.parse(JSON.stringify(value))
    const _textNode = _value[path[0]].children[0]
    _textNode.text =
      _textNode.text.slice(0, offset) + event.key + _textNode.text.slice(offset)
    _value[path[0]].key.id += '1'
    setValue(_value)

    const _selection = JSON.parse(JSON.stringify(editor.selection))
    _selection.focus.offset += 1
    _selection.anchor.offset += 1
    setSelection(_selection)
  }
```

#### How does this change work?

To implement this, we had to refactor the `KEY_TO_ELEMENT` from a WeakMap to a Map, updating methods that use this map to index using the string `key.id` instead of the whole `key` object. 

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3507 
