### PR TITLE
fix: cut do not remove void element when only select void element

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -664,8 +664,15 @@ export const Editable = (props: EditableProps) => {
               ReactEditor.setFragmentData(editor, event.clipboardData)
               const { selection } = editor
 
-              if (selection && Range.isExpanded(selection)) {
-                Editor.deleteFragment(editor)
+              if (selection) {
+                if (Range.isExpanded(selection)) {
+                  Editor.deleteFragment(editor)
+                } else {
+                  const node = Node.parent(editor, selection.anchor.path)
+                  if (Editor.isVoid(editor, node)) {
+                    Transforms.delete(editor)
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
**Description**
cut do not remove void element when only select void element

**Issue**
Fixes:  no

**Example**

see context

**Context**

`onCut`  event only deleteFragment when Range.isExpanded and will do nothing when select only one void element.

this pr will remove void element when Range.isCollapsed and selection is in a void element

**Checks**
- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

there is no tests for `slate-react`
