### PR TITLE
Fix selection, if click event fired after

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -7,6 +7,7 @@ import {
   Range,
   Text,
   Transforms,
+  Path,
 } from 'slate'
 import throttle from 'lodash/throttle'
 import scrollIntoView from 'scroll-into-view-if-needed'
@@ -554,8 +555,16 @@ export const Editable = (props: EditableProps) => {
               const node = ReactEditor.toSlateNode(editor, event.target)
               const path = ReactEditor.findPath(editor, node)
               const start = Editor.start(editor, path)
+              const end = Editor.end(editor, path)
 
-              if (Editor.void(editor, { at: start })) {
+              const startVoid = Editor.void(editor, { at: start })
+              const endVoid = Editor.void(editor, { at: end })
+
+              if (
+                startVoid &&
+                endVoid &&
+                Path.equals(startVoid[1], endVoid[1])
+              ) {
                 const range = Editor.range(editor, start)
                 Transforms.select(editor, range)
               }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
 fixing a _bug_ #3316
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
After selecting text, selection is not collapsed to leading void node.
![screencast-localhost_3000-2020 05 04-14_25_54](https://user-images.githubusercontent.com/8193821/80961780-554fba80-8e14-11ea-82c2-290913ded158.gif)

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
In some cases after `selectionchange` event browser emit `click` event, especially when using mouse. Because trigger of these events is the same - `mousedown` event.
According to https://github.com/facebook/react/issues/9678 this is normal behaviour of react.

Сonsidering this fact try to check in `onClick` handler that void node is selected explicitly.


<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3316
Reviewers: @
