### PR TITLE
Add controlled updates example

### DIFF
--- a/docs/walkthroughs/XX-controlled-updates.md
+++ b/docs/walkthroughs/XX-controlled-updates.md
@@ -1,0 +1,42 @@
+One of the powerful features of Slate is the ability to use it as a controlled input. This means that in our `onChange`, we can mutate the `value` and pass it back to the `<Slate />` component. 
+
+For example, let's say we have a document in which we always want the first paragraph to be uppercase. In a controlled implementation, we would want something like the code below:
+
+```js
+const App = () => {
+  const [value, setValue] = useState([
+    {
+      children: [{ text: 'This line should be uppercase' }],
+    },
+  ])
+
+  const onChange = value => {
+    value[0].children[0].text = value[0].children[0].text.toUpperCase()
+    setValue(value)
+  }
+
+  return (
+    <Slate editor={editor} value={value} onChange={onChange}>
+      <Editable renderElement={renderElement} autoFocus />
+    </Slate>
+  )
+}
+```
+
+However, if we try this we'll get an error like `Cannot assign to read only property 'text' of object`. This is because the Slate `value` is [frozen](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze), e.g. immutable. 
+
+To correctly mutate our controlled `value`, we use the [immer.js](https://immerjs.github.io/) library, which is what Slate uses internally to manage state updates. We simply use the `createDraft` of immer to create a mutable "draft" of our `value`, make our changes, and then call `finishDraft` on our draft `value` before passing it back to Slate.
+
+```js
+import { createDraft, finishDraft } from 'immer'
+
+const onChange = value => {
+  const _value = createDraft(value)
+  _value[0].children[0].text = _value[0].children[0].text.toUpperCase()
+  setValue(finishDraft(_value))
+}
+```
+
+With the working code, we'll see our first line transformed to `THIS LINE SHOULD BE UPPERCASE` and if you type anything else on that line, it will be converted to uppercase as you type!
+
+You can find a more advanced example of controlled updates in the [Controlled Updates](https://slatejs.org/examples/controlled-updates) example.

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
     "slate-hyperscript": "*",
     "slate-react": "*",
     "typescript": "^3.7.2"
+  },
+  "dependencies": {
+    "immer": "^5.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react": "^7.16.0",
     "faker": "^4.1.0",
     "image-extensions": "^1.1.0",
+    "immer": "^5.3.6",
     "is-hotkey": "^0.1.6",
     "is-url": "^1.2.2",
     "lerna": "^3.19.0",
@@ -84,8 +85,5 @@
     "slate-hyperscript": "*",
     "slate-react": "*",
     "typescript": "^3.7.2"
-  },
-  "dependencies": {
-    "immer": "^5.3.6"
   }
 }

--- a/site/examples/controlled-updates.js
+++ b/site/examples/controlled-updates.js
@@ -18,25 +18,19 @@ const SHORTCUTS = {
   '######': 'heading-six',
 }
 
