### PR TITLE
Fix scrolling boundary detection (see #3463)

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -175,7 +175,10 @@ export const Editable = (props: EditableProps) => {
     if (newDomRange) {
       domSelection.addRange(newDomRange!)
       const leafEl = newDomRange.startContainer.parentElement!
-      scrollIntoView(leafEl, { scrollMode: 'if-needed' })
+      scrollIntoView(leafEl, {
+        scrollMode: 'if-needed',
+        boundary: el,
+      })
     }
 
     setTimeout(() => {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Supplies the selected element specifically as a ["boundary"](https://github.com/stipsan/compute-scroll-into-view#boundary) to the scroll-into-view-if-needed library to determine whether or not Slate's selection is in the viewport.

This seems to solve well for cases where we may have multiple editors in a page, or where the bounding box of the page is not the same as the bounding box of the Slate editor.

I think longer term this behaviour _should_ be configurable in user space but this is a tactical solution to fix a broad use case and a blocker to adoption of new Slate for me and others.

#### How does this change work?

See above.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3463 
Reviewers: @CameronAckermanSEL 
