### PR TITLE
Prevent immer from freeze operations.

### DIFF
--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -292,7 +292,7 @@ export const Node: NodeInterface = {
       )
     }
 
-    const newRoot = produce(root, r => {
+    const newRoot = produce({ children: root.children }, r => {
       const [start, end] = Range.edges(range)
       const nodeEntries = Node.nodes(r, {
         reverse: true,


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug.
<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?
After copy (editor.getFragment), the editor.operations is not frozen (then no crash due to any update). if in case you actually using immer 7+ though Slate using v5 but if the client code has other dependencies which using higher version of immer, finally the Slate could actually calling immer 7+. 

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?
Like https://github.com/ianstormtaylor/slate/pull/3850/files#r480954559 suggested, but without upgrade the immer version in package.json
<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #4034
Reviewers: @BrentFarese
