### PR TITLE
Fix beforeInput bug for Chromium browsers (Torch Browser, Ghost Browser)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.58.4",
+  "version": "0.58.5",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.58.4",
+  "version": "0.58.5",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -18,8 +18,8 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.58.4",
-    "slate-hyperscript": "^0.58.4"
+    "slate": "^0.58.5",
+    "slate-hyperscript": "^0.58.5"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-hyperscript",
   "description": "A hyperscript helper for creating Slate documents.",
-  "version": "0.58.4",
+  "version": "0.58.5",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.58.4"
+    "slate": "^0.58.5"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.58.4",
+  "version": "0.58.5",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -23,8 +23,8 @@
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "devDependencies": {
-    "slate": "^0.58.4",
-    "slate-hyperscript": "^0.58.4"
+    "slate": "^0.58.5",
+    "slate-hyperscript": "^0.58.5"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -20,7 +20,7 @@ export const IS_EDGE_LEGACY =
   typeof navigator !== 'undefined' &&
   /Edge?\/(?:[0-6][0-9]|[0-7][0-8])/i.test(navigator.userAgent)
 
-// Native beforeInput events don't work well with react on Chrome 75 and older, Chrome 76+ can use beforeInput
+// Native beforeInput events don't work well with react on Chrome 81 and older, Chrome 82+ can use beforeInput
 export const IS_CHROME_LEGACY =
   typeof navigator !== 'undefined' &&
-  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])/i.test(navigator.userAgent)
+  /Chrome?\/(?:[0-8][0-1]|[0-7][0-9]|[0-6][0-9])/i.test(navigator.userAgent)

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.58.4",
+  "version": "0.58.5",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",


### PR DESCRIPTION
#### _bug_

#### What's the new behavior?

Fix check for beforeInput support on Torch and Ghost browsers

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

Update the regex to match the versions of those browsers.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
