### PR TITLE
Fix merge conflicts with newly introduced interfaces

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -83,6 +83,7 @@ export interface EditorInterface {
     options?: {
       distance?: number
       unit?: 'offset' | 'character' | 'word' | 'line' | 'block'
+      voids?: boolean
     }
   ) => Point | undefined
   before: (
@@ -91,6 +92,7 @@ export interface EditorInterface {
     options?: {
       distance?: number
       unit?: 'offset' | 'character' | 'word' | 'line' | 'block'
+      voids?: boolean
     }
   ) => Point | undefined
   deleteBackward: (
@@ -246,7 +248,13 @@ export interface EditorInterface {
   rangeRefs: (editor: Editor) => Set<RangeRef>
   removeMark: (editor: Editor, key: string) => void
   start: (editor: Editor, at: Location) => Point
-  string: (editor: Editor, at: Location) => string
+  string: (
+    editor: Editor,
+    at: Location,
+    options?: {
+      voids?: boolean
+    }
+  ) => string
   unhangRange: (
     editor: Editor,
     range: Range,

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -17,6 +17,7 @@ export interface PathInterface {
   endsAt: (path: Path, another: Path) => boolean
   endsBefore: (path: Path, another: Path) => boolean
   equals: (path: Path, another: Path) => boolean
+  hasPrevious: (path: Path) => boolean
   isAfter: (path: Path, another: Path) => boolean
   isAncestor: (path: Path, another: Path) => boolean
   isBefore: (path: Path, another: Path) => boolean


### PR DESCRIPTION
The changes from https://github.com/ianstormtaylor/slate/pull/3835 introduced explicitly defined typescript interfaces. I noticed some intermediate PRs that made it in started throwing errors because they added properties/functions that weren't in the original interfaces


- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

