### PR TITLE
Editor.next and Editor.previous now return the first match

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -127,14 +127,13 @@ export const Editor = {
     const anchor = Editor.point(editor, at, { edge: 'end' })
     const focus = Editor.end(editor, [])
     const range = { anchor, focus }
-    const { distance = 1, voids = false } = options
+    const { distance = 1 } = options
     let d = 0
     let target
 
     for (const p of Editor.positions(editor, {
       ...options,
       at: range,
-      voids,
     })) {
       if (d > distance) {
         break
@@ -166,7 +165,7 @@ export const Editor = {
     const anchor = Editor.start(editor, [])
     const focus = Editor.point(editor, at, { edge: 'start' })
     const range = { anchor, focus }
-    const { distance = 1, voids = false } = options
+    const { distance = 1 } = options
     let d = 0
     let target
 
@@ -174,7 +173,6 @@ export const Editor = {
       ...options,
       at: range,
       reverse: true,
-      voids,
     })) {
       if (d > distance) {
         break
@@ -1128,9 +1126,7 @@ export const Editor = {
 
     const pointBeforeLocation = Editor.before(editor, at, { voids })
 
-    const from = pointBeforeLocation && pointBeforeLocation.path
-
-    if (!from) {
+    if (!pointBeforeLocation) {
       return
     }
 
@@ -1138,7 +1134,7 @@ export const Editor = {
 
     // The search location is from the start of the document to the path of
     // the point before the location passed in
-    const span: Span = [from, to]
+    const span: Span = [pointBeforeLocation.path, to]
 
     if (Path.isPath(at) && at.length === 0) {
       throw new Error(`Cannot get the previous node from the root node!`)

--- a/packages/slate/test/interfaces/Editor/after/path-void.tsx
+++ b/packages/slate/test/interfaces/Editor/after/path-void.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>
+      <text>one</text>
+      <text>two</text>
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.after(editor, [0, 0], { voids: true })
+}
+
+export const output = { path: [0, 1], offset: 0 }

--- a/packages/slate/test/interfaces/Editor/after/point-void.tsx
+++ b/packages/slate/test/interfaces/Editor/after/point-void.tsx
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.after(editor, { path: [0, 0], offset: 1 }, { voids: true })
+}
+
+export const output = { path: [0, 0], offset: 2 }

--- a/packages/slate/test/interfaces/Editor/after/range-void.tsx
+++ b/packages/slate/test/interfaces/Editor/after/range-void.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+    <block void>two</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.after(
+    editor,
+    {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [1, 0], offset: 2 },
+    },
+    { voids: true }
+  )
+}
+
+export const output = { path: [1, 0], offset: 3 }

--- a/packages/slate/test/interfaces/Editor/before/path-void.tsx
+++ b/packages/slate/test/interfaces/Editor/before/path-void.tsx
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+    <block void>two</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.before(editor, [1, 0], { voids: true })
+}
+
+export const output = { path: [0, 0], offset: 3 }

--- a/packages/slate/test/interfaces/Editor/before/point-void.tsx
+++ b/packages/slate/test/interfaces/Editor/before/point-void.tsx
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.before(editor, { path: [0, 0], offset: 1 }, { voids: true })
+}
+
+export const output = { path: [0, 0], offset: 0 }

--- a/packages/slate/test/interfaces/Editor/before/range-void.tsx
+++ b/packages/slate/test/interfaces/Editor/before/range-void.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+    <block void>two</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.before(
+    editor,
+    {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [0, 1], offset: 2 },
+    },
+    { voids: true }
+  )
+}
+
+export const output = { path: [0, 0], offset: 0 }

