### PR TITLE
[WIP] Introduce Mutation Observer reconciliation strategy to support Android

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -552,7 +552,8 @@ export const Editable = (props: EditableProps) => {
             if (
               !readOnly &&
               hasEditableTarget(editor, event.target) &&
-              !isEventHandled(event, attributes.onKeyDown)
+              !isEventHandled(event, attributes.onKeyDown) &&
+              !isEventHandled(event, inputStrategy.attributes.onKeyDown)
             ) {
               const { nativeEvent } = event
               const { selection } = editor

--- a/packages/slate-react/src/input-strategy/before-input/index.ts
+++ b/packages/slate-react/src/input-strategy/before-input/index.ts
@@ -1,0 +1,1 @@
+export { useBeforeInputStrategy } from './use-before-input'

--- a/packages/slate-react/src/input-strategy/before-input/use-before-input.ts
+++ b/packages/slate-react/src/input-strategy/before-input/use-before-input.ts
@@ -1,0 +1,270 @@
+import { RefObject, useCallback, useMemo, useRef } from 'react'
+import { Editor, Range, Transforms } from 'slate'
+
+import { useIsomorphicLayoutEffect } from '../../hooks/use-isomorphic-layout-effect'
+import { useSlate } from '../../hooks/use-slate'
+import { ReactEditor } from '../../plugin/react-editor'
+import { DOMStaticRange } from '../../utils/dom'
+import {
+  HAS_BEFORE_INPUT_SUPPORT,
+  IS_FIREFOX,
+  IS_SAFARI,
+} from '../../utils/environment'
+import { hasEditableTarget, isEventHandled } from '../../utils/helpers'
+
+import { InputStrategy } from '../types'
+
+export const useBeforeInputStrategy: InputStrategy = ({
+  nodeRef,
+  handlers,
+  readOnly,
+}) => {
+  const editor = useSlate()
+  const isComposingRef = useRef(false)
+
+  // Listen on the native `beforeinput` event to get real "Level 2" events. This
+  // is required because React's `beforeinput` is fake and never really attaches
+  // to the real event sadly. (2019/11/01)
+  // https://github.com/facebook/react/issues/11211
+  const onDOMBeforeInput = useCallback(
+    (
+      event: Event & {
+        data: string | null
+        dataTransfer: DataTransfer | null
+        getTargetRanges(): DOMStaticRange[]
+        inputType: string
+        isComposing: boolean
+      }
+    ) => {
+      if (
+        !readOnly &&
+        hasEditableTarget(editor, event.target) &&
+        !isDOMEventHandled(event, handlers.onDOMBeforeInput)
+      ) {
+        const { selection } = editor
+        const { inputType: type } = event
+        const data = event.dataTransfer || event.data || undefined
+
+        // These two types occur while a user is composing text and can't be
+        // cancelled. Let them through and wait for the composition to end.
+        if (
+          type === 'insertCompositionText' ||
+          type === 'deleteCompositionText'
+        ) {
+          return
+        }
+
+        event.preventDefault()
+
+        // COMPAT: For the deleting forward/backward input types we don't want
+        // to change the selection because it is the range that will be deleted,
+        // and those commands determine that for themselves.
+        if (!type.startsWith('delete') || type.startsWith('deleteBy')) {
+          const [targetRange] = event.getTargetRanges()
+
+          if (targetRange) {
+            const range = ReactEditor.toSlateRange(editor, targetRange)
+
+            if (!selection || !Range.equals(selection, range)) {
+              Transforms.select(editor, range)
+            }
+          }
+        }
+
+        // COMPAT: If the selection is expanded, even if the command seems like
+        // a delete forward/backward command it should delete the selection.
+        if (
+          selection &&
+          Range.isExpanded(selection) &&
+          type.startsWith('delete')
+        ) {
+          Editor.deleteFragment(editor)
+          return
+        }
+
+        switch (type) {
+          case 'deleteByComposition':
+          case 'deleteByCut':
+          case 'deleteByDrag': {
+            Editor.deleteFragment(editor)
+            break
+          }
+
+          case 'deleteContent':
+          case 'deleteContentForward': {
+            Editor.deleteForward(editor)
+            break
+          }
+
+          case 'deleteContentBackward': {
+            Editor.deleteBackward(editor)
+            break
+          }
+
+          case 'deleteEntireSoftLine': {
+            Editor.deleteBackward(editor, { unit: 'line' })
+            Editor.deleteForward(editor, { unit: 'line' })
+            break
+          }
+
+          case 'deleteHardLineBackward': {
+            Editor.deleteBackward(editor, { unit: 'block' })
+            break
+          }
+
+          case 'deleteSoftLineBackward': {
+            Editor.deleteBackward(editor, { unit: 'line' })
+            break
+          }
+
+          case 'deleteHardLineForward': {
+            Editor.deleteForward(editor, { unit: 'block' })
+            break
+          }
+
+          case 'deleteSoftLineForward': {
+            Editor.deleteForward(editor, { unit: 'line' })
+            break
+          }
+
+          case 'deleteWordBackward': {
+            Editor.deleteBackward(editor, { unit: 'word' })
+            break
+          }
+
+          case 'deleteWordForward': {
+            Editor.deleteForward(editor, { unit: 'word' })
+            break
+          }
+
+          case 'insertLineBreak':
+          case 'insertParagraph': {
+            Editor.insertBreak(editor)
+            break
+          }
+
+          case 'insertFromComposition':
+          case 'insertFromDrop':
+          case 'insertFromPaste':
+          case 'insertFromYank':
+          case 'insertReplacementText':
+          case 'insertText': {
+            if (data instanceof DataTransfer) {
+              ReactEditor.insertData(editor, data)
+            } else if (typeof data === 'string') {
+              Editor.insertText(editor, data)
+            }
+
+            break
+          }
+        }
+      }
+    },
+    [readOnly, handlers.onDOMBeforeInput]
+  )
+
+  // Attach a native DOM event handler for `beforeinput` events, because React's
+  // built-in `onBeforeInput` is actually a leaky polyfill that doesn't expose
+  // real `beforeinput` events sadly... (2019/11/04)
+  // https://github.com/facebook/react/issues/11211
+  useIsomorphicLayoutEffect(() => {
+    if (nodeRef.current && HAS_BEFORE_INPUT_SUPPORT) {
+      // @ts-ignore The `beforeinput` event isn't recognized.
+      nodeRef.current.addEventListener('beforeinput', onDOMBeforeInput)
+    }
+
+    return () => {
+      if (nodeRef.current && HAS_BEFORE_INPUT_SUPPORT) {
+        // @ts-ignore The `beforeinput` event isn't recognized.
+        nodeRef.current.removeEventListener('beforeinput', onDOMBeforeInput)
+      }
+    }
+  }, [onDOMBeforeInput])
+
+  const syntheticBeforeInputHandler = useCallback(
+    (event: React.FormEvent<HTMLDivElement>) => {
+      // COMPAT: Certain browsers don't support the `beforeinput` event, so we
+      // fall back to React's leaky polyfill instead just for it. It
+      // only works for the `insertText` input type.
+      if (
+        !HAS_BEFORE_INPUT_SUPPORT &&
+        !readOnly &&
+        !isEventHandled(event, handlers.onBeforeInput) &&
+        hasEditableTarget(editor, event.target)
+      ) {
+        event.preventDefault()
+        const text = (event as any).data as string
+        Editor.insertText(editor, text)
+      }
+    },
+    [readOnly, handlers.onBeforeInput]
+  )
+
+  const syntheticCompositionStartHandler = useCallback(
+    (event: React.CompositionEvent<HTMLDivElement>) => {
+      if (
+        hasEditableTarget(editor, event.target) &&
+        !isEventHandled(event, handlers.onCompositionStart)
+      ) {
+        isComposingRef.current = true
+      }
+    },
+    [handlers.onCompositionStart]
+  )
+
+  const syntheticCompositionEndHandler = useCallback(
+    (event: React.CompositionEvent<HTMLDivElement>) => {
+      if (
+        hasEditableTarget(editor, event.target) &&
+        !isEventHandled(event, handlers.onCompositionEnd)
+      ) {
+        isComposingRef.current = false
+
+        // COMPAT: In Chrome, `beforeinput` events for compositions
+        // aren't correct and never fire the "insertFromComposition"
+        // type that we need. So instead, insert whenever a composition
+        // ends since it will already have been committed to the DOM.
+        if (!IS_SAFARI && !IS_FIREFOX && event.data) {
+          Editor.insertText(editor, event.data)
+        }
+      }
+    },
+    [handlers.onCompositionEnd]
+  )
+
+  const syntheticHandlers = useMemo(
+    () => ({
+      onBeforeInput: syntheticBeforeInputHandler,
+      onCompositionEnd: syntheticCompositionEndHandler,
+      onCompositionStart: syntheticCompositionStartHandler,
+    }),
+    [
+      syntheticBeforeInputHandler,
+      syntheticCompositionStartHandler,
+      syntheticCompositionEndHandler,
+    ]
+  )
+
+  return useMemo(
+    () => ({
+      attributes: {
+        ...syntheticHandlers,
+      },
+      isComposing: isComposingRef,
+    }),
+    [syntheticHandlers]
+  )
+}
+
+/**
+ * Check if a DOM event is overrided by a handler.
+ */
+
+const isDOMEventHandled = (event: Event, handler?: (event: Event) => void) => {
+  if (!handler) {
+    return false
+  }
+
+  handler(event)
+  return event.defaultPrevented
+}

--- a/packages/slate-react/src/input-strategy/index.ts
+++ b/packages/slate-react/src/input-strategy/index.ts
@@ -1,0 +1,1 @@
+export { getInputStrategy, useInputStrategy } from './input-strategy'

--- a/packages/slate-react/src/input-strategy/input-strategy.ts
+++ b/packages/slate-react/src/input-strategy/input-strategy.ts
@@ -1,0 +1,15 @@
+import { IS_ANDROID } from '../utils/environment'
+
+import { InputStrategyArguments } from './types'
+import { useBeforeInputStrategy } from './before-input'
+import { useMutationObserverStrategy } from './mutation-observer'
+
+export function getInputStrategy() {
+  if (IS_ANDROID) {
+    return useMutationObserverStrategy
+  }
+
+  return useBeforeInputStrategy
+}
+
+export const useInputStrategy = getInputStrategy()

--- a/packages/slate-react/src/input-strategy/mutation-observer/diff-text.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/diff-text.ts
@@ -1,0 +1,110 @@
+/**
+ * Returns the number of characters that are the same at the beginning of the
+ * String.
+ *
+ * @param {String} prev
+ * @param {String} next
+ */
+
+function getDiffStart(prev: string, next: string): number | null {
+  const length = Math.min(prev.length, next.length)
+
+  for (let i = 0; i < length; i++) {
+    if (prev.charAt(i) !== next.charAt(i)) return i
+  }
+
+  if (prev.length !== next.length) return length
+  return null
+}
+
+/**
+ * Returns the number of characters that are the same at the end of the String
+ * up to `max`. Max prevents double-counting characters when there are
+ * multiple duplicate characters around the diff area.
+ *
+ * @param {String} prev
+ * @param {String} next
+ * @param {Number} max
+ */
+
+function getDiffEnd(prev: string, next: string, max: number): number | null {
+  const prevLength = prev.length
+  const nextLength = next.length
+  const length = Math.min(prevLength, nextLength, max)
+
+  for (let i = 0; i < length; i++) {
+    const prevChar = prev.charAt(prevLength - i - 1)
+    const nextChar = next.charAt(nextLength - i - 1)
+    if (prevChar !== nextChar) return i
+  }
+
+  if (prev.length !== next.length) return length
+  return null
+}
+
+type Offsets = {
+  start: number
+  end: number
+}
+
+/**
+ * Takes two strings and returns an object representing two offsets. The
+ * first, `start` represents the number of characters that are the same at
+ * the front of the String. The `end` represents the number of characters
+ * that are the same at the end of the String.
+ *
+ * Returns null if they are identical.
+ *
+ * @param {String} prev
+ * @param {String} next
+ */
+
+function getDiffOffsets(prev: string, next: string): Offsets | null {
+  if (prev === next) return null
+  const start = getDiffStart(prev, next)
+  if (start === null) return null
+  const maxEnd = Math.min(prev.length - start, next.length - start)
+  const end = getDiffEnd(prev, next, maxEnd)!
+  if (end === null) return null
+  return { start, end }
+}
+
+/**
+ * Takes a text string and returns a slice from the string at the given offses
+ *
+ * @param {String} text
+ * @param {Object} offsets
+ */
+
+function sliceText(text: string, offsets: Offsets): string {
+  return text.slice(offsets.start, text.length - offsets.end)
+}
+
+export type Diff = {
+  start: number
+  end: number
+  insertText: string
+  removeText: string
+}
+
+/**
+ * Takes two strings and returns a smart diff that can be used to describe the
+ * change in a way that can be used as operations like inserting, removing or
+ * replacing text.
+ *
+ * @param {String} prev
+ * @param {String} next
+ */
+
+export function diffText(prev: string, next: string): Diff | null {
+  const offsets = getDiffOffsets(prev, next)
+  if (offsets == null) return null
+  const insertText = sliceText(next, offsets)
+  const removeText = sliceText(prev, offsets)
+  return {
+    start: offsets.start,
+    end: prev.length - offsets.end,
+    insertText,
+    removeText,
+  }
+}

--- a/packages/slate-react/src/input-strategy/mutation-observer/diff-text.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/diff-text.ts
@@ -1,3 +1,5 @@
+import { Path } from 'slate'
+
 /**
  * Returns the number of characters that are the same at the beginning of the
  * String.
@@ -107,4 +109,13 @@ export function diffText(prev: string, next: string): Diff | null {
     insertText,
     removeText,
   }
+}
+
+export interface InsertedText {
+  text: Diff
+  path: Path
+}
+
+export function getInsertedText(insertedText: InsertedText[]): string {
+  return insertedText.reduce((acc, { text }) => `${acc}${text.insertText}`, '')
 }

--- a/packages/slate-react/src/input-strategy/mutation-observer/index.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/index.ts
@@ -1,0 +1,1 @@
+export { useMutationObserverStrategy } from './use-mutation-observer'

--- a/packages/slate-react/src/input-strategy/mutation-observer/use-mutation-observer.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/use-mutation-observer.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from 'react'
+import { Text, Transforms } from 'slate'
+
+import { ReactEditor } from '../../plugin/react-editor'
+import { useSlate } from '../../hooks/use-slate'
+import { useIsomorphicLayoutEffect } from '../../hooks/use-isomorphic-layout-effect'
+import { InputStrategy } from '../types'
+
+import { diffText } from './diff-text'
+
+const MUTATION_OBSERVER_CONFIG: MutationObserverInit = {
+  childList: true,
+  characterData: true,
+  attributes: true,
+  subtree: true,
+  characterDataOldValue: true,
+}
+
+export const useMutationObserverStrategy: InputStrategy = ({ nodeRef }) => {
+  const editor = useSlate()
+  const handleMutations = useCallback((mutations: MutationRecord[]) => {
+    if (mutations.length === 0) {
+      return
+    }
+
+    const mutation = mutations[0]
+
+    if (mutation.type === 'characterData') {
+      const domNode = mutation.target.parentNode!
+      const node = ReactEditor.toSlateNode(editor, domNode) as Text
+      const prevText = node.text
+      let nextText = domNode.textContent!
+
+      // textContent will pad an extra \n when the textContent ends with an \n
+      if (nextText.endsWith('\n')) {
+        nextText = nextText.slice(0, nextText.length - 1)
+      }
+
+      // If the text is no different, there is no diff.
+      if (nextText !== prevText) {
+        const textDiff = diffText(prevText, nextText)
+        if (textDiff !== null) {
+          const path = ReactEditor.findPath(editor, node)
+          Transforms.insertText(editor, textDiff.insertText, {
+            at: {
+              anchor: { path, offset: textDiff.start },
+              focus: { path, offset: textDiff.end },
+            },
+          })
+        }
+      }
+    }
+  }, [])
+  const [mutationObserver] = useState(
+    () => new MutationObserver(handleMutations)
+  )
+  const isComposingRef = useRef(false)
+
+  useIsomorphicLayoutEffect(() => {
+    if (!nodeRef.current) {
+      throw new Error('Editor root node is not present')
+    }
+
+    mutationObserver.observe(nodeRef.current, MUTATION_OBSERVER_CONFIG)
+
+    return () => mutationObserver.disconnect()
+  }, [])
+
+  return {
+    attributes: {},
+    isComposing: isComposingRef,
+  }
+}

--- a/packages/slate-react/src/input-strategy/mutation-observer/use-mutation-observer.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/use-mutation-observer.ts
@@ -1,73 +1,173 @@
 import { useCallback, useRef, useState } from 'react'
-import { Text, Transforms } from 'slate'
+import { Editor, Path, Range, Text, Transforms } from 'slate'
 
 import { ReactEditor } from '../../plugin/react-editor'
 import { useSlate } from '../../hooks/use-slate'
 import { useIsomorphicLayoutEffect } from '../../hooks/use-isomorphic-layout-effect'
 import { InputStrategy } from '../types'
 
-import { diffText } from './diff-text'
+import { diffText, getInsertedText, InsertedText } from './diff-text'
+import { useTrackUserInput } from './use-track-user-input'
+import { useRestoreDOM } from './use-restore-dom'
 
 const MUTATION_OBSERVER_CONFIG: MutationObserverInit = {
   childList: true,
   characterData: true,
-  attributes: true,
-  subtree: true,
   characterDataOldValue: true,
+  subtree: true,
 }
 
 export const useMutationObserverStrategy: InputStrategy = ({ nodeRef }) => {
   const editor = useSlate()
+  const isComposing = useRef(false)
+  const {
+    userInput,
+    attributes: trackUserInputAttributes,
+  } = useTrackUserInput()
+  const { restoreDOM, attributes: restoreDOMAttributes } = useRestoreDOM()
+
   const handleMutations = useCallback((mutations: MutationRecord[]) => {
-    if (mutations.length === 0) {
+    if (!userInput.current || mutations.length === 0) {
       return
     }
 
-    const mutation = mutations[0]
+    const { selection } = editor
+    const addedNodes: Node[] = []
+    const removedNodes: Node[] = []
+    const insertedText: InsertedText[] = []
+    let shouldRestoreDOM = true
+    let insertLineBreakMutation = false
 
-    if (mutation.type === 'characterData') {
-      const domNode = mutation.target.parentNode!
-      const node = ReactEditor.toSlateNode(editor, domNode) as Text
-      const prevText = node.text
-      let nextText = domNode.textContent!
+    mutations.forEach(mutation => {
+      switch (mutation.type) {
+        case 'childList': {
+          if (mutation.addedNodes.length) {
+            if (mutation.target === nodeRef.current) {
+              // Detected line break insertion mutation
+              insertLineBreakMutation = true
+              break
+            }
 
-      // textContent will pad an extra \n when the textContent ends with an \n
-      if (nextText.endsWith('\n')) {
-        nextText = nextText.slice(0, nextText.length - 1)
-      }
+            mutation.addedNodes.forEach(addedNode => {
+              if (
+                addedNodes.includes(addedNode) ||
+                addedNodes.some(node => node.contains(addedNode))
+              ) {
+                return
+              }
 
-      // If the text is no different, there is no diff.
-      if (nextText !== prevText) {
-        const textDiff = diffText(prevText, nextText)
-        if (textDiff !== null) {
-          const path = ReactEditor.findPath(editor, node)
-          Transforms.insertText(editor, textDiff.insertText, {
-            at: {
-              anchor: { path, offset: textDiff.start },
-              focus: { path, offset: textDiff.end },
-            },
+              addedNodes.push(addedNode)
+            })
+          }
+
+          mutation.removedNodes.forEach(removedNode => {
+            if (
+              removedNodes.includes(removedNode) ||
+              removedNodes.some(node => node.contains(removedNode))
+            ) {
+              return
+            }
+
+            removedNodes.push(removedNode)
           })
+
+          break
+        }
+        case 'characterData': {
+          // Changes to text nodes should consider the parent element
+          const { parentNode } = mutation.target
+
+          if (!parentNode) {
+            return
+          }
+
+          const node = ReactEditor.toSlateNode(editor, parentNode) as Text
+          const prevText = node.text
+          let nextText = parentNode.textContent!
+
+          // textContent will pad an extra \n when the textContent ends with an \n
+          if (nextText.endsWith('\n')) {
+            nextText = nextText.slice(0, nextText.length - 1)
+          }
+
+          // If the text is no different, there is no diff.
+          if (nextText !== prevText) {
+            const textDiff = diffText(prevText, nextText)
+            if (textDiff !== null) {
+              const textPath = ReactEditor.findPath(editor, node)
+
+              if (
+                insertedText.some(({ path }) => Path.equals(path, textPath))
+              ) {
+                return
+              }
+
+              insertedText.push({ text: textDiff, path: textPath })
+            }
+          }
         }
       }
+    })
+
+    if (selection && Range.isExpanded(selection) && removedNodes.length) {
+      // Delete expanded selection
+      Editor.deleteFragment(editor)
+
+      const text = getInsertedText(insertedText)
+      if (text.length) {
+        // Selection was replaced by text
+        Editor.insertText(editor, text)
+      }
+    } else if (insertLineBreakMutation) {
+      // Insert line break
+      Editor.insertBreak(editor)
+      isComposing.current = false
+    } else if (removedNodes.length) {
+      // Delete contents backwards
+      Editor.deleteBackward(editor)
+    } else if (insertedText.length) {
+      // Insert text
+      insertedText.forEach(({ text, path }) =>
+        Transforms.insertText(editor, text.insertText, {
+          at: {
+            anchor: { path, offset: text.start },
+            focus: { path, offset: text.end },
+          },
+        })
+      )
+
+      shouldRestoreDOM = false
+    }
+
+    if (shouldRestoreDOM) {
+      // When the Slate document gets out of sync with the DOM, we need to
+      // force restore the DOM by incementing the `key` prop on the Editor
+      // This approach is expensive, in the future, perhaps only certain
+      // portions sof the document could be restored
+      restoreDOM()
     }
   }, [])
   const [mutationObserver] = useState(
     () => new MutationObserver(handleMutations)
   )
-  const isComposingRef = useRef(false)
 
   useIsomorphicLayoutEffect(() => {
     if (!nodeRef.current) {
       throw new Error('Editor root node is not present')
     }
 
+    // Attach mutation observer to the editor's root node
     mutationObserver.observe(nodeRef.current, MUTATION_OBSERVER_CONFIG)
 
     return () => mutationObserver.disconnect()
-  }, [])
+  })
 
   return {
-    attributes: {},
-    isComposing: isComposingRef,
+    attributes: {
+      ...restoreDOMAttributes,
+      ...trackUserInputAttributes,
+    },
+    isComposing,
   }
 }
+

--- a/packages/slate-react/src/input-strategy/mutation-observer/use-restore-dom.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/use-restore-dom.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from 'react'
+
+export function useRestoreDOM() {
+  const [key, setKey] = useState(0)
+  const restoreDOM = useCallback(() => setKey(value => value + 1), [])
+
+  return {
+    restoreDOM,
+    attributes: { key },
+  }
+}

--- a/packages/slate-react/src/input-strategy/mutation-observer/use-track-user-input.ts
+++ b/packages/slate-react/src/input-strategy/mutation-observer/use-track-user-input.ts
@@ -1,0 +1,27 @@
+import { useCallback, useRef } from 'react'
+
+export function useTrackUserInput() {
+  const userInputRef = useRef<boolean>(false)
+  const animationFrameRef = useRef<number | null>(null)
+
+  const handleUserInput = useCallback(() => {
+    // Distinguish user input from other DOM mutations
+    if (userInputRef.current === false) {
+      userInputRef.current = true
+
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current)
+      }
+
+      animationFrameRef.current = requestAnimationFrame(() => {
+        userInputRef.current = false
+        animationFrameRef.current = null
+      })
+    }
+  }, [])
+
+  return {
+    userInput: userInputRef,
+    attributes: { onKeyDown: handleUserInput },
+  }
+}

--- a/packages/slate-react/src/input-strategy/types.ts
+++ b/packages/slate-react/src/input-strategy/types.ts
@@ -1,0 +1,21 @@
+import { RefObject, TextareaHTMLAttributes } from 'react'
+
+export interface InputStrategyArguments {
+  nodeRef: RefObject<HTMLDivElement>
+  readOnly: boolean
+  handlers: {
+    onDOMBeforeInput?: (event: Event) => void
+  } & Pick<
+    TextareaHTMLAttributes<HTMLDivElement>,
+    'onBeforeInput' | 'onCompositionStart' | 'onCompositionEnd'
+  >
+}
+
+export interface InputStrategyReturnValue {
+  isComposing: RefObject<boolean>
+  attributes: TextareaHTMLAttributes<HTMLDivElement>
+}
+
+export type InputStrategy = (
+  args: InputStrategyArguments
+) => InputStrategyReturnValue

--- a/packages/slate-react/src/input-strategy/types.ts
+++ b/packages/slate-react/src/input-strategy/types.ts
@@ -1,4 +1,4 @@
-import { RefObject, TextareaHTMLAttributes } from 'react'
+import { Key, RefObject, TextareaHTMLAttributes } from 'react'
 
 export interface InputStrategyArguments {
   nodeRef: RefObject<HTMLDivElement>
@@ -13,7 +13,9 @@ export interface InputStrategyArguments {
 
 export interface InputStrategyReturnValue {
   isComposing: RefObject<boolean>
-  attributes: TextareaHTMLAttributes<HTMLDivElement>
+  attributes: TextareaHTMLAttributes<HTMLDivElement> & {
+    key?: Key
+  }
 }
 
 export type InputStrategy = (

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -4,6 +4,9 @@ export const IS_IOS =
   /iPad|iPhone|iPod/.test(navigator.userAgent) &&
   !window.MSStream
 
+export const IS_ANDROID =
+  typeof navigator !== 'undefined' && /Android/.test(navigator.userAgent)
+
 export const IS_APPLE =
   typeof navigator !== 'undefined' && /Mac OS X/.test(navigator.userAgent)
 
@@ -24,3 +27,11 @@ export const IS_EDGE_LEGACY =
 export const IS_CHROME_LEGACY =
   typeof navigator !== 'undefined' &&
   /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])/i.test(navigator.userAgent)
+
+// COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
+// Chrome Legacy doesn't support `beforeinput` correctly
+export const HAS_BEFORE_INPUT_SUPPORT = !(
+  IS_FIREFOX ||
+  IS_EDGE_LEGACY ||
+  IS_CHROME_LEGACY
+)

--- a/packages/slate-react/src/utils/helpers.ts
+++ b/packages/slate-react/src/utils/helpers.ts
@@ -1,0 +1,31 @@
+import { DOMNode, isDOMNode } from '../utils/dom'
+import { ReactEditor } from '../plugin/react-editor'
+
+/**
+ * Check if the target is editable and in the editor.
+ */
+
+export function hasEditableTarget(
+  editor: ReactEditor,
+  target: EventTarget | null
+): target is DOMNode {
+  return (
+    isDOMNode(target) &&
+    ReactEditor.hasDOMNode(editor, target, { editable: true })
+  )
+}
+
+/**
+ * Check if an event is overrided by a handler.
+ */
+
+export function isEventHandled<
+  EventType extends React.SyntheticEvent<unknown, unknown>
+>(event: EventType, handler?: (event: EventType) => void) {
+  if (!handler) {
+    return false
+  }
+
+  handler(event)
+  return event.isDefaultPrevented() || event.isPropagationStopped()
+}

--- a/site/examples/mentions.tsx
+++ b/site/examples/mentions.tsx
@@ -105,6 +105,7 @@ const MentionExample = () => {
         onKeyDown={onKeyDown}
         placeholder="Enter some text..."
       />
+      <pre>{JSON.stringify(value, undefined, 2)}</pre>
       {target && chars.length > 0 && (
         <Portal>
           <div

--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -56,6 +56,7 @@ const RichTextExample = () => {
           }
         }}
       />
+      <pre>{JSON.stringify(value, undefined, 2)}</pre>
     </Slate>
   )
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
This PR is adding a new _feature_, and is a work in progress. The code is still fairly scrappy, and should be reviewed as a proof-of-concept, which is why the PR is opened as a draft. In the future, if it moves forward, this PR should be broken down into smaller PRs.

I'm aware that there is currently [already an initiative in progress to bring Android support to Slate](https://github.com/ianstormtaylor/slate/issues/3786). Some of the code around text-diffing in this PR is based on that work.

The intent of the PR is to spark discussion in the hopes of helping to accelerate development of Android support for Slate, and move to developing the Android compatibility layer in the open so that it is open to community feedback.

#### What's the new behavior?

It introduces changes to support [different input reconciliation strategies that can be swapped out depending on the navigator and operating system.
](https://github.com/ianstormtaylor/slate/pull/4071/commits/0b42a32e8b7138d69cfb5885ba9449c3969815e5)
It also introduces a work in progress [Mutation Observer]() based [reconciliation layer to bring Android support to Slate](https://github.com/ianstormtaylor/slate/pull/4071/commits/ee42f5cc997998c8ebc04d940ad899fc501a05e1).

https://user-images.githubusercontent.com/1416436/107285339-fe26e800-6a2c-11eb-878b-eb67d91c44af.mp4

**Things that are currently working:**
- Distinguish between mutations that originate from user-input vs other mutations
- Update text (with some issues)
- Replace selection (with some issues)
- Delete selection
- Insert line break
- Delete backwards

**List of known issues (non-exhaustive):**
- Issues updating cursor position when inserting identical text (for example, inserting the letter `e` multiple times in the word `text` when the cursor is after `t`: `te|eext`)
- Copy/paste should not be tracked as user input by the MutationObserver layer, but currently is
- Need to ignore mutations that happen within void nodes (`contenteditable="false"`)
- Handle `readOnly` prop of editor
- Issues initially updating selection position on some Android devices
- Potentially need to batch observed mutations and flush manually, calling [`observer.takeRecords()`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/takeRecords) to process mutations that have not been processed by the callback yet

Feedback is welcome, and please report all issues so we can discuss them and find solutions. This PR is a rough first draft and there are likely many issues with it.
