### PR TITLE
Add button to remove link in Links example

### DIFF
--- a/site/examples/links.tsx
+++ b/site/examples/links.tsx
@@ -17,6 +17,7 @@ const LinkExample = () => {
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>
       <Toolbar>
         <LinkButton />
+        <RemoveLinkButton />
       </Toolbar>
       <Editable
         renderElement={props => <Element {...props} />}
@@ -116,6 +117,23 @@ const LinkButton = () => {
       }}
     >
       <Icon>link</Icon>
+    </Button>
+  )
+}
+
+const RemoveLinkButton = () => {
+  const editor = useSlate()
+
+  return (
+    <Button
+      active={isLinkActive(editor)}
+      onMouseDown={event => {
+        if (isLinkActive(editor)) {
+          unwrapLink(editor)
+        }
+      }}
+    >
+      <Icon>link_off</Icon>
     </Button>
   )
 }


### PR DESCRIPTION
Just added a remove link button in the Links example to make things clearer (took me a while to figure out how to implement that).

Here is how it works:

![CleanShot 2020-11-12 at 09 49 15](https://user-images.githubusercontent.com/715405/98917348-89dfb580-24cc-11eb-835a-77360b3a950a.gif)
