### PR TITLE
Added CSS Class to Placeholder for Optional Styling

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -32,6 +32,7 @@ const Leaf = (props: {
     children = (
       <React.Fragment>
         <span
+          className="slate-placeholder"
           contentEditable={false}
           style={{
             pointerEvents: 'none',

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -42,6 +42,9 @@ const Leaf = (props: {
             whiteSpace: 'nowrap',
             opacity: '0.333',
             userSelect: 'none',
+            fontStyle: 'normal',
+            fontWeight: 'normal',
+            textDecoration: 'none',
           }}
         >
           {leaf.placeholder as React.ReactNode}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -41,6 +41,7 @@ const Leaf = (props: {
             maxWidth: '100%',
             whiteSpace: 'nowrap',
             opacity: '0.333',
+            userSelect: none,
           }}
         >
           {leaf.placeholder as React.ReactNode}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -41,7 +41,7 @@ const Leaf = (props: {
             maxWidth: '100%',
             whiteSpace: 'nowrap',
             opacity: '0.333',
-            userSelect: none,
+            userSelect: 'none',
           }}
         >
           {leaf.placeholder as React.ReactNode}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
improving a _feature_ 
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
You can now apply custom styles to the placeholder thanks to having a CSS class tied to the placeholder.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
DraftJS has a CSS class to the placeholder which not only allows you to style it according to your needs (without any plugins 😀 ) but also enables the user to change the following behavior most users would probably agree with is very undesirable.

When having no text in the editor, but toggling a block style. The placeholder matches the block style too. See the screenshots below:

![image](https://user-images.githubusercontent.com/53095479/83135332-595ab980-a0ee-11ea-8893-c4529283f30d.png)

![image](https://user-images.githubusercontent.com/53095479/83135353-61b2f480-a0ee-11ea-9ecf-e326f988e4d3.png)

So now thanks to having a placeholder with a CSS class, you can check if there isn't any text in the editor, and the block type isn't the default one (meaning i.e.: header, unordered list, etc.), and then add a dynamic className to the Editable component.

And then with CSS assuming the dynamic className provided to the Editable component is `Editable-HidePlaceholder` and the class name of the placeholder is `slate-placeholder`:

`.Editable-HidePlaceholder .slate-placeholder {
    display: none;
}`

Now, you successfully hid the placeholder when there is no text and when a custom block type is toggled! Congrats! 🎉

![image](https://user-images.githubusercontent.com/53095479/83136054-7e9bf780-a0ef-11ea-8a7b-974afc2e7cc3.png)


![image](https://user-images.githubusercontent.com/53095479/83136014-6e841800-a0ef-11ea-89af-020e043880eb.png)


Here is an example of how you might achieve that behaviour:

```javascript
// the usual stuff
const editor = useMemo(() => withReact(createEditor()), []);
const [value, setValue] = useState([{ type: 'paragraph', children: [{ text: '' }] }]);

let EditorClassName;
// serialize the value to plain text
const editorText = value.map(n => Node.string(n)).join('')

// add placeholder class if there is no text and if the block type is not a paragraph
if (!editorText && editor.children[0]) {
    if (editor.children[0].type !== 'paragraph') {
        EditorClassName = "Editable-HidePlaceholder";
    }
}

return (
    <Slate 
        // the usual stuff
    >
        <Editable
            // the usual stuff
            className={EditorClassName} />
    </Slate>
```

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
