### PR TITLE
Proposal for Remove useCallback from walkthroughs documentation

### DIFF
--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -7,6 +7,15 @@ In this guide, we'll show you how to add custom formatting options, like **bold*
 So we start with our app from earlier:
 
 ```jsx
+function renderElement(props) {
+  switch (props.element.type) {
+    case 'code':
+      return <CodeElement {...props} />
+    default:
+      return <DefaultElement {...props} />
+  }
+})
+
 const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
   const [value, setValue] = useState([
@@ -15,15 +24,6 @@ const App = () => {
       children: [{ text: 'A line of text in a paragraph.' }],
     },
   ])
-
-  const renderElement = useCallback(props => {
-    switch (props.element.type) {
-      case 'code':
-        return <CodeElement {...props} />
-      default:
-        return <DefaultElement {...props} />
-    }
-  }, [])
 
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -7,7 +7,7 @@ In this guide, we'll show you how to add custom formatting options, like **bold*
 So we start with our app from earlier:
 
 ```jsx
-function renderElement(props) {
+const renderElement = (props) => {
   switch (props.element.type) {
     case 'code':
       return <CodeElement {...props} />


### PR DESCRIPTION
I have seen in the walkthrough the use of `useCallback` but I don't think are need it, and add a small complexity while understanding the concept, if we moved out the function outside of the component will be stable and will not require to maintain either referential identity or calculated complex logic. 

If people think this is a good idea I can go and update all documentation to remove unnecessary `useCallback` from the example.

unless I'm missing something.

**Description**
Improving documentation

**Issue**
Removing little complexity from the example.

**Example**
I don't think the use of useCallback is necessary on the examples for the walkthroughs 

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

