### PR TITLE
Enable Extending `Editor` types in TypeScript

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.60.9",
+  "version": "0.60.10",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.60.7",
+  "version": "0.60.8",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.60.8",
+  "version": "0.60.9",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.60.8",
+  "version": "0.60.9",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -18,8 +18,8 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.60.8",
-    "slate-hyperscript": "^0.60.8"
+    "slate": "^0.60.9",
+    "slate-hyperscript": "^0.60.9"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.60.9",
+  "version": "0.60.10",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.60.7",
+  "version": "0.60.8",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -18,8 +18,8 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.60.7",
-    "slate-hyperscript": "^0.60.7"
+    "slate": "^0.60.8",
+    "slate-hyperscript": "^0.60.8"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -1,4 +1,4 @@
-import { Editor } from 'slate'
+import { BaseEditor, Editor } from 'slate'
 import { History } from './history'
 
 /**
@@ -13,7 +13,7 @@ export const MERGING = new WeakMap<Editor, boolean | undefined>()
  * `HistoryEditor` contains helpers for history-enabled editors.
  */
 
-export interface HistoryEditor extends Editor {
+export interface HistoryEditor extends BaseEditor {
   history: History
   undo: () => void
   redo: () => void

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -13,7 +13,7 @@ export const MERGING = new WeakMap<Editor, boolean | undefined>()
  * `HistoryEditor` contains helpers for history-enabled editors.
  */
 
-export type HistoryEditor = Editor & {
+export interface HistoryEditor extends Editor {
   history: History
   undo: () => void
   redo: () => void

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-hyperscript",
   "description": "A hyperscript helper for creating Slate documents.",
-  "version": "0.60.8",
+  "version": "0.60.9",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.60.8"
+    "slate": "^0.60.9"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-hyperscript",
   "description": "A hyperscript helper for creating Slate documents.",
-  "version": "0.60.7",
+  "version": "0.60.8",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.60.7"
+    "slate": "^0.60.8"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.60.8",
+  "version": "0.60.9",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -23,9 +23,9 @@
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "devDependencies": {
-    "slate": "^0.60.8",
-    "slate-history": "^0.60.8",
-    "slate-hyperscript": "^0.60.8"
+    "slate": "^0.60.9",
+    "slate-history": "^0.60.9",
+    "slate-hyperscript": "^0.60.9"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.60.7",
+  "version": "0.60.8",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -23,9 +23,9 @@
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "devDependencies": {
-    "slate": "^0.60.7",
-    "slate-history": "^0.60.7",
-    "slate-hyperscript": "^0.60.7"
+    "slate": "^0.60.8",
+    "slate-history": "^0.60.8",
+    "slate-hyperscript": "^0.60.8"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.60.9",
+  "version": "0.60.10",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "slate": "^0.60.9",
-    "slate-history": "^0.60.9",
+    "slate-history": "^0.60.10",
     "slate-hyperscript": "^0.60.9"
   },
   "peerDependencies": {

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -1,4 +1,4 @@
-import { Editor, Node, Path, Point, Range, Transforms, Descendant } from 'slate'
+import { Editor, Node, Path, Point, Range, Transforms, BaseEditor } from 'slate'
 
 import { Key } from '../utils/key'
 import {
@@ -28,7 +28,7 @@ import {
  * A React and DOM-specific version of the `Editor` interface.
  */
 
-export interface ReactEditor extends Editor {
+export interface ReactEditor extends BaseEditor {
   insertData: (data: DataTransfer) => void
   setFragmentData: (data: DataTransfer) => void
 }

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.60.8",
+  "version": "0.60.9",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.60.7",
+  "version": "0.60.8",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",


### PR DESCRIPTION
**Description**
Extending `Editor` did not work properly because of issues with `ReactEditor` and `HistoryEditor`.

There were two primary issues:

1. `HistoryEditor` was a type and not an interface which was inconsistent with `ReactEditor`. This was problematic in itself because there should not be two different ways to extend the editor with these plugins.
2. `ReactEditor` and `HistoryEditor` extended `Editor` which caused a circular reference which would cause them to become `any`. This was fixed by having then extend `BaseEditor` instead.

**Issue**
No issue submitted but is related to getting TypeScript working

**Example**
Since it's types, there are no examples.

**Context**
Unfortunately, TypeScript can be unpredictable, especially through published NPM packages, so the solution involved trial and error which involved publishing `@experimental` releases through NPM and trying them against a code base.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

