### PR TITLE
Do not store focus/blur in history

### DIFF
--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -44,16 +44,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
           const inverseOps = batch.map(Operation.inverse).reverse()
 
           for (const op of inverseOps) {
-            // If the final operation is deselecting the editor, skip it. This is
-            if (
-              op === inverseOps[inverseOps.length - 1] &&
-              op.type === 'set_selection' &&
-              op.newProperties == null
-            ) {
-              continue
-            } else {
-              e.apply(op)
-            }
+            e.apply(op)
           }
         })
       })
@@ -150,7 +141,10 @@ const shouldMerge = (op: Operation, prev: Operation | undefined): boolean => {
  */
 
 const shouldSave = (op: Operation, prev: Operation | undefined): boolean => {
-  if (op.type === 'set_selection' && op.newProperties == null) {
+  if (
+    op.type === 'set_selection' &&
+    (op.properties == null || op.newProperties == null)
+  ) {
     return false
   }
 

--- a/packages/slate-history/test/undo/cursor/keep_after_focus_and_remove_text_undo.js
+++ b/packages/slate-history/test/undo/cursor/keep_after_focus_and_remove_text_undo.js
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+
+import assert from 'assert'
+import { Transforms, Editor } from 'slate'
+import { jsx } from '../..'
+
+export const run = editor => {
+  // focus at the end
+  Transforms.select(editor, {
+    anchor: { path: [0, 0], offset: 5 },
+    focus: { path: [0, 0], offset: 5 },
+  })
+  // select all
+  Transforms.select(editor, {
+    anchor: { path: [0, 0], offset: 5 },
+    focus: { path: [0, 0], offset: 0 },
+  })
+  // remove
+  Editor.deleteFragment(editor)
+  // blur
+  Transforms.deselect(editor)
+  // focus back
+  Transforms.select(editor, {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 0], offset: 0 },
+  })
+}
+
+export const input = (
+  <editor>
+    <block>Hello</block>
+  </editor>
+)
+
+export const output = {
+  children: [
+    {
+      children: [
+        {
+          text: 'Hello',
+        },
+      ],
+    },
+  ],
+  selection: {
+    anchor: { path: [0, 0], offset: 5 },
+    focus: { path: [0, 0], offset: 5 },
+  },
+}


### PR DESCRIPTION
#### Description of a bug
![loosing focus and crash](https://user-images.githubusercontent.com/9800850/79443439-1deeaa80-7fda-11ea-99ee-4c5bb0a141fa.gif)

Notice how after text gets reinserted the cursor is gone and if we call `.undo` once again after that, the error pops up.

#### What's the new behavior?

Cursor gets preserved after such `undo` and calling `undo` after that doesn't cause an error.

#### How does this change work?

This happens because
1. a batch to be undone contains: [removeText, focus]
2. this gets inversed to [blur, insertText]
3. after this gets processed the cursor is gone 😢 
4. we try to undo once more - undo batch contains now: [selectAll]
5. when processing this it crashes on: https://github.com/ianstormtaylor/slate/blob/16ff44d0566889a843a346215d3fb7621fc0ed8c/packages/slate/src/interfaces/editor.ts#L1438-L1445

I've thought about various possible fixes for this - at various stages/layers - and I came to the conclusion that it really doesn't make sense to store both "focus" and "blur" set_selections (or does it?). So if we just filter them out this problem won't happen because there won't be any attempts to undo them. 

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
