### PR TITLE
Fix Editable onPaste handler not getting called

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -924,11 +924,11 @@ export const Editable = (props: EditableProps) => {
             // when "paste without formatting" option is used.
             // This unfortunately needs to be handled with paste events instead.
             if (
+              !isEventHandled(event, attributes.onPaste) &&
               (!HAS_BEFORE_INPUT_SUPPORT ||
                 isPlainTextOnlyPaste(event.nativeEvent)) &&
               !readOnly &&
-              hasEditableTarget(editor, event.target) &&
-              !isEventHandled(event, attributes.onPaste)
+              hasEditableTarget(editor, event.target)
             ) {
               event.preventDefault()
               ReactEditor.insertData(editor, event.clipboardData)


### PR DESCRIPTION
#### Bug fix
Previously the `onPaste` handler was not being called, it was being short-circuited in the conditional.

#### What's the new behavior?
`onPaste` handler now gets called.

#### How does this change work?
Check `isHandledEvent` first in the conditional so that it does not get short-circuited.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3668
Reviewers: @ianstormtaylor @CameronAckermanSEL 
