### PR TITLE
Replace Iterable with Generator.

### DIFF
--- a/config/rollup/rollup.config.js
+++ b/config/rollup/rollup.config.js
@@ -180,7 +180,7 @@ function configure(pkg, env, target) {
           file: `packages/${pkg.name}/${pkg.module}`,
           format: 'es',
           sourcemap: true,
-        }
+        },
       ],
       // We need to explicitly state which modules are external, meaning that
       // they are present at runtime. In the case of non-UMD configs, this means

--- a/docs/api/locations.md
+++ b/docs/api/locations.md
@@ -114,7 +114,7 @@ Check if a `range` is forward. This is the opposite of `Range.isBackward` and is
 
 Check if a `value` implements the `Range` interface.
 
-###### `Range.points(range: Range): Iterable<PointEntry>`
+###### `Range.points(range: Range): Generator<PointEntry>`
 
 Iterate through all the point entries in a `range`.
 

--- a/docs/api/nodes.md
+++ b/docs/api/nodes.md
@@ -15,9 +15,9 @@ type Ancestor = Editor | Element
 
 Get the node at a specific `path`, asserting that it is an ancestor node. If the specified node is not an ancestor node, throw an error.
 
-###### `Node.ancestors(root: Node, path: Path, options?): Iterable<NodeEntry<Ancestor>>`
+###### `Node.ancestors(root: Node, path: Path, options?): Generator<NodeEntry<Ancestor>>`
 
-Return an iterable of all the ancestor nodes above a specific path. By default, the order is bottom-up, from lowest to highest ancestor in the tree, but you can pass the `reverse: true` option to go top-down.
+Return a generator of all the ancestor nodes above a specific path. By default, the order is bottom-up, from lowest to highest ancestor in the tree, but you can pass the `reverse: true` option to go top-down.
 
 Options: `{reverse?: boolean}`
 
@@ -25,7 +25,7 @@ Options: `{reverse?: boolean}`
 
 Get the child of a node at the specified `index`.
 
-###### `Node.children(root: Node, path: Path, options?): Iterable<NodeEntry<Descendant>>`
+###### `Node.children(root: Node, path: Path, options?): Generator<NodeEntry<Descendant>>`
 
 Iterate over the children of a node at a specific path.
 
@@ -39,15 +39,15 @@ Get an entry for the common ancestor node of two paths.
 
 Get the node at a specific path, asserting that it's a descendant node.
 
-###### `Node.descendants(root: Node, options?): Iterable<NodeEntry<Descendant>>`
+###### `Node.descendants(root: Node, options?): Generator<NodeEntry<Descendant>>`
 
-Return an iterable of all the descendant node entries inside a root node. Each iteration will return a `NodeEntry` tuple consisting of `[Node, Path]`.
+Return a generator of all the descendant node entries inside a root node. Each iteration will return a `NodeEntry` tuple consisting of `[Node, Path]`.
 
 Options: `{from?: Path, to?: Path, reverse?: boolean, pass?: (node: NodeEntry => boolean)}`
 
-###### `Node.elements(root: Node, options?): Iterable<ElementEntry>`
+###### `Node.elements(root: Node, options?): Generator<ElementEntry>`
 
-Return an iterable of all the element nodes inside a root node. Each iteration will return an `ElementEntry` tuple consisting of `[Element, Path]`. If the root node is an element, it will be included in the iteration as well.
+Return a generator of all the element nodes inside a root node. Each iteration will return an `ElementEntry` tuple consisting of `[Element, Path]`. If the root node is an element, it will be included in the iteration as well.
 
 Options: `{from?: Path, to?: Path, reverse?: boolean, pass?: (node: NodeEntry => boolean)}`
 
@@ -83,9 +83,9 @@ Get the last node entry in a root node at a specific `path`.
 
 Get the node at a specific `path`, ensuring it's a leaf text node. If the node is not a leaf text node, throw an error.
 
-###### `Node.levels(root: Node, path: Path, options?): Iterable<NodeEntry>`
+###### `Node.levels(root: Node, path: Path, options?): Generator<NodeEntry>`
 
