### PR TITLE
Differentiate between useSlate and useEditor hooks

### DIFF
--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -52,7 +52,7 @@ Get the current editor object from the React context. Re-renders the context whe
 
 ###### `useSlateStatic`
 
-Get the current editor object from the React context. A version of useSlate that does not re-render the context.
+Get the current editor object from the React context. A version of useSlate that does not re-render the context. Previously called `useEditor`.
 
 ## ReactEditor
 

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -18,11 +18,11 @@ React components for rendering Slate editors
 
 The main Slate editor.
 
-###### `DefaultElement(props: RenderElementProps)` 
+###### `DefaultElement(props: RenderElementProps)`
 
 The default element renderer.
 
-###### `DefaultLeaf(props: RenderLeafProps)` 
+###### `DefaultLeaf(props: RenderLeafProps)`
 
 The default custom leaf renderer.
 
@@ -33,10 +33,6 @@ A wrapper around the provider to handle `onChange` events, because the editor is
 ## Hooks
 
 React hooks for Slate editors
-
-###### `useEditor`
-
-Get the current editor object from the React context.
 
 ###### `useFocused`
 
@@ -52,7 +48,11 @@ Get the current `selected` state of an element.
 
 ###### `useSlate`
 
-Get the current editor object from the React context.
+Get the current editor object from the React context. Re-renders the context whenever changes occur in the editor.
+
+###### `useSlateStatic`
+
+Get the current editor object from the React context. A version of useSlate that does not re-render the context.
 
 ## ReactEditor
 
@@ -137,4 +137,3 @@ Adds React and DOM specific behaviors to the editor.
 ## Utils
 
 Private convenience modules
-

--- a/packages/slate-react/src/components/children.tsx
+++ b/packages/slate-react/src/components/children.tsx
@@ -4,7 +4,7 @@ import { Editor, Range, Element, NodeEntry, Ancestor, Descendant } from 'slate'
 import ElementComponent from './element'
 import TextComponent from './text'
 import { ReactEditor } from '..'
-import { useEditor } from '../hooks/use-editor'
+import { useSlateStatic } from '../hooks/use-slate-static'
 import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
 import { RenderElementProps, RenderLeafProps } from './editable'
 
