### PR TITLE
do not change selection while delete fragment

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -248,7 +248,7 @@ export const Editable = (props: EditableProps) => {
         // COMPAT: For the deleting forward/backward input types we don't want
         // to change the selection because it is the range that will be deleted,
         // and those commands determine that for themselves.
-        if (!type.startsWith('delete') || !type.startsWith('deleteBy')) {
+        if (!(type.startsWith('delete') || type.startsWith('deleteBy'))) {
           const [targetRange] = event.getTargetRanges()
 
           if (targetRange) {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -248,7 +248,7 @@ export const Editable = (props: EditableProps) => {
         // COMPAT: For the deleting forward/backward input types we don't want
         // to change the selection because it is the range that will be deleted,
         // and those commands determine that for themselves.
-        if (!type.startsWith('delete') || type.startsWith('deleteBy')) {
+        if (!type.startsWith('delete') || !type.startsWith('deleteBy')) {
           const [targetRange] = event.getTargetRanges()
 
           if (targetRange) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a bug

#### What's the new behavior?

We will skip change selection while delete fragment as comment.

It will broken history merge while drag & drop content in slate

see below example

![xx](https://user-images.githubusercontent.com/17848159/91120136-899efd80-e6c7-11ea-8fc1-ef52b7cee1e8.gif)

original schema is

```
├─ 0
│  └─ children
│     └─ 0
│        └─ text: dragTest1
└─ 1
   └─ children
      └─ 0
         └─ text: dragTest2
```

1. select dragTest2
2. drop it to the end of dragTest2
3. new shema is
```
├─ 0
│  └─ children
│     └─ 0
│        └─ text: dragTest1dragTest2
└─ 1
   └─ children
      └─ 0
         └─ text: 
```
4. press `ctrl+z` to undo
5. new shema is
```
├─ 0
│  └─ children
│     └─ 0
│        └─ text: dragTest1
└─ 1
   └─ children
      └─ 0
         └─ text: 
```

We lost `dragTest2`

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
