### PR TITLE
Fix ios chrome ime double input issue.

### DIFF
--- a/.changeset/metal-trees-rest.md
+++ b/.changeset/metal-trees-rest.md
@@ -1,6 +1,6 @@
 ---
-"slate-react": patch
-"slate": patch
+'slate-react': patch
+'slate': patch
 ---
 
 Fix ios chrome ime double input issue.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -17,6 +17,7 @@ import useChildren from '../hooks/use-children'
 import Hotkeys from '../utils/hotkeys'
 import {
   HAS_BEFORE_INPUT_SUPPORT,
+  IS_IOS,
   IS_CHROME,
   IS_FIREFOX,
   IS_FIREFOX_LEGACY,
@@ -654,7 +655,7 @@ export const Editable = (props: EditableProps) => {
                 // aren't correct and never fire the "insertFromComposition"
                 // type that we need. So instead, insert whenever a composition
                 // ends since it will already have been committed to the DOM.
-                if (!IS_SAFARI && !IS_FIREFOX_LEGACY && event.data) {
+                if (!IS_SAFARI && !IS_FIREFOX_LEGACY && !IS_IOS && event.data) {
                   Editor.insertText(editor, event.data)
                 }
               }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->
Fix a bug

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->
IME input won't duplicate.

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->
IOS chrome looks just fine, so no need special code on compositionEnd to insertData.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
