### PR TITLE
fix input in editable void example

### DIFF
--- a/site/examples/editable-voids.js
+++ b/site/examples/editable-voids.js
@@ -73,6 +73,7 @@ const EditableVoidElement = ({ attributes, children, element }) => {
       >
         <h4>Name:</h4>
         <input
+          data-slate-editor
           className={css`
             margin: 8px 0;
           `}


### PR DESCRIPTION
It seems like this is required to make the text field editable?
New to slate but spent the past several hours trying to figure out why I couldn't edit the field in the void and this fixed it.

