### PR TITLE
getDirtyPaths can now be customized by Slate users

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -57,7 +57,7 @@ export const createEditor = (): Editor => {
       }
 
       const oldDirtyPaths = DIRTY_PATHS.get(editor) || []
-      const newDirtyPaths = getDirtyPaths(op)
+      const newDirtyPaths = editor.getDirtyPaths(op)
 
       for (const path of oldDirtyPaths) {
         const newPath = Path.transform(path, op)
@@ -132,6 +132,78 @@ export const createEditor = (): Editor => {
 
       if (selection && Range.isExpanded(selection)) {
         Transforms.delete(editor)
+      }
+    },
+
+    /**
+     * Get the "dirty" paths generated from an operation for normalization
+     */
+
+    getDirtyPaths: (op: Operation) => {
+      switch (op.type) {
+        case 'insert_text':
+        case 'remove_text':
+        case 'set_node': {
+          const { path } = op
+          return Path.levels(path)
+        }
+
+        case 'insert_node': {
+          const { node, path } = op
+          const levels = Path.levels(path)
+          const descendants = Text.isText(node)
+            ? []
+            : Array.from(Node.nodes(node), ([, p]) => path.concat(p))
+
+          return [...levels, ...descendants]
+        }
+
+        case 'merge_node': {
+          const { path } = op
+          const ancestors = Path.ancestors(path)
+          const previousPath = Path.previous(path)
+          return [...ancestors, previousPath]
+        }
+
+        case 'move_node': {
+          const { path, newPath } = op
+
+          if (Path.equals(path, newPath)) {
+            return []
+          }
+
+          const oldAncestors: Path[] = []
+          const newAncestors: Path[] = []
+
+          for (const ancestor of Path.ancestors(path)) {
+            const p = Path.transform(ancestor, op)
+            oldAncestors.push(p!)
+          }
+
+          for (const ancestor of Path.ancestors(newPath)) {
+            const p = Path.transform(ancestor, op)
+            newAncestors.push(p!)
+          }
+
+          return [...oldAncestors, ...newAncestors]
+        }
+
+        case 'remove_node': {
+          const { path } = op
+          const ancestors = Path.ancestors(path)
+          return [...ancestors]
+        }
+
+        case 'split_node': {
+          const { path } = op
+          const levels = Path.levels(path)
+          const nextPath = Path.next(path)
+          return [...levels, nextPath]
+        }
+
+        default: {
+          return []
+        }
       }
     },
 
@@ -301,76 +373,4 @@ export const createEditor = (): Editor => {
   }
 
   return editor
-}
-
-/**
- * Get the "dirty" paths generated from an operation.
- */
-
-const getDirtyPaths = (op: Operation): Path[] => {
-  switch (op.type) {
-    case 'insert_text':
-    case 'remove_text':
-    case 'set_node': {
-      const { path } = op
-      return Path.levels(path)
-    }
-
-    case 'insert_node': {
-      const { node, path } = op
-      const levels = Path.levels(path)
-      const descendants = Text.isText(node)
-        ? []
-        : Array.from(Node.nodes(node), ([, p]) => path.concat(p))
-
-      return [...levels, ...descendants]
-    }
-
-    case 'merge_node': {
-      const { path } = op
-      const ancestors = Path.ancestors(path)
-      const previousPath = Path.previous(path)
-      return [...ancestors, previousPath]
-    }
-
-    case 'move_node': {
-      const { path, newPath } = op
-
-      if (Path.equals(path, newPath)) {
-        return []
-      }
-
-      const oldAncestors: Path[] = []
-      const newAncestors: Path[] = []
-
-      for (const ancestor of Path.ancestors(path)) {
-        const p = Path.transform(ancestor, op)
-        oldAncestors.push(p!)
-      }
-
-      for (const ancestor of Path.ancestors(newPath)) {
-        const p = Path.transform(ancestor, op)
-        newAncestors.push(p!)
-      }
-
-      return [...oldAncestors, ...newAncestors]
-    }
-
-    case 'remove_node': {
-      const { path } = op
-      const ancestors = Path.ancestors(path)
-      return [...ancestors]
-    }
-
-    case 'split_node': {
-      const { path } = op
-      const levels = Path.levels(path)
-      const nextPath = Path.next(path)
-      return [...levels, nextPath]
-    }
-
-    default: {
-      return []
-    }
-  }
 }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -45,6 +45,7 @@ export interface BaseEditor {
   marks: Omit<Text, 'text'> | null
 
   // Schema-specific node behaviors.
+  getDirtyPaths: (op: Operation) => Path[]
   isInline: (element: Element) => boolean
   isVoid: (element: Element) => boolean
   normalizeNode: (entry: NodeEntry) => void
@@ -549,6 +550,7 @@ export const Editor: EditorInterface = {
       typeof value.deleteBackward === 'function' &&
       typeof value.deleteForward === 'function' &&
       typeof value.deleteFragment === 'function' &&
+      typeof value.getDirtyPaths === 'function' &&
       typeof value.insertBreak === 'function' &&
       typeof value.insertFragment === 'function' &&
       typeof value.insertNode === 'function' &&

--- a/packages/slate/test/interfaces/Element/isElement/editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/editor.tsx
@@ -10,6 +10,7 @@ export const input = {
   deleteBackward() {},
   deleteForward() {},
   deleteFragment() {},
+  getDirtyPaths() {},
   insertBreak() {},
   insertFragment() {},
   insertNode() {},

--- a/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
@@ -11,6 +11,7 @@ export const input = [
     deleteBackward() {},
     deleteForward() {},
     deleteFragment() {},
+    getDirtyPaths() {},
     insertBreak() {},
     insertFragment() {},
     insertNode() {},


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a new feature as suggested with issue #3956.

#### What's the new behavior?

I moved the `getDirtyPaths()` function from an external function in `create-editor.ts` into the editor object as `editor.getDirtyPaths()`, so you can override Slate's default calculation of dirty paths for an operation. It's meant to be used in conjunction with `editor.normalizeNode()` where you might want to check additional paths due to custom normalization constraints as show by this issue #3758.

To use this, you would create a plugin to override Slate's default behavior. It actually works _very_ similarly to creating custom normalization behavior for `editor.normalizeNode()`. There will be an example in the nextsection.

#### How does this change work?

Most of the customizable slate functions like `editor.normalizeNode()` are created with the `editor` instance in `create-editor.ts`. `getDirtyPaths` was actually also inside the same file, but outside of the editor object as a standalone function. This prevented the function from being customizable via the plugin system unlike `editor.normalizeNode()`. By moving this function into the `editor` instance, it's behavior is the same, but Slate users now get the ability to customize that function if they have additional normalization rules that require different dirty paths to be calculated for an operation.

To demonstrate an example, here's the default behavior of `getDirtyPaths()` as indicated by issue #3758. This example has custom normalization that shouldn't allow bold links, but normalization doesn't trigger initially because the relevant operations don't calculate dirty paths underneath where the operation occurred. However, if you insert a space inside the link, this new operation will indeed give a dirty path to the node that we wanted to nomarlize from the tart. For more detail, [this comment gives a much better explanation](https://github.com/ianstormtaylor/slate/issues/3758#issuecomment-663727566).

![Default dirty path calculation example](https://user-images.githubusercontent.com/5305150/86286427-b7475900-bbe6-11ea-81e1-854fda2acecc.gif)

And here is an example with this new customizable `editor.getDirtyPaths()` where I override the dirty path calculation for the relevant operation (which ended up being `move_node`). Since I can now use a plugin to override `editor.getDirtyPaths()` the normalization runs as soon as you wrap the link because I was able to return the dirty path for the node below the operation.

<details>
<summary>Example code for `editor.getDirtyPaths()` override</summary>


You can use this new `withDirtyPaths()` function as a plugin like
```ts
const editor = useMemo(
    () =>
      withLinks(
        withNormalization(
          withDirtyPaths(withReact(createEditor()))
        )
      ),
    []
  )
```


```ts
const withDirtyPaths = editor => {
  const { getDirtyPaths } = editor

  editor.getDirtyPaths = op => {
    if (op.type === 'move_node') {
      const { path, newPath, node } = op

      if (Path.equals(path, newPath)) {
        return []
      }

      const oldAncestors: Path[] = []
      const newAncestors: Path[] = []

      for (const ancestor of Path.ancestors(path)) {
        const p = Path.transform(ancestor, op)
        oldAncestors.push(p!)
      }

      for (const ancestor of Path.ancestors(newPath)) {
        const p = Path.transform(ancestor, op)
        newAncestors.push(p!)
      }

      const ancestors = [...oldAncestors, ...newAncestors]

      // Since editor.wrapNodes() performs an insert and then a move function
      // to do the actual wrapping, we need to get the path of the node
      // after moving the node. However, the newPath isn't the true path
      // because the newPath of the node will be different after the operation
      // GeneralTransforms.transform() likely has a more robust implementation
      // compared to this example.
      let truePath: Path = []

      if (newPath.length - path.length === 1 && Path.isBefore(path, newPath)) {
        const pathEnd = path.length - 1
        if (newPath[pathEnd] - path[pathEnd] === 1) {
          truePath = [...newPath]
          truePath[pathEnd] = path[pathEnd]
        }
      }

      return [...ancestors, truePath]
    }

    return getDirtyPaths(op)
  }

  return editor
}
```


</details>

![link-bold-normalize](https://user-images.githubusercontent.com/28582336/101556045-8d594600-397f-11eb-9a20-5ff89d3b298a.gif)

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3956 
Fixes: #3758