### PR TITLE
docs(libraries): better distinguish useEditor and useSlate

### DIFF
--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -36,7 +36,7 @@ React hooks for Slate editors
 
 ###### `useEditor`
 
-Get the current editor object from the React context.
+Get the current editor object from the React context. Differs from `useSlate` in that this is a context for sharing the editor object in a way that does **not** re-render the context whenever changes occur. To be used in most cases as `useSlate` can cause unnecessary re-renders of components that consume it.
 
 ###### `useFocused`
 
@@ -52,7 +52,7 @@ Get the current `selected` state of an element.
 
 ###### `useSlate`
 
-Get the current editor object from the React context.
+Get the current editor object from the React context. Differs from `useEditor` in that this is a context for sharing the editor object in a way that re-renders the context whenever changes occur. To be used if you need the component consuming it to re-render on `onChange`.
 
 ## ReactEditor
 

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -36,7 +36,7 @@ React hooks for Slate editors
 
 ###### `useEditor`
 
-Get the current editor object from the React context. Differs from `useSlate` in that this is a context for sharing the editor object in a way that does **not** re-render the context whenever changes occur. To be used in most cases as `useSlate` can cause unnecessary re-renders of components that consume it.
+Get the current editor object from the React context. Differs from `useSlate` in that this is a context for sharing the editor object in a way that does **not** re-render the context whenever changes occur. Consider using `useEditor` if you do not explicitly need to trigger a re-render of the consuming component as it can result in improved performance.
 
 ###### `useFocused`
 
@@ -137,4 +137,3 @@ Adds React and DOM specific behaviors to the editor.
 ## Utils
 
 Private convenience modules
-

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -52,7 +52,7 @@ Get the current `selected` state of an element.
 
 ###### `useSlate`
 
-Get the current editor object from the React context. Differs from `useEditor` in that this is a context for sharing the editor object in a way that re-renders the context whenever changes occur. To be used if you need the component consuming it to re-render on `onChange`.
+Get the current editor object from the React context. Differs from `useEditor` in that this is a context for sharing the editor object in a way that re-renders the context whenever changes occur. To be used if you need the component consuming it to re-render on `onChange` calls or computations based on the `editor.selection` value.
 
 ## ReactEditor
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

No, documentation update

#### What's the new behavior?

N/A

#### How does this change work?

N/A

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: Better distinguishes between the two similar hooks of [`useEditor`](https://docs.slatejs.org/libraries/slate-react#useeditor) and [`useSlate`](https://docs.slatejs.org/libraries/slate-react#useslate).