### PR TITLE
Import Transforms in custom elements walkthough

### DIFF
--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -117,8 +117,8 @@ const DefaultElement = props => {
 Okay, but now we'll need a way for the user to actually turn a block into a code block. So let's change our `onKeyDown` function to add a `` Ctrl-` `` shortcut that does just that:
 
 ```jsx
-// Import the `Editor` helpers from Slate.
-import { Editor } from 'slate'
+// Import the `Editor` and `Transforms` helpers from Slate.
+import { Editor, Transforms } from 'slate'
 
 const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Updating documentation

#### What's the new behavior?

In the defining custom elements walkthrough, when following the code and attempting to use the `Ctrl-` to switch to a code block the following error is shown:

```
ReferenceError: Transforms is not defined
onKeyDown
./pages/index.js:35
  32 |   match: (n) => n.type === 'code',
  33 | });
  34 | // Toggle the block type depending on whether there's already a match.
> 35 | Transforms.setNodes(
     | ^  36 |   editor,
  37 |   { type: match ? 'paragraph' : 'code' },
  38 |   { match: (n) => Editor.isBlock(editor, n) }
```

The code in the documentation appears to be missing the import of Transforms. Updated the documentation to include it resulting in a working example.

#### How does this change work?

N/A

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3462
Reviewers: @
