### PR TITLE
Mark transform type explicitly

### DIFF
--- a/packages/slate/src/transforms/index.ts
+++ b/packages/slate/src/transforms/index.ts
@@ -3,7 +3,10 @@ import { NodeTransforms } from './node'
 import { SelectionTransforms } from './selection'
 import { TextTransforms } from './text'
 
-export const Transforms = {
+export const Transforms: GeneralTransforms &
+  NodeTransforms &
+  SelectionTransforms &
+  TextTransforms = {
   ...GeneralTransforms,
   ...NodeTransforms,
   ...SelectionTransforms,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug

#### What's the new behavior?

Transforms methods respect custom types


#### How does this change work?


`Transforms` is not an actual interface, and instead it combines objects that each define their own interface. These interfaces all refer to the 'ExtendedTypes', however since the Transform object generates an inferred interface during package generation, it doesn't have any extended types, resulting in an interface that uses the base types.

By explicitly combining these interfaces in the declaration we let typescript keep the extended types in the declaration for us. 

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

Reviewers: @BrentFarese 
