### PR TITLE
Memoize Node.isNodeList and Editor.isEditor

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -273,6 +273,8 @@ export interface EditorInterface {
   withoutNormalizing: (editor: Editor, fn: () => void) => void
 }
 
+const IS_EDITOR_CACHE = new WeakMap<object, boolean>()
+
 export const Editor: EditorInterface = {
   /**
    * Get the ancestor above a location in the document.
@@ -550,8 +552,12 @@ export const Editor: EditorInterface = {
    */
 
   isEditor(value: any): value is Editor {
-    return (
-      isPlainObject(value) &&
+    if (!isPlainObject(value)) return false
+    const cachedIsEditor = IS_EDITOR_CACHE.get(value)
+    if (cachedIsEditor !== undefined) {
+      return cachedIsEditor
+    }
+    const isEditor =
       typeof value.addMark === 'function' &&
       typeof value.apply === 'function' &&
       typeof value.deleteBackward === 'function' &&
@@ -570,7 +576,8 @@ export const Editor: EditorInterface = {
       (value.selection === null || Range.isRange(value.selection)) &&
       Node.isNodeList(value.children) &&
       Operation.isOperationList(value.operations)
-    )
+    IS_EDITOR_CACHE.set(value, isEditor)
+    return isEditor
   },
 
   /**

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -87,6 +87,8 @@ export interface NodeInterface {
   ) => Generator<NodeEntry<Text>, void, undefined>
 }
 
+const IS_NODE_LIST_CACHE = new WeakMap<any[], boolean>()
+
 export const Node: NodeInterface = {
   /**
    * Get the node at a specific path, asserting that it's an ancestor node.
@@ -383,7 +385,16 @@ export const Node: NodeInterface = {
    */
 
   isNodeList(value: any): value is Node[] {
-    return Array.isArray(value) && value.every(val => Node.isNode(val))
+    if (!Array.isArray(value)) {
+      return false
+    }
+    const cachedResult = IS_NODE_LIST_CACHE.get(value)
+    if (cachedResult !== undefined) {
+      return cachedResult
+    }
+    const isNodeList = value.every(val => Node.isNode(val))
+    IS_NODE_LIST_CACHE.set(value, isNodeList)
+    return isNodeList
   },
 
   /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

It's fixing a performance problem.

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Becasue of #4061, any call to Editor.isEditor/Element.isElement or etc. on the editor instance or an element with lots of children causes that entire tree to be walked which can be quite expensive.

Here's typing on the rich text example with ~800 root level nodes before:
<img width="582" alt="Before Node.isNodeList memoization on rich text example" src="https://user-images.githubusercontent.com/11481355/107316244-fa09d180-6ae3-11eb-97f9-aeb404fe103d.png">

After:
<img width="595" alt="After Node.isNodeList memoization on rich text example" src="https://user-images.githubusercontent.com/11481355/107316247-fc6c2b80-6ae3-11eb-8110-171667d60f83.png">

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

It memoizes `Node.isNodeList` with a `WeakMap`. I'm happy to memoize `Element.isElement` and `Editor.isEditor` as well if people want that, I just did `Node.isNodeList` because it catches the bulk of the cost. It's worth mentioning that there's the potential for this to be wrong if a node list is a node list at one point and then it's mutated and it's no longer a node list, I feel like that's not a huge issue because these things shouldn't really be mutated but just wanted to raise it.

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
