### PR TITLE
spliteNode by path will  do nothing when node is first child

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1461,10 +1461,12 @@ export const Editor = {
             `Cannot apply a "split_node" operation at path [${path}] because the root node cannot be split.`
           )
         }
-
+        const index = path[path.length - 1]
+        if (index === 0) {
+          return
+        }
         const node = Node.get(editor, path)
         const parent = Node.parent(editor, path)
-        const index = path[path.length - 1]
         let newNode: Descendant
 
         if (Text.isText(node)) {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fixing a _bug

#### What's the new behavior?

We will get a strange new node when spliteNode by path which node is the first child of it's parent.

```tsx
export const run = (editor) => {
  Transforms.splitNodes(editor, { at: [0, 0] })
}
export const input = (
  <editor>
    <block>
      <block>two</block>
      <block>three</block>
    </block>
  </editor>
)
export const output = (
  <editor>
    <block>
	  <Text />
    </block>
    <block>
      <block>two</block>
      <block>three</block>
    </block>
  </editor>
)
```

since we cant splitNodes after all child node like  [0, 2]. We should do nothing when splitNodes in [0, 0] at the same time.

#### How does this change work?

See code

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
