### PR TITLE
Fix broken attribute references

### DIFF
--- a/site/examples/code-highlighting.tsx
+++ b/site/examples/code-highlighting.tsx
@@ -125,7 +125,7 @@ const Leaf = ({ attributes, children, leaf }) => {
           leaf.tag ||
           leaf.constant ||
           leaf.symbol ||
-          leaf.attr - name ||
+          leaf['attr-name'] ||
           leaf.selector) &&
           css`
             color: #905;
@@ -138,7 +138,7 @@ const Leaf = ({ attributes, children, leaf }) => {
           css`
             color: #690;
           `}
-        ${(leaf.function || leaf.class - name) &&
+        ${(leaf.function || leaf['class-name']) &&
           css`
             color: #dd4a68;
           `}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Properly accessing properties with hyphens in them

#### How does this change work?

It looks like when the syntax highlighting change originally went in during #3762, the attribute access was typed as `leaf.attr-name`, and then the linter/prettier came and added whitespace to make it `leaf.attr - name`, which is incorrect, although it doesn't 'fail' because there happens to be the global `name` variable

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

