### PR TITLE
added html properties to void nodes

### DIFF
--- a/site/examples/editable-voids.tsx
+++ b/site/examples/editable-voids.tsx
@@ -28,6 +28,7 @@ const EditableVoidsExample = () => {
   )
 }
 
+
 const withEditableVoids = editor => {
   const { isVoid } = editor
 
@@ -71,7 +72,7 @@ const EditableVoidElement = ({ attributes, children, element }) => {
           padding: 8px;
         `}
       >
-        <h4>Name:</h4>
+        <h4 tabIndex={-1}>Name:</h4>
         <input
           className={css`
             margin: 8px 0;
@@ -82,7 +83,7 @@ const EditableVoidElement = ({ attributes, children, element }) => {
             setInputValue(e.target.value)
           }}
         />
-        <h4>Left or right handed:</h4>
+        <h4 tabIndex={-1}>Left or right handed:</h4>
         <input
           className={unsetWidthStyle}
           type="radio"
@@ -98,7 +99,7 @@ const EditableVoidElement = ({ attributes, children, element }) => {
           value="right"
         />{' '}
         Right
-        <h4>Tell us about yourself:</h4>
+        <h4 tabIndex={-1}>Tell us about yourself:</h4>
         <div
           className={css`
             padding: 20px;


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Allows a user to select text in a void node.
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
An inefficient way to allow a user to select text in void nodes that inserts a property into the html tag. A proper fix would probably be to normalize all void nodes, but I can't figure out how.
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3863