### PR TITLE
Fix toSlatePoint wrong offset for void element.

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -438,6 +438,9 @@ export const ReactEditor = {
         textNode = leafNode.closest('[data-slate-node="text"]')!
         domNode = leafNode
         offset = domNode.textContent!.length
+        domNode.querySelectorAll('[data-slate-zero-width]').forEach(el => {
+          offset -= el.textContent!.length
+        })
       }
 
       // COMPAT: If the parent node is a Slate zero-width space, editor is


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->
Fixing a bug

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->
If you put some input/textarea in your void element, the input.textarea can be focused (though still need 2nd click)

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->
Currently, the offset counting is wrong, since the zero-length span count as length 1. This PR fix the offset counting, then the offset is correct.
Without this fix, one click will trigger in onClick one time Transform.select, and the other time Transform.select in onDOMSelectionChange, but the two select is targeting to the different range (with offset 0 and offset 1 then), because the change and the invalid offset, the click (input/textarea trying to focus) will finally got nothing. After the offset fix, finally user can focus the input/textarea inside a void element.

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
