### PR TITLE
Need help with useEditor hook when adding an image from file explorer

### DIFF
--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, RefObject } from 'react'
 import imageExtensions from 'image-extensions'
 import isUrl from 'is-url'
 import { Node, Transforms, createEditor } from 'slate'
@@ -14,6 +14,7 @@ import { withHistory } from 'slate-history'
 import { css } from 'emotion'
 
 import { Button, Icon, Toolbar } from '../components'
+
 
 const ImagesExample = () => {
   const [value, setValue] = useState<Node[]>(initialValue)
@@ -54,6 +55,7 @@ const withImages = editor => {
         if (mime === 'image') {
           reader.addEventListener('load', () => {
             const url = reader.result
+            console.log(url);
             insertImage(editor, url)
           })
 
@@ -108,9 +110,34 @@ const ImageElement = ({ attributes, children, element }) => {
   )
 }
 
+let inputOpenFileRef : RefObject<HTMLInputElement>
+
+const showOpenFileDlg = (event) => {
+  inputOpenFileRef.current.click()
+  let file = event.target.files[0];
+  console.log(file);
+}
+const uploadFile = event => {
+  let file = event.target.files[0];
+  console.log(file);
+  const reader = new FileReader();
+
+  reader.addEventListener("load", function () {
+    // convert image file to base64 string
+    const url = reader.result;
+    console.log(url);
+  }, false);
+
+  if (file) {
+    reader.readAsDataURL(file);
+  }
+}
+
 const InsertImageButton = () => {
   const editor = useEditor()
+  inputOpenFileRef = React.createRef();
   return (
+    <>
     <Button
       onMouseDown={event => {
         event.preventDefault()
@@ -121,6 +148,14 @@ const InsertImageButton = () => {
     >
       <Icon>image</Icon>
     </Button>
+    {/* <input ref={inputOpenFileRef} type="file" style={{ display: "none" }}/>
+    <button onClick={showOpenFileDlg}>Open</button> */}
+    <p></p>
+     <input type="file"
+        name="myFile"
+        style={{ width:'30%'}}
+        onChange={uploadFile} />
+    </>
   )
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Adding a feature
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
A button now exists that allows a user to upload a file from their computer.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
The form fires an onChange event when the user opens a file. That file is then run through the File Reader to get the image URL. What I cant figure out is how to call insertImage to insert the imageURL into the editor. When I try to create a hook for useEditor(), React complains that I broke a rule. Possibly because the hook is already being used in the Button component?
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3797
