### PR TITLE
next.js fix for portals

### DIFF
--- a/site/components.js
+++ b/site/components.js
@@ -122,11 +122,11 @@ export const Menu = React.forwardRef(({ className, ...props }, ref) => (
 ))
 
 export const Portal = ({ children }) => {
-  let portal = null;
+  let portal = null
   if (globalThis.document) {
-    portal = ReactDOM.createPortal(children, document.body);
+    portal = ReactDOM.createPortal(children, document.body)
   }
-  return portal;
+  return portal
 }
 
 export const Toolbar = React.forwardRef(({ className, ...props }, ref) => (

--- a/site/components.js
+++ b/site/components.js
@@ -122,7 +122,11 @@ export const Menu = React.forwardRef(({ className, ...props }, ref) => (
 ))
 
 export const Portal = ({ children }) => {
-  return ReactDOM.createPortal(children, document.body)
+  let portal = null;
+  if (globalThis.document) {
+    portal = ReactDOM.createPortal(children, document.body);
+  }
+  return portal;
 }
 
 export const Toolbar = React.forwardRef(({ className, ...props }, ref) => (

--- a/site/components.js
+++ b/site/components.js
@@ -122,11 +122,9 @@ export const Menu = React.forwardRef(({ className, ...props }, ref) => (
 ))
 
 export const Portal = ({ children }) => {
-  let portal = null
-  if (globalThis.document) {
-    portal = ReactDOM.createPortal(children, document.body)
-  }
-  return portal
+  return typeof document === 'object'
+    ? ReactDOM.createPortal(children, document.body)
+    : null
 }
 
 export const Toolbar = React.forwardRef(({ className, ...props }, ref) => (


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

hovering-toolbar.js example doesn't work with Next.js. Reason of this is simple - no portals on ssr.

#### What's the new behavior?

hoverting-toolbar example works with next.js fine (although their is console error saying about client-server render inconsistency. 