### PR TITLE
Add edge case in normalize to prevent excessive remove_node

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -221,6 +221,11 @@ export const createEditor = (): Editor => {
         const isInlineOrText =
           Text.isText(child) ||
           (Element.isElement(child) && editor.isInline(child))
+        let prevIsFocused = false
+        if (editor.selection) {
+          const [focusNode] = Editor.node(editor, editor.selection.focus)
+          prevIsFocused = focusNode === prev
+        }
 
         // Only allow block nodes in the top-level children and parent blocks
         // that only contain block nodes. Similarly, only allow inline nodes in
@@ -254,7 +259,9 @@ export const createEditor = (): Editor => {
             if (Text.equals(child, prev, { loose: true })) {
               Transforms.mergeNodes(editor, { at: path.concat(n), voids: true })
               n--
-            } else if (prev.text === '') {
+            } else if (prev.text === '' && !prevIsFocused) {
+              // Only clean up the empty node if it doesn't currently have focus.
+              // This prevents an overly aggressive removal when split happens between nodes.
               Transforms.removeNodes(editor, {
                 at: path.concat(n - 1),
                 voids: true,

--- a/packages/slate/test/normalization/text/no-merge-adjacent-empty-with-focus.js
+++ b/packages/slate/test/normalization/text/no-merge-adjacent-empty-with-focus.js
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text a>1</text>
+      <text b>
+        <cursor />
+      </text>
+      <text c>1</text>
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>
+      <text a>1</text>
+      <text b>
+        <cursor />
+      </text>
+      <text c>1</text>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/normalization/text/no-merge-adjacent-empty-with-focus.js
+++ b/packages/slate/test/normalization/text/no-merge-adjacent-empty-with-focus.js
@@ -9,7 +9,7 @@ export const input = (
       <text b>
         <cursor />
       </text>
-      <text c>1</text>
+      <text c>2</text>
     </block>
   </editor>
 )
@@ -21,7 +21,7 @@ export const output = (
       <text b>
         <cursor />
       </text>
-      <text c>1</text>
+      <text c>2</text>
     </block>
   </editor>
 )


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixes #3600

#### What's the new behavior?
When ENTER key is pressed after marked text (e.g. bold, italics), cursor advances to the following line and mark is maintained, as expected.

#### How does this change work?
An edge case was added to the `normalizeNode` method, which by design cleans up empty nodes. The edge case prevents this cleanup if the current editor focus is on the empty node. This is the case when a `split_node` happens after an ENTER key press when the focus was at the end of a node. See video in #3600 for broken behavior and video below for corrected behavior.

![fix](https://user-images.githubusercontent.com/2692844/78923628-d4153a00-7a98-11ea-97ba-f33995297459.gif)

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
