### PR TITLE
Fix: Backward selection with empty text nodes

### DIFF
--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -69,6 +69,13 @@ export const isPlainTextOnlyPaste = (event: ClipboardEvent) => {
 }
 
 /**
+ * Check if a DOM node is a TextNode without content.
+ */
+
+export const isEmptyTextNode = (node: DOMNode): Boolean =>
+  node.nodeType === 3 && /^\s$/.test(node.textContent!)
+
+/**
  * Normalize a DOM point so that it always refers to a text node.
  */
 


### PR DESCRIPTION
As described in #3544 selecting text by dragging backward causes issues if the anchor is an empty text node.

This is due to an inconsistency between slate and native DOM selection ranges (see also [this comment](https://github.com/ianstormtaylor/slate/issues/3544#issuecomment-602718866) from @kilrain). Native DOM selection points of empty text nodes have an offset of 1, while slates selection points have an offset of 0.
So when slate [sets a new DOM range](https://github.com/ianstormtaylor/slate/blob/16ff44d0566889a843a346215d3fb7621fc0ed8c/packages/slate-react/src/components/editable.tsx#L165) (starting and/or ending in an empty text node) based on the slate range, the DOM range point is set with an offset of 0, while native DOM would expect an offset of 1. This causes the described issue and is fixed by correcting this inconsistency when converting a slate range into a DOM range.

With this fix, the issue can no longer be observed:
![u3GwLx3CZc](https://user-images.githubusercontent.com/19997520/78251975-672afe80-74f2-11ea-8ff3-f3a72a3008d3.gif)


