### PR TITLE
Fix a few issues with the documentation

### DIFF
--- a/docs/concepts/02-nodes.md
+++ b/docs/concepts/02-nodes.md
@@ -107,7 +107,7 @@ But in certain cases, like for links, you might want to make them "inline" flowi
 
 You can define which nodes are treated as inline nodes by overriding the `editor.isInline` function. (By default it always returns `false`.) Note that inline nodes cannot be the first or last child of a parent block, nor can it be next to another inline node in the children array. Slate will automatically space these with `{ text: '' }` children by default with [`normalizeNode`](https://docs.slatejs.org/concepts/10-normalizing#built-in-constraints).
 
-Elements can either contain block elements as children. Or they can contain inline elements intermingled with text nodes as children. But elements **cannot** contain some children that are blocks and some that are inlines.
+Elements can either contain block elements or inline elements intermingled with text nodes as children. But elements **cannot** contain some children that are blocks and some that are inlines.
 
 ## Voids
 

--- a/docs/concepts/07-plugins.md
+++ b/docs/concepts/07-plugins.md
@@ -11,7 +11,7 @@ const withImages = editor => {
   const { isVoid } = editor
 
   editor.isVoid = element => {
-    return element.type === 'image' ? true : isVoid(editor)
+    return element.type === 'image' ? true : isVoid(element)
   }
 
   return editor

--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -20,6 +20,7 @@ These products use Slate, and can give you an idea of what's possible:
 - [Grafana](https://grafana.com/)
 - [Guilded](https://www.guilded.gg)
 - [Guru](https://www.getguru.com/)
+- [Kitemaker](https://kitemaker.co)
 - [Netlify CMS](https://www.netlifycms.org)
 - [Outline](https://www.getoutline.com/)
 - [Prezly](https://www.prezly.com/)

--- a/docs/walkthroughs/02-adding-event-handlers.md
+++ b/docs/walkthroughs/02-adding-event-handlers.md
@@ -86,4 +86,4 @@ const App = () => {
 
 With that added, try typing `&`, and you should see it suddenly become `and` instead!
 
-This offers a sense of what can be done with Slate's event handlers. Each one will be called with the `event` object, and the `editor` that lets you perform commands. Simple!
+This offers a sense of what can be done with Slate's event handlers. Each one will be called with the `event` object, and you can use your `editor` to perform commands in response. Simple!

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -134,7 +134,7 @@ const Leaf = props => {
 
 Pretty familiar, right?
 
-And now, let's tell Slate about that leaf. To do that, we'll pass in the `renderLeaf` prop to our editor. Also, let's allow our formatting to be toggled by adding active-checking logic.
+And now, let's tell Slate about that leaf. To do that, we'll pass in the `renderLeaf` prop to our editor.
 
 ```jsx
 const App = () => {


### PR DESCRIPTION
When migrating to the latest and greatest slate, I noticed a few issues in the documentation.

#### Is this adding or improving a _feature_ or fixing a _bug_?

Updating documentation and adding Kitemaker to the list of sites using Slate

#### What's the new behavior?

None

#### How does this change work?

N/A

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

No