### PR TITLE
Remove legacy target operation property

### DIFF
--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -20,7 +20,6 @@ export type MergeNodeOperation = {
   type: 'merge_node'
   path: Path
   position: number
-  target: number | null
   properties: Partial<Node>
   [key: string]: unknown
 }
@@ -79,7 +78,6 @@ export type SplitNodeOperation = {
   type: 'split_node'
   path: Path
   position: number
-  target: number | null
   properties: Partial<Node>
   [key: string]: unknown
 }
@@ -135,7 +133,6 @@ export const Operation = {
       case 'merge_node':
         return (
           typeof value.position === 'number' &&
-          (typeof value.target === 'number' || value.target === null) &&
           Path.isPath(value.path) &&
           isPlainObject(value.properties)
         )
@@ -166,7 +163,6 @@ export const Operation = {
         return (
           Path.isPath(value.path) &&
           typeof value.position === 'number' &&
-          (typeof value.target === 'number' || value.target === null) &&
           isPlainObject(value.properties)
         )
       default:

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -323,7 +323,6 @@ export const NodeTransforms = {
           type: 'merge_node',
           path: newPath,
           position,
-          target: null,
           properties,
         })
       }
@@ -611,7 +610,6 @@ export const NodeTransforms = {
       const [, highestPath] = highest
       const lowestPath = at.path.slice(0, depth)
       let position = height === 0 ? at.offset : at.path[depth] + nudge
-      let target: number | null = null
 
       for (const [node, path] of Editor.levels(editor, {
         at: lowestPath,
@@ -638,12 +636,10 @@ export const NodeTransforms = {
             type: 'split_node',
             path,
             position,
-            target,
             properties,
           })
         }
 
-        target = position
         position = path[path.length - 1] + (split || isEnd ? 1 : 0)
       }
 

--- a/packages/slate/test/interfaces/Operation/isOperation/merge_node.js
+++ b/packages/slate/test/interfaces/Operation/isOperation/merge_node.js
@@ -4,7 +4,6 @@ export const input = {
   type: 'merge_node',
   path: [0],
   position: 0,
-  target: 0,
   properties: {},
 }
 

--- a/packages/slate/test/interfaces/Operation/isOperation/split_node.js
+++ b/packages/slate/test/interfaces/Operation/isOperation/split_node.js
@@ -4,7 +4,6 @@ export const input = {
   type: 'split_node',
   path: [0],
   position: 0,
-  target: 0,
   properties: {},
 }
 


### PR DESCRIPTION
Removing some operation properties that are not used. Looks like cruft from earlier revisions.

#### Have you checked that...?

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

