### PR TITLE
Handle sibling moves in moveNodes transform

### DIFF
--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -486,6 +486,13 @@ export const NodeTransforms: NodeTransforms = {
         if (path.length !== 0) {
           editor.apply({ type: 'move_node', path, newPath })
         }
+
+        if (Path.isSibling(newPath, path) && Path.isAfter(newPath, path)) {
+          // When performing a sibling move to a later index, the path at the destination is shifted
+          // to before the insertion point instead of after. To ensure our group of nodes are inserted
+          // in the correct order we increment toRef to account for that
+          toRef.current = Path.next(toRef.current!)
+        }
       }
 
       toRef.unref()

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -487,11 +487,15 @@ export const NodeTransforms: NodeTransforms = {
           editor.apply({ type: 'move_node', path, newPath })
         }
 
-        if (Path.isSibling(newPath, path) && Path.isAfter(newPath, path)) {
+        if (
+          toRef.current &&
+          Path.isSibling(newPath, path) &&
+          Path.isAfter(newPath, path)
+        ) {
           // When performing a sibling move to a later index, the path at the destination is shifted
           // to before the insertion point instead of after. To ensure our group of nodes are inserted
           // in the correct order we increment toRef to account for that
-          toRef.current = Path.next(toRef.current!)
+          toRef.current = Path.next(toRef.current)
         }
       }
 

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
@@ -1,0 +1,41 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = (editor) => {
+  Transforms.moveNodes(editor, {
+    match: (n) => Editor.isBlock(editor, n),
+    to: [2],
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      one
+    </block>
+    <block>
+      two
+      <focus />
+    </block>
+    <block>
+      three
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>
+      three
+    </block>
+    <block>
+      <anchor />
+      one
+    </block>
+    <block>
+      two
+      <focus />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
@@ -2,9 +2,9 @@
 import { Editor, Transforms } from 'slate'
 import { jsx } from '../../..'
 
-export const run = (editor) => {
+export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: (n) => Editor.isBlock(editor, n),
+    match: n => Editor.isBlock(editor, n),
     to: [2],
   })
 }

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
@@ -18,17 +18,13 @@ export const input = (
       two
       <focus />
     </block>
-    <block>
-      three
-    </block>
+    <block>three</block>
   </editor>
 )
 
 export const output = (
   <editor>
-    <block>
-      three
-    </block>
+    <block>three</block>
     <block>
       <anchor />
       one

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
@@ -10,9 +10,7 @@ export const run = (editor) => {
 }
 export const input = (
   <editor>
-    <block>
-      one
-    </block>
+    <block>one</block>
     <block>
       two
       <anchor />
@@ -34,8 +32,6 @@ export const output = (
       three
       <focus />
     </block>
-    <block>
-      one
-    </block>
+    <block>one</block>
   </editor>
 )

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
@@ -2,9 +2,9 @@
 import { Editor, Transforms } from 'slate'
 import { jsx } from '../../..'
 
-export const run = (editor) => {
+export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: (n) => Editor.isBlock(editor, n),
+    match: n => Editor.isBlock(editor, n),
     to: [0],
   })
 }

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
@@ -1,0 +1,41 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = (editor) => {
+  Transforms.moveNodes(editor, {
+    match: (n) => Editor.isBlock(editor, n),
+    to: [0],
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      one
+    </block>
+    <block>
+      two
+      <anchor />
+    </block>
+    <block>
+      three
+      <focus />
+    </block>
+  </editor>
+)
+
+export const output = (
+  <editor>
+    <block>
+      two
+      <anchor />
+    </block>
+    <block>
+      three
+      <focus />
+    </block>
+    <block>
+      one
+    </block>
+  </editor>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug

#### What's the new behavior?
moveNodes transform properly handles sibling moves when multiple nodes are moved

During application, 'moveNodes' uses path refs to track the nodes that are being moved, as well as the destination path. This relied on the fact that when a node is inserted, the node that was originally at that location is pushed after, so the transform would ensure subsequent moves occur after the previous ones. 

However when a sibling move occurs from an earlier to later index, the node at that location actually shifts earlier. This means when we loop through the move ops, subsequent moves end up being targeted to before the previous ones, reversing the order of the nodes. 

#### How does this change work?

Detect a sibling move, and adjust the destination of the move in the loop when that's the case

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