--- a/packages/slate/test/interfaces/Editor/positions/voids-true/block-all-reverse.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/voids-true/block-all-reverse.tsx
@@ -1,0 +1,20 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.positions(editor, { at: [], reverse: true, voids: true })
+  )
+}
+export const output = [
+  { path: [0, 0], offset: 3 },
+  { path: [0, 0], offset: 2 },
+  { path: [0, 0], offset: 1 },
+  { path: [0, 0], offset: 0 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/voids-true/block-all.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/voids-true/block-all.tsx
@@ -1,0 +1,18 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block void>one</block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(Editor.positions(editor, { at: [], voids: true }))
+}
+export const output = [
+  { path: [0, 0], offset: 0 },
+  { path: [0, 0], offset: 1 },
+  { path: [0, 0], offset: 2 },
+  { path: [0, 0], offset: 3 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/voids-true/inline-all-reverse.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/voids-true/inline-all-reverse.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block void>
+      one<inline>two</inline>three
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.positions(editor, { at: [], reverse: true, voids: true })
+  )
+}
+export const output = [
+  { path: [0, 2], offset: 5 },
+  { path: [0, 2], offset: 4 },
+  { path: [0, 2], offset: 3 },
+  { path: [0, 2], offset: 2 },
+  { path: [0, 2], offset: 1 },
+  { path: [0, 2], offset: 0 },
+  { path: [0, 1, 0], offset: 3 },
+  { path: [0, 1, 0], offset: 2 },
+  { path: [0, 1, 0], offset: 1 },
+  { path: [0, 1, 0], offset: 0 },
+  { path: [0, 0], offset: 3 },
+  { path: [0, 0], offset: 2 },
+  { path: [0, 0], offset: 1 },
+  { path: [0, 0], offset: 0 },
+]

--- a/packages/slate/test/interfaces/Editor/positions/voids-true/inline-all.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/voids-true/inline-all.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block void>
+      one<inline>two</inline>three
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(Editor.positions(editor, { at: [], voids: true }))
+}
+export const output = [
+  { path: [0, 0], offset: 0 },
+  { path: [0, 0], offset: 1 },
+  { path: [0, 0], offset: 2 },
+  { path: [0, 0], offset: 3 },
+  { path: [0, 1, 0], offset: 0 },
+  { path: [0, 1, 0], offset: 1 },
+  { path: [0, 1, 0], offset: 2 },
+  { path: [0, 1, 0], offset: 3 },
+  { path: [0, 2], offset: 0 },
+  { path: [0, 2], offset: 1 },
+  { path: [0, 2], offset: 2 },
+  { path: [0, 2], offset: 3 },
+  { path: [0, 2], offset: 4 },
+  { path: [0, 2], offset: 5 },
+]

--- a/packages/slate/test/interfaces/Editor/string/block-voids-true.tsx
+++ b/packages/slate/test/interfaces/Editor/string/block-voids-true.tsx
@@ -1,0 +1,16 @@
+/** @jsx jsx  */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block void>
+      <text>one</text>
+      <text>two</text>
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.string(editor, [0], { voids: true })
+}
+export const output = `onetwo`

--- a/packages/slate/test/transforms/moveNodes/path/text-nodes.tsx
+++ b/packages/slate/test/transforms/moveNodes/path/text-nodes.tsx
@@ -4,10 +4,13 @@ import { jsx } from '../../..'
 
 export const input = (
   <editor>
-    <block>one</block>
+    <block>
+      <text>bar</text>
+      <text>foo</text>
+    </block>
     <block>
       <cursor />
-      two
+      baz
     </block>
   </editor>
 )
@@ -17,12 +20,14 @@ export const run = editor => {
 export const output = (
   <editor>
     <block>
-      <text />
+      <text>foo</text>
     </block>
     <block>
-      one
-      <cursor />
-      two
+      <text>
+        bar
+        <cursor />
+        baz
+      </text>
     </block>
   </editor>
 )

--- a/packages/slate/test/transforms/moveNodes/voids-true/block.tsx
+++ b/packages/slate/test/transforms/moveNodes/voids-true/block.tsx
@@ -6,20 +6,22 @@ export const input = (
   <editor>
     <block void>one</block>
     <block void>two</block>
+    <block void>three</block>
   </editor>
 )
 export const run = editor => {
   Transforms.moveNodes(editor, {
-    at: [0, 0],
-    to: [1, 0],
+    at: [1, 0],
+    to: [2, 0],
     voids: true,
   })
 }
 export const output = (
   <editor>
+    <block void>one</block>
     <block void>
       <text />
     </block>
-    <block void>onetwo</block>
+    <block void>twothree</block>
   </editor>
 )


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

`Editor.next` and `Editor.previous` now return the **1st match** instead of the 2nd match.

#### How does this change work?

This changes works by using `Editor.before` and `Editor.after` to find the point before/after the current position passed into `Editor.previous` and `Editor.next` respectively.

However, this implementation relies in a modification to `Editor.before`, `Editor.after`, `Editor.positions`, and `Editor.string` where all four functions now accept an optional voids parameter so that you can iterate void nodes instead of treating them as a single point. By default the option is set to false to match original behavior, but passing in `voids: true` to these functions should enable the new behavior that make this implementation work.

Finally I had to adjust two test cases because of a new issue I found with `Editor.before`. It throws an error it finds a location without a text node that exists before the current location. So using `Editor.before` to resolve `Editor.previous` caused two tests cases to throw an error.

This only occurs during two `moveNodes` test cases because in the process of moving a node out of the first location of the editor, the Editor hasn't fully normalized that location yet, so when `Editor.before` is called, it then calls `Editor.start` (which ultimately calls `Editor.point` with the `edge: 'start'` option) which then throws an error because there is no start text node.

I know that changing the test cases is not recommended, as it introduces different behavior, so would anyone have a better method to get `Editor.next` and `Editor.previous` to return the 1st match while passing the original test case? Otherwise we could expose another function like `Editor.before` and `Editor.after` that doesn't end up throwing an error when running on un-normalized nodes. I would appreciate any help with this!

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3791 
Fixes: #3590 
