### PR TITLE
Disable spellCheck/autoCorrect/autoCapitalize in browsers without onBeforeInput

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -473,14 +473,10 @@ export const Editable = (props: EditableProps) => {
         {...attributes}
         // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
         // have to use hacks to make these replacement-based features work.
-        spellCheck={
-          !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.spellCheck
-        }
-        autoCorrect={
-          !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.autoCorrect
-        }
+        spellCheck={!HAS_BEFORE_INPUT_SUPPORT ? false : attributes.spellCheck}
+        autoCorrect={!HAS_BEFORE_INPUT_SUPPORT ? false : attributes.autoCorrect}
         autoCapitalize={
-          !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.autoCapitalize
+          !HAS_BEFORE_INPUT_SUPPORT ? false : attributes.autoCapitalize
         }
         data-slate-editor
         data-slate-node="value"


### PR DESCRIPTION
Currently you're unable to set spellCheck/autoCorrect/autoCapitalize attributes in browsers without support for the `onBeforeInput` event.

That's ok, because it's supposed to fix some buggy behavior, but `spellcheck` is enabled by default in firefox with no way of disabling it.

This PR fixes that, by explicitly setting these attributes to false, rather than undefined.