### PR TITLE
Rename data-slate-editor to not interfere with data-gramm

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -491,7 +491,7 @@ export const Editable = (props: EditableProps) => {
         autoCapitalize={
           !HAS_BEFORE_INPUT_SUPPORT ? undefined : attributes.autoCapitalize
         }
-        data-slate-editor
+        data-slate-react-editor
         data-slate-node="value"
         contentEditable={readOnly ? undefined : true}
         suppressContentEditableWarning

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -190,7 +190,7 @@ export const ReactEditor = {
     }
 
     return (
-      targetEl.closest(`[data-slate-editor]`) === editorEl &&
+      targetEl.closest(`[data-slate-react-editor]`) === editorEl &&
       (!editable ||
         targetEl.isContentEditable ||
         !!targetEl.getAttribute('data-slate-zero-width'))

--- a/site/public/index.css
+++ b/site/public/index.css
@@ -75,6 +75,6 @@ iframe {
   border: 1px solid #eee;
 }
 
-[data-slate-editor] > * + * {
+[data-slate-react-editor] > * + * {
   margin-top: 1em;
 }


### PR DESCRIPTION
Rename data-slate-editor to data-slate-react-editor because it inteferes with the data-gramm attribute which should disable the Grammarly extension

**Description**
When the Grammarly extension is installed, it does not get disabled even if `data-gramm` is set to `false`.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4124

**Example**

Default:
<img width="660" alt="Screen Shot 2021-03-16 at 2 55 30 PM" src="https://user-images.githubusercontent.com/558200/111385262-c03e6480-8667-11eb-892e-bca001f48ea3.png">

When `data-gramm={undefined}`:
<img width="661" alt="Screen Shot 2021-03-16 at 2 55 07 PM" src="https://user-images.githubusercontent.com/558200/111385265-c16f9180-8667-11eb-8d74-6f2ef55f05d2.png">

**Context**
The issue stems from `data-slate-editor` which seems to interfere with Grammarly's logic to determine whether the extension is enabled or disabled for an editor.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

