### PR TITLE
Upgrade immer to 7.0.0

### DIFF
--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "dependencies": {
-    "immer": "^5.0.0",
+    "immer": "^7.0.0",
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/esrever": "^0.2.0",
     "esrever": "^0.2.0",
-    "immer": "^5.0.0",
+    "immer": "^7.0.0",
     "is-plain-object": "^3.0.0",
     "tiny-warning": "^1.0.3"
   },

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -292,7 +292,7 @@ export const Node: NodeInterface = {
       )
     }
 
-    const newRoot = produce(root, r => {
+    const newRoot = produce({ children: root.children }, r => {
       const [start, end] = Range.edges(range)
       const nodeEntries = Node.nodes(r, {
         reverse: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5693,10 +5693,10 @@ image-extensions@^1.1.0:
   resolved "https://registry.yarnpkg.com/image-extensions/-/image-extensions-1.1.0.tgz#b8e6bf6039df0056e333502a00b6637a3105d894"
   integrity sha1-uOa/YDnfAFbjM1AqALZjejEF2JQ=
 
-immer@^5.0.0:
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"
-  integrity sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==
+immer@^7.0.0:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.7.tgz#9dfe713d49bf871cc59aedfce59b1992fa37a977"
+  integrity sha512-Q8yYwVADJXrNfp1ZUAh4XDHkcoE3wpdpb4mC5abDSajs2EbW8+cGdPyAnglMyLnm7EF6ojD2xBFX7L5i4TIytw==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Upgrading a dependency.

#### What's the new behavior?

Hopefully none.

I'm proposing this upgrade because I've run across immerjs/immer#559, a fix for which is included in immer >= 6.0.4. This issue does not occur in Slate itself (hence why I didn't mark this PR as fixing a bug), but rather when a Slate type such as `Range` is stored in an immer-controlled container, and `transform`ed. For example this:
```typescript
let state = {
    anchor: { path: [0, 0], offset: 0 },
    focus: { path: [0, 0], offset: 10 },
}

state = produce(state, s => Range.transform(s, { type: 'insert_text', path: [0, 0], offset: 5, text: 'new' }))
```
will result in `state.focus.path` being a revoked proxy.

Since this changes a major version of a public dependency it is also a breaking change in Slate. However, I have verified that Slate works with Immer 5, 6, and 7, so in theory we could accept immer >= 5.00 < 8.0.0 and let the consumer choose which version of Immer they want, thus avoiding a breaking change. I'm not proposing that in this PR as I don't know how to do that in npm.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: 
Reviewers: 
