### PR TITLE
fix: `Operation.isOperationList`  just check value[0]

### DIFF
--- a/packages/slate/Readme.md
+++ b/packages/slate/Readme.md
@@ -1,3 +1,3 @@
 This package contains the core logic of Slate. Feel free to poke around to learn more!
 
-Note: A number of source files contain extracted types for `Interfaces` or `Transforms`. This is done currently to enable custom type extensions as found in `packages/src/interfaces/custom-types.ts`. 
+Note: A number of source files contain extracted types for `Interfaces` or `Transforms`. This is done currently to enable custom type extensions as found in `packages/src/interfaces/custom-types.ts`.

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -47,10 +47,7 @@ export const Element: ElementInterface = {
    */
 
   isElementList(value: any): value is Element[] {
-    return (
-      Array.isArray(value) &&
-      (value.length === 0 || Element.isElement(value[0]))
-    )
+    return Array.isArray(value) && value.every(val => Element.isElement(val))
   },
 
   /**

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -383,7 +383,7 @@ export const Node: NodeInterface = {
    */
 
   isNodeList(value: any): value is Node[] {
-    return Array.isArray(value) && (value.length === 0 || Node.isNode(value[0]))
+    return Array.isArray(value) && value.every(val => Node.isNode(val))
   },
 
   /**

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -218,10 +218,15 @@ export const Operation: OperationInterface = {
    */
 
   isOperationList(value: any): value is Operation[] {
-    return (
-      Array.isArray(value) &&
-      (value.length === 0 || Operation.isOperation(value[0]))
-    )
+    if (!Array.isArray(value)) {
+      return false
+    }
+    for (const valueItem of value) {
+      if (!Operation.isOperation(valueItem)) {
+        return false
+      }
+    }
+    return true
   },
 
   /**

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -218,15 +218,9 @@ export const Operation: OperationInterface = {
    */
 
   isOperationList(value: any): value is Operation[] {
-    if (!Array.isArray(value)) {
-      return false
-    }
-    for (const valueItem of value) {
-      if (!Operation.isOperation(valueItem)) {
-        return false
-      }
-    }
-    return true
+    return (
+      Array.isArray(value) && value.every(val => Operation.isOperation(val))
+    )
   },
 
   /**

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -71,7 +71,7 @@ export const Text: TextInterface = {
    */
 
   isTextList(value: any): value is Text[] {
-    return Array.isArray(value) && (value.length === 0 || Text.isText(value[0]))
+    return Array.isArray(value) && value.every(val => Text.isText(val))
   },
 
   /**

--- a/packages/slate/test/interfaces/Element/isElementList/not-full-element.tsx
+++ b/packages/slate/test/interfaces/Element/isElementList/not-full-element.tsx
@@ -1,15 +1,17 @@
-import { Operation } from 'slate'
+import { Element } from 'slate'
 
 export const input = [
+  {
+    children: [],
+  },
   {
     type: 'set_node',
     path: [0],
     properties: {},
     newProperties: {},
   },
-  's string',
 ]
 export const test = value => {
-  return Operation.isOperationList(value)
+  return Element.isElementList(value)
 }
 export const output = false

--- a/packages/slate/test/interfaces/Node/isNodeList/not-full-node.tsx
+++ b/packages/slate/test/interfaces/Node/isNodeList/not-full-node.tsx
@@ -1,0 +1,13 @@
+import { Node } from 'slate'
+
+export const input = [
+  {
+    children: [],
+    selection: null,
+  },
+  'a string',
+]
+export const test = value => {
+  return Node.isNodeList(value)
+}
+export const output = false

--- a/packages/slate/test/interfaces/Operation/isOperationList/not-full-operaion.tsx
+++ b/packages/slate/test/interfaces/Operation/isOperationList/not-full-operaion.tsx
@@ -1,0 +1,17 @@
+import { Operation } from 'slate'
+
+export const input = [
+  {
+    type: 'set_node',
+    path: [0],
+    properties: {},
+    newProperties: {},
+  },
+  {
+    text: '',
+  },
+]
+export const test = value => {
+  return Operation.isOperationList(value)
+}
+export const output = false

--- a/packages/slate/test/interfaces/Operation/isOperationList/notOperaion.tsx
+++ b/packages/slate/test/interfaces/Operation/isOperationList/notOperaion.tsx
@@ -1,0 +1,15 @@
+import { Operation } from 'slate'
+
+export const input = [
+  {
+    type: 'set_node',
+    path: [0],
+    properties: {},
+    newProperties: {},
+  },
+  's string',
+]
+export const test = value => {
+  return Operation.isOperationList(value)
+}
+export const output = false

--- a/packages/slate/test/interfaces/Text/isTextList/not-full-text.tsx
+++ b/packages/slate/test/interfaces/Text/isTextList/not-full-text.tsx
@@ -1,0 +1,17 @@
+import { Text } from 'slate'
+
+export const input = [
+  {
+    text: '',
+  },
+  {
+    type: 'set_node',
+    path: [0],
+    properties: {},
+    newProperties: {},
+  },
+]
+export const test = value => {
+  return Text.isTextList(value)
+}
+export const output = false

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -19,12 +15,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ]
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

fix a bug

#### What's the new behavior?

old code
```javascript
// packages/slate/src/interfaces/operation.ts
isOperationList(value: any): value is Operation[] {
    return (
      Array.isArray(value) &&
      (value.length === 0 || Operation.isOperation(value[0]))
    )
}
```
The old code just Determine if `value[0]` is a `Operation` Object

#### How does this change work?

```javascript
 // packages/slate/src/interfaces/operation.ts
 isOperationList(value: any): value is Operation[] {
    if (!Array.isArray(value)) {
      return false
    }
    for (const valueItem of value) {
      if (!Operation.isOperation(valueItem)) {
        return false
      }
    }
    return true
},
```


#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Reviewers: @thesunny 
