### PR TITLE
Add useStable hook to slate-react and update docs.

### DIFF
--- a/docs/concepts/08-rendering.md
+++ b/docs/concepts/08-rendering.md
@@ -10,10 +10,10 @@ For example if you wanted to render custom element components, you'd pass in the
 
 ```jsx
 import { createEditor } from 'slate'
-import { Slate, Editable, withReact } from 'slate-react'
+import { Slate, Editable, withReact, useStable } from 'slate-react'
 
 const MyEditor = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const renderElement = useCallback(({ attributes, children, element }) => {
     switch (element.type) {
       case 'quote':
@@ -115,7 +115,7 @@ A common use case for this is rendering a toolbar with formatting buttons that a
 
 ```jsx
 const MyEditor = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   return (
     <Slate editor={editor}>
       <Toolbar />

--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -19,12 +19,12 @@ Once you've installed Slate, you'll need to import it.
 
 ```jsx
 // Import React dependencies.
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 // Import the Slate editor factory.
 import { createEditor } from 'slate'
 
 // Import the Slate components and React plugin.
-import { Slate, Editable, withReact } from 'slate-react'
+import { Slate, Editable, withReact, useStable } from 'slate-react'
 ```
 
 Before we use those imports, let's start with an empty `<App>` component:
@@ -36,12 +36,12 @@ const App = () => {
 }
 ```
 
-The next step is to create a new `Editor` object. We want the editor to be stable across renders, so we use the `useMemo` hook:
+The next step is to create a new `Editor` object. We want the editor to be stable across renders, so we use the `useStable` hook exported by slate-react:
 
 ```jsx
 const App = () => {
   // Create a Slate editor object that won't change across renders.
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   return null
 }
 ```
@@ -52,7 +52,7 @@ Next we want to create state for `value`:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
 
   // Keep track of state for the value of the editor.
   const [value, setValue] = useState([])
@@ -66,7 +66,7 @@ The provider component keeps track of your Slate editor, its plugins, its value,
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([])
   // Render the Slate context.
   return (
@@ -85,7 +85,7 @@ Okay, so the next step is to render the `<Editable>` component itself:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([])
   return (
     // Add the editable component inside the context.
@@ -104,7 +104,7 @@ The value is just plain JSON. Here's one containing a single paragraph block wit
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   // Add the initial value when setting up our state.
   const [value, setValue] = useState([
     {

--- a/docs/walkthroughs/02-adding-event-handlers.md
+++ b/docs/walkthroughs/02-adding-event-handlers.md
@@ -10,7 +10,7 @@ Here's our app from earlier:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -30,7 +30,7 @@ Now we add an `onKeyDown` handler:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -59,7 +59,7 @@ Our `onKeyDown` handler might look like this:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',

--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -8,7 +8,7 @@ We'll show you how. Let's start with our app from earlier:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -66,7 +66,7 @@ Now, let's add that renderer to our `Editor`:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -121,7 +121,7 @@ Okay, but now we'll need a way for the user to actually turn a block into a code
 import { Editor, Transforms } from 'slate'
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -178,7 +178,7 @@ But we forgot one thing. When you hit `` Ctrl-` `` again, it should change the c
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -8,7 +8,7 @@ So we start with our app from earlier:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -53,7 +53,7 @@ And now, we'll edit the `onKeyDown` handler to make it so that when you press `c
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -138,7 +138,7 @@ And now, let's tell Slate about that leaf. To do that, we'll pass in the `render
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -12,7 +12,7 @@ We'll start with our app from earlier:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -118,7 +118,7 @@ const CustomEditor = {
 }
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -174,7 +174,7 @@ Now our commands are clearly defined and you can invoke them from anywhere we ha
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -8,7 +8,7 @@ Let's start with a basic editor:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -32,7 +32,7 @@ So, in our `onChange` handler, we need to save the `value`:
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -64,7 +64,7 @@ But... if you refresh the page, everything is still reset. That's because we nee
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   // Update the initial content to be pulled from Local Storage if it exists.
   const [value, setValue] = useState(
     JSON.parse(localStorage.getItem('content')) || [
@@ -123,7 +123,7 @@ const deserialize = string => {
 }
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useStable(() => withReact(createEditor()))
   // Use our deserializing function to read the data from Local Storage.
   const [value, setValue] = useState(
     deserialize(localStorage.getItem('content')) || ''

--- a/packages/slate-react/src/hooks/use-stable.ts
+++ b/packages/slate-react/src/hooks/use-stable.ts
@@ -7,7 +7,7 @@ const UNINITIALIZED = {}
 const isUninitialized = (v: unknown): v is typeof UNINITIALIZED =>
   v === UNINITIALIZED
 
-export function useStable<T>(init: () => T): T {
+export const useStable = <T>(init: () => T): T => {
   const ref = useRef<T | typeof UNINITIALIZED>(UNINITIALIZED)
   // If the ref hasn't been initialized, initialize it; else don't. then return the initialized value
   // This is written as a single expression to help typescript understand what's going on.

--- a/packages/slate-react/src/hooks/use-stable.tsx
+++ b/packages/slate-react/src/hooks/use-stable.tsx
@@ -1,0 +1,15 @@
+import { useRef } from 'react'
+import { ReactEditor } from '../plugin/react-editor'
+
+// Uninitialized value is an object so that no value a user could pass in can === it
+const UNINITIALIZED = {}
+// This helper function is required to help typescript track the type of ref.current below
+const isUninitialized = (v: unknown): v is typeof UNINITIALIZED =>
+  v === UNINITIALIZED
+
+export function useStable<T>(init: () => T): T {
+  const ref = useRef<T | typeof UNINITIALIZED>(UNINITIALIZED)
+  // If the ref hasn't been initialized, initialize it; else don't. then return the initialized value
+  // This is written as a single expression to help typescript understand what's going on.
+  return isUninitialized(ref.current) ? (ref.current = init()) : ref.current
+}

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -14,6 +14,7 @@ export { useFocused } from './hooks/use-focused'
 export { useReadOnly } from './hooks/use-read-only'
 export { useSelected } from './hooks/use-selected'
 export { useSlate } from './hooks/use-slate'
+export { useStable } from './hooks/use-stable'
 
 // Plugin
 export { ReactEditor } from './plugin/react-editor'


### PR DESCRIPTION
#### Is this adding or improving a feature or fixing a bug?
This PR implements #3198 by adding a `useStable` hook to the `slate-react` package and updating the documentation to use it in place of `useMemo` for persisting the editor state; as `useMemo` doesn't guarantee persistence of the memoized value.

#### What's the new behavior?
From the updated docs:
```jsx
// Import React dependencies.
import React, { useEffect, useState } from "react";
// Import the Slate editor factory.
import { createEditor } from 'slate'

// Import the Slate components and React plugin.
import { Slate, Editable, withReact, useStable } from 'slate-react'

const App = () => {
  // Create a Slate editor object that won't change across renders.
  const editor = useStable(() => withReact(createEditor()))
  return null
}

```

#### How does this change work?

The `useStable` hook uses a react ref to store the editor, and initializes on the first call using the function passed by the user.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)


#### Does this fix any issues or need any specific reviewers?

Fixes: #3198 
