### PR TITLE
Fix Underline <FormatButton /> in `Hovering Toolbar Example`

### DIFF
--- a/site/examples/hovering-toolbar.tsx
+++ b/site/examples/hovering-toolbar.tsx
@@ -126,7 +126,7 @@ const HoveringToolbar = () => {
       >
         <FormatButton format="bold" icon="format_bold" />
         <FormatButton format="italic" icon="format_italic" />
-        <FormatButton format="underlined" icon="format_underlined" />
+        <FormatButton format="underline" icon="format_underlined" />
       </Menu>
     </Portal>
   )

--- a/site/examples/hovering-toolbar.tsx
+++ b/site/examples/hovering-toolbar.tsx
@@ -33,7 +33,7 @@ const HoveringMenuExample = () => {
             case 'formatItalic':
               return toggleFormat(editor, 'italic')
             case 'formatUnderline':
-              return toggleFormat(editor, 'underline')
+              return toggleFormat(editor, 'underlined')
           }
         }}
       />
@@ -126,7 +126,7 @@ const HoveringToolbar = () => {
       >
         <FormatButton format="bold" icon="format_bold" />
         <FormatButton format="italic" icon="format_italic" />
-        <FormatButton format="underline" icon="format_underlined" />
+        <FormatButton format="underlined" icon="format_underlined" />
       </Menu>
     </Portal>
   )


### PR DESCRIPTION
**Description**
I ran the example code and the underline button in `Hovering Toolbar Example` did not work.

**To reproduce**
* Run the example code for `Hovering Toolbar Example`
* Highlight text
* Click the "Underline" format button

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

