### PR TITLE
docs: update help label and link

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -35,7 +35,7 @@ Please use the Slack instead of asking questions in issues, since we want to res
 
 ## Submitting Pull Requests
 
-All pull requests are super welcomed and greatly appreciated! Issues in need of a solution are marked with a [`♥ help please`](https://github.com/ianstormtaylor/slate/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%99%A5+help+please%22) label if you're looking for somewhere to start.
+All pull requests are super welcomed and greatly appreciated! Issues in need of a solution are marked with a [`♥ help`](https://github.com/ianstormtaylor/slate/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%99%A5+help%22) label if you're looking for somewhere to start.
 
 Please include tests and docs with every pull request!
 


### PR DESCRIPTION
Minor fix for the help link in the Contributing docs.

The link currently filters issues by the label [`♥ help please`](https://github.com/ianstormtaylor/slate/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%99%A5+help+please%22) which shows zero results. But this update filters by the correct label of [`♥ help`](https://github.com/ianstormtaylor/slate/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%99%A5+help%22) instead.