### PR TITLE
Trigger editor.insertText by paste too

### DIFF
--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -148,7 +148,7 @@ export const withReact = <T extends Editor>(editor: T) => {
     if (fragment) {
       const decoded = decodeURIComponent(window.atob(fragment))
       const parsed = JSON.parse(decoded) as Node[]
-      Transforms.insertFragment(e, parsed)
+      e.insertFragment(parsed)
       return
     }
 
@@ -163,7 +163,7 @@ export const withReact = <T extends Editor>(editor: T) => {
           Transforms.splitNodes(e, { always: true })
         }
 
-        Transforms.insertText(e, line)
+        e.insertText(line)
         split = true
       }
     }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
fixing a bug
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
`editor.insertText` is triggered by paste event too.

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3775
Reviewers: @
