### PR TITLE
slate-react: MVP for working with non-global window objects

### DIFF
--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -33,7 +33,7 @@ declare global {
 export type DOMPoint = [Node, number]
 
 /**
- * Returns the host window of a a DOM node
+ * Returns the host window of a DOM node
  */
 
 export const getDefaultView = (value: any): Window | null => {

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -22,7 +22,25 @@ export {
   DOMStaticRange,
 }
 
+declare global {
+  interface Window {
+    Selection: typeof Selection['constructor']
+    DataTransfer: typeof DataTransfer['constructor']
+    Node: typeof Node['constructor']
+  }
+}
+
 export type DOMPoint = [Node, number]
+
+/**
+ * Returns the host window of a a DOM node
+ */
+
+export const getDefaultView = (value: any): Window | null => {
+  return (
+    (value && value.ownerDocument && value.ownerDocument.defaultView) || null
+  )
+}
 
 /**
  * Check if a DOM node is a comment node.
@@ -45,7 +63,17 @@ export const isDOMElement = (value: any): value is DOMElement => {
  */
 
 export const isDOMNode = (value: any): value is DOMNode => {
-  return value instanceof Node
+  const window = getDefaultView(value)
+  return !!window && value instanceof window.Node
+}
+
+/**
+ * Check if a value is a DOM selection.
+ */
+
+export const isDOMSelection = (value: any): value is DOMSelection => {
+  const window = value && value.anchorNode && getDefaultView(value.anchorNode)
+  return !!window && value instanceof window.Selection
 }
 
 /**

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -14,7 +14,7 @@ export const NODE_TO_PARENT: WeakMap<Node, Ancestor> = new WeakMap()
  * Weak maps that allow us to go between Slate nodes and DOM nodes. These
  * are used to resolve DOM event-related logic into Slate actions.
  */
-
+export const EDITOR_TO_WINDOW: WeakMap<Editor, Window> = new WeakMap()
 export const EDITOR_TO_ELEMENT: WeakMap<Editor, HTMLElement> = new WeakMap()
 export const EDITOR_TO_PLACEHOLDER: WeakMap<Editor, string> = new WeakMap()
 export const ELEMENT_TO_NODE: WeakMap<HTMLElement, Node> = new WeakMap()

--- a/site/examples/iframe.js
+++ b/site/examples/iframe.js
@@ -16,7 +16,10 @@ const HOTKEYS = {
 
 const IFrameExample = () => {
   const [value, setValue] = useState(initialValue)
-  const renderElement = useCallback(props => <Element {...props} />, [])
+  const renderElement = useCallback(
+    ({ attributes, children }) => <p {...attributes}>{children}</p>,
+    []
+  )
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
 
@@ -64,17 +67,6 @@ const toggleMark = (editor, format) => {
 const isMarkActive = (editor, format) => {
   const marks = Editor.marks(editor)
   return marks ? marks[format] === true : false
-}
-
-const Element = ({ attributes, children, element }) => {
-  switch (element.type) {
-    case 'block-quote':
-      return <blockquote {...attributes}>{children}</blockquote>
-    case 'heading-one':
-      return <h1 {...attributes}>{children}</h1>
-    default:
-      return <p {...attributes}>{children}</p>
-  }
 }
 
 const Leaf = ({ attributes, children, leaf }) => {

--- a/site/examples/iframe.js
+++ b/site/examples/iframe.js
@@ -1,0 +1,166 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import isHotkey from 'is-hotkey'
+import { Editable, withReact, useSlate, Slate, ReactEditor } from 'slate-react'
+import { Editor, createEditor } from 'slate'
+import { withHistory } from 'slate-history'
+
+import { Button, Icon, Toolbar } from '../components'
+
+const HOTKEYS = {
+  'mod+b': 'bold',
+  'mod+i': 'italic',
+  'mod+u': 'underline',
+  'mod+`': 'code',
+}
+
+const IFrameExample = () => {
+  const [value, setValue] = useState(initialValue)
+  const renderElement = useCallback(props => <Element {...props} />, [])
+  const renderLeaf = useCallback(props => <Leaf {...props} />, [])
+  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+
+  const handleBlur = useCallback(() => ReactEditor.deselect(editor), [editor])
+
+  return (
+    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+      <Toolbar>
+        <MarkButton format="bold" icon="format_bold" />
+        <MarkButton format="italic" icon="format_italic" />
+        <MarkButton format="underline" icon="format_underlined" />
+        <MarkButton format="code" icon="code" />
+      </Toolbar>
+      <IFrame onBlur={handleBlur}>
+        <Editable
+          renderElement={renderElement}
+          renderLeaf={renderLeaf}
+          placeholder="Enter some rich text…"
+          spellCheck
+          autoFocus
+          onKeyDown={event => {
+            for (const hotkey in HOTKEYS) {
+              if (isHotkey(hotkey, event)) {
+                event.preventDefault()
+                const mark = HOTKEYS[hotkey]
+                toggleMark(editor, mark)
+              }
+            }
+          }}
+        />
+      </IFrame>
+    </Slate>
+  )
+}
+
+const toggleMark = (editor, format) => {
+  const isActive = isMarkActive(editor, format)
+  if (isActive) {
+    Editor.removeMark(editor, format)
+  } else {
+    Editor.addMark(editor, format, true)
+  }
+}
+
+const isMarkActive = (editor, format) => {
+  const marks = Editor.marks(editor)
+  return marks ? marks[format] === true : false
+}
+
+const Element = ({ attributes, children, element }) => {
+  switch (element.type) {
+    case 'block-quote':
+      return <blockquote {...attributes}>{children}</blockquote>
+    case 'heading-one':
+      return <h1 {...attributes}>{children}</h1>
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+const Leaf = ({ attributes, children, leaf }) => {
+  if (leaf.bold) {
+    children = <strong>{children}</strong>
+  }
+
+  if (leaf.code) {
+    children = <code>{children}</code>
+  }
+
+  if (leaf.italic) {
+    children = <em>{children}</em>
+  }
+
+  if (leaf.underline) {
+    children = <u>{children}</u>
+  }
+
+  return <span {...attributes}>{children}</span>
+}
+
+const MarkButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isMarkActive(editor, format)}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleMark(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+const IFrame = ({ children, ...props }) => {
+  const [contentRef, setContentRef] = useState(null)
+  const mountNode =
+    contentRef &&
+    contentRef.contentWindow &&
+    contentRef.contentWindow.document.body
+  return (
+    <iframe {...props} ref={setContentRef}>
+      {mountNode && createPortal(React.Children.only(children), mountNode)}
+    </iframe>
+  )
+}
+
+const initialValue = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: 'In this example, the document gets rendered into a controlled ',
+      },
+      { text: '<iframe>', code: true },
+      {
+        text: '. This is ',
+      },
+      {
+        text: 'particularly',
+        italic: true,
+      },
+      {
+        text:
+          ' useful, when you need to separate the styles for your editor contents from the ones addressing your UI.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: 'This also the only reliable method to preview any ',
+      },
+      {
+        text: 'media queries',
+        bold: true,
+      },
+      {
+        text: ' in your CSS.',
+      },
+    ],
+  },
+]
+
+export default IFrameExample

--- a/site/pages/examples/[example].tsx
+++ b/site/pages/examples/[example].tsx
@@ -25,6 +25,7 @@ import RichText from '../../examples/richtext'
 import SearchHighlighting from '../../examples/search-highlighting'
 import CodeHighlighting from '../../examples/code-highlighting'
 import Tables from '../../examples/tables'
+import IFrames from '../../examples/iframe'
 
 // node
 import { getAllExamples } from '../api'
@@ -48,6 +49,7 @@ const EXAMPLES = [
   ['Search Highlighting', SearchHighlighting, 'search-highlighting'],
   ['Code Highlighting', CodeHighlighting, 'code-highlighting'],
   ['Tables', Tables, 'tables'],
+  ['Rendering in iframes', IFrames, 'iframes'],
 ]
 
 const Header = props => (

--- a/site/pages/examples/[example].tsx
+++ b/site/pages/examples/[example].tsx
@@ -49,7 +49,7 @@ const EXAMPLES = [
   ['Search Highlighting', SearchHighlighting, 'search-highlighting'],
   ['Code Highlighting', CodeHighlighting, 'code-highlighting'],
   ['Tables', Tables, 'tables'],
-  ['Rendering in iframes', IFrames, 'iframes'],
+  ['Rendering in iframes', IFrames, 'iframe'],
 ]
 
 const Header = props => (

--- a/site/public/index.css
+++ b/site/public/index.css
@@ -70,6 +70,11 @@ input:focus {
   border-color: blue;
 }
 
+iframe {
+  width: 100%;
+  border: 1px solid #eee;
+}
+
 [data-slate-editor] > * + * {
   margin-top: 1em;
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

It's an improvement (I think)

#### What's the new behavior?

Since the rewrite, rendering `<Editable>` components into an `<iframe>` was no longer possible due to the `slate-react` package relying on the global `window` object for literally anything DOM-related: Event-handling, `instanceof` checks etc. 
With this PR, you can render your state into another `window.document` and everything should still work as expected. 

To retrieve the `window` object, on which a given editor instance is working, you'd call `ReactEditor.getWindow(editor)`. 

For a working example, check [this diff](#diff-e009c066107f606f805039682a84e53d) from below. It's also included in the [preview deploy of the website](https://deploy-preview-3819--slatejs.netlify.app), just select the example "Rendering in iframes" from the menu. To run it locally, `yarn build && yarn start` this PR and visit `http://localhost:3000/examples/iframes`. 

My main focus here was to put together a working MVP, which is a) fully backwards compatible and b) doesn't add to the existing public API surface (too much anyway).

#### How does this change work?

##### Finding the "right" window object

Whenever the `ref` of an `<Editable>` DOM element becomes available, the related `window` is deduced by querying `ownerDocument.defaultView` and saved in a new WeakMap `EDITOR_TO_WINDOW`, with the editor instance as key. This allowed me to substitute any hard `window` calls from within `ReactEditor` methods (or wherever we have seamless access to the editor facade) with minimal hassle and stay somewhat inline with existing patterns. 

So instead of 
```
const domSelection = window.getSelection()
```
you would 
```
const window = ReactEditor.getWindow(editor)
const domSelection = window.getSelection()
```

Personally, I quite like this approach and the resulting API and it looks slate-ish enough to me.

##### Fixing `instanceof` checks

The most notable changes this PR introduces happen in the `utils/dom` module of `slate-react`. Every `window` instance comes with its own set of prototypes. This might not be super-obvious (especially in TS) but what `domNode instanceof Node` actually does is `domNode instanceof window.Node`. So, to safely assume the right prototype chain, I had to adjust some of the equality checks to work on arbitrary `window` objects. In order to not having to change/extend all the signatures of these methods, and given the fact that none of those helpers take an editor instance argument, I decided to go with something like this:

```
// isDOMNode?
!!(domNode &&
domNode.ownerDocument &&
domNode.ownerDocument.defaultView) &&
domNode instanceof domNode.ownerDocument.defaultView.Node
``` 

I'm not quite sure whether this approach is inline with the rest of the codebase and I also don't know to what extent such lookups impact overall performance, so please bear with me. It allowed me to keep the diff sensibly small, but I most definitely would appreciate any feedback in that regard.  

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3582, #3742 (these are the ones I found anyway)
Reviewers: @
