### PR TITLE
Cutting (Ctrl + X) on a void element copies content to clip board AND removes the element from the editor

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -653,9 +653,14 @@ export const Editable = (props: EditableProps) => {
               ReactEditor.setFragmentData(editor, event.clipboardData)
               const { selection } = editor
               const node = ReactEditor.toSlateNode(editor, event.target)
+              const path = ReactEditor.findPath(editor, node)
+              const voidMatch = Editor.void(editor, { at: path })
 
-              if (selection && (Range.isExpanded(selection) || Editor.isVoid(editor, node))) {
+              if (selection && Range.isExpanded(selection)) {
                 Editor.deleteFragment(editor)
+              }
+              else if (selection && voidMatch) {
+                Transforms.delete(editor, {at: voidMatch[1]});
               }
             }
           },

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -652,8 +652,9 @@ export const Editable = (props: EditableProps) => {
               event.preventDefault()
               ReactEditor.setFragmentData(editor, event.clipboardData)
               const { selection } = editor
+              const node = ReactEditor.toSlateNode(editor, event.target)
 
-              if (selection && Range.isExpanded(selection)) {
+              if (selection && (Range.isExpanded(selection) || Editor.isVoid(editor, node))) {
                 Editor.deleteFragment(editor)
               }
             }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -658,9 +658,8 @@ export const Editable = (props: EditableProps) => {
 
               if (selection && Range.isExpanded(selection)) {
                 Editor.deleteFragment(editor)
-              }
-              else if (selection && voidMatch) {
-                Transforms.delete(editor, {at: voidMatch[1]});
+              } else if (selection && voidMatch) {
+                Transforms.delete(editor, { at: voidMatch[1] })
               }
             }
           },


### PR DESCRIPTION
#### Cutting (Ctrl + X) on a void element copies content to clip board AND removes the element from the editor 
This is a fix for issue number [3857](https://github.com/ianstormtaylor/slate/issues/3857) -- and also fixes the image example allowing the image to be cut and pasted.

#### What's the new behavior?

When a void is selected and a user tries to cut the object to the clipboard, the element is both copied to the clipboard removed from the editor as expected.


#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3857
