### PR TITLE
Allow useSlate and useSlateStatic to use a generic to return a Custom Editor

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.60.11",
+  "version": "0.60.12",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.60.13",
+  "version": "0.60.14",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.60.12",
+  "version": "0.60.13",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.60.11",
+  "version": "0.60.12",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.60.12",
+  "version": "0.60.13",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.60.13",
+  "version": "0.60.14",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/src/custom-types.ts
+++ b/packages/slate-react/src/custom-types.ts
@@ -1,12 +1,14 @@
 import { BaseRange, BaseText } from 'slate'
+import { ReactEditor } from './plugin/react-editor'
 
 declare module 'slate' {
   interface CustomTypes {
-    Text: {
+    Editor: ReactEditor
+    Text: BaseText & {
       placeholder: string
-    } & BaseText
-    Range: {
+    }
+    Range: BaseRange & {
       placeholder?: string
-    } & BaseRange
+    }
   }
 }

--- a/packages/slate-react/src/hooks/use-slate-static.tsx
+++ b/packages/slate-react/src/hooks/use-slate-static.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react'
 import { ReactEditor } from '../plugin/react-editor'
+import { Editor } from 'slate'
 
 /**
  * A React context for sharing the editor object.
@@ -11,8 +12,8 @@ export const EditorContext = createContext<ReactEditor | null>(null)
  * Get the current editor object from the React context.
  */
 
-export const useSlateStatic = <T extends ReactEditor>() => {
-  const editor = useContext(EditorContext) as T | null
+export const useSlateStatic = (): Editor => {
+  const editor = useContext(EditorContext)
 
   if (!editor) {
     throw new Error(

--- a/packages/slate-react/src/hooks/use-slate-static.tsx
+++ b/packages/slate-react/src/hooks/use-slate-static.tsx
@@ -1,12 +1,11 @@
 import { createContext, useContext } from 'react'
-
-import { ReactEditor } from '../plugin/react-editor'
+import { Editor } from 'slate'
 
 /**
  * A React context for sharing the editor object.
  */
 
-export const EditorContext = createContext<ReactEditor | null>(null)
+export const EditorContext = createContext<Editor | null>(null)
 
 /**
  * Get the current editor object from the React context.

--- a/packages/slate-react/src/hooks/use-slate-static.tsx
+++ b/packages/slate-react/src/hooks/use-slate-static.tsx
@@ -1,18 +1,18 @@
 import { createContext, useContext } from 'react'
-import { Editor } from 'slate'
+import { ReactEditor } from '../plugin/react-editor'
 
 /**
  * A React context for sharing the editor object.
  */
 
-export const EditorContext = createContext<Editor | null>(null)
+export const EditorContext = createContext<ReactEditor | null>(null)
 
 /**
  * Get the current editor object from the React context.
  */
 
-export const useSlateStatic = () => {
-  const editor = useContext(EditorContext)
+export const useSlateStatic = <T extends ReactEditor>() => {
+  const editor = useContext(EditorContext) as T | null
 
   if (!editor) {
     throw new Error(

--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -1,19 +1,19 @@
 import { createContext, useContext } from 'react'
-import { Editor } from 'slate'
+import { ReactEditor } from '../plugin/react-editor'
 
 /**
  * A React context for sharing the editor object, in a way that re-renders the
  * context whenever changes occur.
  */
 
-export const SlateContext = createContext<[Editor] | null>(null)
+export const SlateContext = createContext<[ReactEditor] | null>(null)
 
 /**
  * Get the current editor object from the React context.
  */
 
-export const useSlate = () => {
-  const context = useContext(SlateContext)
+export const useSlate = <T extends ReactEditor>() => {
+  const context = useContext(SlateContext) as [T] | null
 
   if (!context) {
     throw new Error(

--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -1,13 +1,12 @@
 import { createContext, useContext } from 'react'
-
-import { ReactEditor } from '../plugin/react-editor'
+import { Editor } from 'slate'
 
 /**
  * A React context for sharing the editor object, in a way that re-renders the
  * context whenever changes occur.
  */
 
-export const SlateContext = createContext<[ReactEditor] | null>(null)
+export const SlateContext = createContext<[Editor] | null>(null)
 
 /**
  * Get the current editor object from the React context.

--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react'
+import { Editor } from 'slate'
 import { ReactEditor } from '../plugin/react-editor'
 
 /**
@@ -12,8 +13,8 @@ export const SlateContext = createContext<[ReactEditor] | null>(null)
  * Get the current editor object from the React context.
  */
 
-export const useSlate = <T extends ReactEditor>() => {
-  const context = useContext(SlateContext) as [T] | null
+export const useSlate = (): Editor => {
+  const context = useContext(SlateContext)
 
   if (!context) {
     throw new Error(

--- a/site/examples/custom-types.d.ts
+++ b/site/examples/custom-types.d.ts
@@ -1,4 +1,14 @@
-import { Text, createEditor, Node, Element, Editor, Descendant } from 'slate'
+import {
+  Text,
+  createEditor,
+  Node,
+  Element,
+  Editor,
+  Descendant,
+  BaseEditor,
+} from 'slate'
+import { ReactEditor } from 'slate-react'
+import { HistoryEditor } from 'slate-history'
 
 export type BlockQuoteElement = { type: 'block-quote'; children: Descendant[] }
 
@@ -79,8 +89,11 @@ export type EmptyText = {
   text: string
 }
 
+export type CustomEditor = BaseEditor & ReactEditor & HistoryEditor
+
 declare module 'slate' {
   interface CustomTypes {
+    Editor: CustomEditor
     Element: CustomElement
     Text: CustomText | EmptyText
   }


### PR DESCRIPTION
**Description**
`useSlate` and `useSlateStatic` returns `ReactEditor` but we need it to return the custom `Editor`

**Issue**
n/a

**Example**
n/a

**Context**
Tried to do this by having `useSlate` and `useSlateStatic` to return the `Editor` type from `slate`; however, TypeScript seems to do an optimization which replaced `Editor` with `ReactEditor` during the build. So the workaround for now is to set it up as a generic.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

