### PR TITLE
rerender slate when focus changes.

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -6,6 +6,7 @@ import { FocusedContext } from '../hooks/use-focused'
 import { EditorContext } from '../hooks/use-slate-static'
 import { SlateContext } from '../hooks/use-slate'
 import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
+import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 
 /**
  * A wrapper around the provider to handle `onChange` events, because the editor
@@ -40,10 +41,40 @@ export const Slate = (props: {
     }
   }, [])
 
+  const [isFocused, setIsFocused] = useState(ReactEditor.isFocused(editor))
+
+  useEffect(() => {
+    setIsFocused(ReactEditor.isFocused(editor))
+  })
+
+  const focusHandler = useCallback(() => {
+    setIsFocused(ReactEditor.isFocused(editor))
+  }, [])
+
+  useIsomorphicLayoutEffect(() => {
+    document.addEventListener('focus', focusHandler, true)
+
+    return () => {
+      document.removeEventListener('focus', focusHandler, true)
+    }
+  }, [focusHandler])
+
+  const blurHandler = useCallback(() => {
+    setIsFocused(ReactEditor.isFocused(editor))
+  }, [])
+
+  useIsomorphicLayoutEffect(() => {
+    document.addEventListener('blur', blurHandler, true)
+
+    return () => {
+      document.removeEventListener('blur', blurHandler, true)
+    }
+  }, [blurHandler])
+
   return (
     <SlateContext.Provider value={context}>
       <EditorContext.Provider value={editor}>
-        <FocusedContext.Provider value={ReactEditor.isFocused(editor)}>
+        <FocusedContext.Provider value={isFocused}>
           {children}
         </FocusedContext.Provider>
       </EditorContext.Provider>


### PR DESCRIPTION
Rerender slate when focus changes. Fixes #3987


#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

I've shown the old behavior in the initial bug report. When the editor loses focus due to the user pressing tab or escape the `useFocused` hook does not update. While debugging I found that this is due to the `Slate` wrapper not rerendering, so the `useFocused` Context Provider never receives a new value.

Here is a code snippet which can be used to demonstrate the new behavior. Without the new code `is focused` only logs when you click outside the editor. With the new behavior `is focused` logs when you tab outside of the editor or press escape.

```tsx
import React, { useEffect, useMemo, useState } from 'react'
import { createEditor, Node } from 'slate'
import { Editable, Slate, useFocused, withReact } from 'slate-react'

const FocusTester = () => {
  const focused = useFocused()
  useEffect(() => {
    console.log('is focused', focused)
  }, [focused])

  return <></>
}

const FocusExample: React.FC = props => {
  const editor = useMemo(() => withReact(createEditor()), [])
  // Add the initial value when setting up our state.
  const [value, setValue] = useState<Node[]>([
    {
      type: 'paragraph',
      children: [{ text: 'A line of text in a paragraph.' }],
    },
  ])

  return (
    <Slate
      editor={editor}
      value={value}
      onChange={newValue => setValue(newValue)}
    >
      <Editable />
      <FocusTester />
    </Slate>
  )
}

export default FocusExample
```

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

When looking at the code I realized `ReactEditor.isFocused` does return the correct value at all time already. `Blur` and `Focus` events are already getting handled correctly. The only issue is `Slate` is not rendering when the `ReactEditor.isFocused` value changes.

In order to resolve the issue I just need to get slate to rerender when focus changes. My solution is in `slate.tsx`. In my solution I move `isFocused` to local react state. I listen to `focus` and `blur` events at the document level and then update the local state with `ReactEditor.isFocused`. I also update the local state on every render with `useEffect`. You can see this implementation in `slate.tsx`.  

If `useState` returns the same value as the previous state then react will not rerender. So this code should not cause any unnecessary renders.



#### Have you checked that...?

I wanted to try and avoid the `focus` and `blur` handlers in `editable` because there is a bunch of edge case behavior handled there. All of those edge cases should still be handled the exact same way, because my change is essentially a read only change to read `ReactEditor.isFocused` when the focus changes on the page.

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3987
Reviewers: 