### PR TITLE
Make Range.transform options optional

### DIFF
--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -181,7 +181,9 @@ export const Range = {
   transform(
     range: Range,
     op: Operation,
-    options: { affinity: 'forward' | 'backward' | 'outward' | 'inward' | null }
+    options: {
+      affinity?: 'forward' | 'backward' | 'outward' | 'inward' | null
+    } = {}
   ): Range | null {
     const { affinity = 'inward' } = options
     let affinityAnchor: 'forward' | 'backward' | null


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This is just bringing this method inline with its other equivalents. Given the first line of the function is setting a default value I think this was always intended and just overlooked.

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
