### PR TITLE
fix: ensure Editor.previous() returns the correct node even when the `at` Location doesn't satisfy the match function.

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1126,17 +1126,19 @@ export const Editor = {
       mode,
       voids,
     })
+
     if (first) {
-      // If the first result is the first in the at, it can't be the previous
-      // one. This can happen when the supplied `at` doesn't satisfy the
-      // supplied `match`.
-      // https://github.com/ianstormtaylor/slate/issues/3590
       const [, firstPath] = first
       const [, resultPath] = Editor.first(editor, firstPath)
       if (Path.equals(resultPath, from)) {
+        // The first match was the node of the Location we were
+        // searching from itself, so return the second one.
         return second
       }
     }
+
+    // This can happen when the supplied `at` doesn't satisfy the supplied `match`.
+    // https://github.com/ianstormtaylor/slate/issues/3590
     return first
   },
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1119,15 +1119,25 @@ export const Editor = {
       }
     }
 
-    const [, previous] = Editor.nodes(editor, {
+    const [first, second] = Editor.nodes(editor, {
       reverse: true,
       at: span,
       match,
       mode,
       voids,
     })
-
-    return previous
+    if (first) {
+      // If the first result is the first in the at, it can't be the previous
+      // one. This can happen when the supplied `at` doesn't satisfy the
+      // supplied `match`.
+      // https://github.com/ianstormtaylor/slate/issues/3590
+      const [, firstPath] = first
+      const [, resultPath] = Editor.first(editor, firstPath)
+      if (Path.equals(resultPath, from)) {
+        return second
+      }
+    }
+    return first
   },
 
   /**

--- a/packages/slate/test/interfaces/Editor/previous/non-matching-at.js
+++ b/packages/slate/test/interfaces/Editor/previous/non-matching-at.js
@@ -19,9 +19,7 @@ export const input = (
 export const test = editor => {
   const [node] = Editor.previous(editor, {
     at: [0, 5],
-    match: n => {
-      return !n.bold
-    },
+    match: n => !n.bold,
   })
   return node
 }

--- a/packages/slate/test/interfaces/Editor/previous/text-with-props.js
+++ b/packages/slate/test/interfaces/Editor/previous/text-with-props.js
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>one</text>
+      <text bold>two</text>
+      <text>three</text>
+      <text bold>four</text>
+      <text>five</text>
+      <text bold>six</text>
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  const [node] = Editor.previous(editor, {
+    at: [0, 5],
+    match: n => {
+      return !n.bold
+    },
+  })
+  return node
+}
+
+export const output = { text: 'five' }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a _bug_

#### What's the new behavior?

The previous node is now returned even when the `at` location doesn't match the specified match function. Previously, calls with that characteristic would return the second previous location.

I added a failing test that outlines the behaviour, then fixed it.

#### How does this change work?

We look at the first returned result and compare its to that of the first node at the specified location. If it is the same, then the result must be the second node. If it is not the same, which happens when the supplied location does not satisfy the match function, we return the first node.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3590
Reviewers: @CameronAckermanSEL @ianstormtaylor 
