### PR TITLE
Fix useEditor not inside Slate error caused by introduce useSlateStatic

### DIFF
--- a/packages/slate-react/src/hooks/use-editor.tsx
+++ b/packages/slate-react/src/hooks/use-editor.tsx
@@ -1,16 +1,10 @@
-import { createContext, useContext } from 'react'
+import { useContext } from 'react'
 
-import { ReactEditor } from '../plugin/react-editor'
-
-/**
- * A React context for sharing the editor object.
- * @deprecated Use useSlateStatic instead.
- */
-
-export const EditorContext = createContext<ReactEditor | null>(null)
+import { EditorContext } from './use-slate-static'
 
 /**
  * Get the current editor object from the React context.
+ * @deprecated Use useSlateStatic instead.
  */
 
 export const useEditor = () => {


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fix ```The `useEditor` hook must be used inside the <Slate> component's context.``` error since useSlateStatic introduced.

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
Slate will still work with useEditor
<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
During introduce useSlateStatic, the EditorContext inside use-editor.tsx is no longer referenced and set editor instance to it.
But for old code which still use useEditor, it will get null editor value by the useEditor call. So this PR change this behaviour by share use the same EditorContext between useSlateStatic and useEditor, so they both works now.

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
