### PR TITLE
Attach the cloned DOM node before coputing its plaintext representation when copying.

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1087,13 +1087,18 @@ const setFragmentData = (
   // Add the content to a <div> so that we can get its inner HTML.
   const div = document.createElement('div')
   div.appendChild(contents)
+  div.setAttribute('hidden', 'true')
+  document.body.appendChild(div)
   dataTransfer.setData('text/html', div.innerHTML)
   dataTransfer.setData('text/plain', getPlainText(div))
+  document.body.removeChild(div)
 }
 
 /**
  * Get a plaintext representation of the content of a node, accounting for block
  * elements which get a newline appended.
+ *
+ * The domNode must be attached to the DOM.
  */
 
 const getPlainText = (domNode: DOMNode) => {


### PR DESCRIPTION
The cloned dom node constructed when copying must be attached to the dom for getComputedStyle to work.

This adds the div to the body as a hidden element and removes after computing its text representation.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

#### What's the new behavior?

See above description.

#### How does this change work?

See above description.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3505 
Reviewers: @
