### PR TITLE
fix older chrome support

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -14,7 +14,12 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 
 import Children from './children'
 import Hotkeys from '../utils/hotkeys'
-import { IS_FIREFOX, IS_SAFARI, IS_EDGE_LEGACY } from '../utils/environment'
+import {
+  IS_FIREFOX,
+  IS_SAFARI,
+  IS_EDGE_LEGACY,
+  IS_CHROME_LEGACY,
+} from '../utils/environment'
 import { ReactEditor } from '..'
 import { ReadOnlyContext } from '../hooks/use-read-only'
 import { useSlate } from '../hooks/use-slate'
@@ -39,7 +44,12 @@ import {
 } from '../utils/weak-maps'
 
 // COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
-const HAS_BEFORE_INPUT_SUPPORT = !(IS_FIREFOX || IS_EDGE_LEGACY)
+// Chrome Legacy doesn't support `beforeinput` correctly
+const HAS_BEFORE_INPUT_SUPPORT = !(
+  IS_FIREFOX ||
+  IS_EDGE_LEGACY ||
+  IS_CHROME_LEGACY
+)
 
 /**
  * `RenderElementProps` are passed to the `renderElement` handler.
@@ -347,13 +357,13 @@ export const Editable = (props: EditableProps) => {
   // real `beforeinput` events sadly... (2019/11/04)
   // https://github.com/facebook/react/issues/11211
   useIsomorphicLayoutEffect(() => {
-    if (ref.current) {
+    if (ref.current && HAS_BEFORE_INPUT_SUPPORT) {
       // @ts-ignore The `beforeinput` event isn't recognized.
       ref.current.addEventListener('beforeinput', onDOMBeforeInput)
     }
 
     return () => {
-      if (ref.current) {
+      if (ref.current && HAS_BEFORE_INPUT_SUPPORT) {
         // @ts-ignore The `beforeinput` event isn't recognized.
         ref.current.removeEventListener('beforeinput', onDOMBeforeInput)
       }

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -23,4 +23,4 @@ export const IS_EDGE_LEGACY =
 // Native beforeInput events don't work well with react on Chrome 75 and older, Chrome 76+ can use beforeInput
 export const IS_CHROME_LEGACY =
   typeof navigator !== 'undefined' &&
-  /Chrome?\/(?:[0-7][0-5].)/i.test(navigator.userAgent)
+  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])/i.test(navigator.userAgent)

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -19,3 +19,8 @@ export const IS_SAFARI =
 export const IS_EDGE_LEGACY =
   typeof navigator !== 'undefined' &&
   /Edge?\/(?:[0-6][0-9]|[0-7][0-8])/i.test(navigator.userAgent)
+
+// Native beforeInput events don't work well with react on Chrome 75 and older, Chrome 76+ can use beforeInput
+export const IS_CHROME_LEGACY =
+  typeof navigator !== 'undefined' &&
+  /Chrome?\/(?:[0-7][0-5].)/i.test(navigator.userAgent)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug.

This is the behavior on Chrome 75 and lower. I tested to Chrome 65. An extra character was being inserted during render that slate didn't know about. So it blows up when you try to type again, because it can't resolve a DOM point. 

In the GIF, I typed a single `k` but 2 are rendered. Then, when you type an additional char, the crash occurs. 

![slate-blows-up](https://user-images.githubusercontent.com/15693413/83826388-08703580-a699-11ea-9afc-641115930216.gif)


#### What's the new behavior?

This now works on Chrome 75 and lower. 
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->



#### How does this change work?
I found that in Chrome, versions below 75, when using the native `beforeinput` event was somehow causing React to fire an extra synthetic event called `textInput` that would inject an extra piece of text into the DOM. This extra character however was not inserted into the SLATE data object. 

Here is where the extra event was affecting the DOM:
<img width="1382" alt="Screen Shot 2020-06-04 at 2 24 01 PM" src="https://user-images.githubusercontent.com/15693413/83827690-268b6500-a69c-11ea-9b27-25798841cad8.png">

By not using the native `beforeinput` this extra event is not fired and works great! So I added a detection for chrome versions prior to 75 to not use the `beforeinput`. I am honestly, still not sure how that extra synthetic event was being triggered.

![slate-doesnt-blow-up](https://user-images.githubusercontent.com/15693413/83827788-65211f80-a69c-11ea-918a-a6002e0f408c.gif)


#### Have you checked that...?
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?
I never opened an issue for this.

#### Testing
I couldn't have solved this with out BrowserStack. I used BrowserStack to manually test the `richText.js` example, by typing and using the bold and itals buttons and hot keys on the following:

*Windows 10*
Chrome: 83, 80,78,76,75,65,60, 50
Edge: 80, 18
Firefox: 75, 68, 60

*Mac High Sierra* 
Safari: 11.1
Chrome: 79, 69

The example worked as expected on all versions above. I also spot tested a few on Windows 8 with no issues. I spot tested Safari and Chrome on iOS 11 it worked. I also spot tested Android on Pixel 4 with Chrome and Firefox and it seemed to work.


IE 11 did not work, but also the example site didn't render. 

Would be good to implement write auto tests on BrowserStack to test against the different browsers. You get free access with an open source lib. 