### PR TITLE
docs(resources): add product and editor

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -15,6 +15,7 @@ These products use Slate, and can give you an idea of what's possible:
 - [Archbee](https://archbee.io)
 - [Cake](https://www.cake.co/)
 - [Chatterbug](https://chatterbug.com)
+- [Clause](https://clause.io)
 - [GitBook](https://www.gitbook.com/)
 - [Grafana](https://grafana.com/)
 - [Guilded](https://www.guilded.gg)
@@ -32,6 +33,7 @@ These products use Slate, and can give you an idea of what's possible:
 
 These pre-packaged editors are built on top of Slate, and can be helpful to see how you might structure your code:
 
+- [Accord Project Markdown Editor](https://github.com/accordproject/markdown-editor/) is a WYSIWYG editor for [CommonMark](https://commonmark.org/).
 - [Canner Editor](https://github.com/Canner/canner-slate-editor) is a rich text editor.
 - [Chatterslate](https://github.com/chatterbugapp/chatterslate) helps teach language grammar and more at [Chatterbug](https://chatterbug.com).
 - [French Press Editor](https://github.com/roast-cms/french-press-editor) is a customizeable editor with offline support.


### PR DESCRIPTION
Proposing Clause as an example of usage, which is built on top of the Accord Project Markdown Editor - based on Slate.