### PR TITLE
use state to avoid cursor jumping in controlled input

### DIFF
--- a/site/examples/embeds.js
+++ b/site/examples/embeds.js
@@ -63,21 +63,35 @@ const VideoElement = ({ attributes, children, element }) => {
             }}
           />
         </div>
-        <input
-          value={url}
-          onClick={e => e.stopPropagation()}
-          style={{
-            marginTop: '5px',
-            boxSizing: 'border-box',
-          }}
-          onChange={e => {
+        <UrlInput
+          url={url}
+          onChange={val => {
             const path = ReactEditor.findPath(editor, element)
-            Transforms.setNodes(editor, { url: e.target.value }, { at: path })
+            Transforms.setNodes(editor, { url: val }, { at: path })
           }}
         />
       </div>
       {children}
     </div>
+  )
+}
+
+const UrlInput = ({ url, onChange }) => {
+  const [value, setValue] = React.useState(url)
+  return (
+    <input
+      value={value}
+      onClick={e => e.stopPropagation()}
+      style={{
+        marginTop: '5px',
+        boxSizing: 'border-box',
+      }}
+      onChange={e => {
+        const newUrl = e.target.value
+        setValue(newUrl)
+        onChange(newUrl)
+      }}
+    />
   )
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Cursor is not jumping to end in Embeds example

#### How does this change work?

Controlled inputs need a separate state to handle proper cursor management. This PR adds a state to the input that stores the current url value.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
