### PR TITLE
Migrating from mocha to jest for testing

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,14 @@
+{
+    "presets": [
+        "@babel/preset-typescript",
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "node": "current"
+                }
+            }
+        ],
+        "@babel/preset-react"
+    ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: [ "**/test/*.js", ],
+  globals: {
+    // we must specify a custom tsconfig for tests because we need the typescript transform
+    // to transform jsx into js rather than leaving it jsx such as the next build requires.  you
+    // can see this setting in tsconfig.jest.json -> "jsx": "react"
+    "ts-jest": {
+      tsConfig: "tsconfig.jest.json",
+      babelConfig: './config/babel/register.cjs'
+    }
+  },
+  transform: {
+    '^.+\\.[t|j]sx?$': 'babel-jest',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "release": "cross-env NODE_ENV=production yarn build:rollup && yarn test && yarn lint && lerna publish",
     "serve": "cd ./site && next",
     "start": "npm-run-all --parallel --print-label watch serve",
-    "test": "mocha --require ./config/babel/register.cjs ./packages/*/test/index.js",
-    "test:inspect": "yarn test --inspect-brk",
+    "test": "jest",
+    "test:inspect": "yarn test jest --inspect-brk",
     "watch": "yarn build:rollup --watch"
   },
   "devDependencies": {
@@ -31,11 +31,12 @@
     "@babel/plugin-transform-modules-commonjs": "^7.7.4",
     "@babel/plugin-transform-runtime": "^7.7.4",
     "@babel/polyfill": "^7.6.0",
-    "@babel/preset-env": "^7.7.4",
+    "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.7.4",
     "@babel/preset-typescript": "^7.7.4",
     "@babel/register": "^7.7.4",
     "@babel/runtime": "^7.7.4",
+    "@types/jest": "^26.0.15",
     "@types/lodash": "^4.14.149",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.14",
@@ -44,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^2.9.0",
     "@typescript-eslint/parser": "^2.9.0",
     "babel-eslint": "^10.0.3",
+    "babel-jest": "^26.6.1",
     "babel-plugin-dev-expression": "^0.2.2",
     "babel-plugin-module-resolver": "^3.1.1",
     "cross-env": "6.0.3",
@@ -57,6 +59,7 @@
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",
     "is-url": "^1.2.2",
+    "jest": "^26.6.1",
     "lerna": "^3.19.0",
     "lodash": "^4.17.4",
     "mocha": "^6.2.0",
@@ -85,6 +88,8 @@
     "slate-hyperscript": "*",
     "slate-react": "*",
     "source-map-loader": "^0.2.4",
+    "ts-jest": "^26.4.2",
     "typescript": "^3.7.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/slate-history/test/index.js
+++ b/packages/slate-history/test/index.js
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { fixtures } from '../../../support/fixtures'
 import { createHyperscript } from 'slate-hyperscript'
 import { withHistory } from '..'
@@ -9,8 +8,8 @@ describe('slate-history', () => {
     const editor = withTest(withHistory(input))
     run(editor)
     editor.undo()
-    assert.deepEqual(editor.children, output.children)
-    assert.deepEqual(editor.selection, output.selection)
+    expect(editor.children).toEqual(output.children)
+    expect(editor.selection).toEqual(output.selection)
   })
 })
 

--- a/packages/slate-hyperscript/test/index.js
+++ b/packages/slate-hyperscript/test/index.js
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { resolve } from 'path'
 import { fixtures } from '../../../support/fixtures'
 
@@ -15,6 +14,6 @@ describe('slate-hyperscript', () => {
       }
     }
 
-    assert.deepEqual(actual, output)
+    expect(actual).toEqual(output)
   })
 })

--- a/packages/slate-react/test/index.js
+++ b/packages/slate-react/test/index.js
@@ -1,1 +1,23 @@
-describe('slate-react', () => {})
+import { fixtures } from '../../../support/fixtures'
+import { Editor } from 'slate'
+
+describe('slate-react', () => {
+  fixtures(__dirname, 'selection', ({ module }) => {
+    let { input, test, output } = module
+    if (Editor.isEditor(input)) {
+      input = withTest(input)
+    }
+    const result = test(input)
+    expect(result).toEqual(output)
+  })
+})
+const withTest = editor => {
+  const { isInline, isVoid } = editor
+  editor.isInline = element => {
+    return element.inline === true ? true : isInline(element)
+  }
+  editor.isVoid = element => {
+    return element.void === true ? true : isVoid(element)
+  }
+  return editor
+}

--- a/packages/slate-react/test/selection/oneNode.tsx
+++ b/packages/slate-react/test/selection/oneNode.tsx
@@ -1,0 +1,9 @@
+/** @jsx jsx */
+import { Point } from 'slate'
+import { ReactEditor } from '../../src/plugin/react-editor'
+
+export const input = {}
+
+export const test = editor => {}
+
+export const output = undefined

--- a/packages/slate-react/tsconfig.json
+++ b/packages/slate-react/tsconfig.json
@@ -3,7 +3,8 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "composite": true
   },
   "references": [{ "path": "../slate" }]
 }

--- a/packages/slate/test/index.js
+++ b/packages/slate/test/index.js
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { fixtures } from '../../../support/fixtures'
 import { Editor } from 'slate'
 import { createHyperscript } from 'slate-hyperscript'
@@ -10,7 +9,7 @@ describe('slate', () => {
       input = withTest(input)
     }
     const result = test(input)
-    assert.deepEqual(result, output)
+    expect(result).toEqual(output)
   })
   fixtures(__dirname, 'operations', ({ module }) => {
     const { input, operations, output } = module
@@ -20,22 +19,22 @@ describe('slate', () => {
         editor.apply(op)
       }
     })
-    assert.deepEqual(editor.children, output.children)
-    assert.deepEqual(editor.selection, output.selection)
+    expect(editor.children).toEqual(output.children)
+    expect(editor.selection).toEqual(output.selection)
   })
   fixtures(__dirname, 'normalization', ({ module }) => {
     const { input, output } = module
     const editor = withTest(input)
     Editor.normalize(editor, { force: true })
-    assert.deepEqual(editor.children, output.children)
-    assert.deepEqual(editor.selection, output.selection)
+    expect(editor.children).toEqual(output.children)
+    expect(editor.selection).toEqual(output.selection)
   })
   fixtures(__dirname, 'transforms', ({ module }) => {
     const { input, run, output } = module
     const editor = withTest(input)
     run(editor)
-    assert.deepEqual(editor.children, output.children)
-    assert.deepEqual(editor.selection, output.selection)
+    expect(editor.children).toEqual(output.children)
+    expect(editor.selection).toEqual(output.selection)
   })
 })
 const withTest = editor => {

--- a/support/fixtures.js
+++ b/support/fixtures.js
@@ -37,18 +37,11 @@ export const fixtures = (...args) => {
         it(`${name} `, function () {
           const module = require(p)
 
-          if (module.skip) {
-            this.skip()
-            return
+          if (!module.skip) {
+            fn({ name, path, module })
           }
-
-          fn({ name, path, module })
         })
       }
     }
   })
-}
-
-fixtures.skip = (...args) => {
-  fixtures(...args, { skip: true })
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature (testing)

#### What's the new behavior?

Now using jest for testing. This allows for the use of features not available in mocha such as jest's better assertions, and mocking.

#### How does this change work?

I changed the repository to use Jest instead of Mocha for testing. I had to modify a number of configuration files and I am still trying to figure out what is required vs what is not.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3934
Reviewers: @
