### PR TITLE
Changed selection reconciliation in the React Editor to work with zero width characters added to void elements.

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -367,8 +367,8 @@ export const Editable = (props: EditableProps) => {
 
         if (
           domRange &&
-          hasEditableTarget(editor, domRange.startContainer) &&
-          hasEditableTarget(editor, domRange.endContainer)
+          hasSelectableTarget(editor, domRange.startContainer) &&
+          hasSelectableTarget(editor, domRange.endContainer)
         ) {
           const range = ReactEditor.toSlateRange(editor, domRange)
           Transforms.select(editor, range)
@@ -968,6 +968,20 @@ const hasEditableTarget = (
   return (
     isDOMNode(target) &&
     ReactEditor.hasDOMNode(editor, target, { editable: true })
+  )
+}
+
+/**
+ * Check if the target is selectable and in the editor.
+ */
+
+const hasSelectableTarget = (
+  editor: ReactEditor,
+  target: EventTarget | null
+): target is DOMNode => {
+  return (
+    isDOMNode(target) &&
+    ReactEditor.hasDOMNode(editor, target, { selectable: true })
   )
 }
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -146,9 +146,9 @@ export const ReactEditor = {
   hasDOMNode(
     editor: ReactEditor,
     target: DOMNode,
-    options: { editable?: boolean } = {}
+    options: { editable?: boolean; selectable?: boolean } = {}
   ): boolean {
-    const { editable = false } = options
+    const { editable = false, selectable = false } = options
     const editorEl = ReactEditor.toDOMNode(editor, editor)
     let targetEl
 
@@ -174,7 +174,11 @@ export const ReactEditor = {
 
     return (
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
-      (!editable || targetEl.isContentEditable)
+      (!editable || targetEl.isContentEditable) &&
+      // Selectable nodes are editable or the zero width elements for void nodes.
+      (!selectable ||
+        targetEl.isContentEditable ||
+        targetEl.hasAttribute('data-slate-zero-width'))
     )
   },
 

--- a/site/examples/images.js
+++ b/site/examples/images.js
@@ -91,18 +91,16 @@ const ImageElement = ({ attributes, children, element }) => {
   const selected = useSelected()
   const focused = useFocused()
   return (
-    <div {...attributes}>
-      <div contentEditable={false}>
-        <img
-          src={element.url}
-          className={css`
-            display: block;
-            max-width: 100%;
-            max-height: 20em;
-            box-shadow: ${selected && focused ? '0 0 0 3px #B4D5FF' : 'none'};
-          `}
-        />
-      </div>
+    <div contentEditable={false} {...attributes}>
+      <img
+        src={element.url}
+        className={css`
+          display: block;
+          max-width: 100%;
+          max-height: 20em;
+          box-shadow: ${selected && focused ? '0 0 0 3px #B4D5FF' : 'none'};
+        `}
+      />
       {children}
     </div>
   )


### PR DESCRIPTION
Void elements are selected by the insertion of a zero-width character
that the browser can select.

Currently, the selection reconciliation (making sure the Slate selection
state matches the DOM) will only select things that are within the
Editor it is responsible for, and the DOM element that is the target of
the selection is editable in the editor.

A lot of times, void nodes have their rendered root elements marked as not
content editable, thus making this zero-width character not marked as
editable, and the selection reconciliation will not mark the selection as
allowed.

A way around this is to always have an inner element in a void node
that is marked as not content editable if needed, leaving the zero-width
character out of the wrapping. This adds an unneeded DOM node however
and might get confusing without being explicit in the documentation.

This creates a new check if a node is selectable. Being selectable
means its editable or a void nodes zero-width element.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug, #3518 

#### What's the new behavior?

The expected behavior of the ticket. Also see the above description.

#### How does this change work?

See above description.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3518 
Reviewers: @
