### PR TITLE
Use children

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-core.md
+++ b/.github/ISSUE_TEMPLATE/bug-core.md
@@ -1,4 +1,5 @@
 ---
+
 name: "\U0001F6A8 Bug: Core"
 about: A bug that occurs in Slate's core logic, on all platforms
 title: ''

--- a/.github/ISSUE_TEMPLATE/bug-core.md
+++ b/.github/ISSUE_TEMPLATE/bug-core.md
@@ -4,10 +4,7 @@ about: A bug that occurs in Slate's core logic, on all platforms
 title: ''
 labels: bug
 assignees: ''
-
----
-
-**Description**
+---**Description**
 A clear and concise description of what the bug is.
 
 **Recording**
@@ -18,6 +15,7 @@ A link to a sandbox where the error can be reproduced. (You can start from the b
 
 **Steps**
 To reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,6 +25,7 @@ To reproduce the behavior:
 A clear and concise description of what you expected to happen. (Often it's helpful to test out the behavior of other editors like Google Docs, Medium, Notion, etc. to see how they handle the same issue.)
 
 **Environment**
+
 - Slate Version: [e.g. 0.59]
 - Operating System: [e.g. iOS]
 - Browser: [e.g. Chrome, Safari]

--- a/.github/ISSUE_TEMPLATE/bug-platform.md
+++ b/.github/ISSUE_TEMPLATE/bug-platform.md
@@ -1,4 +1,5 @@
 ---
+
 name: "\U0001F5A5 Bug: Platform"
 about: A bug that occurs in a specific browser or platform
 title: ''

--- a/.github/ISSUE_TEMPLATE/bug-platform.md
+++ b/.github/ISSUE_TEMPLATE/bug-platform.md
@@ -4,10 +4,7 @@ about: A bug that occurs in a specific browser or platform
 title: ''
 labels: bug, ⚑ cross platform
 assignees: ''
-
----
-
-**Description**
+---**Description**
 A clear and concise description of what the bug is.
 
 **Recording**
@@ -18,6 +15,7 @@ A link to a sandbox where the error can be reproduced. (You can start from the b
 
 **Steps**
 To reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,6 +25,7 @@ To reproduce the behavior:
 A clear and concise description of what you expected to happen. (Often it's helpful to test out the behavior of other editors like Google Docs, Medium, Notion, etc. to see how they handle the same issue.)
 
 **Environment**
+
 - Slate Version: [e.g. 0.59]
 - Operating System: [e.g. iOS]
 - Browser: [e.g. Chrome, Safari]

--- a/.github/ISSUE_TEMPLATE/request-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-feature.md
@@ -1,4 +1,5 @@
 ---
+
 name: "\U0001F4E6 Request: Feature"
 about: An idea or request for new functionality
 title: ''

--- a/.github/ISSUE_TEMPLATE/request-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-feature.md
@@ -4,10 +4,7 @@ about: An idea or request for new functionality
 title: ''
 labels: feature
 assignees: ''
-
----
-
-**Problem**
+---**Problem**
 A clear and concise description of what the problem is. (Eg. I'm always frustrated when [...])
 
 **Solution**

--- a/.github/ISSUE_TEMPLATE/request-improvement.md
+++ b/.github/ISSUE_TEMPLATE/request-improvement.md
@@ -1,4 +1,5 @@
 ---
+
 name: "\U0001F6E0 Request: Improvement"
 about: An improvement to existing functionality
 title: ''

--- a/.github/ISSUE_TEMPLATE/request-improvement.md
+++ b/.github/ISSUE_TEMPLATE/request-improvement.md
@@ -4,10 +4,7 @@ about: An improvement to existing functionality
 title: ''
 labels: improvement
 assignees: ''
-
----
-
-**Problem**
+---**Problem**
 A clear and concise description of what the problem is. (Eg. I'm always frustrated when [...])
 
 **Solution**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@ A GIF or video showing the old and new behaviors after this pull request is merg
 If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)
 
 **Checks**
+
 - [ ] The new code matches the existing patterns and styles.
 - [ ] The tests pass with `yarn test`.
 - [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
 - [ ] The relevant examples still work. (Run examples with `yarn start`.)
-

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -13,7 +13,7 @@ import { HistoryEditor } from 'slate-history'
 import throttle from 'lodash/throttle'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
-import Children from './children'
+import useChildren from '../hooks/use-children'
 import Hotkeys from '../utils/hotkeys'
 import {
   IS_FIREFOX,
@@ -986,14 +986,14 @@ export const Editable = (props: EditableProps) => {
           [readOnly, attributes.onPaste]
         )}
       >
-        <Children
-          decorate={decorate}
-          decorations={decorations}
-          node={editor}
-          renderElement={renderElement}
-          renderLeaf={renderLeaf}
-          selection={editor.selection}
-        />
+        {useChildren({
+          decorate,
+          decorations,
+          node: editor,
+          renderElement,
+          renderLeaf,
+          selection: editor.selection,
+        })}
       </Component>
     </ReadOnlyContext.Provider>
   )

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -3,7 +3,7 @@ import getDirection from 'direction'
 import { Editor, Node, Range, NodeEntry, Element as SlateElement } from 'slate'
 
 import Text from './text'
-import Children from './children'
+import useChildren from '../hooks/use-children'
 import { ReactEditor, useSlateStatic, useReadOnly } from '..'
 import { SelectedContext } from '../hooks/use-selected'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
@@ -42,16 +42,14 @@ const Element = (props: {
   const isInline = editor.isInline(element)
   const key = ReactEditor.findKey(editor, element)
 
-  let children: JSX.Element | null = (
-    <Children
-      decorate={decorate}
-      decorations={decorations}
-      node={element}
-      renderElement={renderElement}
-      renderLeaf={renderLeaf}
-      selection={selection}
-    />
-  )
+  let children: JSX.Element | null = useChildren({
+    decorate,
+    decorations,
+    node: element,
+    renderElement,
+    renderLeaf,
+    selection,
+  })
 
   // Attributes that the developer must mix into the element in their
   // custom node renderer component.

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 import { Editor, Range, Element, NodeEntry, Ancestor, Descendant } from 'slate'
 
-import ElementComponent from './element'
-import TextComponent from './text'
+import ElementComponent from '../components/element'
+import TextComponent from '../components/text'
 import { ReactEditor } from '..'
 import { useSlateStatic } from './use-slate-static'
 import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
-import { RenderElementProps, RenderLeafProps } from './editable'
+import { RenderElementProps, RenderLeafProps } from '../components/editable'
 
 /**
  * Children.
  */
 
-const Children = (props: {
+const useChildren = (props: {
   decorate: (entry: NodeEntry) => Range[]
   decorations: Range[]
   node: Ancestor
@@ -81,7 +81,7 @@ const Children = (props: {
     NODE_TO_PARENT.set(n, node)
   }
 
-  return <React.Fragment>{children}</React.Fragment>
+  return children
 }
 
-export default Children
+export default useChildren

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -4,7 +4,7 @@ import { Editor, Range, Element, NodeEntry, Ancestor, Descendant } from 'slate'
 import ElementComponent from './element'
 import TextComponent from './text'
 import { ReactEditor } from '..'
-import { useSlateStatic } from '../hooks/use-slate-static'
+import { useSlateStatic } from './use-slate-static'
 import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
 import { RenderElementProps, RenderLeafProps } from './editable'
 


### PR DESCRIPTION
**Description**
This is tiny change from `Children` component to `useChildren` hook. This is not breaking because `Children` was not public endpoint. This change allows traversing children with `React.Children`.

**Issue**
Fixes: #3966 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

(Other changes were performed by` yarn fix`, only relevant file changes are in `use-children.tsx`, `editable.tsx` and `element.tsx`.)