### PR TITLE
fix(slate-react): update onDOMBeforeInput when onDOMBeforeInput prop changes (#3617)

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -349,7 +349,7 @@ export const Editable = (props: EditableProps) => {
         }
       }
     },
-    [readOnly]
+    [readOnly, propsOnDOMBeforeInput]
   )
 
   // Attach a native DOM event handler for `beforeinput` events, because React's


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a _bug_ as outlined in https://github.com/ianstormtaylor/slate/issues/3617
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
onDOMBeforeInput will update when the prop passed to `Editable` as onDOMBeforeInput changes.

Old behavior: https://codesandbox.io/s/slate-reproductions-svctp?file=/index.js:0-1406
New behavior: https://www.loom.com/share/fcf4adfa5c754cd98744fa04aacf745d
<!--

Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
 - React updates the function passed to `useCallback` when any of its dependencies have changed. I have added `propsOnDOMBeforeInput` to the dependency array for `onDOMBeforeInput`
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3617 
Reviewers: @CameronAckermanSEL 
