### PR TITLE
Resolves iamstormtaylor/slate#3778: Check if editable target before handling paste event

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -946,11 +946,11 @@ export const Editable = (props: EditableProps) => {
             // when "paste without formatting" option is used.
             // This unfortunately needs to be handled with paste events instead.
             if (
+              hasEditableTarget(editor, event.target) &&
               !isEventHandled(event, attributes.onPaste) &&
               (!HAS_BEFORE_INPUT_SUPPORT ||
                 isPlainTextOnlyPaste(event.nativeEvent)) &&
-              !readOnly &&
-              hasEditableTarget(editor, event.target)
+              !readOnly
             ) {
               event.preventDefault()
               ReactEditor.insertData(editor, event.clipboardData)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Resolves #3778 by checking for an editable event target before handling the paste event (calling the provided paste prop).

#### What's the new behavior?

Does what it says on the tin. We don't want the paste handler to be firing for non-Slate nodes (e.g. an input in the React tree). I think that #3670 accidentally reordered the two calls that were being moved, so this just reorders it correctly.

#### How does this change work?
N/A

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3778 
Reviewers: @CameronAckermanSEL (since you have context)
