### PR TITLE
export useEditor back out of package

### DIFF
--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -9,6 +9,7 @@ export { DefaultLeaf } from './components/leaf'
 export { Slate } from './components/slate'
 
 // Hooks
+export { useEditor } from './hooks/use-editor'
 export { useSlateStatic } from './hooks/use-slate-static'
 export { useFocused } from './hooks/use-focused'
 export { useReadOnly } from './hooks/use-read-only'


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

closes: #3960 

#### What's the new behavior?

Based on this comment, https://github.com/ianstormtaylor/slate/pull/3941#issuecomment-718927157, we still want `useEditor` to be exported out of the package for people to use.