### PR TITLE
Fix error when trying to grab 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -435,9 +435,13 @@ export const ReactEditor = {
         // ancestor, so find it by going down from the nearest void parent.
 
         leafNode = voidNode.querySelector('[data-slate-leaf]')!
-        textNode = leafNode.closest('[data-slate-node="text"]')!
-        domNode = leafNode
-        offset = domNode.textContent!.length
+        if (!leafNode) {
+          offset = 1
+        } else {
+          textNode = leafNode.closest('[data-slate-node="text"]')!
+          domNode = leafNode
+          offset = domNode.textContent!.length
+        }
       }
 
       // COMPAT: If the parent node is a Slate zero-width space, editor is


### PR DESCRIPTION
fix(react-editor): text node spacer can be non-existent if editor is in readonly mode

#### fixing a _bug_

```
TypeError: Cannot read property 'closest' of null
    at Object.toSlatePoint 
    at Object.toSlateRange 
```

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

Here's my usecase:
I have a void node with a click handler that selects itself, opens a dialog, and sets the editor to readonly to save the selection while focus is lost. Changing the selection causes `useIsomorphicLayoutEffect` to trigger which tries to grab selection (https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/src/components/editable.tsx#L183) and causes the stracktrace above when it eventually hits this line https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/src/plugin/react-editor.ts#L438. 

---

Here's the root cause I found:
When the editor is set to readonly, void nodes have their text spacers removed (https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/src/components/element.tsx#L96), but there is code elsewhere that depends on this spacer always being there (https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/src/plugin/react-editor.ts#L438). 

#### How does this change work?

I get around this by doing a null check and defaulting the offset to 1, which would be the same offset if the spacer was there.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