-Return an iterable of the nodes in a branch of the tree, from a specific `path`.  By default, the order is top-down, from the lowest to the highest node in the tree, but you can pass the `reverse: true` option to go bottom-up.
+Return a generator of the nodes in a branch of the tree, from a specific `path`.  By default, the order is top-down, from the lowest to the highest node in the tree, but you can pass the `reverse: true` option to go bottom-up.
 
 Options: `{reverse?: boolean}`
 
@@ -93,9 +93,9 @@ Options: `{reverse?: boolean}`
 
 Check if a node matches a set of `props`.
 
-###### `Node.nodes(root: Node, options?): Iterable<NodeEntry>`
+###### `Node.nodes(root: Node, options?): Generator<NodeEntry>`
 
-Return an iterable of all the node entries of a root node. Each entry is returned as a `[Node, Path]` tuple, with the path referring to the node's position inside the root node.
+Return a generator of all the node entries of a root node. Each entry is returned as a `[Node, Path]` tuple, with the path referring to the node's position inside the root node.
 
 Options: `{from?: Path, to?: Path, reverse?: boolean, pass?: (node: NodeEntry => boolean)}`
 
@@ -107,9 +107,9 @@ Get the parent of a node at a specific `path`.
 
 Get the concatenated text string of a node's content. Note that this will not include spaces or line breaks between block nodes. This is not intended as a user-facing string, but as a string for performing offset-related computations for a node.
 
-###### `Node.texts(root: Node, options?): Iterable<NodeEntry<Text>>`
+###### `Node.texts(root: Node, options?): Generator<NodeEntry<Text>>`
 
-Return an iterable of all leaf text nodes in a root node.
+Return a generator of all leaf text nodes in a root node.
 
 Options: `{from?: Path, to?: Path, reverse?: boolean, pass?: (node: NodeEntry => boolean)}`
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -465,7 +465,7 @@ export const Editor = {
       reverse?: boolean
       voids?: boolean
     } = {}
