### PR TITLE
fix the bug for issue 3538(typing Chinese in Apple environment)

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -776,7 +776,7 @@ export const Editable = (props: EditableProps) => {
               if (Hotkeys.isMoveBackward(nativeEvent)) {
                 event.preventDefault()
 
-                if (selection && Range.isCollapsed(selection)) {
+                if (selection && !state.isComposing && Range.isCollapsed(selection)) {
                   Transforms.move(editor, { reverse: true })
                 } else {
                   Transforms.collapse(editor, { edge: 'start' })

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -13,7 +13,12 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 
 import Children from './children'
 import Hotkeys from '../utils/hotkeys'
-import { IS_FIREFOX, IS_SAFARI, IS_EDGE_LEGACY } from '../utils/environment'
+import {
+  IS_FIREFOX,
+  IS_SAFARI,
+  IS_EDGE_LEGACY,
+  IS_APPLE,
+} from '../utils/environment'
 import { ReactEditor } from '..'
 import { ReadOnlyContext } from '../hooks/use-read-only'
 import { useSlate } from '../hooks/use-slate'
@@ -313,12 +318,15 @@ export const Editable = (props: EditableProps) => {
           case 'insertFromYank':
           case 'insertReplacementText':
           case 'insertText': {
+            if (type === 'insertFromComposition' && IS_APPLE) {
+              return
+            }
+
             if (data instanceof DataTransfer) {
               ReactEditor.insertData(editor, data)
             } else if (typeof data === 'string') {
               Editor.insertText(editor, data)
             }
-
             break
           }
         }
@@ -558,7 +566,7 @@ export const Editable = (props: EditableProps) => {
               // aren't correct and never fire the "insertFromComposition"
               // type that we need. So instead, insert whenever a composition
               // ends since it will already have been committed to the DOM.
-              if (!IS_SAFARI && !IS_FIREFOX && event.data) {
+              if (!IS_FIREFOX && event.data) {
                 Editor.insertText(editor, event.data)
               }
             }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -318,13 +318,12 @@ export const Editable = (props: EditableProps) => {
           case 'insertFromYank':
           case 'insertReplacementText':
           case 'insertText': {
-            if (type === 'insertFromComposition' && IS_APPLE) {
-              return
-            }
-
             if (data instanceof DataTransfer) {
               ReactEditor.insertData(editor, data)
             } else if (typeof data === 'string') {
+              if (type === 'insertFromComposition' && IS_APPLE) {
+                return
+              }
               Editor.insertText(editor, data)
             }
             break


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug when typing Chinese in
Safari, Mac OS.
Chrome, iPhone,
Safari, iPhone

![](http://g.recordit.co/sWkZpAKJb8.gif)

#### What's the new behavior?
Making typing Chinese works normally in the environment mentioned above.
![](http://g.recordit.co/JVTYy4gCre.gif)
Demo: https://slate-3538.now.sh/

#### How does this change work?
In onDOMBeforeInput, when typing Chinese, I found the insertFromComposition event type is  fired in Apple environment, and make the Slate editor selection forward. Therefore, in onDOMBeforeInput, I additional check if the environment is APPLE to determine whether to insertText or not.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- The new code matches the existing patterns and styles. YES
- The tests pass with `yarn test`.  YES
- The linter passes with `yarn lint`. (Fix errors with `yarn fix`.) YES
- The relevant examples still work. (Run examples with `yarn start`.) YES

#### Does this fix any issues or need any specific reviewers?

Fixes: #3538
Reviewers: @
