### PR TITLE
Make onDomSelectionChange triggered after onClick.

### DIFF
--- a/.changeset/cold-beans-give.md
+++ b/.changeset/cold-beans-give.md
@@ -1,6 +1,6 @@
 ---
-"slate-react": patch
-"slate": patch
+'slate-react': patch
+'slate': patch
 ---
 
 Make onDomSelectionChange trigger after onClick.

--- a/.changeset/cold-beans-give.md
+++ b/.changeset/cold-beans-give.md
@@ -1,0 +1,6 @@
+---
+"slate-react": patch
+"slate": patch
+---
+
+Make onDomSelectionChange trigger after onClick.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -511,6 +511,11 @@ export const Editable = (props: EditableProps) => {
     [readOnly]
   )
 
+  const scheduleOnDOMSelectionChange = useCallback(
+    () => setTimeout(onDOMSelectionChange),
+    [onDOMSelectionChange]
+  )
+
   // Attach a native DOM event handler for `selectionchange`, because React's
   // built-in `onSelect` handler doesn't fire for all selection changes. It's a
   // leaky polyfill that only fires on keypresses or clicks. Instead, we want to
@@ -518,15 +523,18 @@ export const Editable = (props: EditableProps) => {
   // https://github.com/facebook/react/issues/5785
   useIsomorphicLayoutEffect(() => {
     const window = ReactEditor.getWindow(editor)
-    window.document.addEventListener('selectionchange', onDOMSelectionChange)
+    window.document.addEventListener(
+      'selectionchange',
+      scheduleOnDOMSelectionChange
+    )
 
     return () => {
       window.document.removeEventListener(
         'selectionchange',
-        onDOMSelectionChange
+        scheduleOnDOMSelectionChange
       )
     }
-  }, [onDOMSelectionChange])
+  }, [scheduleOnDOMSelectionChange])
 
   const decorations = decorate([editor, []])
 


### PR DESCRIPTION
**Description**
onDomSelectionChange is called before the same click event triggered and processed, which may cause another round (if some element check useSelected and then render or by css/class name display differently) rerender which may change the dom and then cause the click event got unexpected event.target.

**Issue**
Fixes:

**Example**
No simple example, but if we do not delay onDomSelectionChange process, it will make the onClick event not reliable and got wrong event target and unexpected result.

**Context**
since the onDomSelectionChange does throttle with 100ms, and which is not time critical, but onClick is. So we first make sure onClick get correct event, then as throttled delay 100ms to check the dom selection change, which is harmless.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.) (Original code does not pass this, so leave it as it was)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

