### PR TITLE
Fixed converting querySelectorAll results to array for Babel loose mode.

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -433,8 +433,12 @@ export const ReactEditor = {
         range.setEnd(nearestNode, nearestOffset)
         const contents = range.cloneContents()
         const removals = [
-          ...contents.querySelectorAll('[data-slate-zero-width]'),
-          ...contents.querySelectorAll('[contenteditable=false]'),
+          ...Array.prototype.slice.call(
+            contents.querySelectorAll('[data-slate-zero-width]')
+          ),
+          ...Array.prototype.slice.call(
+            contents.querySelectorAll('[contenteditable=false]')
+          ),
         ]
 
         removals.forEach(el => {


### PR DESCRIPTION

**Description**
Slate-react support of Babel loose mode.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4098

**Example**

https://user-images.githubusercontent.com/79687911/109308385-c4931100-7863-11eb-8252-c0433b3baf39.mp4

https://user-images.githubusercontent.com/79687911/109310679-ac70c100-7866-11eb-935c-ba665e21a40f.mp4

**Context**
After using Babel in ReactEditor from slate-react querySelectorAll does not actually return an array and concat just adds as one element instead of expanding everything. Babel convert original code:
`var removals = [...contents.querySelectorAll('[data-slate-zero-width]'), ...contents.querySelectorAll('[contenteditable=false]')];`
into
`var removals = [].concat(contents.querySelectorAll('[data-slate-zero-width]'), contents.querySelectorAll('[contenteditable=false]'));`
so as result `removals` has 2 items of NodeList. 

Solution is explicitly converting of NodeList to array before concat.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
