### PR TITLE
`Text.equals` now works with more nested Text nodes, and non-primitive attributes.

### DIFF
--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -18,6 +18,7 @@
     "esrever": "^0.2.0",
     "immer": "^5.0.0",
     "is-plain-object": "^3.0.0",
+    "lodash": "^4.17.4",
     "tiny-warning": "^1.0.3"
   },
   "keywords": [

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -1,4 +1,6 @@
 import isPlainObject from 'is-plain-object'
+import isEqual from 'lodash/isEqual'
+import omit from 'lodash/omit'
 import { Range } from '..'
 
 /**
@@ -24,27 +26,10 @@ export const Text = {
   ): boolean {
     const { loose = false } = options
 
-    for (const key in text) {
-      if (loose && key === 'text') {
-        continue
-      }
-
-      if (text[key] !== another[key]) {
-        return false
-      }
-    }
-
-    for (const key in another) {
-      if (loose && key === 'text') {
-        continue
-      }
-
-      if (text[key] !== another[key]) {
-        return false
-      }
-    }
-
-    return true
+    return isEqual(
+      loose ? omit(text, 'text') : text,
+      loose ? omit(another, 'text') : another
+    )
   },
 
   /**

--- a/packages/slate/test/interfaces/Text/equals/complex-exact-equals.js
+++ b/packages/slate/test/interfaces/Text/equals/complex-exact-equals.js
@@ -1,0 +1,20 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: false },
+  },
+  textNodeB: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: false },
+  },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: false })
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Text/equals/complex-exact-not-equal.js
+++ b/packages/slate/test/interfaces/Text/equals/complex-exact-not-equal.js
@@ -1,0 +1,20 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: false },
+  },
+  textNodeB: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: true },
+  },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: false })
+}
+
+export const output = false

--- a/packages/slate/test/interfaces/Text/equals/complex-loose-equals.js
+++ b/packages/slate/test/interfaces/Text/equals/complex-loose-equals.js
@@ -1,0 +1,20 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: false },
+  },
+  textNodeB: {
+    text: 'diff text',
+    bold: true,
+    italic: { origin: 'inherited', value: false },
+  },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: true })
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Text/equals/complex-loose-not-equal.js
+++ b/packages/slate/test/interfaces/Text/equals/complex-loose-not-equal.js
@@ -1,0 +1,20 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: false },
+  },
+  textNodeB: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: true },
+  },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: false })
+}
+
+export const output = false

--- a/packages/slate/test/interfaces/Text/equals/exact-equals.js
+++ b/packages/slate/test/interfaces/Text/equals/exact-equals.js
@@ -1,0 +1,12 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: { text: 'same text', bold: true },
+  textNodeB: { text: 'same text', bold: true },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: false })
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Text/equals/exact-not-equal.js
+++ b/packages/slate/test/interfaces/Text/equals/exact-not-equal.js
@@ -1,0 +1,12 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: { text: 'same text', bold: true },
+  textNodeB: { text: 'same text', bold: true, italic: true },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: false })
+}
+
+export const output = false

--- a/packages/slate/test/interfaces/Text/equals/loose-equals.js
+++ b/packages/slate/test/interfaces/Text/equals/loose-equals.js
@@ -1,0 +1,12 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: { text: 'some text', bold: true },
+  textNodeB: { text: 'diff text', bold: true },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: true })
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Text/equals/loose-not-equal.js
+++ b/packages/slate/test/interfaces/Text/equals/loose-not-equal.js
@@ -1,0 +1,12 @@
+import { Text } from 'slate'
+
+export const input = {
+  textNodeA: { text: 'same text', bold: true },
+  textNodeB: { text: 'same text', bold: true, italic: true },
+}
+
+export const test = ({ textNodeA, textNodeB }) => {
+  return Text.equals(textNodeA, textNodeB, { loose: true })
+}
+
+export const output = false


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### What's the new behavior?

Related to the problem with the `Text.matches` function called out #3299, the `Text.equals(nodeA, nodeB)` function would incorrectly return false if a property on both nodes were equivalent objects/arrays.

This means that some consumers of this library (such as my company), who would expect Slate to merge Text nodes together if they have similar properties, to find that expectation false if they use non-primitive values for Text node properties.

#### How does this change work?

The new logic merely makes use of `lodash`'s  `isEqual` function to recurse through the objects looking for discrepancies. It will also omit the `text` property for each node under `loose` mode.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
