### PR TITLE
Fix inverse of sibling move operation

### DIFF
--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -235,9 +235,9 @@ export const Operation = {
         }
 
         // If the move does not happen within a single parent it is possible
-        // that the move impact the true path to the location of where the node
-        // was removed and where it was inserted. We have to adjust for this
-        // and the original path. We can accomplish this (only in non-sibling)
+        // for the move to impact the true path to the location where the node
+        // was removed from and where it was inserted. We have to adjust for this
+        // and find the original path. We can accomplish this (only in non-sibling)
         // moves by looking at the impact of the move operation on the node
         // after the original move path.
         const inversePath = Path.transform(path, op)!

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -228,9 +228,18 @@ export const Operation = {
           return op
         }
 
-        // We need to get the original path here, but sometimes the `newPath`
-        // is a younger sibling of (or ends before) the original, and this
-        // accounts for it.
+        // If the move happens completely within a single parent the path and
+        // newPath are stable with respect to each other.
+        if (Path.isSibling(path, newPath)) {
+          return { ...op, path: newPath, newPath: path }
+        }
+
+        // If the move does not happen within a single parent it is possible
+        // that the move impact the true path to the location of where the node
+        // was removed and where it was inserted. We have to adjust for this
+        // and the original path. We can accomplish this (only in non-sibling)
+        // moves by looking at the impact of the move operation on the node
+        // after the original move path.
         const inversePath = Path.transform(path, op)!
         const inverseNewPath = Path.transform(Path.next(path), op)!
         return { ...op, path: inversePath, newPath: inverseNewPath }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/backward-in-parent.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/backward-in-parent.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 2], newPath: [0, 1] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 1], newPath: [0, 2] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-ends-after-parent.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-ends-after-parent.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 2, 1], newPath: [0, 3] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 3], newPath: [0, 2, 1] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-ends-before-parent.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-ends-before-parent.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 2, 1], newPath: [0, 1] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 1], newPath: [0, 3, 1] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-parent.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-parent.js
@@ -1,5 +1,8 @@
 import { Operation } from 'slate'
 
+// This test covers moving a child to the location of where the current parent is (not becoming its parent).
+// When the move happens the child is inserted infront of its old parent causing its former parent's index to shiftp
+// back within its former grandparent (now parent).
 export const input = { type: 'move_node', path: [0, 2, 1], newPath: [0, 2] }
 
 export const test = value => {

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-parent.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/child-to-parent.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 2, 1], newPath: [0, 2] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 2], newPath: [0, 3, 1] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/ends-after-parent-to-child.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/ends-after-parent-to-child.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 3], newPath: [0, 2, 1] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 2, 1], newPath: [0, 3] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/ends-before-parent-to-child.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/ends-before-parent-to-child.js
@@ -6,4 +6,5 @@ export const test = value => {
   return Operation.inverse(value)
 }
 
+// The path has changed here because the removal of [0, 1] caused [0, 2] to shift forward into its location.
 export const output = { type: 'move_node', path: [0, 1, 1], newPath: [0, 1] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/ends-before-parent-to-child.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/ends-before-parent-to-child.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 1], newPath: [0, 2, 1] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 1, 1], newPath: [0, 1] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/forward-in-parent.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/forward-in-parent.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 1], newPath: [0, 2] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [0, 2], newPath: [0, 1] }

--- a/packages/slate/test/interfaces/Operation/inverse/moveNode/non-sibling.js
+++ b/packages/slate/test/interfaces/Operation/inverse/moveNode/non-sibling.js
@@ -1,0 +1,9 @@
+import { Operation } from 'slate'
+
+export const input = { type: 'move_node', path: [0, 2], newPath: [1, 0, 0] }
+
+export const test = value => {
+  return Operation.inverse(value)
+}
+
+export const output = { type: 'move_node', path: [1, 0, 0], newPath: [0, 2] }


### PR DESCRIPTION
Another breaking fix, but should be safer as it seems like only slate-history uses inverse in the main packages. 

PTAL @CameronAckermanSEL @ianstormtaylor 
