### PR TITLE
docs : Update duplicated toSlatePoint to toSlateRange

### DIFF
--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -122,7 +122,7 @@ Get the target range from a DOM `event`.
 
 Find a Slate point from a DOM selection's `domNode` and `domOffset`.
 
-###### `toSlatePoint(editor: ReactEditor, domPoint: DOMPoint)`
+###### `toSlateRange(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection)`
 
 Find a Slate range from a DOM range or selection.
 


### PR DESCRIPTION
**Description**
In docs `ReacEditor.toSlatePoint` has been written twice instead of `ReactEditor.toSlatePoint` and `ReactEditor.toSlateRange`. So I updated it

**Example**

Old docs

```md
###### `toSlatePoint(editor: ReactEditor, domPoint: DOMPoint)`
```

New docs

```md
###### `toSlateRange(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection)`
```
