### PR TITLE
[#3917] Add to isDOMNode function check for iframe implementation

### DIFF
--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -45,7 +45,11 @@ export const isDOMElement = (value: any): value is DOMElement => {
  */
 
 export const isDOMNode = (value: any): value is DOMNode => {
-  return value instanceof Node
+  const frame = document.querySelector('iframe')
+  return (
+    value instanceof Node ||
+    !!(frame && value instanceof frame.contentWindow.Node)
+  )
 }
 
 /**


### PR DESCRIPTION
Fixing a _bug_ #3917

#### What's the new behavior?

Now when you're using slate inside iframe there are will not be isDOMNode will not always return false and you can attach event handlers. The check didn't work before because iframe has its own internal Node and it's not equal to parent Node.

#### Have you checked that...?
Checked with `yarn test`, `yarn lint` and `yarn start`

Fixes: #3917
