### PR TITLE
Fix skip in editor positions

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -990,6 +990,7 @@ export const Editor = {
     const range = Editor.range(editor, at)
     const [start, end] = Range.edges(range)
     const first = reverse ? end : start
+    const last = reverse ? start : end
     let string = ''
     let available = 0
     let offset = 0
@@ -1040,7 +1041,6 @@ export const Editor = {
           const s = Path.isAncestor(path, start.path)
             ? start
             : Editor.start(editor, path)
-
           const text = Editor.string(editor, { anchor: s, focus: e })
           string = reverse ? reverseText(text) : text
           isNewBlock = true
@@ -1062,8 +1062,12 @@ export const Editor = {
         }
 
         while (true) {
-          // If there's no more string, continue to the next block.
-          if (string === '') {
+          // If there's no more string (and we've exhausted the available space
+          // or we're at the end of the range), break from the current node.
+          if (
+            string === '' &&
+            (available === 0 || Point.equals(last, { path, offset }))
+          ) {
             break
           } else {
             advance()

--- a/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-reverse.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-reverse.tsx
@@ -1,0 +1,51 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      two
+      <inline>
+        three
+        <inline>four</inline>
+      </inline>
+      <inline>five</inline>
+    </block>
+    <block>six</block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(Editor.positions(editor, { reverse: true, at: [] }))
+}
+export const output = [
+  { path: [2, 0], offset: 3 },
+  { path: [2, 0], offset: 2 },
+  { path: [2, 0], offset: 1 },
+  { path: [2, 0], offset: 0 },
+  { path: [1, 2, 0], offset: 4 },
+  { path: [1, 2, 0], offset: 3 },
+  { path: [1, 2, 0], offset: 2 },
+  { path: [1, 2, 0], offset: 1 },
+  { path: [1, 2, 0], offset: 0 },
+  { path: [1, 1, 1, 0], offset: 4 },
+  { path: [1, 1, 1, 0], offset: 3 },
+  { path: [1, 1, 1, 0], offset: 2 },
+  { path: [1, 1, 1, 0], offset: 1 },
+  { path: [1, 1, 1, 0], offset: 0 },
+  { path: [1, 1, 0], offset: 5 },
+  { path: [1, 1, 0], offset: 4 },
+  { path: [1, 1, 0], offset: 3 },
+  { path: [1, 1, 0], offset: 2 },
+  { path: [1, 1, 0], offset: 1 },
+  { path: [1, 1, 0], offset: 0 },
+  { path: [1, 0], offset: 3 },
+  { path: [1, 0], offset: 2 },
+  { path: [1, 0], offset: 1 },
+  { path: [1, 0], offset: 0 },
+  { path: [0, 0], offset: 3 },
+  { path: [0, 0], offset: 2 },
+  { path: [0, 0], offset: 1 },
+  { path: [0, 0], offset: 0 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word-reverse.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word-reverse.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      two
+      <inline>
+        three
+        <inline>four</inline>
+      </inline>
+      <inline>five</inline>
+    </block>
+    <block>six</block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.positions(editor, {
+      at: [],
+      reverse: true,
+      unit: 'word'
+    })
+  )
+}
+export const output = [
+  { path: [2, 0], offset: 3 },
+  { path: [2, 0], offset: 0 },
+  { path: [1, 2, 0], offset: 4 },
+  { path: [1, 0], offset: 0 },
+  { path: [0, 0], offset: 3 },
+  { path: [0, 0], offset: 0 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word-reverse.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word-reverse.tsx
@@ -21,7 +21,7 @@ export const test = editor => {
     Editor.positions(editor, {
       at: [],
       reverse: true,
-      unit: 'word'
+      unit: 'word',
     })
   )
 }

--- a/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word.tsx
@@ -1,0 +1,34 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      two
+      <inline>
+        three
+        <inline>four</inline>
+      </inline>
+      <inline>five</inline>
+    </block>
+    <block>six</block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.positions(editor, {
+      at: [],
+      unit: 'word'
+    })
+  )
+}
+export const output = [
+  { path: [0, 0], offset: 0 },
+  { path: [0, 0], offset: 3 },
+  { path: [1, 0], offset: 0 },
+  { path: [1, 2, 0], offset: 4 },
+  { path: [2, 0], offset: 0 },
+  { path: [2, 0], offset: 3 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple-unit-word.tsx
@@ -20,7 +20,7 @@ export const test = editor => {
   return Array.from(
     Editor.positions(editor, {
       at: [],
-      unit: 'word'
+      unit: 'word',
     })
   )
 }

--- a/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/all/block-multiple-inline-multiple.tsx
@@ -1,0 +1,51 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      two
+      <inline>
+        three
+        <inline>four</inline>
+      </inline>
+      <inline>five</inline>
+    </block>
+    <block>six</block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(Editor.positions(editor, { at: [] }))
+}
+export const output = [
+  { path: [0, 0], offset: 0 },
+  { path: [0, 0], offset: 1 },
+  { path: [0, 0], offset: 2 },
+  { path: [0, 0], offset: 3 },
+  { path: [1, 0], offset: 0 },
+  { path: [1, 0], offset: 1 },
+  { path: [1, 0], offset: 2 },
+  { path: [1, 0], offset: 3 },
+  { path: [1, 1, 0], offset: 0 },
+  { path: [1, 1, 0], offset: 1 },
+  { path: [1, 1, 0], offset: 2 },
+  { path: [1, 1, 0], offset: 3 },
+  { path: [1, 1, 0], offset: 4 },
+  { path: [1, 1, 0], offset: 5 },
+  { path: [1, 1, 1, 0], offset: 0 },
+  { path: [1, 1, 1, 0], offset: 1 },
+  { path: [1, 1, 1, 0], offset: 2 },
+  { path: [1, 1, 1, 0], offset: 3 },
+  { path: [1, 1, 1, 0], offset: 4 },
+  { path: [1, 2, 0], offset: 0 },
+  { path: [1, 2, 0], offset: 1 },
+  { path: [1, 2, 0], offset: 2 },
+  { path: [1, 2, 0], offset: 3 },
+  { path: [1, 2, 0], offset: 4 },
+  { path: [2, 0], offset: 0 },
+  { path: [2, 0], offset: 1 },
+  { path: [2, 0], offset: 2 },
+  { path: [2, 0], offset: 3 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/range/inline-reverse.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/range/inline-reverse.tsx
@@ -1,0 +1,44 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block>
+      one<inline>two</inline>three<inline>four</inline>five
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.positions(editor, {
+      reverse: 'true',
+      at: {
+        anchor: { path: [0, 0], offset: 2 },
+        focus: { path: [0, 4], offset: 2 },
+      },
+    })
+  )
+}
+export const output = [
+  { path: [0, 4], offset: 2 },
+  { path: [0, 4], offset: 1 },
+  { path: [0, 4], offset: 0 },
+  { path: [0, 3, 0], offset: 4 },
+  { path: [0, 3, 0], offset: 3 },
+  { path: [0, 3, 0], offset: 2 },
+  { path: [0, 3, 0], offset: 1 },
+  { path: [0, 3, 0], offset: 0 },
+  { path: [0, 2], offset: 5 },
+  { path: [0, 2], offset: 4 },
+  { path: [0, 2], offset: 3 },
+  { path: [0, 2], offset: 2 },
+  { path: [0, 2], offset: 1 },
+  { path: [0, 2], offset: 0 },
+  { path: [0, 1, 0], offset: 3 },
+  { path: [0, 1, 0], offset: 2 },
+  { path: [0, 1, 0], offset: 1 },
+  { path: [0, 1, 0], offset: 0 },
+  { path: [0, 0], offset: 3 },
+  { path: [0, 0], offset: 2 },
+]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### What's the new behavior?
Does _not_ merge a block with its previous one when the user is backspacing over the first node and their cursor is in the second node. The fix works the same whether deleting backwards at the start of a block or deleting forwards at the end.

- With a styled text node:
![richtext_char_backspace_fix](https://user-images.githubusercontent.com/11330558/93725213-048df380-fb62-11ea-9455-41ee4e2e3efd.gif)

- Also works with inline nodes:
![inline_char_backspace_fix](https://user-images.githubusercontent.com/11330558/93725262-81b96880-fb62-11ea-9e95-9e7308251bde.gif)

#### How does this change work?

_Before the fix_: While scanning a text node for cursor positions, the loop [breaks early](https://github.com/ianstormtaylor/slate/blob/4c3e737dda95d5ab67a94af903b25512d926c7fe/packages/slate/src/interfaces/editor.ts#L1066) when there is no more string left. But if the [element node](https://github.com/ianstormtaylor/slate/blob/4c3e737dda95d5ab67a94af903b25512d926c7fe/packages/slate/src/interfaces/editor.ts#L1045) containing the string content is comprised of multiple inlines or text nodes, the edge position of the element node is effectively ignored and never [yielded](https://github.com/ianstormtaylor/slate/blob/4c3e737dda95d5ab67a94af903b25512d926c7fe/packages/slate/src/interfaces/editor.ts#L1075). This skip can be seen both while deleting over the first node and also while simply jumping over it with the cursor.

_The fix_: Constrain when to break the loop early using additional conditions.

#### Have you checked that...?

- [ x ] The new code matches the existing patterns and styles.
          - I tried staying within the existing pattern. Please let me know if anything needs to be adjusted.
- [ x ] The tests pass with `yarn test`.
          - Existing tests pass, and new tests have been added.
- [ x ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
          - The lint passes locally **except** for line endings (I'm working on Windows). Wasn't sure whether to update the eslint config to accommodate it? Will pose this question in slack and follow up with the change here.
- [ x ] The relevant examples still work. (Run examples with `yarn start`.)
          - Yes the examples still work.

#### Does this fix any issues or need any specific reviewers?

Fixes: #3339 and #3466 