### PR TITLE
Allow void nodes to be copied. Fixes #3665

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -138,7 +138,7 @@ export const createEditor = (): Editor => {
     getFragment: () => {
       const { selection } = editor
 
-      if (selection && Range.isExpanded(selection)) {
+      if (selection) {
         return Node.fragment(editor, selection)
       }
       return []


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a _bug_

#### What's the new behavior?

#3620 broke copying of void nodes with a slightly different default behaviour for getting the fragment to copy. Prior to that PR, it was not checking for an expanded range. I mistakenly introduced a stricter check, which prevented void nodes from being copied when they were the only thing selected.

With this PR, copying the image in the images example works again.

#### How does this change work?

It removes the superfluous expanded range check.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3665
Reviewers: @CameronAckermanSEL, @lcswillems, @evasteingrims
