### PR TITLE
Add support for longer placeholder values

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -495,6 +495,8 @@ export const Editable = (props: EditableProps) => {
           whiteSpace: 'pre-wrap',
           // Allow words to break if they are too long.
           wordWrap: 'break-word',
+          // Allow implementer to position absolutely against editor div
+          position: 'relative',
           // Allow for passed-in styles to override anything.
           ...style,
         }}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import { Element, Text } from 'slate'
 import String from './string'
 import { PLACEHOLDER_SYMBOL } from '../utils/weak-maps'
@@ -23,6 +23,25 @@ const Leaf = (props: {
     renderLeaf = (props: RenderLeafProps) => <DefaultLeaf {...props} />,
   } = props
 
+  const placeholderRef = useRef<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    const placeholderEl = placeholderRef?.current
+    const editorEl = document.querySelector<HTMLDivElement>(
+      '[data-slate-editor="true"]'
+    )
+
+    if (!placeholderEl || !editorEl) {
+      return
+    }
+
+    editorEl.style.minHeight = `${placeholderEl.clientHeight}px`
+
+    return () => {
+      editorEl.style.minHeight = 'auto'
+    }
+  }, [placeholderRef])
+
   let children = (
     <String isLast={isLast} leaf={leaf} parent={parent} text={text} />
   )
@@ -35,15 +54,16 @@ const Leaf = (props: {
           style={{
             pointerEvents: 'none',
             display: 'inline-block',
-            width: '0',
+            width: '100%',
             maxWidth: '100%',
-            whiteSpace: 'nowrap',
             opacity: '0.333',
             userSelect: 'none',
             fontStyle: 'normal',
             fontWeight: 'normal',
             textDecoration: 'none',
+            position: 'absolute',
           }}
+          ref={placeholderRef}
         >
           {leaf.placeholder}
         </span>


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Instead of long placeholder values overflowing the editor bounds horizontally, we now wrap the text and have the editor grow in height.

#### How does this change work?

When the `Leaf` component is rendered, grab the height of the placeholder and the editor. Then, in a `useEffect` dynamically set the editor `minHeight` to that of the placeholder.

Also removed the, now unneeded, styles from the placeholder that were causing the horizontal overlap.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #4018, #2922 
