### PR TITLE
Making search-highlighting case insensitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "slate-react": "*",
     "source-map-loader": "^0.2.4",
     "typescript": "^3.7.2"
+  },
+  "dependencies": {
+    "react-pick-color": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8382,6 +8382,13 @@ react-is@16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-pick-color@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-pick-color/-/react-pick-color-1.0.1.tgz#bc19c2bf31eab1fbb6169d41f9917dafdcaa2871"
+  integrity sha512-f+25a8CTtzwfUWwFkFd/KhMVLSRSputbt8ih9jUdOU68p+2b6Jn51iNbQ0oXvU/5wgeaGuiolr2ihfXtqoF2WQ==
+  dependencies:
+    tinycolor2 "^1.4.1"
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -9913,6 +9920,11 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tinycolor2@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
+  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
**Description**
#4076  Makes Search Highlight Case insensitive. I've used case insensitive RegExp str.split() to achieve that. 

**Issue**
#4076 

**Example**
These are the search results before changes
![BeforeChanges](https://user-images.githubusercontent.com/59924327/108610010-33054880-73f8-11eb-90cd-9cd89e6893ec.png)

These are the search results after changes
![AfterChanges](https://user-images.githubusercontent.com/59924327/108610028-4dd7bd00-73f8-11eb-9e97-826829001bbc.png)

**Context**
I've modified text.split(search) method. I've made use of case insensitive RegExp. I've included additional checks to make sure the input string that begins or ends with '\' is handled as that was throwing errors due to how RegExps work.
**Checks**
- [ YES ] The new code matches the existing patterns and styles.
- [ YES ] The tests pass with `yarn test`.
- [ YES ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ YES ] The relevant examples still work. (Run examples with `yarn start`.)

