### PR TITLE
fix node-to-key weakmap refresh 

### DIFF
--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -52,7 +52,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
             ) {
               continue
             } else {
-              e.apply(op)
+              editor.apply(op)
             }
           }
         })

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -22,7 +22,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
       HistoryEditor.withoutSaving(e, () => {
         Editor.withoutNormalizing(e, () => {
           for (const op of batch) {
-            e.apply(op)
+            editor.apply(op)
           }
         })
       })

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -133,7 +133,7 @@ const Element = (props: {
 const MemoizedElement = React.memo(Element, (prev, next) => {
   return (
     prev.decorate === next.decorate &&
-    prev.element === next.element &&
+    isElementEqual(prev.element, next.element) &&
     prev.renderElement === next.renderElement &&
     prev.renderLeaf === next.renderLeaf &&
     isRangeListEqual(prev.decorations, next.decorations) &&
@@ -157,6 +157,30 @@ export const DefaultElement = (props: RenderElementProps) => {
       {children}
     </Tag>
   )
+}
+
+const isElementEqual = (
+  element: SlateElement,
+  another: SlateElement
+): boolean => {
+  if (element !== another) {
+    return false
+  }
+
+  if (element.children.length !== another.children.length) {
+    return false
+  }
+
+  for (let i = 0; i < element.children.length; i++) {
+    const childNode = element.children[i]
+    const other = another.children[i]
+
+    if (childNode !== other) {
+      return false
+    }
+  }
+
+  return true
 }
 
 /**

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -213,18 +213,20 @@ export const withReact = <T extends Editor>(editor: T) => {
   }
 
   e.onChange = () => {
-    // COMPAT: React doesn't batch `setState` hook calls, which means that the
-    // children and selection can get out of sync for one render pass. So we
-    // have to use this unstable API to ensure it batches them. (2019/12/03)
-    // https://github.com/facebook/react/issues/14259#issuecomment-439702367
-    ReactDOM.unstable_batchedUpdates(() => {
-      const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
+    setTimeout(() => {
+      // COMPAT: React doesn't batch `setState` hook calls, which means that the
+      // children and selection can get out of sync for one render pass. So we
+      // have to use this unstable API to ensure it batches them. (2019/12/03)
+      // https://github.com/facebook/react/issues/14259#issuecomment-439702367
+      ReactDOM.unstable_batchedUpdates(() => {
+        const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
 
-      if (onContextChange) {
-        onContextChange()
-      }
+        if (onContextChange) {
+          onContextChange()
+        }
 
-      onChange()
+        onChange()
+      })
     })
   }
 

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -213,20 +213,18 @@ export const withReact = <T extends Editor>(editor: T) => {
   }
 
   e.onChange = () => {
-    setTimeout(() => {
-      // COMPAT: React doesn't batch `setState` hook calls, which means that the
-      // children and selection can get out of sync for one render pass. So we
-      // have to use this unstable API to ensure it batches them. (2019/12/03)
-      // https://github.com/facebook/react/issues/14259#issuecomment-439702367
-      ReactDOM.unstable_batchedUpdates(() => {
-        const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
+    // COMPAT: React doesn't batch `setState` hook calls, which means that the
+    // children and selection can get out of sync for one render pass. So we
+    // have to use this unstable API to ensure it batches them. (2019/12/03)
+    // https://github.com/facebook/react/issues/14259#issuecomment-439702367
+    ReactDOM.unstable_batchedUpdates(() => {
+      const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
 
-        if (onContextChange) {
-          onContextChange()
-        }
+      if (onContextChange) {
+        onContextChange()
+      }
 
-        onChange()
-      })
+      onChange()
     })
   }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fix a bug 

#### What's the new behavior?

We will update node-to-key weakMap when apply transform but it does not work well now.

1. revert transform do not update node-to-key weakmap
2. weakmap update before react batchUpdate
3. related element is not correct

#### How does this change work?

RT see code

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

Notice: slate-react do not test code 

#### Does this fix any issues or need any specific reviewers?

Fixes: #3656 #3740 partial fix
Reviewers: @
