### PR TITLE
fix: move_node path transformation when op and onp is sibling

### DIFF
--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -377,28 +377,19 @@ export const Path = {
         case 'move_node': {
           const { path: op, newPath: onp } = operation
 
-          // If the old and new path are the same, it's a no-op.
-          if (Path.equals(op, onp)) {
+          // If the old and new path are the same or next sibling, it's a no-op.
+          if (Path.equals(op, onp) || Path.equals(Path.next(op), onp)) {
             return
           }
 
           if (Path.isAncestor(op, p) || Path.equals(op, p)) {
             const copy = onp.slice()
 
-            if (Path.endsBefore(op, onp) && op.length < onp.length) {
+            if (Path.endsBefore(op, onp)) {
               copy[op.length - 1] -= 1
             }
 
             return copy.concat(p.slice(op.length))
-          } else if (
-            Path.isSibling(op, onp) &&
-            (Path.isAncestor(onp, p) || Path.equals(onp, p))
-          ) {
-            if (Path.endsBefore(op, p)) {
-              p[op.length - 1] -= 1
-            } else {
-              p[op.length - 1] += 1
-            }
           } else if (
             Path.endsBefore(onp, p) ||
             Path.equals(onp, p) ||
@@ -410,7 +401,11 @@ export const Path = {
 
             p[onp.length - 1] += 1
           } else if (Path.endsBefore(op, p)) {
-            if (Path.equals(onp, p)) {
+            if (
+              Path.endsBefore(onp, p) ||
+              Path.equals(onp, p) ||
+              Path.isAncestor(onp, p)
+            ) {
               p[onp.length - 1] += 1
             }
 

--- a/packages/slate/test/interfaces/Path/transform/move_node/ancestor-sibling-ends-before-to-ancestor.tsx
+++ b/packages/slate/test/interfaces/Path/transform/move_node/ancestor-sibling-ends-before-to-ancestor.tsx
@@ -9,4 +9,4 @@ const op = {
 export const test = () => {
   return Path.transform(path, op)
 }
-export const output = [2, 3, 3]
+export const output = [3, 3, 3]

--- a/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-ancestor.tsx
+++ b/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-ancestor.tsx
@@ -1,12 +1,12 @@
 import { Path } from 'slate'
 
-const path = [0, 1]
+const path = [3, 3, 3]
 const op = {
   type: 'move_node',
-  path: [0, 0],
-  newPath: [0, 1],
+  path: [3, 2],
+  newPath: [3],
 }
 export const test = () => {
   return Path.transform(path, op)
 }
-export const output = [0, 1]
+export const output = [4, 2, 3]

--- a/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-ends-before.tsx
+++ b/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-ends-before.tsx
@@ -1,12 +1,12 @@
 import { Path } from 'slate'
 
-const path = [0, 1]
+const path = [3, 3, 3]
 const op = {
   type: 'move_node',
-  path: [0, 0],
-  newPath: [0, 1],
+  path: [3, 2],
+  newPath: [2],
 }
 export const test = () => {
   return Path.transform(path, op)
 }
-export const output = [0, 1]
+export const output = [4, 2, 3]

--- a/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-equal.ts
+++ b/packages/slate/test/interfaces/Path/transform/move_node/ends-before-to-equal.ts
@@ -1,12 +1,12 @@
 import { Path } from 'slate'
 
-const path = [0, 1]
+const path = [3, 3, 3]
 const op = {
   type: 'move_node',
-  path: [0, 0],
-  newPath: [0, 1],
+  path: [3, 2],
+  newPath: [3, 3, 3],
 }
 export const test = () => {
   return Path.transform(path, op)
 }
-export const output = [0, 1]
+export const output = [3, 2, 4]

--- a/packages/slate/test/interfaces/Path/transform/move_node/equal-to-sibling-ends-after.tsx
+++ b/packages/slate/test/interfaces/Path/transform/move_node/equal-to-sibling-ends-after.tsx
@@ -3,10 +3,10 @@ import { Path } from 'slate'
 const path = [0, 1]
 const op = {
   type: 'move_node',
-  path: [0, 0],
-  newPath: [0, 1],
+  path: [0, 1],
+  newPath: [0, 3],
 }
 export const test = () => {
   return Path.transform(path, op)
 }
-export const output = [0, 1]
+export const output = [0, 2]

--- a/packages/slate/test/transforms/moveNodes/selection/block.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block.tsx
@@ -14,7 +14,7 @@ export const input = (
 export const run = editor => {
   Transforms.moveNodes(editor, {
     match: n => Editor.isBlock(editor, n),
-    to: [1],
+    to: [2],
   })
 }
 export const output = (

--- a/packages/slate/test/transforms/moveNodes/voids-true/inline.tsx
+++ b/packages/slate/test/transforms/moveNodes/voids-true/inline.tsx
@@ -17,7 +17,7 @@ export const input = (
   </editor>
 )
 export const run = editor => {
-  Transforms.moveNodes(editor, { at: [0, 1], to: [0, 3] })
+  Transforms.moveNodes(editor, { at: [0, 1], to: [0, 4] })
 }
 export const output = (
   <editor>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fix a bug

#### What's the new behavior?

I'm using slate.js for my real-time collaborative editor and focusing on the operational transformation recently. I found out that `Path.transform` is useful, elegant and heuristic. But some logics of `move_node` path transform functions made me confused at the begining, and some calculations of them might be wrong.

For example: when `op` is sibling with `onp`, `onp` equals `p`, and `op` ends before `p`, the result of transformed path should be exactly the same as `p`.

![image](https://user-images.githubusercontent.com/12724894/90496274-3503fb80-e178-11ea-8f10-10cefeac207c.png)

Let me draw a picture to show why the result is `p`.

![image](https://user-images.githubusercontent.com/12724894/90397115-f0218b80-e0c9-11ea-9559-ce25b79da1f7.png)

It is obvious that the transformed path of `move_node` in the aboved case is `[0, 2]`.

Here is another code snippet I found that may not be right. When `op` equals `p`, `op` ends before `onp`, and `op.length` equals `onp.length`. The result of transformed path should also do the logic of `copy[op.length - 1] -= 1`.

![image](https://user-images.githubusercontent.com/12724894/90497676-ece5d880-e179-11ea-99d2-3c80aed3df9e.png)

Let's take a look at the real world example again.

![image](https://user-images.githubusercontent.com/12724894/90498810-5c0ffc80-e17b-11ea-82ca-e000b7bb6fae.png)

It is obvious that the transformed path of `move_node` in the aboved case is `[0, 2]`.

#### How does this change work?

Then I  sort out the logics of `move_node` path transform and try to make it more beautiful. In my opinion, `move_node` is a bit like the composition of `remove_node` and `insert_node`. So the relationship of `move_node` paths (p, op, and onp)  can be divided into two parts. This idea instructs my changes to the `move_node` path tranform logic.

Moreover, I add this logic below in the code as a `quick return`:

![image](https://user-images.githubusercontent.com/12724894/90497510-bdcf6700-e179-11ea-8656-47e44771b3c4.png)

It will leads to the same transformed path result without this `quick return` code snnipet. 

But this `quick return` should make sense since the `path` and `Path.next(path)` actually means the same position in the node movement. I draw another picture below to demonstrate this.

![image](https://user-images.githubusercontent.com/12724894/90399020-e2213a00-e0cc-11ea-8970-47bb5cdca623.png)

Let me know if I have some misunderstanding. Discussion is welcome.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @ianstormtaylor @CameronAckermanSEL @jason-krypton 
