### PR TITLE
docs: fix links to the examples in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,16 +103,16 @@ Check out the [**live demo**](http://slatejs.org) of all of the examples!
 
 To get a sense for how you might use Slate, check out a few of the examples:
 
-- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/plaintext.js) — showing the most basic case: a glorified `<textarea>`.
-- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/richtext.js) — showing the features you'd expect from a basic editor.
-- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/markdown-preview.js) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Links**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/links.js) — showing how wrap text in inline nodes with associated data.
-- [**Images**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/images.js) — showing how to use void (text-less) nodes to add images.
-- [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/hovering-toolbar.js) — showing how a hovering toolbar can be implemented.
-- [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/tables.js) — showing how to nest blocks to render more advanced components.
-- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
-- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/mentions.js) — showing how to use inline void nodes for simple @-mentions.
-- [**See all the examples...**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/)
+- [**Plain text**](./site/examples/plaintext.tsx) — showing the most basic case: a glorified `<textarea>`.
+- [**Rich text**](./site/examples/richtext.tsx) — showing the features you'd expect from a basic editor.
+- [**Markdown preview**](./site/examples/markdown-preview.tsx) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Links**](./site/examples/links.tsx) — showing how wrap text in inline nodes with associated data.
+- [**Images**](./site/examples/images.tsx) — showing how to use void (text-less) nodes to add images.
+- [**Hovering toolbar**](./site/examples/hovering-toolbar.tsx) — showing how a hovering toolbar can be implemented.
+- [**Tables**](./site/examples/tables.tsx) — showing how to nest blocks to render more advanced components.
+- [**Paste HTML**](./site/examples/paste-html.tsx) — showing how to use an HTML serializer to handle pasted HTML.
+- [**Mentions**](./site/examples/mentions.tsx) — showing how to use inline void nodes for simple @-mentions.
+- [**See all the examples...**](./site/examples/)
 
 If you have an idea for an example that shows a common use case, pull request it!
 


### PR DESCRIPTION
I noticed that the links in `Readme.md` are broken.