### PR TITLE
added support for deleting selection properties by setting them to null

### DIFF
--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -212,18 +212,32 @@ export const GeneralTransforms: GeneralTransforms = {
 
         if (newProperties == null) {
           selection = newProperties
-        } else if (selection == null) {
-          if (!Range.isRange(newProperties)) {
-            throw new Error(
-              `Cannot apply an incomplete "set_selection" operation properties ${JSON.stringify(
-                newProperties
-              )} when there is no current selection.`
-            )
+        } else {
+          if (selection == null) {
+            if (!Range.isRange(newProperties)) {
+              throw new Error(
+                `Cannot apply an incomplete "set_selection" operation properties ${JSON.stringify(
+                  newProperties
+                )} when there is no current selection.`
+              )
+            }
+
+            selection = { ...newProperties }
           }
 
-          selection = newProperties
-        } else {
-          Object.assign(selection, newProperties)
+          for (const key in newProperties) {
+            const value = newProperties[key]
+
+            if (value == null) {
+              if (key === 'anchor' || key === 'focus') {
+                throw new Error(`Cannot remove the "${key}" selection property`)
+              }
+
+              delete selection[key]
+            } else {
+              selection[key] = value
+            }
+          }
         }
 
         break

--- a/packages/slate/test/operations/set_selection/custom-props.tsx
+++ b/packages/slate/test/operations/set_selection/custom-props.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+import { Transforms, Editor } from 'slate'
+
+export const input = (
+  <editor>
+    <element>
+      a<cursor />
+    </element>
+  </editor>
+)
+
+export const operations = [
+  {
+    type: 'set_selection',
+    oldProperties: {},
+    newProperties: { custom: 123 },
+  },
+]
+
+export const output = (
+  <editor>
+    <element>
+      a<cursor />
+    </element>
+  </editor>
+)
+
+Transforms.setSelection(output, { custom: 123 })

--- a/packages/slate/test/operations/set_selection/remove.tsx
+++ b/packages/slate/test/operations/set_selection/remove.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+import { Transforms, Editor } from 'slate'
+
+export const input = (
+  <editor>
+    <element>
+      a<cursor />
+    </element>
+  </editor>
+)
+
+Transforms.setSelection(input, { custom: 123 })
+
+export const operations = [
+  {
+    type: 'set_selection',
+    oldProperties: {},
+    newProperties: { custom: null },
+  },
+]
+
+export const output = (
+  <editor>
+    <element>
+      a<cursor />
+    </element>
+  </editor>
+)


### PR DESCRIPTION
**Description**
This adds support for removing custom selection properties using `Transforms.setSelection` we use the editor.selection object to store implementation specific selection states. Without this change it's impossible to remove that state once it's set.

**Context**
This will update or delete the properties on editor.selection when the `set_selection` is applied instead of just adding. It also clones the newProperties if the current selection is null this is because immer will Object.freeze the original input selection range since that was set as a direct reference on the editor. It's written to be small not efficient so it does both delete/set in for loop even when it goes from null to selection but I think that transition is rare, it's far more common that new properties are being set on an existing selection.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

