### PR TITLE
Add hasPrevious method to Path

### DIFF
--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -123,7 +123,7 @@ export const Path = {
    */
 
   hasPrevious(path: Path): boolean {
-    return path.length !== 0 && path[path.length - 1] > 0
+    return path[path.length - 1] > 0
   },
 
   /**

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -119,6 +119,14 @@ export const Path = {
   },
 
   /**
+   * Check if the path of previous sibling node exists
+   */
+
+  hasPrevious(path: Path): boolean {
+    return path.length !== 0 && path[path.length - 1] > 0
+  },
+
+  /**
    * Check if a path is after another.
    */
 

--- a/packages/slate/test/interfaces/Path/hasPrevious/root.tsx
+++ b/packages/slate/test/interfaces/Path/hasPrevious/root.tsx
@@ -4,4 +4,4 @@ export const input = [0, 0]
 export const test = path => {
   return Path.hasPrevious(path)
 }
-export const output = false;
+export const output = false

--- a/packages/slate/test/interfaces/Path/hasPrevious/root.tsx
+++ b/packages/slate/test/interfaces/Path/hasPrevious/root.tsx
@@ -2,7 +2,6 @@ import { Path } from 'slate'
 
 export const input = [0, 0]
 export const test = path => {
-  console.log(Path.hasPrevious(path));
   return Path.hasPrevious(path)
 }
 export const output = false;

--- a/packages/slate/test/interfaces/Path/hasPrevious/root.tsx
+++ b/packages/slate/test/interfaces/Path/hasPrevious/root.tsx
@@ -1,0 +1,8 @@
+import { Path } from 'slate'
+
+export const input = [0, 0]
+export const test = path => {
+  console.log(Path.hasPrevious(path));
+  return Path.hasPrevious(path)
+}
+export const output = false;

--- a/packages/slate/test/interfaces/Path/hasPrevious/success.tsx
+++ b/packages/slate/test/interfaces/Path/hasPrevious/success.tsx
@@ -4,4 +4,4 @@ export const input = [0, 1]
 export const test = path => {
   return Path.hasPrevious(path)
 }
-export const output = true;
+export const output = true

--- a/packages/slate/test/interfaces/Path/hasPrevious/success.tsx
+++ b/packages/slate/test/interfaces/Path/hasPrevious/success.tsx
@@ -1,0 +1,7 @@
+import { Path } from 'slate'
+
+export const input = [0, 1]
+export const test = path => {
+  return Path.hasPrevious(path)
+}
+export const output = true;


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving a feature 

#### What's the new behavior?

A new method to address some of the concern in #3422

Add's a new method to the Path API called `hasPrevious` which checks if the path of previous sibling node exists

#### How does this change work?

as per the `previous` API which returns a path, but returns an error if the path of the previous sibling does not exist, this is safe check you can make before calling `previous`

#### Have you checked that...?

- [Y] The new code matches the existing patterns and styles.
- [Y] The tests pass with `yarn test`.
- [Y] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [Y] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3422 
Reviewers: @
