### PR TITLE
Update Slate walkthrough example documentation to Typescript

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -19,9 +19,9 @@ Once you've installed Slate, you'll need to import it.
 
 ```jsx
 // Import React dependencies.
-import React, { useEffect, useMemo, useState } from "react";
-// Import the Slate editor factory.
-import { createEditor } from 'slate'
+import React, { useMemo, useState } from "react";
+// Import the Slate editor factory and Node interface.
+import { createEditor, Node } from 'slate'
 
 // Import the Slate components and React plugin.
 import { Slate, Editable, withReact } from 'slate-react'
@@ -55,7 +55,7 @@ const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
 
   // Keep track of state for the value of the editor.
-  const [value, setValue] = useState([])
+  const [value, setValue] = useState<Node[]>([])
   return null
 }
 ```
@@ -67,7 +67,7 @@ The provider component keeps track of your Slate editor, its plugins, its value,
 ```jsx
 const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
-  const [value, setValue] = useState([])
+  const [value, setValue] = useState<Node[]>([])
   // Render the Slate context.
   return (
     <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)} />
@@ -86,7 +86,7 @@ Okay, so the next step is to render the `<Editable>` component itself:
 ```jsx
 const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
-  const [value, setValue] = useState([])
+  const [value, setValue] = useState<Node[]>([])
   return (
     // Add the editable component inside the context.
     <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)}>
@@ -106,7 +106,7 @@ The value is just plain JSON. Here's one containing a single paragraph block wit
 const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
   // Add the initial value when setting up our state.
-  const [value, setValue] = useState([
+  const [value, setValue] = useState<Node>([
     {
       type: 'paragraph',
       children: [{ text: 'A line of text in a paragraph.' }],


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Improving existing walkthrough documentation by updating the sample code to typescript
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
