### PR TITLE
Expose interface to setNormalizing

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -254,6 +254,7 @@ export interface EditorInterface {
   ) => RangeRef
   rangeRefs: (editor: Editor) => Set<RangeRef>
   removeMark: (editor: Editor, key: string) => void
+  setNormalizing: (editor: Editor, isNormalizing: boolean) => void
   start: (editor: Editor, at: Location) => Point
   string: (
     editor: Editor,
@@ -1550,6 +1551,16 @@ export const Editor: EditorInterface = {
   },
 
   /**
+   * Manually set if the editor should currently be normalizing.
+   *
+   * Note: Using this incorrectly can leave the editor in an invalid state.
+   *
+   */
+  setNormalizing(editor: Editor, isNormalizing: boolean): void {
+    NORMALIZING.set(editor, isNormalizing)
+  },
+
+  /**
    * Get the start point of a location.
    */
 
@@ -1669,11 +1680,11 @@ export const Editor: EditorInterface = {
 
   withoutNormalizing(editor: Editor, fn: () => void): void {
     const value = Editor.isNormalizing(editor)
-    NORMALIZING.set(editor, false)
+    Editor.setNormalizing(editor, false)
     try {
       fn()
     } finally {
-      NORMALIZING.set(editor, value)
+      Editor.setNormalizing(editor, value)
     }
     Editor.normalize(editor)
   },


### PR DESCRIPTION
This PR exposes an API on Editor to control the normalization state. The reason for exposing this is `withoutNormalizing` is not sufficient in complex systems. Imaging a complex product where slate is just one collaborative surface. The main operation sync loop might look something like:

```
onOperationBatchReceived(ops: Operations): void {
  this.emit(START_BATCH);
  for (const op of ops) {
    // Not every op in a batch has the same objectId
    const obj = findObj(op.objectId);
    // Not every object here is a Slate Editor and the API is a shared interface for all collaborative objects
    obj.apply(op);
  }
  this.emit(END_BATCH);
}
```

The op batches are handled at a level and abstraction above slate which makes applying all operations in a withoutNormalizing callback difficult. Instead our SlateEditor listens to START_BATCH / END_BATCH events and toggles normalizing appropriately.

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

