### PR TITLE
Avoid mutating the selection in Transforms.setPoint

### DIFF
--- a/packages/slate/src/transforms/selection.ts
+++ b/packages/slate/src/transforms/selection.ts
@@ -157,13 +157,10 @@ export const SelectionTransforms = {
 
     const { anchor, focus } = selection
     const point = edge === 'anchor' ? anchor : focus
-    const newPoint = Object.assign(point, props)
 
-    if (edge === 'anchor') {
-      Transforms.setSelection(editor, { anchor: newPoint })
-    } else {
-      Transforms.setSelection(editor, { focus: newPoint })
-    }
+    Transforms.setSelection(editor, {
+      [edge === 'anchor' ? 'anchor' : 'focus']: { ...point, ...props },
+    })
   },
 
   /**

--- a/packages/slate/test/transforms/setPoint/offset.js
+++ b/packages/slate/test/transforms/setPoint/offset.js
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../..'
+
+export const run = editor => {
+  Transforms.move(editor)
+  Transforms.setPoint(editor, { offset: 0 }, { edge: 'focus' })
+}
+
+export const input = (
+  <editor>
+    <block>
+      f<cursor />
+      oo
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>
+      <focus />
+      fo
+      <anchor />o
+    </block>
+  </editor>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

The test case included in this PR and this code currently fail on `master`:

```javascript
Transforms.move(editor); // This can be anything that triggers a selection change.
Transforms.setPoint(editor, { offset: 0 }, { edge: 'focus' }); //=> TypeError: Cannot assign to read only property 'offset' of object '#<Object>'
```

The reason for this is that after the first selection change (`Transforms.move(editor)`), Immer has frozen the selection. In `Transforms.setPoint` there's a `Object.assign` call on the selection point, which throws the TypeError. This PR fixes this.

#### How does this change work?

I never try to mutate any selection points. Instead I just create a new object.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)