### PR TITLE
docs: add react-force/slate-editor to the list of pre-packaged editors

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -40,6 +40,7 @@ These pre-packaged editors are built on top of Slate, and can be helpful to see 
 - [French Press Editor](https://github.com/roast-cms/french-press-editor) is a customizeable editor with offline support.
 - [Nossas Editor](http://slate-editor.bonde.org/) is a drop-in WYSIWYG editor.
 - [ORY Editor](https://editor.ory.am/) is a self-contained, inline WYSIWYG editor library.
+- [React Force Slate Editor](https://github.com/nareshbhatia/react-force/tree/master/packages/slate-editor) is a light-weight medium-style editor with no editor chrome.
 - [Slate Plugins Next](https://github.com/zbeyens/slate-plugins-next) provides an editor with configurable and extendable plugins.
 
 (Or, if you have their exact use case, can be a drop-in editor for you.)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

No. I have simply added a line in the docs to reference a pre-packaged editor.

#### What's the new behavior?

N/A

#### How does this change work?

N/A

#### Have you checked that...?

N/A

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

No

Fixes: #
Reviewers: @
