### PR TITLE
[WIP] Made changes to unhangRange function

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -534,7 +534,8 @@ export const ReactEditor = {
     const focus = isCollapsed
       ? anchor
       : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset])
-
-    return { anchor, focus }
+      
+      let unhangedRange = Editor.unhangRange(editor, {anchor, focus})
+      return unhangedRange
   },
 }

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -1,4 +1,4 @@
-import { Editor, Node, Path, Point, Range, Transforms, Descendant } from 'slate'
+import { Editor, Node, Path, Point, Range, Transforms } from 'slate'
 
 import { Key } from '../utils/key'
 import {
@@ -534,8 +534,17 @@ export const ReactEditor = {
     const focus = isCollapsed
       ? anchor
       : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset])
-      
-      let unhangedRange = Editor.unhangRange(editor, {anchor, focus})
-      return unhangedRange
+
+    // return {anchor, focus}
+    const isReversed = Range.isBackward({ anchor, focus })
+    const unhangedRange = Editor.unhangRange(editor, { anchor, focus })
+    if (isReversed) {
+      const reversedRange = {
+        anchor: unhangedRange.focus,
+        focus: unhangedRange.anchor,
+      }
+      return reversedRange
+    }
+    return unhangedRange
   },
 }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1505,21 +1505,32 @@ export const Editor: EditorInterface = {
   ): Range {
     const { voids = false } = options
     let [start, end] = Range.edges(range)
+    const startPointAtEndOfNode = Editor.isEnd(editor, start, start.path);
+    const endPointAtStartOfNode = Editor.isStart(editor, end, end.path);
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if (start.offset !== 0 || end.offset !== 0 || Range.isCollapsed(range)) {
+    if (!(startPointAtEndOfNode || endPointAtStartOfNode) || Range.isCollapsed(range)) {
       return range
     }
 
+    const startBlock = Editor.above(editor, {
+      at: start,
+      match: n => Editor.isBlock(editor, n),
+    })
+    const startBlockPath = startBlock ? startBlock[1] : []
     const endBlock = Editor.above(editor, {
       at: end,
       match: n => Editor.isBlock(editor, n),
     })
-    const blockPath = endBlock ? endBlock[1] : []
+    const endBlockPath = endBlock ? endBlock[1] : []
     const first = Editor.start(editor, [])
+    const last = Editor.end(editor, [])
     const before = { anchor: first, focus: end }
-    let skip = true
+    const after = { anchor: start, focus: last }
 
+    //Unhang from the end if it lies at the start of a node (end.offset = 0) and move to the next text node.
+    let skip = true;
+    if(endPointAtStartOfNode)
     for (const [node, path] of Editor.nodes(editor, {
       at: before,
       match: Text.isText,
@@ -1530,9 +1541,26 @@ export const Editor: EditorInterface = {
         skip = false
         continue
       }
-
-      if (node.text !== '' || Path.isBefore(path, blockPath)) {
+      if (node.text !== '' || Path.isBefore(path, endBlockPath)) {
         end = { path, offset: node.text.length }
+        break
+      }
+    }
+    
+    //Unhang from the start if it lies on the end of a node (start.offset = startNode.length) and move to the next text node.
+    skip = true
+    if(startPointAtEndOfNode)
+    for (const [node, path] of Editor.nodes(editor, {
+      at: after,
+      match: Text.isText,
+      voids,
+    })) {
+      if (skip) {
+        skip = false
+        continue
+      }
+      if (node.text !== '' || Path.isAfter(path, startBlockPath)) {
+        start = { path, offset: 0 }
         break
       }
     }


### PR DESCRIPTION
**Description**
When a selection is made on browsers like Firefox which share its edges with edges of a node using double click, its range leaked onto the adjacent nodes as well like leaking to previous text node with offset equal to the length of node value or leaking to next node with offset=0.

**Issue**
This fixes the [issue #3923](https://github.com/ianstormtaylor/slate/issues/3923)

**Example**
Old behavior:
<img src="https://i.imgur.com/JVpMc3A.gif"></img>
New behavior:
<img src="https://i.imgur.com/05s0YA5.gif"></img>

**Context**
In the unhangRange function which is a part of editor interface, the old check used a condition ```(start.offset!=0)```
This did not check the particular condition when ```start.offset ===start.length``` i.e. the range leaks to the end of start node and doesn't actually hold any text/element of start node. This causes the range to not be identified in the first place and then when a property is set, it sets the property to the nodes where the range leaked as well (which were both adjacent nodes in above example).

To correct this, I first included the condition ```!(startPointAtEndOfNode || endPointAtStartOfNode)```, which says that we cannot confirm an un-hung range if the start point is at the end of the first node or the end point is at the start of a node.

Now the logic which was previously used for choosing the previous text node if in case it leaked from the end, I have implemented a similar one for the start.

Then I have just used this unhangRange function in ```toSlateRange``` as as well to clip the selection as soon as it is made in react.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

