### PR TITLE
Add discord to the list of products that use slate

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -17,6 +17,7 @@ These products use Slate, and can give you an idea of what's possible:
 - [Chatterbug](https://chatterbug.com)
 - [Clause](https://clause.io)
 - [GitBook](https://www.gitbook.com/)
+- [Discord](https://discord.com/)
 - [Grafana](https://grafana.com/)
 - [GraphCMS](https://graphcms.com)
 - [Guilded](https://www.guilded.gg)


### PR DESCRIPTION
Discord uses slate

**Description**
Add Discord to the list of products

**Issue**
Discord uses slate and they are not on this list

**Example**

![image](https://user-images.githubusercontent.com/25142905/109401387-f663b080-7913-11eb-934b-4958c883b6f8.png)

**Checks**
- [ x ] The new code matches the existing patterns and styles.
- [ x ] The tests pass with `yarn test`.
- [ x ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ x ] The relevant examples still work. (Run examples with `yarn start`.)

