### PR TITLE
Normalize moved node

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -353,7 +353,11 @@ const getDirtyPaths = (op: Operation) => {
         newAncestors.push(p!)
       }
 
-      return [...oldAncestors, ...newAncestors]
+      const newParent = newAncestors[newAncestors.length - 1]
+      const newIndex = newPath[newPath.length - 1]
+      const resultPath = newParent.concat(newIndex)
+
+      return [...oldAncestors, ...newAncestors, resultPath]
     }
 
     case 'remove_node': {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

feature

#### What's the new behavior?

Normalize the node moved by a `move_node` operation.

When normalizations of a custom node depend on its parent, one currently must write them as

```typescript
editor.normalizeNode = entry => {
    const [node, path] = entry

    if (isCustomNode(node)) {
        // parent-independent normalization
    }

    for (const [child, childPath] of Node.children(editor, path)) {
        if (isCustomNode(child) && isCustomNodeParent(node)) {
            // parent-dependent normalization
        }
    }
}
```

with this change this can be instead written as

```typescript
editor.normalizeNode = entry => {
    const [node, path] = entry

    if (isCustomNode(node)) {
        // parent-independent normalization

        const [parent, parentPath] = Editor.parent(editor, path)
        if (isCustomNodeParent(node)) {
            // parent-dependent normalization
        }
    }
}
```

which helps keep related normalizations together and improves readability.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: 
Reviewers: 
