### PR TITLE
Fix: ESlint Error (eslint: no-shadow)

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -70,7 +70,7 @@ const App = () => {
   const [value, setValue] = useState([])
   // Render the Slate context.
   return (
-    <Slate editor={editor} value={value} onChange={value => setValue(value)} />
+    <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)} />
   )
 }
 ```
@@ -89,7 +89,7 @@ const App = () => {
   const [value, setValue] = useState([])
   return (
     // Add the editable component inside the context.
-    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+    <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)}>
       <Editable />
     </Slate>
   )
@@ -114,7 +114,7 @@ const App = () => {
   ])
 
   return (
-    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+    <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)}>
       <Editable />
     </Slate>
   )


### PR DESCRIPTION
### Docs Fix

PROBLEM: "Value is defined in the upper scope (eslint: no-shadow)"
If you are trying to follow the guide using eslint there is "no-shadow" error because "value" is defined as a state variable and being used again in onChange.

![Screenshot 2020-05-17 at 6 12 11 PM](https://user-images.githubusercontent.com/16781300/82147989-ebe79700-986a-11ea-866b-68c007ff1ba2.png)


FIX:
replace value with "newValue" on onChange.