-  ): Generator<NodeEntry<T>> {
+  ): Generator<NodeEntry<T>, void, undefined> {
     const { at = editor.selection, reverse = false, voids = false } = options
     let { match } = options
 
@@ -622,7 +622,7 @@ export const Editor = {
       reverse?: boolean
       voids?: boolean
     } = {}
-  ): Generator<NodeEntry<T>> {
+  ): Generator<NodeEntry<T>, void, undefined> {
     const {
       at = editor.selection,
       mode = 'all',
@@ -980,7 +980,7 @@ export const Editor = {
       unit?: 'offset' | 'character' | 'word' | 'line' | 'block'
       reverse?: boolean
     } = {}
-  ): Generator<Point> {
+  ): Generator<Point, void, undefined> {
     const { at = editor.selection, unit = 'offset', reverse = false } = options
 
     if (!at) {

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -465,7 +465,7 @@ export const Editor = {
       reverse?: boolean
       voids?: boolean
     } = {}
-  ): Iterable<NodeEntry<T>> {
+  ): Generator<NodeEntry<T>> {
     const { at = editor.selection, reverse = false, voids = false } = options
     let { match } = options
 
@@ -622,7 +622,7 @@ export const Editor = {
       reverse?: boolean
       voids?: boolean
     } = {}
-  ): Iterable<NodeEntry<T>> {
+  ): Generator<NodeEntry<T>> {
     const {
       at = editor.selection,
       mode = 'all',
@@ -653,7 +653,7 @@ export const Editor = {
       to = reverse ? first : last
     }
 
-    const iterable = Node.nodes(editor, {
+    const nodeEntries = Node.nodes(editor, {
       reverse,
       from,
       to,
@@ -663,7 +663,7 @@ export const Editor = {
     const matches: NodeEntry<T>[] = []
     let hit: NodeEntry<T> | undefined
 
-    for (const [node, path] of iterable) {
+    for (const [node, path] of nodeEntries) {
       const isLower = hit && Path.compare(path, hit[1]) === 0
 
       // In highest mode any node lower than the last hit is not a match.
@@ -980,7 +980,7 @@ export const Editor = {
       unit?: 'offset' | 'character' | 'word' | 'line' | 'block'
       reverse?: boolean
     } = {}
-  ): Iterable<Point> {
+  ): Generator<Point> {
     const { at = editor.selection, unit = 'offset', reverse = false } = options
 
     if (!at) {

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -38,7 +38,7 @@ export const Node = {
     options: {
       reverse?: boolean
     } = {}
-  ): Generator<NodeEntry<Ancestor>> {
+  ): Generator<NodeEntry<Ancestor>, void, undefined> {
     for (const p of Path.ancestors(path, options)) {
       const n = Node.ancestor(root, p)
       const entry: NodeEntry<Ancestor> = [n, p]
@@ -80,7 +80,7 @@ export const Node = {
     options: {
       reverse?: boolean
     } = {}
-  ): Generator<NodeEntry<Descendant>> {
+  ): Generator<NodeEntry<Descendant>, void, undefined> {
     const { reverse = false } = options
     const ancestor = Node.ancestor(root, path)
     const { children } = ancestor
@@ -132,7 +132,7 @@ export const Node = {
       reverse?: boolean
       pass?: (node: NodeEntry) => boolean
     } = {}
-  ): Generator<NodeEntry<Descendant>> {
+  ): Generator<NodeEntry<Descendant>, void, undefined> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (path.length !== 0) {
         // NOTE: we have to coerce here because checking the path's length does
@@ -156,7 +156,7 @@ export const Node = {
       reverse?: boolean
       pass?: (node: NodeEntry) => boolean
     } = {}
-  ): Generator<ElementEntry> {
+  ): Generator<ElementEntry, void, undefined> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (Element.isElement(node)) {
         yield [node, path]
@@ -341,7 +341,7 @@ export const Node = {
     options: {
       reverse?: boolean
     } = {}
-  ): Generator<NodeEntry> {
+  ): Generator<NodeEntry, void, undefined> {
     for (const p of Path.levels(path, options)) {
       const n = Node.get(root, p)
       yield [n, p]
@@ -373,7 +373,7 @@ export const Node = {
       reverse?: boolean
       pass?: (entry: NodeEntry) => boolean
     } = {}
-  ): Generator<NodeEntry> {
+  ): Generator<NodeEntry, void, undefined> {
     const { pass, reverse = false } = options
     const { from = [], to } = options
     const visited = new Set()
@@ -484,7 +484,7 @@ export const Node = {
       reverse?: boolean
       pass?: (node: NodeEntry) => boolean
     } = {}
-  ): Generator<NodeEntry<Text>> {
+  ): Generator<NodeEntry<Text>, void, undefined> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (Text.isText(node)) {
         yield [node, path]

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -26,7 +26,7 @@ export const Node = {
   },
 
   /**
-   * Return an iterable of all the ancestor nodes above a specific path.
+   * Return a generator of all the ancestor nodes above a specific path.
    *
    * By default the order is bottom-up, from lowest to highest ancestor in
    * the tree, but you can pass the `reverse: true` option to go top-down.
@@ -38,7 +38,7 @@ export const Node = {
     options: {
       reverse?: boolean
     } = {}
-  ): Iterable<NodeEntry<Ancestor>> {
+  ): Generator<NodeEntry<Ancestor>> {
     for (const p of Path.ancestors(path, options)) {
       const n = Node.ancestor(root, p)
       const entry: NodeEntry<Ancestor> = [n, p]
@@ -80,7 +80,7 @@ export const Node = {
     options: {
       reverse?: boolean
     } = {}
-  ): Iterable<NodeEntry<Descendant>> {
+  ): Generator<NodeEntry<Descendant>> {
     const { reverse = false } = options
     const ancestor = Node.ancestor(root, path)
     const { children } = ancestor
@@ -121,7 +121,7 @@ export const Node = {
   },
 
   /**
-   * Return an iterable of all the descendant node entries inside a root node.
+   * Return a generator of all the descendant node entries inside a root node.
    */
 
   *descendants(
@@ -132,7 +132,7 @@ export const Node = {
       reverse?: boolean
       pass?: (node: NodeEntry) => boolean
     } = {}
-  ): Iterable<NodeEntry<Descendant>> {
+  ): Generator<NodeEntry<Descendant>> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (path.length !== 0) {
         // NOTE: we have to coerce here because checking the path's length does
@@ -143,7 +143,7 @@ export const Node = {
   },
 
   /**
-   * Return an iterable of all the element nodes inside a root node. Each iteration
+   * Return a generator of all the element nodes inside a root node. Each iteration
    * will return an `ElementEntry` tuple consisting of `[Element, Path]`. If the
    * root node is an element it will be included in the iteration as well.
    */
@@ -156,7 +156,7 @@ export const Node = {
       reverse?: boolean
       pass?: (node: NodeEntry) => boolean
     } = {}
-  ): Iterable<ElementEntry> {
+  ): Generator<ElementEntry> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (Element.isElement(node)) {
         yield [node, path]
@@ -199,12 +199,12 @@ export const Node = {
 
     const newRoot = produce(root, r => {
       const [start, end] = Range.edges(range)
-      const iterable = Node.nodes(r, {
+      const nodeEntries = Node.nodes(r, {
         reverse: true,
         pass: ([, path]) => !Range.includes(range, path),
       })
 
-      for (const [, path] of iterable) {
+      for (const [, path] of nodeEntries) {
         if (!Range.includes(range, path)) {
           const parent = Node.parent(r, path)
           const index = path[path.length - 1]
@@ -329,7 +329,7 @@ export const Node = {
   },
 
   /**
-   * Return an iterable of the in a branch of the tree, from a specific path.
+   * Return a generator of the in a branch of the tree, from a specific path.
    *
    * By default the order is top-down, from lowest to highest node in the tree,
    * but you can pass the `reverse: true` option to go bottom-up.
@@ -341,7 +341,7 @@ export const Node = {
     options: {
       reverse?: boolean
     } = {}
-  ): Iterable<NodeEntry> {
+  ): Generator<NodeEntry> {
     for (const p of Path.levels(path, options)) {
       const n = Node.get(root, p)
       yield [n, p]
@@ -360,7 +360,7 @@ export const Node = {
   },
 
   /**
-   * Return an iterable of all the node entries of a root node. Each entry is
+   * Return a generator of all the node entries of a root node. Each entry is
    * returned as a `[Node, Path]` tuple, with the path referring to the node's
    * position inside the root node.
    */
@@ -373,7 +373,7 @@ export const Node = {
       reverse?: boolean
       pass?: (entry: NodeEntry) => boolean
     } = {}
-  ): Iterable<NodeEntry> {
+  ): Generator<NodeEntry> {
     const { pass, reverse = false } = options
     const { from = [], to } = options
     const visited = new Set()
@@ -473,7 +473,7 @@ export const Node = {
   },
 
   /**
-   * Return an iterable of all leaf text nodes in a root node.
+   * Return a generator of all leaf text nodes in a root node.
    */
 
   *texts(
@@ -484,7 +484,7 @@ export const Node = {
       reverse?: boolean
       pass?: (node: NodeEntry) => boolean
     } = {}
-  ): Iterable<NodeEntry<Text>> {
+  ): Generator<NodeEntry<Text>> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (Text.isText(node)) {
         yield [node, path]

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -160,7 +160,7 @@ export const Range = {
    * Iterate through all of the point entries in a range.
    */
 
-  *points(range: Range): Generator<PointEntry> {
+  *points(range: Range): Generator<PointEntry, void, undefined> {
     yield [range.anchor, 'anchor']
     yield [range.focus, 'focus']
   },

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -160,7 +160,7 @@ export const Range = {
    * Iterate through all of the point entries in a range.
    */
 
-  *points(range: Range): Iterable<PointEntry> {
+  *points(range: Range): Generator<PointEntry> {
     yield [range.anchor, 'anchor']
     yield [range.focus, 'focus']
   },


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Replace the `Iterable` type used in Slate core with the correct `Generator` type.

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

The `Iterable` type used in Slate core is not technically correct.  What is returned from most `*functions` is a `Generator`.  The types should be updated to reflect this so you can use things like `.next()` and not have Typescript complain at you that `.next()` doesn't exist on the `Iterable` type.

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @CameronAckermanSEL, @timbuckley 
