### PR TITLE
Fixing selection across a void node (i.e. mention or image) with the mouse

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -364,11 +364,21 @@ export const Editable = (props: EditableProps) => {
           IS_FOCUSED.delete(editor)
         }
 
-        if (
-          domSelection &&
-          hasEditableTarget(editor, domSelection.anchorNode) &&
-          hasEditableTarget(editor, domSelection.focusNode)
-        ) {
+        if (!domSelection) {
+          return Transforms.deselect(editor)
+        }
+
+        const { anchorNode, focusNode } = domSelection
+
+        const anchorNodeSelectable =
+          hasEditableTarget(editor, anchorNode) ||
+          isTargetInsideVoid(editor, anchorNode)
+
+        const focusNodeSelectable =
+          hasEditableTarget(editor, focusNode) ||
+          isTargetInsideVoid(editor, focusNode)
+
+        if (anchorNodeSelectable && focusNodeSelectable) {
           const range = ReactEditor.toSlateRange(editor, domSelection)
           Transforms.select(editor, range)
         } else {
@@ -975,6 +985,19 @@ const hasEditableTarget = (
     isDOMNode(target) &&
     ReactEditor.hasDOMNode(editor, target, { editable: true })
   )
+}
+
+/**
+ * Check if the target is inside void and in the editor.
+ */
+
+const isTargetInsideVoid = (
+  editor: ReactEditor,
+  target: EventTarget | null
+): boolean => {
+  const slateNode =
+    hasTarget(editor, target) && ReactEditor.toSlateNode(editor, target)
+  return Editor.isVoid(editor, slateNode)
 }
 
 /**

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -177,7 +177,7 @@ export const ReactEditor = {
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
       (!editable ||
         targetEl.isContentEditable ||
-        !!targetEl.closest(`[data-slate-void]`))
+        !!targetEl.getAttribute('data-slate-zero-width'))
     )
   },
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -177,7 +177,7 @@ export const ReactEditor = {
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
       (!editable ||
         targetEl.isContentEditable ||
-        !!targetEl.getAttribute('data-slate-zero-width'))
+        !!targetEl.closest(`[data-slate-void]`))
     )
   },
 


### PR DESCRIPTION
Related pull #3572 
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a bug
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
![screencast-localhost_3000-2020 05 04-05_53_32](https://user-images.githubusercontent.com/8193821/80933279-bb641f80-8dcb-11ea-88ed-236259985f84.gif)
![screencast-localhost_3000-2020 05 04-05_52_52](https://user-images.githubusercontent.com/8193821/80933288-c0c16a00-8dcb-11ea-86e5-5614d95f5a44.gif)


<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3647 #3648
Reviewers: @
