### PR TITLE
Fix path transform against sibling move operations

### DIFF
--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -391,6 +391,12 @@ export const Path = {
             }
 
             return copy.concat(p.slice(op.length))
+          } else if (Path.isSibling(op, p) && Path.equals(onp, p)) {
+            if (Path.endsBefore(op, p)) {
+              p[op.length - 1] -= 1
+            } else {
+              p[op.length - 1] += 1
+            }
           } else if (
             Path.endsBefore(onp, p) ||
             Path.equals(onp, p) ||

--- a/packages/slate/test/interfaces/Path/transform/move_node/ends-after-to-ends-equal.js
+++ b/packages/slate/test/interfaces/Path/transform/move_node/ends-after-to-ends-equal.js
@@ -1,0 +1,15 @@
+import { Path } from 'slate'
+
+const path = [0, 1]
+
+const op = {
+  type: 'move_node',
+  path: [0, 3],
+  newPath: [0, 1],
+}
+
+export const test = () => {
+  return Path.transform(path, op)
+}
+
+export const output = [0, 2]

--- a/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-ends-equal.js
+++ b/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-ends-equal.js
@@ -1,0 +1,15 @@
+import { Path } from 'slate'
+
+const path = [0, 1]
+
+const op = {
+  type: 'move_node',
+  path: [0, 0],
+  newPath: [0, 1],
+}
+
+export const test = () => {
+  return Path.transform(path, op)
+}
+
+export const output = [0, 0]


### PR DESCRIPTION
Fixing a bug I discovered while working on Slate collab OT. Added unit tests to around the fix. 

Reviewers: @ianstormtaylor 
