### PR TITLE
Disable attributes when !HAS_BEFORE_INPUT_SUPPORT

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -474,13 +474,13 @@ export const Editable = (props: EditableProps) => {
         // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
         // have to use hacks to make these replacement-based features work.
         spellCheck={
-          !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.spellCheck
+          !HAS_BEFORE_INPUT_SUPPORT ? false : attributes.spellCheck
         }
         autoCorrect={
-          !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.autoCorrect
+          !HAS_BEFORE_INPUT_SUPPORT ? false : attributes.autoCorrect
         }
         autoCapitalize={
-          !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.autoCapitalize
+          !HAS_BEFORE_INPUT_SUPPORT ? false : attributes.autoCapitalize
         }
         data-slate-editor
         data-slate-node="value"


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

_bug_

By setting these props to `undefined` we're not actually disabling them, we're instead just preventing them from being able to be set. `spellcheck` is enabled by default on `contentEditable` trees, which creates a bug with a broken spellCheck and the inability to disable the attribute.

This PR sets these values to `false` when the active browser doesn't support `onBeforeInput` which should actually disable them.
