### PR TITLE
Overrode Mark Styles in Placeholder

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -42,6 +42,9 @@ const Leaf = (props: {
             whiteSpace: 'nowrap',
             opacity: '0.333',
             userSelect: 'none',
+            fontStyle: 'normal',
+            fontWeight: 'normal',
+            textDecoration: 'none',
           }}
         >
           {leaf.placeholder as React.ReactNode}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -41,6 +41,7 @@ const Leaf = (props: {
             maxWidth: '100%',
             whiteSpace: 'nowrap',
             opacity: '0.333',
+            userSelect: none,
           }}
         >
           {leaf.placeholder as React.ReactNode}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -41,7 +41,7 @@ const Leaf = (props: {
             maxWidth: '100%',
             whiteSpace: 'nowrap',
             opacity: '0.333',
-            userSelect: none,
+            userSelect: 'none',
           }}
         >
           {leaf.placeholder as React.ReactNode}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a _bug_
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
When writing into the editor with marked text (i.e.: bold, italic, etc.) and then deleting the text, the placeholder used to show as bold or italic according to the marked text before. Now I overrode the styles of the placeholder to not show as bold or underline or italic.

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

Before:

![image](https://user-images.githubusercontent.com/53095479/83131800-1c3ff880-a0e9-11ea-93a5-ea6aac7b243d.png)

After:

![image](https://user-images.githubusercontent.com/53095479/83131886-3b3e8a80-a0e9-11ea-90f9-763a48371159.png)


#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
