### PR TITLE
Remove Outline since they switched editors

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -22,7 +22,6 @@ These products use Slate, and can give you an idea of what's possible:
 - [Guru](https://www.getguru.com/)
 - [Kitemaker](https://kitemaker.co)
 - [Netlify CMS](https://www.netlifycms.org)
-- [Outline](https://www.getoutline.com/)
 - [Prezly](https://www.prezly.com/)
 - [Sanity.io](https://www.sanity.io)
 - [Slite](https://slite.com)
@@ -40,6 +39,5 @@ These pre-packaged editors are built on top of Slate, and can be helpful to see 
 - [French Press Editor](https://github.com/roast-cms/french-press-editor) is a customizeable editor with offline support.
 - [Nossas Editor](http://slate-editor.bonde.org/) is a drop-in WYSIWYG editor.
 - [ORY Editor](https://editor.ory.am/) is a self-contained, inline WYSIWYG editor library.
-- [Outline Editor](https://github.com/outline/rich-markdown-editor) is the editor that powers the [Outline](https://www.getoutline.com/) wiki.
 
 (Or, if you have their exact use case, can be a drop-in editor for you.)


### PR DESCRIPTION
See https://github.com/outline/rich-markdown-editor/pull/150 

#### Is this adding or improving a _feature_ or fixing a _bug_?

Neither - fixing the docs.