### PR TITLE
Fix placeholder text alignment

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -36,7 +36,6 @@ const Leaf = (props: {
           style={{
             pointerEvents: 'none',
             display: 'inline-block',
-            verticalAlign: 'text-top',
             width: '0',
             maxWidth: '100%',
             whiteSpace: 'nowrap',


### PR DESCRIPTION
Using verticalAlign: text-top was causing a slight height change when entering actual content. So typing the first letter caused the entire editor height to shrink by roughly 1px (notice the bottom edge of the editor jumping as I type)

![screencast 2020-06-05 09-35-31](https://user-images.githubusercontent.com/8009/83888846-009fa800-a710-11ea-9e13-b33f8e421660.gif)

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

The height no longer changes.

#### How does this change work?

Remove `verticalAlign: "text-top"` from the placeholder's inline style.