### PR TITLE
Fix(placeholder): allow ReactNode placeholder, allow multiline wrappi…

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1041,7 +1041,7 @@ const setFragmentData = (
   let attach = contents.childNodes[0] as HTMLElement
 
   // Make sure attach is non-empty, since empty nodes will not get copied.
-  contents.childNodes.forEach((node) => {
+  contents.childNodes.forEach(node => {
     if (node.textContent && node.textContent.trim() !== '') {
       attach = node as HTMLElement
     }
@@ -1069,7 +1069,7 @@ const setFragmentData = (
   // Remove any zero-width space spans from the cloned DOM so that they don't
   // show up elsewhere when pasted.
   Array.from(contents.querySelectorAll('[data-slate-zero-width]')).forEach(
-    (zw) => {
+    zw => {
       const isNewline = zw.getAttribute('data-slate-zero-width') === 'n'
       zw.textContent = isNewline ? '\n' : ''
     }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -76,7 +76,7 @@ export interface RenderLeafProps {
 export type EditableProps = {
   decorate?: (entry: NodeEntry) => Range[]
   onDOMBeforeInput?: (event: Event) => void
-  placeholder?: string
+  placeholder?: string | React.ReactNode
   readOnly?: boolean
   role?: string
   style?: React.CSSProperties
@@ -1041,7 +1041,7 @@ const setFragmentData = (
   let attach = contents.childNodes[0] as HTMLElement
 
   // Make sure attach is non-empty, since empty nodes will not get copied.
-  contents.childNodes.forEach(node => {
+  contents.childNodes.forEach((node) => {
     if (node.textContent && node.textContent.trim() !== '') {
       attach = node as HTMLElement
     }
@@ -1069,7 +1069,7 @@ const setFragmentData = (
   // Remove any zero-width space spans from the cloned DOM so that they don't
   // show up elsewhere when pasted.
   Array.from(contents.querySelectorAll('[data-slate-zero-width]')).forEach(
-    zw => {
+    (zw) => {
       const isNewline = zw.getAttribute('data-slate-zero-width') === 'n'
       zw.textContent = isNewline ? '\n' : ''
     }

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -35,12 +35,10 @@ const Leaf = (props: {
           contentEditable={false}
           style={{
             pointerEvents: 'none',
-            display: 'inline-block',
+            userSelect: 'none',
             verticalAlign: 'text-top',
             width: '0',
             maxWidth: '100%',
-            whiteSpace: 'nowrap',
-            opacity: '0.333',
           }}
         >
           {leaf.placeholder}


### PR DESCRIPTION
…ng of placeholder, remove limiting opacity styling

#### Is this adding or improving a _feature_ or fixing a _bug_?

Improvement of `placeholder` prop

#### What's the new behavior?

Before, the placeholder would always be one line and overflow the editor incase it's too long.
Now it will wrap, while still not being focusable. 
Also changed the type for the prop to include `ReactNode`.


#### How does this change work?

Remove `display: inline-block`, add `user-select: none`, replace `white-space: nowrap` with `prewrap`.
