### PR TITLE
Paste URL works for image URLs that don't have image extensions

### DIFF
--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -130,15 +130,9 @@ const isImageUrl = url => {
   const ext = new URL(url).pathname.split('.').pop()
   if (imageExtensions.includes(ext)) return true // catch when url has image extension
   // last resort to check if url has an image content type
-  return nonAsyncIsHeaderImage(url)
-}
-
-const nonAsyncIsHeaderImage = url => {
-  const proxyurl = 'https://cors-anywhere.herokuapp.com/' // need proxyurl to bypass CORS
-  const req = new XMLHttpRequest()
-  req.open('GET', proxyurl + url, false)
-  req.send(null) // will fire CORS error if no proxy is used
-  return req.getResponseHeader('Content-Type').includes('image')
+  const response = await fetch(url)
+  if(response.ok && response.headers.get('Content-Type')?.includes('image')) return true
+  return false
 }
 
 const initialValue = [

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -128,16 +128,16 @@ const isImageUrl = url => {
   if (!url) return false
   if (!isUrl(url)) return false
   const ext = new URL(url).pathname.split('.').pop()
-  if(imageExtensions.includes(ext)) return true // catch when url has image extension
-  //last resort to check if url has an image content type
+  if (imageExtensions.includes(ext)) return true // catch when url has image extension
+  // last resort to check if url has an image content type
   return nonAsyncIsHeaderImage(url)
 }
 
 const nonAsyncIsHeaderImage = url => {
-  const proxyurl = "https://cors-anywhere.herokuapp.com/"; // need proxyurl to bypass CORS
-  var req = new XMLHttpRequest()
-  req.open('GET', proxyurl+url, false)
-  req.send(null) //will fire CORS error if no proxy is used
+  const proxyurl = 'https://cors-anywhere.herokuapp.com/' // need proxyurl to bypass CORS
+  const req = new XMLHttpRequest()
+  req.open('GET', proxyurl + url, false)
+  req.send(null) // will fire CORS error if no proxy is used
   return req.getResponseHeader('Content-Type').includes('image')
 }
 

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -128,7 +128,17 @@ const isImageUrl = url => {
   if (!url) return false
   if (!isUrl(url)) return false
   const ext = new URL(url).pathname.split('.').pop()
-  return imageExtensions.includes(ext)
+  if(imageExtensions.includes(ext)) return true // catch when url has image extension
+  //last resort to check if url has an image content type
+  return nonAsyncIsHeaderImage(url)
+}
+
+const nonAsyncIsHeaderImage = url => {
+  const proxyurl = "https://cors-anywhere.herokuapp.com/"; // need proxyurl to bypass CORS
+  var req = new XMLHttpRequest()
+  req.open('GET', proxyurl+url, false)
+  req.send(null) //will fire CORS error if no proxy is used
+  return req.getResponseHeader('Content-Type').includes('image')
 }
 
 const initialValue = [


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

![paste_url_fix](https://user-images.githubusercontent.com/25941773/97099109-57b40400-1642-11eb-9601-1bdd9ee14e43.gif)

The fix checks the image URL if it includes an image header.

#### How does this change work?

The recent isImageUrl function only checks the URL if it contains any of the image extensions from the [image extension package](https://www.npmjs.com/package/image-extensions). The problem was that images from unsplash.com do not include image extensions (eg. jpeg, png) in their image URLs, so the function evaluates all images from unsplash.com as not image URLs. 

The change builds off of isImageUrl and adds a last resort check.
It makes a get request to obtain the Content-Type of the URL sent using XMLHttpRequest.
If the response header has a content-type of image then it must be an image, so it will return true in this case. 

Also, I was running into some CORS Blocking issue so I had to use a proxy URL to bypass the CORS issue.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes:  #3935 

