### PR TITLE
fix issue where inline voids can no longer be selected

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -174,11 +174,9 @@ export const ReactEditor = {
 
     return (
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
-      (
-        !editable ||
+      (!editable ||
         targetEl.isContentEditable ||
-        !!targetEl.getAttribute('data-slate-zero-width')
-      )
+        !!targetEl.getAttribute('data-slate-zero-width'))
     )
   },
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -174,7 +174,7 @@ export const ReactEditor = {
 
     return (
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
-      (!editable || targetEl.isContentEditable)
+      (!editable || targetEl.isContentEditable || !!targetEl.getAttribute('data-slate-zero-width'))
     )
   },
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -174,7 +174,11 @@ export const ReactEditor = {
 
     return (
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
-      (!editable || targetEl.isContentEditable || !!targetEl.getAttribute('data-slate-zero-width'))
+      (
+        !editable ||
+        targetEl.isContentEditable ||
+        !!targetEl.getAttribute('data-slate-zero-width')
+      )
     )
   },
 


### PR DESCRIPTION

#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug

#### What's the new behavior?
This fixes #3518 by allowing zero width characters to be considered editable dom targets, thereby alloing `onDOMSelectionChange` to select them.

#### How does this change work?

This adds zero-width characters to the set of editable targets that are considered selectable DOM children of the editor

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
Examples checked:
* Mentions Example
* Editable Voids Example
* Embeds Example
* Checklist example (This defect was introduced accidentally as part of https://github.com/ianstormtaylor/slate/pull/3389)


#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
