### PR TITLE
Fix deletion of hanging ranges with trailing void block

### DIFF
--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -101,7 +101,12 @@ export const TextTransforms: TextTransforms = {
       }
 
       if (!hanging) {
-        at = Editor.unhangRange(editor, at, { voids })
+        const [, end] = Range.edges(at)
+        const endOfDoc = Editor.end(editor, [])
+
+        if (!Point.equals(end, endOfDoc)) {
+          at = Editor.unhangRange(editor, at, { voids })
+        }
       }
 
       let [start, end] = Range.edges(at)

--- a/packages/slate/test/transforms/delete/selection/block-void-end-hanging.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-void-end-hanging.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.delete(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is a first paragraph
+    </block>
+    <block>This is the second paragraph</block>
+    <block void />
+    <block>
+      <focus />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/delete/selection/block-void-end.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-void-end.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.delete(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is a first paragraph
+    </block>
+    <block>This is the second paragraph</block>
+    <block void>
+      <focus />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
This PR fixes deletion of hanging ranges that have a trailing void node. 
It follows the recommended changes that were proposed in the review of this PR https://github.com/ianstormtaylor/slate/pull/3990 by @BrentFarese.

**Issue**
Fixes #4005, Fixes #4021, Fixes #3989

Related:  #3456

**Example**
Hanging ranges that end with a void block are not currently deleted properly.


_Before:_

https://user-images.githubusercontent.com/1416436/111383592-d0ae0980-867e-11eb-9cd1-b6b9dd521e27.mp4

https://user-images.githubusercontent.com/1416436/111384510-fa1b6500-867f-11eb-9981-2d26e6ea23d8.mp4


_After:_

https://user-images.githubusercontent.com/1416436/111383754-0e129700-867f-11eb-8bed-20eb574c3b8e.mp4

https://user-images.githubusercontent.com/1416436/111384517-fdaeec00-867f-11eb-838c-2ff2168857df.mp4



**Context**
Only unhang the range if the end of the range doesn't match the end of the document.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

