### PR TITLE
Ensure round-trip tests don't mutate output before checking against it

### DIFF
--- a/packages/slate-history/test/undo/delete_backward/block-text.js
+++ b/packages/slate-history/test/undo/delete_backward/block-text.js
@@ -2,6 +2,7 @@
 
 import { Transforms } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor)
@@ -17,4 +18,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/custom-prop.js
+++ b/packages/slate-history/test/undo/delete_backward/custom-prop.js
@@ -2,6 +2,7 @@
 
 import { Transforms } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor)
@@ -20,4 +21,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/inline-across.js
+++ b/packages/slate-history/test/undo/delete_backward/inline-across.js
@@ -2,6 +2,7 @@
 
 import { Transforms } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor)
@@ -28,4 +29,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_break/basic.js
+++ b/packages/slate-history/test/undo/insert_break/basic.js
@@ -2,6 +2,7 @@
 
 import { Editor } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   editor.insertBreak()
@@ -19,4 +20,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_fragment/basic.js
+++ b/packages/slate-history/test/undo/insert_fragment/basic.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 const fragment = (
   <block type="d">
@@ -37,6 +38,6 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)
 
 export const skip = true

--- a/packages/slate-history/test/undo/insert_text/basic.js
+++ b/packages/slate-history/test/undo/insert_text/basic.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   editor.insertText('text')
@@ -15,4 +16,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_text/contiguous.js
+++ b/packages/slate-history/test/undo/insert_text/contiguous.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   editor.insertText('t')
@@ -17,4 +18,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate/test/interfaces/Node/ancestor/success.js
+++ b/packages/slate/test/interfaces/Node/ancestor/success.js
@@ -2,6 +2,7 @@
 
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -15,4 +16,4 @@ export const test = value => {
   return Node.ancestor(value, [0])
 }
 
-export const output = input.children[0]
+export const output = cloneDeep(input.children[0])

--- a/packages/slate/test/interfaces/Node/child/success.js
+++ b/packages/slate/test/interfaces/Node/child/success.js
@@ -2,6 +2,7 @@
 
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -15,4 +16,4 @@ export const test = value => {
   return Node.child(value, 0)
 }
 
-export const output = input.children[0]
+export const output = cloneDeep(input.children[0])

--- a/packages/slate/test/interfaces/Node/descendant/success.js
+++ b/packages/slate/test/interfaces/Node/descendant/success.js
@@ -2,6 +2,7 @@
 
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -15,4 +16,4 @@ export const test = value => {
   return Node.descendant(value, [0])
 }
 
-export const output = input.children[0]
+export const output = cloneDeep(input.children[0])

--- a/packages/slate/test/interfaces/Node/get/root.js
+++ b/packages/slate/test/interfaces/Node/get/root.js
@@ -2,6 +2,7 @@
 
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -15,4 +16,4 @@ export const test = value => {
   return Node.get(value, [])
 }
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate/test/transforms/delete/unit-line/text-end.js
+++ b/packages/slate/test/transforms/delete/unit-line/text-end.js
@@ -2,6 +2,7 @@
 
 import { Transforms } from 'slate'
 import { jsx } from '../../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor, { unit: 'line' })
@@ -16,4 +17,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate/test/transforms/delete/unit-line/text-start-reverse.js
+++ b/packages/slate/test/transforms/delete/unit-line/text-start-reverse.js
@@ -2,6 +2,7 @@
 
 import { Transforms } from 'slate'
 import { jsx } from '../../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor, { unit: 'line', reverse: true })
@@ -16,4 +17,4 @@ export const input = (
   </editor>
 )
 
-export const output = input
+export const output = cloneDeep(input)


### PR DESCRIPTION
Some tests use `export const output = input`, which means if the input is mutated the output will also be, so tests that check against round-tripping will become noop.

I added lodash `cloneDeep` around all the places I could see this happening - I just did a string search for it, so I might have missed some cases.

The result is that 4 tests now fail, 3 of which are in slate-history.  It was because I was debugging history issues that I discovered this.

  875 passing (4s)
  9 pending
  4 failing

Failing:

  1) slate-history - undo - delete_backward - block-text
  2) slate-history - undo - delete_backward - custom-prop
  3) slate-history - undo - delete_backward - inline-across
  4) slate - interfaces - Node - get - root

NOTE: I didn't fix these bugs or tests.


#### Is this adding or improving a _feature_ or fixing a _bug_?
#### What's the new behavior?
#### How does this change work?
#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [NO] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
