### PR TITLE
fix issue #3651 where initial click on a void block can cause the editor to crash

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -150,7 +150,7 @@ export const Editable = (props: EditableProps) => {
       const anchor = domSelection.anchorNode
       const focus = domSelection.focusNode
       // assume this isnt undefined if we have an editor
-      const editorElement = EDITOR_TO_ELEMENT.get(editor) as HTMLElement
+      const editorElement = EDITOR_TO_ELEMENT.get(editor)!
       hasDomSelectionInEditor = editorElement.contains(anchor) && editorElement.contains(focus)
     }
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -144,19 +144,20 @@ export const Editable = (props: EditableProps) => {
     if (!selection && !hasDomSelection) {
       return
     }
-    
+
+    // assume this isnt undefined if we have an editor
+    const editorElement = EDITOR_TO_ELEMENT.get(editor)!
     let hasDomSelectionInEditor = false
-    if (domSelection) {
-      const anchor = domSelection.anchorNode
-      const focus = domSelection.focusNode
-      // assume this isnt undefined if we have an editor
-      const editorElement = EDITOR_TO_ELEMENT.get(editor)!
-      hasDomSelectionInEditor = editorElement.contains(anchor) && editorElement.contains(focus)
+    if (
+      editorElement.contains(domSelection.anchorNode) &&
+      editorElement.contains(domSelection.focusNode)
+    ) {
+      hasDomSelectionInEditor = true
     }
 
     // If the DOM selection is in the editor and the editor selection is already correct, we're done.
     if (
-      hasDomSelection && 
+      hasDomSelection &&
       hasDomSelectionInEditor &&
       selection &&
       Range.equals(ReactEditor.toSlateRange(editor, domSelection), selection)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -145,7 +145,7 @@ export const Editable = (props: EditableProps) => {
       return
     }
 
-    // assume this isnt undefined if we have an editor
+    // verify that the dom selection is in the editor
     const editorElement = EDITOR_TO_ELEMENT.get(editor)!
     let hasDomSelectionInEditor = false
     if (

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -144,10 +144,20 @@ export const Editable = (props: EditableProps) => {
     if (!selection && !hasDomSelection) {
       return
     }
+    
+    let hasDomSelectionInEditor = false
+    if (domSelection) {
+      const anchor = domSelection.anchorNode
+      const focus = domSelection.focusNode
+      // assume this isnt undefined if we have an editor
+      const editorElement = EDITOR_TO_ELEMENT.get(editor) as HTMLElement
+      hasDomSelectionInEditor = editorElement.contains(anchor) && editorElement.contains(focus)
+    }
 
-    // If the DOM selection is already correct, we're done.
+    // If the DOM selection is in the editor and the editor selection is already correct, we're done.
     if (
-      hasDomSelection &&
+      hasDomSelection && 
+      hasDomSelectionInEditor &&
       selection &&
       Range.equals(ReactEditor.toSlateRange(editor, domSelection), selection)
     ) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This fixes the bug reported in #3651

When the initial click into an editor controlled tree of the DOM was a void node, the `useIsomorphicLayoutEffect` handler would attempt to generate a slate range from the dom selection, except the dom selection could be anything outside of the editor and therefore not have a valid slate selection state. This would cause an exception.

This was not noticed on non-void blocks because, for some reason, the dom selection there resolves to the text node immediately and there's never a state where it is outside the editor when the `useIsomorphicLayoutEffect` event is firing.

#### What's the new behavior?
The new behavior is that when we handle the `useIsomorphicLayoutEffect`, we check that the anchor and the focus node are inside of the editor before attempting to resolve them to slate points. 

#### How does this change work?

The crash was occurring when trying to see if the editor had the same selection range as it should based on the converted DOM selection range. If the DOM selection range is outside of the editor, then this check is inherently false anyway, so we don't have a meaningful behavior change by side stepping the short circuit if the DOM Selection is not inside the editor at the time it fires. 

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
