### PR TITLE
TypeScript Improvement: Use `[key: string]: unknown`, not `[key: string]: any`

### DIFF
--- a/docs/api/locations.md
+++ b/docs/api/locations.md
@@ -22,7 +22,7 @@ type Path = number[]
 
 ## Point
 
-`Point` objects refer to a specific location in a text node in a Slate document. Its `path` refers to the lcoation of the node in the tree, and its offset refers to distance into the node's string of text. Points may only refer to `Text` nodes.
+`Point` objects refer to a specific location in a text node in a Slate document. Its `path` refers to the location of the node in the tree, and its offset refers to distance into the node's string of text. Points may only refer to `Text` nodes.
 
 ```typescript
 interface Point {

--- a/docs/api/locations.md
+++ b/docs/api/locations.md
@@ -28,7 +28,7 @@ type Path = number[]
 interface Point {
     path: Path
     offset: number  
-    [key: string]: any
+    [key: string]: unknown
 }
 ```
 
@@ -68,7 +68,7 @@ Options: `{affinity?: 'forward' | 'backward' | null}`
 interface Range {
     anchor: Point
     focus: Point
-    [key: string]: any
+    [key: string]: unknown
 }
 ```
 

--- a/docs/api/nodes.md
+++ b/docs/api/nodes.md
@@ -123,7 +123,7 @@ interface Editor {
   selection: Range | null
   operations: Operation[]
   marks: Record<string, any> | null
-  [key: string]: any
+  [key: string]: unknown
 
   // Schema-specific node behaviors.
   isInline: (element: Element) => boolean
@@ -212,7 +212,7 @@ Apply an operation in the editor.
 ```typescript
 interface Element {
   children: Node[]
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 
@@ -237,7 +237,7 @@ Check if an element matches a set of `props`. Note: This checks custom propertie
 ```typescript
 interface Text {
     text: string,
-    [key: string]: any
+    [key: string]: unknown
 }
 ```
 

--- a/docs/concepts/01-interfaces.md
+++ b/docs/concepts/01-interfaces.md
@@ -5,7 +5,7 @@ Slate works with pure JSON objects. All it requires is that those JSON objects c
 ```ts
 interface Text {
   text: string
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 
@@ -22,7 +22,7 @@ To take another example, the `Element` node interface in Slate is:
 ```ts
 interface Element {
   children: Node[]
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 

--- a/docs/concepts/02-nodes.md
+++ b/docs/concepts/02-nodes.md
@@ -55,7 +55,7 @@ Elements make up the middle layers of a richtext document. They are the nodes th
 ```ts
 interface Element {
   children: Node[]
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 
@@ -126,7 +126,7 @@ Text nodes are the lowest-level nodes in the tree, containing the text content o
 ```ts
 interface Text {
   text: string
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 

--- a/docs/concepts/03-locations.md
+++ b/docs/concepts/03-locations.md
@@ -37,7 +37,7 @@ Points are slightly more specific than paths, and contain an `offset` into a spe
 interface Point {
   path: Path
   offset: number
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 
@@ -71,7 +71,7 @@ Ranges are a way to refer not just to a single point in the document, but to a w
 interface Range {
   anchor: Point
   focus: Point
-  [key: string]: any
+  [key: string]: unknown
 }
 ```
 

--- a/docs/concepts/06-editor.md
+++ b/docs/concepts/06-editor.md
@@ -8,7 +8,7 @@ interface Editor {
   selection: Range | null
   operations: Operation[]
   marks: Record<string, any> | null
-  [key: string]: any
+  [key: string]: unknown
 
   // Schema-specific node behaviors.
   isInline: (element: Element) => boolean

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -712,7 +712,7 @@ export const Editable = (props: EditableProps) => {
               if (Hotkeys.isRedo(nativeEvent)) {
                 event.preventDefault()
 
-                if (editor.redo) {
+                if (typeof editor.redo === 'function') {
                   editor.redo()
                 }
 
@@ -722,7 +722,7 @@ export const Editable = (props: EditableProps) => {
               if (Hotkeys.isUndo(nativeEvent)) {
                 event.preventDefault()
 
-                if (editor.undo) {
+                if (typeof editor.undo === 'function') {
                   editor.undo()
                 }
 

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -43,7 +43,7 @@ const Leaf = (props: {
             opacity: '0.333',
           }}
         >
-          {leaf.placeholder}
+          {leaf.placeholder as React.ReactNode}
         </span>
         {children}
       </React.Fragment>

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -17,7 +17,7 @@ export const Slate = (props: {
   value: Node[]
   children: React.ReactNode
   onChange: (value: Node[]) => void
-  [key: string]: any
+  [key: string]: unknown
 }) => {
   const { editor, children, onChange, value, ...rest } = props
   const [key, setKey] = useState(0)

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -38,7 +38,7 @@ export interface Editor {
   selection: Range | null
   operations: Operation[]
   marks: Record<string, any> | null
-  [key: string]: any
+  [key: string]: unknown
 
   // Schema-specific node behaviors.
   isInline: (element: Element) => boolean

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1331,7 +1331,7 @@ export const Editor = {
         // the operation was applied.
         parent.children.splice(index, 1)
         const truePath = Path.transform(path, op)!
-        const newParent = Node.get(editor, Path.parent(truePath))
+        const newParent = Node.get(editor, Path.parent(truePath)) as Ancestor
         const newIndex = truePath[truePath.length - 1]
 
         newParent.children.splice(newIndex, 0, node)

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -9,7 +9,7 @@ import { Editor, Node, Path } from '..'
 
 export interface Element {
   children: Node[]
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export const Element = {

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -5,7 +5,7 @@ export type InsertNodeOperation = {
   type: 'insert_node'
   path: Path
   node: Node
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type InsertTextOperation = {
@@ -13,7 +13,7 @@ export type InsertTextOperation = {
   path: Path
   offset: number
   text: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type MergeNodeOperation = {
@@ -22,21 +22,21 @@ export type MergeNodeOperation = {
   position: number
   target: number | null
   properties: Partial<Node>
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type MoveNodeOperation = {
   type: 'move_node'
   path: Path
   newPath: Path
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type RemoveNodeOperation = {
   type: 'remove_node'
   path: Path
   node: Node
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type RemoveTextOperation = {
@@ -44,7 +44,7 @@ export type RemoveTextOperation = {
   path: Path
   offset: number
   text: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type SetNodeOperation = {
@@ -52,25 +52,25 @@ export type SetNodeOperation = {
   path: Path
   properties: Partial<Node>
   newProperties: Partial<Node>
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type SetSelectionOperation =
   | {
       type: 'set_selection'
-      [key: string]: any
+      [key: string]: unknown
       properties: null
       newProperties: Range
     }
   | {
       type: 'set_selection'
-      [key: string]: any
+      [key: string]: unknown
       properties: Partial<Range>
       newProperties: Partial<Range>
     }
   | {
       type: 'set_selection'
-      [key: string]: any
+      [key: string]: unknown
       properties: Range
       newProperties: null
     }
@@ -81,7 +81,7 @@ export type SplitNodeOperation = {
   position: number
   target: number | null
   properties: Partial<Node>
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type NodeOperation =

--- a/packages/slate/src/interfaces/point.ts
+++ b/packages/slate/src/interfaces/point.ts
@@ -12,7 +12,7 @@ import { Operation, Path } from '..'
 export interface Point {
   path: Path
   offset: number
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export const Point = {

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -11,7 +11,7 @@ import { Operation, Path, Point, PointEntry } from '..'
 export interface Range {
   anchor: Point
   focus: Point
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export const Range = {

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -9,7 +9,7 @@ import { Range } from '..'
 
 export interface Text {
   text: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export const Text = {

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -10,7 +10,7 @@ import {
   Descendant,
   NodeEntry,
   Path,
-  Transforms,
+  Ancestor,
 } from '..'
 
 export const GeneralTransforms = {
@@ -104,7 +104,7 @@ export const GeneralTransforms = {
         // the operation was applied.
         parent.children.splice(index, 1)
         const truePath = Path.transform(path, op)!
-        const newParent = Node.get(editor, Path.parent(truePath))
+        const newParent = Node.get(editor, Path.parent(truePath)) as Ancestor
         const newIndex = truePath[truePath.length - 1]
 
         newParent.children.splice(newIndex, 0, node)

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -8,6 +8,8 @@ import {
   Range,
   Text,
   Transforms,
+  NodeEntry,
+  Ancestor,
 } from '..'
 
 export const NodeTransforms = {
@@ -168,7 +170,8 @@ export const NodeTransforms = {
           )
         }
 
-        const [parent, parentPath] = Editor.node(editor, Path.parent(path))
+        const parentNodeEntry = Editor.node(editor, Path.parent(path))
+        const [parent, parentPath] = parentNodeEntry as NodeEntry<Ancestor>
         const index = path[path.length - 1]
         const { length } = parent.children
 
@@ -721,7 +724,7 @@ export const NodeTransforms = {
 
       for (const pathRef of pathRefs) {
         const path = pathRef.unref()!
-        const [node] = Editor.node(editor, path)
+        const [node] = Editor.node(editor, path) as NodeEntry<Ancestor>
         let range = Editor.range(editor, path)
 
         if (split && rangeRef) {
@@ -823,7 +826,8 @@ export const NodeTransforms = {
             : Path.common(firstPath, lastPath)
 
           const range = Editor.range(editor, firstPath, lastPath)
-          const [commonNode] = Editor.node(editor, commonPath)
+          const commonNodeEntry = Editor.node(editor, commonPath)
+          const [commonNode] = commonNodeEntry as NodeEntry<Ancestor>
           const depth = commonPath.length + 1
           const wrapperPath = Path.next(lastPath.slice(0, depth))
           const wrapper = { ...element, children: [] }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement.
Mostly fixes issue #3416, superseding WIP PR attempt #3473.
(Arguably fixes a bug for TypeScript users)

#### What's the new behavior?

As described in issue #3416, the current type interfaces for most important Slate objects looks something like this:

```ts
interface Text {
  text: string;
  [key: string]: any;
}
```

This PR mainly changes this and similar types to:
```ts
interface Text {
  text: string;
  [key: string]: unknown;
}
```

---
The original purpose of the `[key: string]: any` was to say, effectively "This `Text` object is allowed to have other key-value pairs besides `text`", which is needed.

However, because the value for every arbitrary key is of type `any`, it muffles any errors or warnings TypeScript would otherwise give, causing potential runtime errors. See below:

![Screen Shot 2020-03-28 at 7 11 59 PM](https://user-images.githubusercontent.com/4212194/77835931-08e3d180-7128-11ea-9863-7076a8627894.png)

As in the example, `unknown` is the more appropriate type to use here. It allows any arbitrary keys on the `Text` object, but makes no assumption about its value, and requires the user to typecheck, preventing runtime errors.

This has two major benefits to the codebase.

1) Previous possible type errors in the source are caught. For example, `Node` objects now are no longer assumed to have `children` defined, because they can be `Text` nodes, which are not guaranteed to have that property (and generally don't). Now the codebase has to either guard against those cases, or inform the type system (via `as` assertions) when that is seen as reasonable (eg a parent to a `Node` will be an `Ancestor`).

2) Slate types now play well with user-extended types. When an extension defines another required field, TypeScript can make sure non-defined keys are not treated as defined:

![Screen Shot 2020-03-28 at 7 20 23 PM](https://user-images.githubusercontent.com/4212194/77836206-945e6200-712a-11ea-977a-16ee44632205.png)

I don't believe this offers the full flexibility that full type generics offer, but helps us get there.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3416 (mostly)
Reviewers: @ianstormtaylor, @miracle2k (Because you previously commented on the related issue)
