### PR TITLE
fix: add missing Transform.unsetNodes options

### DIFF
--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -664,6 +664,7 @@ export const NodeTransforms = {
       at?: Location
       match?: (node: Node) => boolean
       mode?: 'all' | 'highest' | 'lowest'
+      hanging?: boolean
       split?: boolean
       voids?: boolean
     } = {}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a bug

#### What's the new behavior?

`setNodes` support `hanging` and `unsetNodes` should support too

#### How does this change work?

fix typing

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
