### PR TITLE
Fix move_node caused full re-render.

### DIFF
--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -44,7 +44,12 @@ export const withReact = <T extends Editor>(editor: T) => {
       }
 
       case 'move_node': {
-        // TODO
+        for (const [node, path] of Editor.levels(e, {
+          at: Path.common(Path.parent(op.path), Path.parent(op.newPath)),
+        })) {
+          const key = ReactEditor.findKey(e, node)
+          matches.push([path, key])
+        }
         break
       }
     }


### PR DESCRIPTION
**Description**
when apply move_node operation, will trigger a fully re-render, because the parents' key is not restored. (There is a TODO comment in current code)

**Issue**
May Fixes: #3740 #3748

**Context**
This is a minimized fix, which does exactly same as those for insert_node/remove_node/merge_node/split_node, except we found the move_node common parents of source and target.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

