### PR TITLE
fix: fix 404 status of iframe example page

### DIFF
--- a/site/examples/iframe.tsx
+++ b/site/examples/iframe.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import isHotkey from 'is-hotkey'
 import { Editable, withReact, useSlate, Slate, ReactEditor } from 'slate-react'
-import { Editor, createEditor } from 'slate'
+import { Editor, createEditor, Node } from 'slate'
 import { withHistory } from 'slate-history'
 
 import { Button, Icon, Toolbar } from '../components'
@@ -15,7 +15,7 @@ const HOTKEYS = {
 }
 
 const IFrameExample = () => {
-  const [value, setValue] = useState(initialValue)
+  const [value, setValue] = useState<Node[]>(initialValue)
   const renderElement = useCallback(
     ({ attributes, children }) => <p {...attributes}>{children}</p>,
     []
@@ -42,7 +42,7 @@ const IFrameExample = () => {
           autoFocus
           onKeyDown={event => {
             for (const hotkey in HOTKEYS) {
-              if (isHotkey(hotkey, event)) {
+              if (isHotkey(hotkey, event as any)) {
                 event.preventDefault()
                 const mark = HOTKEYS[hotkey]
                 toggleMark(editor, mark)


### PR DESCRIPTION
**Description**

I found it 404 when I tried to access the iframe sample page

**Issue**
Fixes: none

**Example**

![Kapture 2021-02-23 at 15 34 58](https://user-images.githubusercontent.com/40483898/108813878-cbfcb500-75ec-11eb-9f99-da0a5e1f1374.gif)

**Context**

I rename the `site/examples/iframe.ts` to `site/examples/iframe.tsx`, and I fix some typescript error.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

