### PR TITLE
Fix for backspace press in list

### DIFF
--- a/site/examples/markdown-shortcuts.js
+++ b/site/examples/markdown-shortcuts.js
@@ -96,6 +96,7 @@ const withShortcuts = editor => {
           if (block.type === 'list-item') {
             Transforms.unwrapNodes(editor, {
               match: n => n.type === 'bulleted-list',
+              split: true,
             })
           }
 


### PR DESCRIPTION
Made a fix for the fact that if you were standing in a `<li>` wrapped in an `<ul>` with no text and pressed backspace, the `<ul>` would go away while the `<li>`'s stay.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

When initially you have this in your editor (with the cursor in the last list item):

![image](https://user-images.githubusercontent.com/24796206/75722677-f4541b00-5cda-11ea-9900-d0ccc15831e6.png)

And then press backspace, the following happens:

![image](https://user-images.githubusercontent.com/24796206/75722691-fae29280-5cda-11ea-9856-58ffa62dfe5d.png)

With this fix, the following (correct behaviour) occurs:

![image](https://user-images.githubusercontent.com/24796206/75723453-a5a78080-5cdc-11ea-975d-1639735dbec4.png)

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

I added `split=true` at the `Transforms.unwrapNodes()` point, just like in the example on the site with lists in rich text.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
