### PR TITLE
Fix text not rerender by decorations change

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Element, Text } from 'slate'
+import isEqual from 'lodash/isEqual'
 import String from './string'
 import { PLACEHOLDER_SYMBOL } from '../utils/weak-maps'
 import { RenderLeafProps } from './editable'
@@ -70,7 +71,7 @@ const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
     next.text === prev.text &&
-    Text.matches(next.leaf, prev.leaf)
+    isEqual(next.leaf, prev.leaf)
   )
 })
 

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react'
 import { Range, Element, Text as SlateText } from 'slate'
+import isEqual from 'lodash/isEqual'
 
 import Leaf from './leaf'
 import { ReactEditor, useSlateStatic } from '..'
@@ -68,8 +69,34 @@ const MemoizedText = React.memo(Text, (prev, next) => {
     next.parent === prev.parent &&
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
-    next.text === prev.text
+    next.text === prev.text &&
+    isRangeListEqual(prev.decorations, next.decorations)
   )
 })
+
+/**
+ * Check if a list of ranges is equal to another.
+ *
+ * PERF: this requires the two lists to also have the ranges inside them in the
+ * same order, but this is an okay constraint for us since decorations are
+ * kept in order, and the odd case where they aren't is okay to re-render for.
+ */
+
+const isRangeListEqual = (list: Range[], another: Range[]): boolean => {
+  if (list.length !== another.length) {
+    return false
+  }
+
+  for (let i = 0; i < list.length; i++) {
+    const range = list[i]
+    const other = another[i]
+
+    if (!isEqual(range, other)) {
+      return false
+    }
+  }
+
+  return true
+}
 
 export default MemoizedText


### PR DESCRIPTION
**Description**
like #4080 tried to fixed, the decorations change does not trigger Text node re-render (because of memo compare not consider decorations).
This PR fix it just straightforward, do lodash isEqual compare between decorations items.

After fix this, I found it still does not work, due to the other bug from Leaf memo, which compare leaf without compare the text field, but, with slate-collaborative as example, we use decorate to render remote caret, when user click the other place of same text but different position, the memo of Leaf does not re-render the updated Leaf (with text updated), because Text.matches does not compare text field, while the text prop transferred to Leaf is the common 'text value' before splitted by the caret (decorate) which does not change.

**Issue**
Fixes: #3751 #3447

**Example**
To make the remote caret (decorations) work, slate-collaborative have to update renderLeaf method each time when any decoration changes, which caused many unnecessary re-render. With this PR, only the updated (effected) text and leaf will be re-rendered.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

