### PR TITLE
fix hovering toolbar format hotkeys

### DIFF
--- a/site/examples/hovering-toolbar.js
+++ b/site/examples/hovering-toolbar.js
@@ -18,6 +18,7 @@ const HoveringMenuExample = () => {
         renderLeaf={props => <Leaf {...props} />}
         placeholder="Enter some text..."
         onDOMBeforeInput={event => {
+          event.preventDefault()
           switch (event.inputType) {
             case 'formatBold':
               return toggleFormat(editor, 'bold')


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing the hovering toolbar hotkeys error

#### What's the new behavior?

The default event has not been blocked before, so the code in the red box will be executed. I don't think this part of the code is necessary. Select should be handled by the plug-in itself
![image](https://user-images.githubusercontent.com/22700758/81471431-a6e8b280-9223-11ea-8441-20496c699de6.png)


#### How does this change work?

N/A

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3661 
Reviewers: @
