### PR TITLE
fix: mergeNodes by point would delete nested multi-child node

### DIFF
--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -271,8 +271,7 @@ export const NodeTransforms = {
       const emptyAncestor = Editor.above(editor, {
         at: path,
         mode: 'highest',
-        match: n =>
-          levels.includes(n) && Element.isElement(n) && n.children.length === 1,
+        match: n => levels.includes(n) && hasSingleChildNest(editor, n),
       })
 
       const emptyRef = emptyAncestor && Editor.pathRef(editor, emptyAncestor[1])
@@ -839,6 +838,23 @@ export const NodeTransforms = {
       }
     })
   },
+}
+
+const hasSingleChildNest = (editor: Editor, node: Node): boolean => {
+  if (Element.isElement(node)) {
+    const element = node as Element
+    if (Editor.isVoid(editor, node)) {
+      return true
+    } else if (element.children.length === 1) {
+      return hasSingleChildNest(editor, element.children[0])
+    } else {
+      return false
+    }
+  } else if (Editor.isEditor(node)) {
+    return false
+  } else {
+    return true
+  }
 }
 
 /**

--- a/packages/slate/test/transforms/mergeNodes/depth-block/block-nested-multi-child.tsx
+++ b/packages/slate/test/transforms/mergeNodes/depth-block/block-nested-multi-child.tsx
@@ -1,0 +1,63 @@
+/** @jsx jsx */
+import { jsx } from '../../..'
+import { Transforms } from 'slate'
+
+export const run = editor => {
+  Transforms.mergeNodes(editor, {
+    at: {
+      path: [0, 1, 1, 0, 0, 0],
+      offset: 0,
+    },
+  })
+}
+
+export const input = (
+  <editor>
+    <block>
+      <block>
+        <text>123</text>
+      </block>
+      <block>
+        <block>
+          <text>45</text>
+        </block>
+        <block>
+          <block>
+            <block>
+              <text>c</text>
+            </block>
+            <block>
+              <block>
+                <text>edf</text>
+              </block>
+            </block>
+          </block>
+        </block>
+      </block>
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>
+      <block>
+        <text>123</text>
+      </block>
+      <block>
+        <block>
+          <text>45c</text>
+        </block>
+        <block>
+          <block>
+            <block>
+              <block>
+                <text>edf</text>
+              </block>
+            </block>
+          </block>
+        </block>
+      </block>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/mergeNodes/depth-block/block-nested-only-child.tsx
+++ b/packages/slate/test/transforms/mergeNodes/depth-block/block-nested-only-child.tsx
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+import { jsx } from '../../..'
+import { Transforms } from 'slate'
+
+export const run = editor => {
+  Transforms.mergeNodes(editor, {
+    at: {
+      path: [0, 1, 1, 0, 0, 0],
+      offset: 0,
+    },
+  })
+}
+
+export const input = (
+  <editor>
+    <block>
+      <block>
+        <text>123</text>
+      </block>
+      <block>
+        <block>
+          <text>45</text>
+        </block>
+        <block>
+          <block>
+            <block>
+              <text>c</text>
+            </block>
+          </block>
+        </block>
+      </block>
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>
+      <block>
+        <text>123</text>
+      </block>
+      <block>
+        <block>
+          <text>45c</text>
+        </block>
+      </block>
+    </block>
+  </editor>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fix bug

#### What's the new behavior?

mergeNodes will remove emptyNode which has only children node

But if emptyNode has nested multi-children node, it will also be remove.

#### How does this change work?

recursive to confirm the node has only one children node

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
