### PR TITLE
docs: update an example's link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,7 +108,7 @@ To get a sense for how you might use Slate, check out a few of the examples:
 - [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/markdown-preview.js) — showing how to add key handlers for Markdown-like shortcuts.
 - [**Links**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/links.js) — showing how wrap text in inline nodes with associated data.
 - [**Images**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/images.js) — showing how to use void (text-less) nodes to add images.
-- [**Hovering menu**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/hovering-menu.js) — showing how a contextual hovering menu can be implemented.
+- [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/hovering-toolbar.js) — showing how a hovering toolbar can be implemented.
 - [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/tables.js) — showing how to nest blocks to render more advanced components.
 - [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
 - [**Mentions**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/mentions.js) — showing how to use inline void nodes for simple @-mentions.

--- a/site/examples/Readme.md
+++ b/site/examples/Readme.md
@@ -8,7 +8,7 @@ This directory contains a set of examples that give you an idea for how you migh
 - [**Markdown Shortcuts**](./markdown-shortcuts.js) — showing how to add key handlers for Markdown-like shortcuts.
 - [**Links**](./links.js) — showing how wrap text in inline nodes with associated data.
 - [**Images**](./images.js) — showing how to use void (text-less) nodes to add images.
-- [**Hovering menu**](./hovering-menu.js) — showing how a contextual hovering menu can be implemented.
+- [**Hovering toolbar**](./hovering-toolbar.js) — showing how a hovering toolbar can be implemented.
 - [**Tables**](./tables.js) — showing how to nest blocks to render more advanced components.
 - [**Paste HTML**](./paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
 - [**Code Highlighting**](./code-highlighting.js) — showing how to use decorations to dynamically format text.


### PR DESCRIPTION
The "hovering menu" example doesn't exists. Instead, there's an example called "hovering toolbar". So I update the link to that example.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Nope.
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Nope.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

I just fixed an unreachable link.
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

No.
