### PR TITLE
Bugfix/fix bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-error-boundary": "^1.2.5",
     "react-router-dom": "^5.1.2",
     "react-values": "^0.3.0",
+    "rimraf": "^3.0.2",
     "rollup": "^1.27.5",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "yarn build:rollup && yarn build:next",
     "build:next": "cd ./site && next build && next export",
     "build:rollup": "rollup --config ./config/rollup/rollup.config.js",
-    "clean": "rm -rf ./node_modules ./packages/*/{dist,lib,node_modules} ./site/{.next,out}",
+    "clean": "rimraf ./node_modules ./packages/*/{dist,lib,node_modules} ./site/{.next,out}",
     "fix": "yarn fix:prettier && yarn fix:eslint",
     "fix:eslint": "yarn lint:eslint --fix",
     "fix:prettier": "yarn lint:prettier --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9629,6 +9629,13 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug

#### What's the new behavior?
The commonjs bundle was not being correctly transpiled as commonjs, instead it was a duplicate es6 module.

#### How does this change work?
There was some (probably confusing) logic that was trying to handle an es6 and commonjs in the same build step in the rollup config factory. I simplified this by just creating an explicit commonjs step instead. Probably more refactoring is warranted at a later time.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
