### PR TITLE
Fix forwardDelete moving nodes out of parent when merging

### DIFF
--- a/packages/slate/test/transforms/delete/point/empty-basic-before-nested.tsx
+++ b/packages/slate/test/transforms/delete/point/empty-basic-before-nested.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.delete(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <cursor />
+    </block>
+    <block>
+      <block>word</block>
+      <block>another</block>
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <block>
+        <cursor />
+        word
+      </block>
+      <block>another</block>
+    </block>
+  </editor>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Forward deleting on an empty block where the next block has nested elements (e.g. a bulleted list with list items) will no longer lift up the first nested element.

An example scenario is an empty paragraph followed by a bulleted list and we forward delete whilst the empty paragraph is selected. Previously this would cause the empty paragraph to be deleted (fine), and the first list item to be pulled out of the bulleted list and up one level (not fine). This can be seen in the Markdown Shortcuts example. Now the empty paragraph is deleted and the list is left alone (good)

#### How does this change work?

When deleting (both forward and backwards) Slate internally is just merging two nodes. In the case of forwards delete the start block will be the block we pressed delete on, and the end block will be the proceeding block. In the case of backwards delete the start block will be the preceeding block of the block being deleted, and the end block will be the block being deleted.

What Transforms.mergeNodes does is move the end block to the position proceeding the start block. So if my start block is at [2] then my end block is now at [3]. It will then check if the end block was contained in another block and if that containing block is now empty. If it is it will delete it. Finally it will check if the start block is empty and if it is delete that as well, otherwise it will merge them.

The problem occurs when the end block happens to be contained in another block, e.g. we have a list item in a bulleted list, AND the start block is BOTH not a sibling of the end block AND is empty. In that case our list item will be moved out of our bulleted list, and the start block will be deleted. This leaves us with an orphaned list item which is bad.

An example scenario is an empty paragraph followed by a bulleted list and we forward delete whilst the empty paragraph is selected.

To my knowledge you can't get in this situation when backward deleting since the end node in this case is the node being deleted, so you can't pull a child block out of it's parent, you can only move the current node to a position preceeding it.

My solution was simply to detect this edge case in the delete function and if it occurs don't merge, instead directly delete the start block which bypasses the whole issue. 

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

I don't believe this fixes any currently open issue.

#### Extra comments

I could also see how another solution could be to modify mergeNodes to not move the end block if the start block is empty and the path to move the end block to is higher than the path it is currently at (e.g. no moving [3,0] to [3]). I was a bit nervous to modify mergeNodes though. However if you think this is a good idea I'm happy to do so, I would just need some guidance on what to test for in this case.