@@ -28,7 +28,7 @@ const Children = (props: {
     renderLeaf,
     selection,
   } = props
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const path = ReactEditor.findPath(editor, node)
   const children = []
   const isLeafBlock =

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -4,7 +4,7 @@ import { Editor, Node, Range, NodeEntry, Element as SlateElement } from 'slate'
 
 import Text from './text'
 import Children from './children'
-import { ReactEditor, useEditor, useReadOnly } from '..'
+import { ReactEditor, useSlateStatic, useReadOnly } from '..'
 import { SelectedContext } from '../hooks/use-selected'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 import {
@@ -37,7 +37,7 @@ const Element = (props: {
     selection,
   } = props
   const ref = useRef<HTMLElement>(null)
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const readOnly = useReadOnly()
   const isInline = editor.isInline(element)
   const key = ReactEditor.findKey(editor, element)
@@ -150,7 +150,7 @@ const MemoizedElement = React.memo(Element, (prev, next) => {
 
 export const DefaultElement = (props: RenderElementProps) => {
   const { attributes, children, element } = props
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const Tag = editor.isInline(element) ? 'span' : 'div'
   return (
     <Tag {...attributes} style={{ position: 'relative' }}>

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -3,7 +3,7 @@ import { Node } from 'slate'
 
 import { ReactEditor } from '../plugin/react-editor'
 import { FocusedContext } from '../hooks/use-focused'
-import { EditorContext } from '../hooks/use-editor'
+import { EditorContext } from '../hooks/use-slate-static'
 import { SlateContext } from '../hooks/use-slate'
 import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
 

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Editor, Text, Path, Element, Node } from 'slate'
 
-import { ReactEditor, useEditor } from '..'
+import { ReactEditor, useSlateStatic } from '..'
 
 /**
  * Leaf content strings.
@@ -14,7 +14,7 @@ const String = (props: {
   text: Text
 }) => {
   const { isLast, leaf, parent, text } = props
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const path = ReactEditor.findPath(editor, text)
   const parentPath = Path.parent(path)
 

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import { Range, Element, Text as SlateText } from 'slate'
 
 import Leaf from './leaf'
-import { ReactEditor, useEditor } from '..'
+import { ReactEditor, useSlateStatic } from '..'
 import { RenderLeafProps } from './editable'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 import {
@@ -23,7 +23,7 @@ const Text = (props: {
   text: SlateText
 }) => {
   const { decorations, isLast, parent, renderLeaf, text } = props
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const ref = useRef<HTMLSpanElement>(null)
   const leaves = SlateText.decorations(text, decorations)
   const key = ReactEditor.findKey(editor, text)

--- a/packages/slate-react/src/hooks/use-editor.tsx
+++ b/packages/slate-react/src/hooks/use-editor.tsx
@@ -3,11 +3,8 @@ import { createContext, useContext } from 'react'
 import { ReactEditor } from '../plugin/react-editor'
 
 /**
- * @deprecated Use useSlateStatic instead.
- */
- 
-/**
  * A React context for sharing the editor object.
+ * @deprecated Use useSlateStatic instead.
  */
 
 export const EditorContext = createContext<ReactEditor | null>(null)

--- a/packages/slate-react/src/hooks/use-editor.tsx
+++ b/packages/slate-react/src/hooks/use-editor.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext } from 'react'
+
+import { ReactEditor } from '../plugin/react-editor'
+
+/**
+ * @deprecated Use useSlateStatic instead.
+ */
+ 
+/**
+ * A React context for sharing the editor object.
+ */
+
+export const EditorContext = createContext<ReactEditor | null>(null)
+
+/**
+ * Get the current editor object from the React context.
+ */
+
+export const useEditor = () => {
+  const editor = useContext(EditorContext)
+
+  if (!editor) {
+    throw new Error(
+      `The \`useEditor\` hook must be used inside the <Slate> component's context.`
+    )
+  }
+
+  return editor
+}

--- a/packages/slate-react/src/hooks/use-slate-static.tsx
+++ b/packages/slate-react/src/hooks/use-slate-static.tsx
@@ -12,12 +12,12 @@ export const EditorContext = createContext<ReactEditor | null>(null)
  * Get the current editor object from the React context.
  */
 
-export const useEditor = () => {
+export const useSlateStatic = () => {
   const editor = useContext(EditorContext)
 
   if (!editor) {
     throw new Error(
-      `The \`useEditor\` hook must be used inside the <Slate> component's context.`
+      `The \`useSlateStatic\` hook must be used inside the <Slate> component's context.`
     )
   }
 

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -9,7 +9,7 @@ export { DefaultLeaf } from './components/leaf'
 export { Slate } from './components/slate'
 
 // Hooks
-export { useEditor } from './hooks/use-editor'
+export { useSlateStatic } from './hooks/use-slate-static'
 export { useFocused } from './hooks/use-focused'
 export { useReadOnly } from './hooks/use-read-only'
 export { useSelected } from './hooks/use-selected'

--- a/site/examples/check-lists.tsx
+++ b/site/examples/check-lists.tsx
@@ -3,7 +3,7 @@ import {
   Slate,
   Editable,
   withReact,
-  useEditor,
+  useSlateStatic,
   useReadOnly,
   ReactEditor,
 } from 'slate-react'
@@ -75,7 +75,7 @@ const Element = props => {
 }
 
 const CheckListItemElement = ({ attributes, children, element }) => {
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const readOnly = useReadOnly()
   const { checked } = element
   return (

--- a/site/examples/editable-voids.tsx
+++ b/site/examples/editable-voids.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react'
 import { Transforms, createEditor, Node } from 'slate'
-import { Slate, Editable, useEditor, withReact } from 'slate-react'
+import { Slate, Editable, useSlateStatic, withReact } from 'slate-react'
 import { withHistory } from 'slate-history'
 import { css } from 'emotion'
 
@@ -114,7 +114,7 @@ const EditableVoidElement = ({ attributes, children, element }) => {
 }
 
 const InsertEditableVoidButton = () => {
-  const editor = useEditor()
+  const editor = useSlateStatic()
   return (
     <Button
       onMouseDown={event => {

--- a/site/examples/embeds.tsx
+++ b/site/examples/embeds.tsx
@@ -4,7 +4,7 @@ import {
   Slate,
   Editable,
   withReact,
-  useEditor,
+  useSlateStatic,
   ReactEditor,
   useFocused,
   useSelected,
@@ -40,7 +40,7 @@ const Element = props => {
 }
 
 const VideoElement = ({ attributes, children, element }) => {
-  const editor = useEditor()
+  const editor = useSlateStatic()
   const { url } = element
   return (
     <div {...attributes}>

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -5,7 +5,7 @@ import { Node, Transforms, createEditor } from 'slate'
 import {
   Slate,
   Editable,
-  useEditor,
+  useSlateStatic,
   useSelected,
   useFocused,
   withReact,
@@ -109,7 +109,7 @@ const ImageElement = ({ attributes, children, element }) => {
 }
 
 const InsertImageButton = () => {
-  const editor = useEditor()
+  const editor = useSlateStatic()
   return (
     <Button
       onMouseDown={event => {


### PR DESCRIPTION
**Is this adding or improving a feature or fixing a bug?**
Naming/documentation improvement

**What's the new behavior?**
Renamed `useEditor` hook to `useSlateStatic` to indicate that the editor object does not re-render when changes occur. Updated documentation to differentiate between `useSlate` and `useSlateStatic`.

**How does this change work?**
`useSlateStatic` should be the hook that is used instead of `useEditor`.

**Have you checked that...?**
- [x]  The new code matches the existing patterns and styles.
- [x]  The tests pass with yarn test.
- [x]  The linter passes with yarn lint. (Fix errors with yarn fix.)
- [x]  The relevant examples still work. (Run examples with yarn start.)

Does this fix any issues or need any specific reviewers?
Fixes: [#3849](https://github.com/ianstormtaylor/slate/issues/3849)