### PR TITLE
Adds path parameter to NodeMatch

### DIFF
--- a/packages/slate/Readme.md
+++ b/packages/slate/Readme.md
@@ -1,3 +1,3 @@
 This package contains the core logic of Slate. Feel free to poke around to learn more!
 
-Note: A number of source files contain extracted types for `Interfaces` or `Transforms`. This is done currently to enable custom type extensions as found in `packages/src/interfaces/custom-types.ts`. 
+Note: A number of source files contain extracted types for `Interfaces` or `Transforms`. This is done currently to enable custom type extensions as found in `packages/src/interfaces/custom-types.ts`.

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -476,7 +476,7 @@ export const Editor: EditorInterface = {
    */
 
   hasBlocks(editor: Editor, element: Element): boolean {
-    return element.children.some(n => Editor.isBlock(editor, n))
+    return element.children.some((n) => Editor.isBlock(editor, n))
   },
 
   /**
@@ -485,7 +485,7 @@ export const Editor: EditorInterface = {
 
   hasInlines(editor: Editor, element: Element): boolean {
     return element.children.some(
-      n => Text.isText(n) || Editor.isInline(editor, n)
+      (n) => Text.isText(n) || Editor.isInline(editor, n)
     )
   },
 
@@ -494,7 +494,7 @@ export const Editor: EditorInterface = {
    */
 
   hasTexts(editor: Editor, element: Element): boolean {
-    return element.children.every(n => Text.isText(n))
+    return element.children.every((n) => Text.isText(n))
   },
 
   /**
@@ -699,7 +699,7 @@ export const Editor: EditorInterface = {
     const path = Editor.path(editor, at)
 
     for (const [n, p] of Node.levels(editor, path)) {
-      if (!match(n)) {
+      if (!match(n, p)) {
         continue
       }
 
@@ -751,7 +751,7 @@ export const Editor: EditorInterface = {
     if (anchor.offset === 0) {
       const prev = Editor.previous(editor, { at: path, match: Text.isText })
       const block = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: (n) => Editor.isBlock(editor, n),
       })
 
       if (prev && block) {
@@ -803,7 +803,7 @@ export const Editor: EditorInterface = {
     if (match == null) {
       if (Path.isPath(at)) {
         const [parent] = Editor.parent(editor, at)
-        match = n => parent.children.includes(n)
+        match = (n) => parent.children.includes(n)
       } else {
         match = () => true
       }
@@ -893,7 +893,7 @@ export const Editor: EditorInterface = {
         continue
       }
 
-      if (!match(node)) {
+      if (!match(node, path)) {
         // If we've arrived at a leaf text node that is not lower than the last
         // hit, then we've found a branch that doesn't include a match, which
         // means the match is not universal.
@@ -1356,7 +1356,7 @@ export const Editor: EditorInterface = {
     if (match == null) {
       if (Path.isPath(at)) {
         const [parent] = Editor.parent(editor, at)
-        match = n => parent.children.includes(n)
+        match = (n) => parent.children.includes(n)
       } else {
         match = () => true
       }
@@ -1513,7 +1513,7 @@ export const Editor: EditorInterface = {
 
     const endBlock = Editor.above(editor, {
       at: end,
-      match: n => Editor.isBlock(editor, n),
+      match: (n) => Editor.isBlock(editor, n),
     })
     const blockPath = endBlock ? endBlock[1] : []
     const first = Editor.start(editor, [])
@@ -1554,7 +1554,7 @@ export const Editor: EditorInterface = {
   ): NodeEntry<Element> | undefined {
     return Editor.above(editor, {
       ...options,
-      match: n => Editor.isVoid(editor, n),
+      match: (n) => Editor.isVoid(editor, n),
     })
   },
 
@@ -1575,6 +1575,6 @@ export const Editor: EditorInterface = {
  * A helper type for narrowing matched nodes with a predicate.
  */
 
-type NodeMatch<T extends Node> =
-  | ((node: Node) => node is T)
-  | ((node: Node) => boolean)
+export type NodeMatch<T extends Node> =
+  | ((node: Node, path: Path) => node is T)
+  | ((node: Node, path: Path) => boolean)

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -476,7 +476,7 @@ export const Editor: EditorInterface = {
    */
 
   hasBlocks(editor: Editor, element: Element): boolean {
-    return element.children.some((n) => Editor.isBlock(editor, n))
+    return element.children.some(n => Editor.isBlock(editor, n))
   },
 
   /**
@@ -485,7 +485,7 @@ export const Editor: EditorInterface = {
 
   hasInlines(editor: Editor, element: Element): boolean {
     return element.children.some(
-      (n) => Text.isText(n) || Editor.isInline(editor, n)
+      n => Text.isText(n) || Editor.isInline(editor, n)
     )
   },
 
@@ -494,7 +494,7 @@ export const Editor: EditorInterface = {
    */
 
   hasTexts(editor: Editor, element: Element): boolean {
-    return element.children.every((n) => Text.isText(n))
+    return element.children.every(n => Text.isText(n))
   },
 
   /**
@@ -751,7 +751,7 @@ export const Editor: EditorInterface = {
     if (anchor.offset === 0) {
       const prev = Editor.previous(editor, { at: path, match: Text.isText })
       const block = Editor.above(editor, {
-        match: (n) => Editor.isBlock(editor, n),
+        match: n => Editor.isBlock(editor, n),
       })
 
       if (prev && block) {
@@ -803,7 +803,7 @@ export const Editor: EditorInterface = {
     if (match == null) {
       if (Path.isPath(at)) {
         const [parent] = Editor.parent(editor, at)
-        match = (n) => parent.children.includes(n)
+        match = n => parent.children.includes(n)
       } else {
         match = () => true
       }
@@ -1356,7 +1356,7 @@ export const Editor: EditorInterface = {
     if (match == null) {
       if (Path.isPath(at)) {
         const [parent] = Editor.parent(editor, at)
-        match = (n) => parent.children.includes(n)
+        match = n => parent.children.includes(n)
       } else {
         match = () => true
       }
@@ -1513,7 +1513,7 @@ export const Editor: EditorInterface = {
 
     const endBlock = Editor.above(editor, {
       at: end,
-      match: (n) => Editor.isBlock(editor, n),
+      match: n => Editor.isBlock(editor, n),
     })
     const blockPath = endBlock ? endBlock[1] : []
     const first = Editor.start(editor, [])
@@ -1554,7 +1554,7 @@ export const Editor: EditorInterface = {
   ): NodeEntry<Element> | undefined {
     return Editor.above(editor, {
       ...options,
-      match: (n) => Editor.isVoid(editor, n),
+      match: n => Editor.isVoid(editor, n),
     })
   },
 

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -11,109 +11,110 @@ import {
   NodeEntry,
   Ancestor,
 } from '..'
+import { NodeMatch } from '../interfaces/editor'
 
 export interface NodeTransforms {
-  insertNodes: (
+  insertNodes: <T extends Node>(
     editor: Editor,
     nodes: Node | Node[],
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       select?: boolean
       voids?: boolean
     }
   ) => void
-  liftNodes: (
+  liftNodes: <T extends Node>(
     editor: Editor,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       voids?: boolean
     }
   ) => void
-  mergeNodes: (
+  mergeNodes: <T extends Node>(
     editor: Editor,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       voids?: boolean
     }
   ) => void
-  moveNodes: (
+  moveNodes: <T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       to: Path
       voids?: boolean
     }
   ) => void
-  removeNodes: (
+  removeNodes: <T extends Node>(
     editor: Editor,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       voids?: boolean
     }
   ) => void
-  setNodes: (
+  setNodes: <T extends Node>(
     editor: Editor,
     props: Partial<Node>,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       hanging?: boolean
       split?: boolean
       voids?: boolean
     }
   ) => void
-  splitNodes: (
+  splitNodes: <T extends Node>(
     editor: Editor,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       always?: boolean
       height?: number
       voids?: boolean
     }
   ) => void
-  unsetNodes: (
+  unsetNodes: <T extends Node>(
     editor: Editor,
     props: string | string[],
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
     }
   ) => void
-  unwrapNodes: (
+  unwrapNodes: <T extends Node>(
     editor: Editor,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
     }
   ) => void
-  wrapNodes: (
+  wrapNodes: <T extends Node>(
     editor: Editor,
     element: Element,
     options?: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
@@ -126,12 +127,12 @@ export const NodeTransforms: NodeTransforms = {
    * Insert nodes at a specific location in the Editor.
    */
 
-  insertNodes(
+  insertNodes<T extends Node>(
     editor: Editor,
     nodes: Node | Node[],
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       select?: boolean
@@ -189,11 +190,11 @@ export const NodeTransforms: NodeTransforms = {
       if (Point.isPoint(at)) {
         if (match == null) {
           if (Text.isText(node)) {
-            match = n => Text.isText(n)
+            match = (n) => Text.isText(n)
           } else if (editor.isInline(node)) {
-            match = n => Text.isText(n) || Editor.isInline(editor, n)
+            match = (n) => Text.isText(n) || Editor.isInline(editor, n)
           } else {
-            match = n => Editor.isBlock(editor, n)
+            match = (n) => Editor.isBlock(editor, n)
           }
         }
 
@@ -244,11 +245,11 @@ export const NodeTransforms: NodeTransforms = {
    * their parent in two if necessary.
    */
 
-  liftNodes(
+  liftNodes<T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       voids?: boolean
     } = {}
@@ -260,7 +261,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : (n) => Editor.isBlock(editor, n)
       }
 
       if (!at) {
@@ -308,11 +309,11 @@ export const NodeTransforms: NodeTransforms = {
    * removing any empty containing nodes after the merge if necessary.
    */
 
-  mergeNodes(
+  mergeNodes<T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       voids?: boolean
@@ -329,9 +330,9 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         if (Path.isPath(at)) {
           const [parent] = Editor.parent(editor, at)
-          match = n => parent.children.includes(n)
+          match = (n) => parent.children.includes(n)
         } else {
-          match = n => Editor.isBlock(editor, n)
+          match = (n) => Editor.isBlock(editor, n)
         }
       }
 
@@ -380,7 +381,7 @@ export const NodeTransforms: NodeTransforms = {
       const emptyAncestor = Editor.above(editor, {
         at: path,
         mode: 'highest',
-        match: n =>
+        match: (n) =>
           levels.includes(n) && Element.isElement(n) && n.children.length === 1,
       })
 
@@ -446,11 +447,11 @@ export const NodeTransforms: NodeTransforms = {
    * Move the nodes at a location to a new location.
    */
 
-  moveNodes(
+  moveNodes<T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       to: Path
       voids?: boolean
@@ -472,7 +473,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : (n) => Editor.isBlock(editor, n)
       }
 
       const toRef = Editor.pathRef(editor, to)
@@ -496,11 +497,11 @@ export const NodeTransforms: NodeTransforms = {
    * Remove the nodes at a specific location in the document.
    */
 
-  removeNodes(
+  removeNodes<T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       hanging?: boolean
       voids?: boolean
@@ -517,7 +518,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : (n) => Editor.isBlock(editor, n)
       }
 
       if (!hanging && Range.isRange(at)) {
@@ -542,12 +543,12 @@ export const NodeTransforms: NodeTransforms = {
    * Set new properties on the nodes at a location.
    */
 
-  setNodes(
+  setNodes<T extends Node>(
     editor: Editor,
     props: Partial<Node>,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       hanging?: boolean
       split?: boolean
@@ -570,7 +571,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : (n) => Editor.isBlock(editor, n)
       }
 
       if (!hanging && Range.isRange(at)) {
@@ -641,11 +642,11 @@ export const NodeTransforms: NodeTransforms = {
    * Split the nodes at a specific location.
    */
 
-  splitNodes(
+  splitNodes<T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'highest' | 'lowest'
       always?: boolean
       height?: number
@@ -657,7 +658,7 @@ export const NodeTransforms: NodeTransforms = {
       let { match, at = editor.selection, height = 0, always = false } = options
 
       if (match == null) {
-        match = n => Editor.isBlock(editor, n)
+        match = (n) => Editor.isBlock(editor, n)
       }
 
       if (Range.isRange(at)) {
@@ -670,7 +671,7 @@ export const NodeTransforms: NodeTransforms = {
         const path = at
         const point = Editor.point(editor, path)
         const [parent] = Editor.parent(editor, path)
-        match = n => n === parent
+        match = (n) => n === parent
         height = point.path.length - path.length + 1
         at = point
         always = true
@@ -766,12 +767,12 @@ export const NodeTransforms: NodeTransforms = {
    * Unset properties on the nodes at a location.
    */
 
-  unsetNodes(
+  unsetNodes<T extends Node>(
     editor: Editor,
     props: string | string[],
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
@@ -795,11 +796,11 @@ export const NodeTransforms: NodeTransforms = {
    * necessary to ensure that only the content in the range is unwrapped.
    */
 
-  unwrapNodes(
+  unwrapNodes<T extends Node>(
     editor: Editor,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
@@ -816,7 +817,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : (n) => Editor.isBlock(editor, n)
       }
 
       if (Path.isPath(at)) {
@@ -838,7 +839,7 @@ export const NodeTransforms: NodeTransforms = {
 
         Transforms.liftNodes(editor, {
           at: range,
-          match: n => Element.isAncestor(node) && node.children.includes(n),
+          match: (n) => Element.isAncestor(node) && node.children.includes(n),
           voids,
         })
       }
@@ -854,12 +855,12 @@ export const NodeTransforms: NodeTransforms = {
    * of the range first to ensure that only the content in the range is wrapped.
    */
 
-  wrapNodes(
+  wrapNodes<T extends Node>(
     editor: Editor,
     element: Element,
     options: {
       at?: Location
-      match?: (node: Node) => boolean
+      match?: NodeMatch<T>
       mode?: 'all' | 'highest' | 'lowest'
       split?: boolean
       voids?: boolean
@@ -877,9 +878,9 @@ export const NodeTransforms: NodeTransforms = {
         if (Path.isPath(at)) {
           match = matchPath(editor, at)
         } else if (editor.isInline(element)) {
-          match = n => Editor.isInline(editor, n) || Text.isText(n)
+          match = (n) => Editor.isInline(editor, n) || Text.isText(n)
         } else {
-          match = n => Editor.isBlock(editor, n)
+          match = (n) => Editor.isBlock(editor, n)
         }
       }
 
@@ -901,8 +902,8 @@ export const NodeTransforms: NodeTransforms = {
         Editor.nodes(editor, {
           at,
           match: editor.isInline(element)
-            ? n => Editor.isBlock(editor, n)
-            : n => Editor.isEditor(n),
+            ? (n) => Editor.isBlock(editor, n)
+            : (n) => Editor.isEditor(n),
           mode: 'lowest',
           voids,
         })
@@ -940,7 +941,7 @@ export const NodeTransforms: NodeTransforms = {
 
           Transforms.moveNodes(editor, {
             at: range,
-            match: n =>
+            match: (n) =>
               Element.isAncestor(commonNode) && commonNode.children.includes(n),
             to: wrapperPath.concat(0),
             voids,
@@ -968,5 +969,5 @@ const deleteRange = (editor: Editor, range: Range): Point | null => {
 
 const matchPath = (editor: Editor, path: Path): ((node: Node) => boolean) => {
   const [node] = Editor.node(editor, path)
-  return n => n === node
+  return (n) => n === node
 }

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -190,11 +190,11 @@ export const NodeTransforms: NodeTransforms = {
       if (Point.isPoint(at)) {
         if (match == null) {
           if (Text.isText(node)) {
-            match = (n) => Text.isText(n)
+            match = n => Text.isText(n)
           } else if (editor.isInline(node)) {
-            match = (n) => Text.isText(n) || Editor.isInline(editor, n)
+            match = n => Text.isText(n) || Editor.isInline(editor, n)
           } else {
-            match = (n) => Editor.isBlock(editor, n)
+            match = n => Editor.isBlock(editor, n)
           }
         }
 
@@ -261,7 +261,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : (n) => Editor.isBlock(editor, n)
+          : n => Editor.isBlock(editor, n)
       }
 
       if (!at) {
@@ -330,9 +330,9 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         if (Path.isPath(at)) {
           const [parent] = Editor.parent(editor, at)
-          match = (n) => parent.children.includes(n)
+          match = n => parent.children.includes(n)
         } else {
-          match = (n) => Editor.isBlock(editor, n)
+          match = n => Editor.isBlock(editor, n)
         }
       }
 
@@ -381,7 +381,7 @@ export const NodeTransforms: NodeTransforms = {
       const emptyAncestor = Editor.above(editor, {
         at: path,
         mode: 'highest',
-        match: (n) =>
+        match: n =>
           levels.includes(n) && Element.isElement(n) && n.children.length === 1,
       })
 
@@ -473,7 +473,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : (n) => Editor.isBlock(editor, n)
+          : n => Editor.isBlock(editor, n)
       }
 
       const toRef = Editor.pathRef(editor, to)
@@ -518,7 +518,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : (n) => Editor.isBlock(editor, n)
+          : n => Editor.isBlock(editor, n)
       }
 
       if (!hanging && Range.isRange(at)) {
@@ -571,7 +571,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : (n) => Editor.isBlock(editor, n)
+          : n => Editor.isBlock(editor, n)
       }
 
       if (!hanging && Range.isRange(at)) {
@@ -658,7 +658,7 @@ export const NodeTransforms: NodeTransforms = {
       let { match, at = editor.selection, height = 0, always = false } = options
 
       if (match == null) {
-        match = (n) => Editor.isBlock(editor, n)
+        match = n => Editor.isBlock(editor, n)
       }
 
       if (Range.isRange(at)) {
@@ -671,7 +671,7 @@ export const NodeTransforms: NodeTransforms = {
         const path = at
         const point = Editor.point(editor, path)
         const [parent] = Editor.parent(editor, path)
-        match = (n) => n === parent
+        match = n => n === parent
         height = point.path.length - path.length + 1
         at = point
         always = true
@@ -817,7 +817,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : (n) => Editor.isBlock(editor, n)
+          : n => Editor.isBlock(editor, n)
       }
 
       if (Path.isPath(at)) {
@@ -839,7 +839,7 @@ export const NodeTransforms: NodeTransforms = {
 
         Transforms.liftNodes(editor, {
           at: range,
-          match: (n) => Element.isAncestor(node) && node.children.includes(n),
+          match: n => Element.isAncestor(node) && node.children.includes(n),
           voids,
         })
       }
@@ -878,9 +878,9 @@ export const NodeTransforms: NodeTransforms = {
         if (Path.isPath(at)) {
           match = matchPath(editor, at)
         } else if (editor.isInline(element)) {
-          match = (n) => Editor.isInline(editor, n) || Text.isText(n)
+          match = n => Editor.isInline(editor, n) || Text.isText(n)
         } else {
-          match = (n) => Editor.isBlock(editor, n)
+          match = n => Editor.isBlock(editor, n)
         }
       }
 
@@ -902,8 +902,8 @@ export const NodeTransforms: NodeTransforms = {
         Editor.nodes(editor, {
           at,
           match: editor.isInline(element)
-            ? (n) => Editor.isBlock(editor, n)
-            : (n) => Editor.isEditor(n),
+            ? n => Editor.isBlock(editor, n)
+            : n => Editor.isEditor(n),
           mode: 'lowest',
           voids,
         })
@@ -941,7 +941,7 @@ export const NodeTransforms: NodeTransforms = {
 
           Transforms.moveNodes(editor, {
             at: range,
-            match: (n) =>
+            match: n =>
               Element.isAncestor(commonNode) && commonNode.children.includes(n),
             to: wrapperPath.concat(0),
             voids,
@@ -969,5 +969,5 @@ const deleteRange = (editor: Editor, range: Range): Point | null => {
 
 const matchPath = (editor: Editor, path: Path): ((node: Node) => boolean) => {
   const [node] = Editor.node(editor, path)
-  return (n) => n === node
+  return n => n === node
 }

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -19,12 +15,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ]
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Feature

#### What's the new behavior?

The NodeMatch function provided in several functions on the  `Editor` and `Transform` now takes a second parameter which is the path of the node provided as the first parameter.

#### How does this change work?

This is a non breaking change.

In the editor.ts, the `Editor.levels` and `Editor.nodes` functions are the only two that explicitly call `match`, so these have been updated to account for the `nodePath` as the second parameter.

In transforms/node.ts, all match functionality is deferred to one of the two functions above but they had a different type, not `NodeMatch<T>` but `(node: node) => boolean`. This has now been updated as well.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3967
Reviewers: @BrentFarese 
