### PR TITLE
Don't clone nodes when applying a split_node operation

### DIFF
--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -248,7 +248,6 @@ export const GeneralTransforms: GeneralTransforms = {
           const after = node.text.slice(position)
           node.text = before
           newNode = {
-            ...node,
             ...(properties as Partial<Text>),
             text: after,
           }
@@ -258,7 +257,6 @@ export const GeneralTransforms: GeneralTransforms = {
           node.children = before
 
           newNode = {
-            ...node,
             ...(properties as Partial<Element>),
             children: after,
           }

--- a/packages/slate/test/operations/split_node/element-empty-properties.tsx
+++ b/packages/slate/test/operations/split_node/element-empty-properties.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <element data>
+      before text
+      <inline>hyperlink</inline>
+      after text
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'split_node',
+    path: [0],
+    position: 1,
+    properties: {},
+  },
+]
+export const output = (
+  <editor>
+    <element data>before text</element>
+    <element>
+      <text />
+      <inline>hyperlink</inline>
+      after text
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/split_node/element.tsx
+++ b/packages/slate/test/operations/split_node/element.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <element data>
+      before text
+      <inline>hyperlink</inline>
+      after text
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'split_node',
+    path: [0],
+    position: 1,
+    properties: {
+      data: true,
+    },
+  },
+]
+export const output = (
+  <editor>
+    <element data>before text</element>
+    <element data>
+      <text />
+      <inline>hyperlink</inline>
+      after text
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/split_node/text-empty-properties.tsx
+++ b/packages/slate/test/operations/split_node/text-empty-properties.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <element>
+      <text bold>some text</text>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'split_node',
+    path: [0, 0],
+    position: 5,
+    properties: {},
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text bold>some </text>
+      <text>text</text>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/split_node/text.tsx
+++ b/packages/slate/test/operations/split_node/text.tsx
@@ -1,0 +1,36 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <element>
+      <text bold>some text</text>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'split_node',
+    path: [0, 0],
+    position: 5,
+    properties: {
+      bold: true,
+    },
+  },
+  {
+    type: 'split_node',
+    path: [0],
+    position: 1,
+    properties: {},
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text bold>some </text>
+    </element>
+    <element>
+      <text bold>text</text>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/transforms/splitNodes/path/block-with-attributes.tsx
+++ b/packages/slate/test/transforms/splitNodes/path/block-with-attributes.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.splitNodes(editor, { at: [0, 2] })
+}
+export const input = (
+  <editor>
+    <block data>
+      <text />
+      <inline>one</inline>
+      <text />
+      <inline>two</inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block data>
+      <text />
+      <inline>one</inline>
+      <text />
+    </block>
+    <block data>
+      <text />
+      <inline>two</inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/splitNodes/point/text-with-marks.tsx
+++ b/packages/slate/test/transforms/splitNodes/point/text-with-marks.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.splitNodes(editor, {
+    at: { path: [0, 0], offset: 2 },
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      <text bold>word</text>
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text bold>wo</text>
+    </block>
+    <block>
+      <text bold>rd</text>
+    </block>
+  </editor>
+)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Slate no longer clones nodes when applying a `split_node` operation. This clone is unnecessary, and it causes a problem in real-time collaboration (I'll explain at the end, it's hard to make a video so I'll try explaining it conceptually).


#### How does this change work?

When Slate constructs a `split_node` operation, it ensures the operation contains all properties except `text` and `children`:
https://github.com/ianstormtaylor/slate/blob/b1f291ef88d6d0ae921e61690e3661a4962db5e9/packages%2Fslate%2Fsrc%2Ftransforms%2Fnode.ts#L634-L640

This change leverages that guarantee by not cloning the existing node when applying a `split_node` operation. I added tests for the existing behaviour to ensure it did not break, and also tests that are resolved by the change.


#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`.
- [x] The relevant examples still work. (Run examples with `yarn start`.)


### Detailed explanation
Given this document structure:
```
<element data>
  some text
</element>
<element>
  <cursor />
</element>
```

Picture two users collaborating on this document, both have their cursor in the marked position. One presses backspace to merge the blocks, the other presses enter to split the second block. Following through what happens for each user:
#### Enter case
The element is split leaving three elements. Note the `split_node` operation contains an empty `properties` object because it applied to the second element.
```
<element data>
  some text
</element>
<element>
</element>
<element>
  <cursor />
</element>
```
#### Backspace case
A merge operation is generated (and a few other things to normalize the document) leaving a single element with a `data` attribute.
```
<element data>
  some text<cursor />
</element>
```

In order to converge these two documents, the transformed operations need to do the following:
* In the enter case, the incoming merge is applied as is (resulting in an identical document)
* In the backspace case, the incoming split must be applied to the single remaining element - but recall the split operation contains no attributes. The result is:
```
<element data>
  some text<cursor />
</element>
<element data>
</element>
```

Due to cloning the first node to apply the split the second case results in a data attribute on the second element and the documents have not converged. The only way to converge under these restrictions is to "consume" the user who pressed enter and leave a single element for both users. This is not a good result. Removing the clone is an easy fix and should not impact general use without collaboration.