### PR TITLE
Fix decorations not rendering because of memoization

### DIFF
--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -68,8 +68,34 @@ const MemoizedText = React.memo(Text, (prev, next) => {
     next.parent === prev.parent &&
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
-    next.text === prev.text
+    next.text === prev.text &&
+    isRangeListEqual(prev.decorations, next.decorations)
   )
 })
+
+/**
+ * Check if a list of ranges is equal to another.
+ *
+ * PERF: this requires the two lists to also have the ranges inside them in the
+ * same order, but this is an okay constraint for us since decorations are
+ * kept in order, and the odd case where they aren't is okay to re-render for.
+ */
+
+const isRangeListEqual = (list: Range[], another: Range[]): boolean => {
+  if (list.length !== another.length) {
+    return false
+  }
+
+  for (let i = 0; i < list.length; i++) {
+    const range = list[i]
+    const other = another[i]
+
+    if (!Range.equals(range, other)) {
+      return false
+    }
+  }
+
+  return true
+}
 
 export default MemoizedText

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -15,9 +15,11 @@
   ],
   "dependencies": {
     "@types/esrever": "^0.2.0",
+    "@types/lodash": "^4.14.149",
     "esrever": "^0.2.0",
     "immer": "^7.0.0",
     "is-plain-object": "^3.0.0",
+    "lodash": "^4.17.4",
     "tiny-warning": "^1.0.3"
   },
   "keywords": [

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -1,5 +1,7 @@
 import { produce } from 'immer'
 import isPlainObject from 'is-plain-object'
+import isEqual from 'lodash/isEqual'
+import omit from 'lodash/omit'
 import { ExtendedType, Operation, Path, Point, PointEntry } from '..'
 
 /**
@@ -77,7 +79,11 @@ export const Range: RangeInterface = {
   equals(range: Range, another: Range): boolean {
     return (
       Point.equals(range.anchor, another.anchor) &&
-      Point.equals(range.focus, another.focus)
+      Point.equals(range.focus, another.focus) &&
+      isEqual(
+        omit(range, ['anchor', 'focus']),
+        omit(another, ['anchor', 'focus'])
+      )
     )
   },
 

--- a/packages/slate/test/interfaces/Range/equals/equal.tsx
+++ b/packages/slate/test/interfaces/Range/equals/equal.tsx
@@ -10,6 +10,7 @@ export const input = {
       path: [0, 1],
       offset: 0,
     },
+    placeholder: 1,
   },
   another: {
     anchor: {
@@ -20,6 +21,7 @@ export const input = {
       path: [0, 1],
       offset: 0,
     },
+    placeholder: 1,
   },
 }
 export const test = ({ range, another }) => {

--- a/packages/slate/test/interfaces/Range/equals/not-equal.tsx
+++ b/packages/slate/test/interfaces/Range/equals/not-equal.tsx
@@ -10,6 +10,7 @@ export const input = {
       path: [0, 4],
       offset: 7,
     },
+    placeholder: 1,
   },
   another: {
     anchor: {
@@ -20,6 +21,7 @@ export const input = {
       path: [0, 1],
       offset: 0,
     },
+    placeholder: 0,
   },
 }
 export const test = ({ range, another }) => {

--- a/site/examples/plaintext.tsx
+++ b/site/examples/plaintext.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 import { Node, createEditor } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 import { withHistory } from 'slate-history'
@@ -6,18 +6,24 @@ import { withHistory } from 'slate-history'
 const PlainTextExample = () => {
   const [value, setValue] = useState<Node[]>(initialValue)
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const [placeholder, setPlaceholder] = useState(1)
+  const newPlaceholder = useCallback(() => setPlaceholder(p => p + 1), [])
+
   return (
-    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
-      <Editable placeholder="Enter some plain text..." />
-    </Slate>
+    <>
+      <button onClick={newPlaceholder}>New Placeholder</button>
+      <Slate editor={editor} value={value} onChange={setValue}>
+        <Editable placeholder={`${placeholder}`} />
+      </Slate>
+      <div>Actual placeholder value: {placeholder}</div>
+      <p>Placeholder will not update until you type something in the editor</p>
+    </>
   )
 }
 
 const initialValue = [
   {
-    children: [
-      { text: 'This is editable plain text, just like a <textarea>!' },
-    ],
+    children: [{ text: '' }],
   },
 ]
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

Fixes #3751

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

Repro of old issue: https://codesandbox.io/s/slate-3751-repro-xte8r

I've modified the plaintext example to demo the fix; we should probably revert/delete that commit (5a03575) before merging.

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

2 things were changed:

1. Copied `isRangeListEqual` from `element.tsx` into `text.tsx`. I'm not sure whether duplicating the code is a great idea, but it seems like `isRangeListEqual` is only meant to be used with arrays of decorations.
2. Changed `Range.equals` to do a deep equal of the remaining properties in the range object. A few potential issues with this:
    1. I'm not sure if we want `Range.equals` to care about other props, but functions like `intersection` forward props so there's at least some implicit support for additional props
    2. `Range.equals` is now a potentially expensive operation
    3. slate now has lodash as a dependency

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3751
