### PR TITLE
Fix intersected Text decorations && add tests for that case

### DIFF
--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -103,15 +103,17 @@ export const Text = {
         o += length
 
         // If the range encompases the entire leaf, add the range.
-        if (start.offset <= offset && end.offset >= offset + length) {
+        if (start.offset <= offset && end.offset >= o) {
           Object.assign(leaf, rest)
           next.push(leaf)
           continue
         }
 
-        // If the range starts after the leaf, or ends before it, continue.
+        // If the range expanded and match the leaf, or starts after, or ends before it, continue.
         if (
-          start.offset > offset + length ||
+          (start.offset !== end.offset &&
+            (start.offset === o || end.offset === offset)) ||
+          start.offset > o ||
           end.offset < offset ||
           (end.offset === offset && offset !== 0)
         ) {
@@ -126,7 +128,7 @@ export const Text = {
         let before
         let after
 
-        if (end.offset < offset + length) {
+        if (end.offset < o) {
           const off = end.offset - offset
           after = { ...middle, text: middle.text.slice(off) }
           middle = { ...middle, text: middle.text.slice(0, off) }

--- a/packages/slate/test/interfaces/Text/decorations/adjacent.js
+++ b/packages/slate/test/interfaces/Text/decorations/adjacent.js
@@ -1,0 +1,51 @@
+import { Text } from 'slate'
+
+export const input = [
+  {
+    anchor: {
+      path: [0],
+      offset: 1,
+    },
+    focus: {
+      path: [0],
+      offset: 2,
+    },
+    decoration1: 'decoration1',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 2,
+    },
+    focus: {
+      path: [0],
+      offset: 3,
+    },
+    decoration2: 'decoration2',
+  },
+]
+
+export const test = decorations => {
+  return Text.decorations({ text: 'abcd', mark: 'mark' }, decorations)
+}
+
+export const output = [
+  {
+    text: 'a',
+    mark: 'mark',
+  },
+  {
+    text: 'b',
+    mark: 'mark',
+    decoration1: 'decoration1',
+  },
+  {
+    text: 'c',
+    mark: 'mark',
+    decoration2: 'decoration2',
+  },
+  {
+    text: 'd',
+    mark: 'mark',
+  },
+]

--- a/packages/slate/test/interfaces/Text/decorations/collapse.js
+++ b/packages/slate/test/interfaces/Text/decorations/collapse.js
@@ -1,0 +1,85 @@
+import { Text } from 'slate'
+
+export const input = [
+  {
+    anchor: {
+      path: [0],
+      offset: 1,
+    },
+    focus: {
+      path: [0],
+      offset: 2,
+    },
+    decoration1: 'decoration1',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 2,
+    },
+    focus: {
+      path: [0],
+      offset: 2,
+    },
+    decoration2: 'decoration2',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 2,
+    },
+    focus: {
+      path: [0],
+      offset: 3,
+    },
+    decoration3: 'decoration3',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 4,
+    },
+    focus: {
+      path: [0],
+      offset: 4,
+    },
+    decoration4: 'decoration4',
+  },
+]
+
+export const test = decorations => {
+  return Text.decorations({ text: 'abcd', mark: 'mark' }, decorations)
+}
+
+export const output = [
+  {
+    text: 'a',
+    mark: 'mark',
+  },
+  {
+    text: 'b',
+    mark: 'mark',
+    decoration1: 'decoration1',
+  },
+  {
+    text: '',
+    mark: 'mark',
+    decoration1: 'decoration1',
+    decoration2: 'decoration2',
+    decoration3: 'decoration3',
+  },
+  {
+    text: 'c',
+    mark: 'mark',
+    decoration3: 'decoration3',
+  },
+  {
+    text: 'd',
+    mark: 'mark',
+  },
+  {
+    text: '',
+    mark: 'mark',
+    decoration4: 'decoration4',
+  },
+]

--- a/packages/slate/test/interfaces/Text/decorations/intersect.js
+++ b/packages/slate/test/interfaces/Text/decorations/intersect.js
@@ -1,0 +1,95 @@
+import { Text } from 'slate'
+
+export const input = [
+  {
+    anchor: {
+      path: [0],
+      offset: 1,
+    },
+    focus: {
+      path: [0],
+      offset: 5,
+    },
+    decoration1: 'decoration1',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 1,
+    },
+    focus: {
+      path: [0],
+      offset: 3,
+    },
+    decoration2: 'decoration2',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 2,
+    },
+    focus: {
+      path: [0],
+      offset: 2,
+    },
+    decoration3: 'decoration3',
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 2,
+    },
+    focus: {
+      path: [0],
+      offset: 4,
+    },
+    decoration4: 'decoration4',
+  },
+]
+
+export const test = decorations => {
+  return Text.decorations({ text: 'abcdef', mark: 'mark' }, decorations)
+}
+
+export const output = [
+  {
+    text: 'a',
+    mark: 'mark',
+  },
+  {
+    text: 'b',
+    mark: 'mark',
+    decoration1: 'decoration1',
+    decoration2: 'decoration2',
+  },
+  {
+    text: '',
+    mark: 'mark',
+    decoration1: 'decoration1',
+    decoration2: 'decoration2',
+    decoration3: 'decoration3',
+    decoration4: 'decoration4',
+  },
+  {
+    text: 'c',
+    mark: 'mark',
+    decoration1: 'decoration1',
+    decoration2: 'decoration2',
+    decoration4: 'decoration4',
+  },
+  {
+    text: 'd',
+    mark: 'mark',
+    decoration1: 'decoration1',
+    decoration4: 'decoration4',
+  },
+  {
+    text: 'e',
+    mark: 'mark',
+    decoration1: 'decoration1',
+  },
+  {
+    text: 'f',
+    mark: 'mark',
+  },
+]


### PR DESCRIPTION
#### This Is fixing a _bug_

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

It seems that intersecting decorations do not separate the text correctly. This creates the problem of implementing multiple cursors when they intersect. 
I came across this when displaying the intersection of several cursors on the same line at https://slate-collaborative.herokuapp.com. Fixed it, added tests for this case.

Also relates and fix [#3714](https://github.com/ianstormtaylor/slate/pull/3714)

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

Now Text decorations function produce correct list of leaves.

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3693