-let i = 0
-
 const initialValue = [
   {
     type: 'heading-one',
-    id: ++i,
     children: [
       {
-        id: `${i}leaf`,
         text: 'Controlled Update Example',
       },
     ],
   },
   {
     type: 'paragraph',
-    id: ++i,
     children: [
       {
-        id: `${i}leaf`,
         text:
           'This example has the same functionality as the "Markdown Shortcuts" example. However, in our implementation we are using `immer.js` to draft a new state in onChange, mutate it, and render the results.',
       },
@@ -44,10 +38,8 @@ const initialValue = [
   },
   {
     type: 'paragraph',
-    id: ++i,
     children: [
       {
-        id: `${i}leaf`,
         text:
           'Try starting a line with a markdown modifier, like "#", "##", ">" or "-" and then press SPACEBAR to see the formatting applied.',
       },
@@ -55,10 +47,8 @@ const initialValue = [
   },
   {
     type: 'paragraph',
-    id: ++i,
     children: [
       {
-        id: `${i}leaf`,
         text:
           'If you show the console, it should only log `Element.render` once for each keypress.',
       },

--- a/site/examples/controlled-updates.js
+++ b/site/examples/controlled-updates.js
@@ -1,0 +1,145 @@
+/* eslint-disable no-console */
+
+import React, { useState, useMemo, useCallback, useRef } from 'react'
+import { createEditor, Transforms } from 'slate'
+import { Slate, Editable, withReact } from 'slate-react'
+import { createDraft, finishDraft } from 'immer'
+
+const SHORTCUTS = {
+  '*': 'list-item',
+  '-': 'list-item',
+  '+': 'list-item',
+  '>': 'block-quote',
+  '#': 'heading-one',
+  '##': 'heading-two',
+  '###': 'heading-three',
+  '####': 'heading-four',
+  '#####': 'heading-five',
+  '######': 'heading-six',
+}
+
+let i = 0
+
+const initialValue = [
+  {
+    type: 'heading-one',
+    id: ++i,
+    children: [
+      {
+        id: `${i}leaf`,
+        text: 'Controlled Update Example',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    id: ++i,
+    children: [
+      {
+        id: `${i}leaf`,
+        text:
+          'This example has the same functionality as the "Markdown Shortcuts" example. However, in our implementation we are using `immer.js` to draft a new state in onChange, mutate it, and render the results.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    id: ++i,
+    children: [
+      {
+        id: `${i}leaf`,
+        text:
+          'Try starting a line with a markdown modifier, like "#", "##", ">" or "-" and then press SPACEBAR to see the formatting applied.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    id: ++i,
+    children: [
+      {
+        id: `${i}leaf`,
+        text:
+          'If you show the console, it should only log `Element.render` once for each keypress.',
+      },
+    ],
+  },
+]
+
+const ControlledUpdatesExample = () => {
+  const [editorState, setEditorState] = useState({
+    value: initialValue,
+    selection: null,
+  })
+  const renderElement = useCallback(props => <Element {...props} />, [])
+
+  const editor = useMemo(() => withReact(createEditor()), [])
+
+  const onChange = value => {
+    if (!editor.selection) {
+      return
+    }
+    const { path } = editor.selection.focus
+
+    const _value = createDraft(value)
+    const _selection = createDraft(editor.selection)
+
+    const _node = _value[path[0]]
+    const _textNode = _node.children[0]
+    const _firstSpace = _textNode.text.indexOf(' ')
+    const _md = _firstSpace > 0 && _textNode.text.slice(0, _firstSpace)
+    const _nextType = SHORTCUTS[_md]
+    if (_nextType) {
+      _node.type = _nextType
+      _textNode.text = _textNode.text.substr(_md.length + 1)
+
+      // we've removed some characters, so move our caret back to 0
+      _selection.focus.offset = 0
+      _selection.anchor.offset = 0
+    }
+
+    // we batch our state updates so our children and selection stay in sync
+    setEditorState({
+      value: finishDraft(_value),
+      selection: finishDraft(_selection),
+    })
+  }
+
+  if (editorState.selection) {
+    Transforms.setSelection(editor, editorState.selection)
+  }
+
+  return (
+    <Slate editor={editor} value={editorState.value} onChange={onChange}>
+      <Editable renderElement={renderElement} autoFocus />
+    </Slate>
+  )
+}
+
+const Element = ({ attributes, children, element }) => {
+  console.log('Element.render')
+  switch (element.type) {
+    case 'block-quote':
+      return <blockquote {...attributes}>{children}</blockquote>
+    case 'bulleted-list':
+      return <ul {...attributes}>{children}</ul>
+    case 'heading-one':
+      return <h1 {...attributes}>{children}</h1>
+    case 'heading-two':
+      return <h2 {...attributes}>{children}</h2>
+    case 'heading-three':
+      return <h3 {...attributes}>{children}</h3>
+    case 'heading-four':
+      return <h4 {...attributes}>{children}</h4>
+    case 'heading-five':
+      return <h5 {...attributes}>{children}</h5>
+    case 'heading-six':
+      return <h6 {...attributes}>{children}</h6>
+    case 'list-item':
+      return <li {...attributes}>{children}</li>
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+export default ControlledUpdatesExample

--- a/site/examples/controlled-updates.js
+++ b/site/examples/controlled-updates.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
-import React, { useState, useMemo, useCallback, useRef } from 'react'
-import { createEditor, Transforms } from 'slate'
+import React, { useState, useMemo, useCallback } from 'react'
+import { createEditor } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 import { createDraft, finishDraft } from 'immer'
 
@@ -95,12 +95,8 @@ const ControlledUpdatesExample = () => {
     })
   }
 
-  if (editorState.selection) {
-    Transforms.setSelection(editor, editorState.selection)
-  }
-
   return (
-    <Slate editor={editor} value={editorState.value} onChange={onChange}>
+    <Slate editor={editor} onChange={onChange} {...editorState}>
       <Editable renderElement={renderElement} autoFocus />
     </Slate>
   )

--- a/site/pages/examples/[example].js
+++ b/site/pages/examples/[example].js
@@ -24,9 +24,11 @@ import ReadOnly from '../../examples/read-only'
 import RichText from '../../examples/richtext'
 import SearchHighlighting from '../../examples/search-highlighting'
 import Tables from '../../examples/tables'
+import ControlledUpdates from '../../examples/controlled-updates'
 
 const EXAMPLES = [
   ['Checklists', CheckLists, 'check-lists'],
+  ['Controlled Updates', ControlledUpdates, 'controlled-updates'],
   ['Embeds', Embeds, 'embeds'],
   ['Forced Layout', ForcedLayout, 'forced-layout'],
   ['Hovering Toolbar', HoveringToolbar, 'hovering-toolbar'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5786,6 +5786,11 @@ immer@^5.0.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-5.0.0.tgz#07f462b7d95f7e86c214a861ecacd766d42b8c0a"
   integrity sha512-G7gRqKbi9NE025XVyqyTV98dxUOtdKvu/P1QRaVZfA55aEcXgjbxPdm+TlWdcSMNPKijlaHNz61DGPyelouRlA==
 
+immer@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"
+  integrity sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This PR adds an example and a new Walkthrough in the docs.

#### What's the new behavior?

One of the powerful features of Slate is the ability to use it as a controlled input. This means that in our `onChange`, we can mutate the `value` and pass it back to the `<Slate />` component. If we mutate it correctly, Slate will efficiently render the new document. However, we must be cautious. Slate uses [immer.js](https://immerjs.github.io/) to handle state updates internally, which means that `value` is [frozen](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze), e.g. immutable, and the JS runtime will throw an error if you try to mutate it in place. We can deep-clone the `value`, mutate it, and pass it back to Slate, but this is not recommended for reasons covered in the discussion of #3509. 

Instead, the recommended pattern is to use `immer.js` to create a new "draft" of the `value` using `createDraft` and then mutate the draft. When we pass the new `value` returned by `finishDraft` to Slate, everything works as intended. This pattern is described in a new "Controlled Updates" section of the docs site, which uses sample code tested in this [CodeSandbox example](https://codesandbox.io/s/controlled-updates-example-u3v70).

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3507
