### PR TITLE
Update examples Readme to link to .tsx files

### DIFF
--- a/site/examples/Readme.md
+++ b/site/examples/Readme.md
@@ -2,16 +2,16 @@
 
 This directory contains a set of examples that give you an idea for how you might use Slate to implement your own editor. Take a look around!
 
-- [**Plain text**](./plaintext.js) — showing the most basic case: a glorified `<textarea>`.
-- [**Rich text**](./richtext.js) — showing the features you'd expect from a basic editor.
-- [**Forced Layout**](./forced-layout.js) - showing how to use constraints to enforce a document structure.
-- [**Markdown Shortcuts**](./markdown-shortcuts.js) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Links**](./links.js) — showing how wrap text in inline nodes with associated data.
-- [**Images**](./images.js) — showing how to use void (text-less) nodes to add images.
-- [**Hovering toolbar**](./hovering-toolbar.js) — showing how a hovering toolbar can be implemented.
-- [**Tables**](./tables.js) — showing how to nest blocks to render more advanced components.
-- [**Paste HTML**](./paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
-- [**Code Highlighting**](./code-highlighting.js) — showing how to use decorations to dynamically format text.
+- [**Plain text**](./plaintext.tsx) — showing the most basic case: a glorified `<textarea>`.
+- [**Rich text**](./richtext.tsx) — showing the features you'd expect from a basic editor.
+- [**Forced Layout**](./forced-layout.tsx) - showing how to use constraints to enforce a document structure.
+- [**Markdown Shortcuts**](./markdown-shortcuts.tsx) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Links**](./links.tsx) — showing how wrap text in inline nodes with associated data.
+- [**Images**](./images.tsx) — showing how to use void (text-less) nodes to add images.
+- [**Hovering toolbar**](./hovering-toolbar.tsx) — showing how a hovering toolbar can be implemented.
+- [**Tables**](./tables.tsx) — showing how to nest blocks to render more advanced components.
+- [**Paste HTML**](./paste-html.tsx) — showing how to use an HTML serializer to handle pasted HTML.
+- [**Code Highlighting**](./code-highlighting.tsx) — showing how to use decorations to dynamically format text.
 - ...and more!
 
 If you have an idea for an example that shows a common use case, pull request it!


### PR DESCRIPTION
Reading through these examples and noticed that all of the links in this file need to be updated from .js -> .tsx. Links work now.

#### Is this adding or improving a _feature_ or fixing a _bug_?

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

Fixing a bug.

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

Links in README work.

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

Fixes the links.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

:+1:

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
