### PR TITLE
Correct onDOMBeforeInput typings

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -75,7 +75,7 @@ export interface RenderLeafProps {
 
 export type EditableProps = {
   decorate?: (entry: NodeEntry) => Range[]
-  onDOMBeforeInput?: (event: Event) => void
+  onDOMBeforeInput?: (event: InputEvent) => void
   placeholder?: string
   readOnly?: boolean
   role?: string


### PR DESCRIPTION


#### Is this adding or improving a _feature_ or fixing a _bug_?

TS will report an error when trying to access event.inputType since it was declared of type "Event" and not "InputEvent".
