### PR TITLE
Fixed issue where virtual keyboard closes when resynchronizing selection in Chrome on Android

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -33,7 +33,6 @@ import {
   isDOMText,
   DOMStaticRange,
   isPlainTextOnlyPaste,
-  setReverseDomSelection,
 } from '../utils/dom'
 import {
   EDITOR_TO_ELEMENT,
@@ -180,21 +179,18 @@ export const Editable = (props: EditableProps) => {
     // Otherwise the DOM selection is out of sync, so update it.
     const el = ReactEditor.toDOMNode(editor, editor)
     state.isUpdatingSelection = true
-    domSelection.removeAllRanges()
 
     const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
 
     if (newDomRange) {
-      if (Range.isBackward(selection!)) {
-        setReverseDomSelection(newDomRange, domSelection)
-      } else {
-        domSelection.addRange(newDomRange!)
-      }
+      domSelection.setBaseAndExtent(newDomRange.startContainer, newDomRange.startOffset, newDomRange.endContainer, newDomRange.endOffset)
       const leafEl = newDomRange.startContainer.parentElement!
       scrollIntoView(leafEl, {
         scrollMode: 'if-needed',
         boundary: el,
       })
+    } else {
+      domSelection.removeAllRanges()
     }
 
     setTimeout(() => {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -183,12 +183,21 @@ export const Editable = (props: EditableProps) => {
     const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
 
     if (newDomRange) {
-      domSelection.setBaseAndExtent(
-        newDomRange.startContainer,
-        newDomRange.startOffset,
-        newDomRange.endContainer,
-        newDomRange.endOffset
-      )
+      if (Range.isBackward(selection!)) {
+        domSelection.setBaseAndExtent(
+          newDomRange.endContainer,
+          newDomRange.endOffset,
+          newDomRange.startContainer,
+          newDomRange.startOffset
+        )
+      } else {
+        domSelection.setBaseAndExtent(
+          newDomRange.startContainer,
+          newDomRange.startOffset,
+          newDomRange.endContainer,
+          newDomRange.endOffset
+        )
+      }
       const leafEl = newDomRange.startContainer.parentElement!
       scrollIntoView(leafEl, {
         scrollMode: 'if-needed',

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -183,7 +183,12 @@ export const Editable = (props: EditableProps) => {
     const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
 
     if (newDomRange) {
-      domSelection.setBaseAndExtent(newDomRange.startContainer, newDomRange.startOffset, newDomRange.endContainer, newDomRange.endOffset)
+      domSelection.setBaseAndExtent(
+        newDomRange.startContainer,
+        newDomRange.startOffset,
+        newDomRange.endContainer,
+        newDomRange.endOffset
+      )
       const leafEl = newDomRange.startContainer.parentElement!
       scrollIntoView(leafEl, {
         scrollMode: 'if-needed',

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -174,24 +174,3 @@ export const getPlainText = (domNode: DOMNode) => {
 
   return text
 }
-
-/**
- * there is no way to create a reverse DOM Range using Range.setStart/setEnd
- * according to https://dom.spec.whatwg.org/#concept-range-bp-set.
- * Luckily it's possible to create a reverse selection via Selection.extend
- *
- * Note: Selection.extend is not implement in any version of IE (up to and including version 11)
- */
-
-export const setReverseDomSelection = (
-  domRange: DOMRange,
-  domSelection: Selection
-) => {
-  const newRange = domRange.cloneRange()
-  // collapses the range to end
-  newRange.collapse()
-  // set both anchor and focus of the selection to domRange's focus
-  domSelection.addRange(newRange)
-  // moves the focus of the selection to domRange's anchor
-  domSelection.extend(domRange.startContainer, domRange.startOffset)
-}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

This pull request fixes an issue where the virtual keyboard in Chrome on Android closes when all selections are removed. The code removes all selections and adds the new selection as part of its resynchronization. However, this causes the virtual keyboard to close.

#### What's the new behavior?

The virtual keyboard on Android does not close when resynchronizing the focus.

#### How does this change work?

Instead of removing the selection and adding a new range, this change will set the selection's base and extent to the desired selection. As the selection is never lost, Chrome on Android doesn't close the virtual keyboard.

As part of this change, I also replaced `setReverseDomSelection` with `Selection#setBaseAndExtent`. As `setReverseDomSelection` assumes the selection has no range, it would not work with the previous changes.

`Selection#setBaseAndExtent` support forward and backward selection.

> If anchor is before focus, set the start the newRange's start to anchor and its end to focus. Otherwise, set the start them to focus and anchor respectively.
> https://w3c.github.io/selection-api/#dom-selection-setbaseandextent

> Note: If the focus position appears before the anchor position in the document, the direction of the selection is reversed — the caret is placed at the beginning of the text rather the end, which matters for any keyboard command that might follow. For example, Shift + ➡︎ would cause the selection to narrow from the beginning rather than grow at the end.
> https://developer.mozilla.org/en-US/docs/Web/API/Selection/setBaseAndExtent

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
