### PR TITLE
Fix cursor movement in RTL elements

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -9,6 +9,7 @@ import {
   Transforms,
   Path,
 } from 'slate'
+import getDirection from 'direction'
 import throttle from 'lodash/throttle'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
@@ -815,6 +816,8 @@ export const Editable = (props: EditableProps) => {
                 return
               }
 
+              const isRTL = getDirection(Node.string(element)) === 'rtl'
+              
               // COMPAT: If a void node is selected, or a zero-width text node
               // adjacent to an inline is selected, we need to handle these
               // hotkeys manually because browsers won't be able to skip over
@@ -824,7 +827,7 @@ export const Editable = (props: EditableProps) => {
                 event.preventDefault()
 
                 if (selection && Range.isCollapsed(selection)) {
-                  Transforms.move(editor, { reverse: true })
+                  Transforms.move(editor, { reverse: !isRTL })
                 } else {
                   Transforms.collapse(editor, { edge: 'start' })
                 }
@@ -836,7 +839,7 @@ export const Editable = (props: EditableProps) => {
                 event.preventDefault()
 
                 if (selection && Range.isCollapsed(selection)) {
-                  Transforms.move(editor)
+                  Transforms.move(editor, { reverse: isRTL })
                 } else {
                   Transforms.collapse(editor, { edge: 'end' })
                 }
@@ -846,13 +849,13 @@ export const Editable = (props: EditableProps) => {
 
               if (Hotkeys.isMoveWordBackward(nativeEvent)) {
                 event.preventDefault()
-                Transforms.move(editor, { unit: 'word', reverse: true })
+                Transforms.move(editor, { unit: 'word', reverse: !isRTL })
                 return
               }
 
               if (Hotkeys.isMoveWordForward(nativeEvent)) {
                 event.preventDefault()
-                Transforms.move(editor, { unit: 'word' })
+                Transforms.move(editor, { unit: 'word', reverse: isRTL })
                 return
               }
 


### PR DESCRIPTION

#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing #2963
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Correct cursor movement in RTL documents.

Inspired by https://github.com/SophiaSaiada/slate/commit/9676f94ce0fe7dd50f2dd5a04a420478b7c68397

Added support for MoveWord too

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Transform now takes into account if the element is RTL or not
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #2963
Reviewers: @
