### PR TITLE
fixed some bugs with the input event handler on the embeds example

### DIFF
--- a/site/examples/embeds.js
+++ b/site/examples/embeds.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react'
-import { Editor, createEditor } from 'slate'
+import { Transforms, createEditor } from 'slate'
 import {
   Slate,
   Editable,
@@ -41,30 +41,12 @@ const Element = props => {
 
 const VideoElement = ({ attributes, children, element }) => {
   const editor = useEditor()
-  const selected = useSelected()
-  const focused = useFocused()
   const { url } = element
   return (
     <div {...attributes}>
       <div
         contentEditable={false}
-        style={{
-          position: 'relative',
-          boxShadow: selected && focused ? '0 0 0 3px #B4D5FF' : 'none',
-        }}
       >
-        <div
-          style={{
-            display: selected && focused ? 'none' : 'block',
-            position: 'absolute',
-            top: '0',
-            left: '0',
-            height: '100%',
-            width: '100%',
-            cursor: 'cell',
-            zIndex: 1,
-          }}
-        />
         <div
           style={{
             padding: '75% 0 0 0',
@@ -83,20 +65,18 @@ const VideoElement = ({ attributes, children, element }) => {
             }}
           />
         </div>
-        {selected && focused ? (
-          <input
-            value={url}
-            onClick={e => e.stopPropagation()}
-            style={{
-              marginTop: '5px',
-              boxSizing: 'border-box',
-            }}
-            onChange={value => {
-              const path = ReactEditor.findPath(editor, element)
-              Transforms.setNodes(editor, { url: value }, { at: path })
-            }}
-          />
-        ) : null}
+        <input
+          value={url}
+          onClick={e => e.stopPropagation()}
+          style={{
+            marginTop: '5px',
+            boxSizing: 'border-box',
+          }}
+          onChange={e => {
+            const path = ReactEditor.findPath(editor, element)
+            Transforms.setNodes(editor, { url: e.target.value }, { at: path })
+          }}
+        />
       </div>
       {children}
     </div>

--- a/site/examples/embeds.js
+++ b/site/examples/embeds.js
@@ -44,9 +44,7 @@ const VideoElement = ({ attributes, children, element }) => {
   const { url } = element
   return (
     <div {...attributes}>
-      <div
-        contentEditable={false}
-      >
+      <div contentEditable={false}>
         <div
           style={{
             padding: '75% 0 0 0',


### PR DESCRIPTION

#### Is this adding or improving a _feature_ or fixing a _bug_?

Bug

#### What's the new behavior?

This PR simplifies some selection based conditional rendering that was making it hard to edit the embedded input. 

#### How does this change work?

* Removed conditionals that were rendering the input only when the VideoEmbed element was selected and focused. 
* Removed the div that was providing an outline to the VideoEmbed element - this was disrupting the input's select state.

#### Have you checked that...?
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
