### PR TITLE
chore: Destructure first first match

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -587,7 +587,7 @@ export const Editor = {
       }
     }
 
-    const [, next] = Editor.nodes(editor, { at: span, match, mode, voids })
+    const [next] = Editor.nodes(editor, { at: span, match, mode, voids })
     return next
   },
 
@@ -1120,7 +1120,7 @@ export const Editor = {
       }
     }
 
-    const [, previous] = Editor.nodes(editor, {
+    const [previous] = Editor.nodes(editor, {
       reverse: true,
       at: span,
       match,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Destructure the first match when using `Editor.next` and `Editor.previous`
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3791
Reviewers: @BrentFarese 
