### PR TITLE
fix inconsistent render reversed selection

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -33,6 +33,7 @@ import {
   isDOMText,
   DOMStaticRange,
   isPlainTextOnlyPaste,
+  setReverseDomSelection,
 } from '../utils/dom'
 import {
   EDITOR_TO_ELEMENT,
@@ -184,7 +185,11 @@ export const Editable = (props: EditableProps) => {
     const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
 
     if (newDomRange) {
-      domSelection.addRange(newDomRange!)
+      if (Range.isBackward(selection!)) {
+        setReverseDomSelection(newDomRange, domSelection)
+      } else {
+        domSelection.addRange(newDomRange!)
+      }
       const leafEl = newDomRange.startContainer.parentElement!
       scrollIntoView(leafEl, {
         scrollMode: 'if-needed',

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -269,6 +269,11 @@ export const ReactEditor = {
 
   /**
    * Find a native DOM range from a Slate `range`.
+   *
+   * Notice: the returned range will always be ordinal regardless of the direction of Slate `range` due to DOM API limit.
+   *
+   * there is no way to create a reverse DOM Range using Range.setStart/setEnd
+   * according to https://dom.spec.whatwg.org/#concept-range-bp-set.
    */
 
   toDOMRange(editor: ReactEditor, range: Range): DOMRange {

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -182,5 +182,5 @@ export const setReverseDomSelection = (
   const newRange = domRange.cloneRange()
   newRange.collapse()
   domSelection.addRange(newRange)
-  domSelection.extend(newRange.startContainer, newRange.startOffset)
+  domSelection.extend(domRange.startContainer, domRange.startOffset)
 }

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -175,6 +175,14 @@ export const getPlainText = (domNode: DOMNode) => {
   return text
 }
 
+/**
+ * there is no way to create a reverse DOM Range using Range.setStart/setEnd
+ * according to https://dom.spec.whatwg.org/#concept-range-bp-set.
+ * Luckily it's possible to create a reverse selection via Selection.extend
+ *
+ * Note: Selection.extend is not implement in any version of IE (up to and including version 11)
+ */
+
 export const setReverseDomSelection = (
   domRange: DOMRange,
   domSelection: Selection

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -174,3 +174,13 @@ export const getPlainText = (domNode: DOMNode) => {
 
   return text
 }
+
+export const setReverseDomSelection = (
+  domRange: DOMRange,
+  domSelection: Selection
+) => {
+  const newRange = domRange.cloneRange()
+  newRange.collapse()
+  domSelection.addRange(newRange)
+  domSelection.extend(newRange.startContainer, newRange.startOffset)
+}

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -188,7 +188,10 @@ export const setReverseDomSelection = (
   domSelection: Selection
 ) => {
   const newRange = domRange.cloneRange()
+  // collapses the range to end
   newRange.collapse()
+  // set both anchor and focus of the selection to domRange's focus
   domSelection.addRange(newRange)
+  // moves the focus of the selection to domRange's anchor
   domSelection.extend(domRange.startContainer, domRange.startOffset)
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This PR would fix a bug.

According to MDN [Range/setStart](https://developer.mozilla.org/en-US/docs/Web/API/Range/setStart), there is no way to create a reverse selection. So `slate` will render a 'no-reverse' dom-selection when `editor.selection` is reverse.

It is broken when user re-render the component when selection is change. Here is an example:

```jsx
export default function Demo() {
  const [currentSelection, setCurrentSelection] = useState('')

  function onChange() {
    const { selection } = editor
    if (selection) {
      setCurrentSelection(JSON.stringify(currentSelection))
    }
  }

  return (
    <Slate editor={editor} value={value} onChange={onChange}>
      <Editable />
    </Slate>
  )
}
```

`Demo` will re-render when selection change, and then `Demo` will re-render `Editable`。

If selection is not reversed(eg selection offset is [X, Y], Y > X),  Editable will rendered dom-selection [X, Y] with `editor.selection` offset like [X, Y], and will return and do nothing to update DomSelection because of `Range.equals`.

If selection is reversed(eg selection offset is [X, Y], Y < X), Editable will rendered dom-selection [Y, X]  with `editor.selection` offset like [X, Y], and then found not `Range.equals` with `editor.selection`. It will try to re-render Editable while user is using mouse selecting text, result to anchor lost.

In the gif, I'm selecting text reverse using code like `Demo` above

![xx](https://user-images.githubusercontent.com/17848159/88636452-870eaf80-d0eb-11ea-9bf1-7f1878ebeac1.gif)


#### What's the new behavior?

make slate render reverse dom-selection when `editor.selection` is reverse to avoid unnessasery re-render due to  inconsistent render

#### How does this change work?

use code from [stackoverflow](https://stackoverflow.com/a/4802994)

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

There is no test code for `slate-react` now.

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
