### PR TITLE
Bugfix/set node

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-core.md
+++ b/.github/ISSUE_TEMPLATE/bug-core.md
@@ -1,13 +1,11 @@
 ---
+
 name: "\U0001F6A8 Bug: Core"
 about: A bug that occurs in Slate's core logic, on all platforms
 title: ''
 labels: bug
 assignees: ''
-
----
-
-**Description**
+---**Description**
 A clear and concise description of what the bug is.
 
 **Recording**
@@ -18,6 +16,7 @@ A link to a sandbox where the error can be reproduced. (You can start from the b
 
 **Steps**
 To reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,6 +26,7 @@ To reproduce the behavior:
 A clear and concise description of what you expected to happen. (Often it's helpful to test out the behavior of other editors like Google Docs, Medium, Notion, etc. to see how they handle the same issue.)
 
 **Environment**
+
 - Slate Version: [e.g. 0.59]
 - Operating System: [e.g. iOS]
 - Browser: [e.g. Chrome, Safari]

--- a/.github/ISSUE_TEMPLATE/bug-platform.md
+++ b/.github/ISSUE_TEMPLATE/bug-platform.md
@@ -1,13 +1,11 @@
 ---
+
 name: "\U0001F5A5 Bug: Platform"
 about: A bug that occurs in a specific browser or platform
 title: ''
 labels: bug, ⚑ cross platform
 assignees: ''
-
----
-
-**Description**
+---**Description**
 A clear and concise description of what the bug is.
 
 **Recording**
@@ -18,6 +16,7 @@ A link to a sandbox where the error can be reproduced. (You can start from the b
 
 **Steps**
 To reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,6 +26,7 @@ To reproduce the behavior:
 A clear and concise description of what you expected to happen. (Often it's helpful to test out the behavior of other editors like Google Docs, Medium, Notion, etc. to see how they handle the same issue.)
 
 **Environment**
+
 - Slate Version: [e.g. 0.59]
 - Operating System: [e.g. iOS]
 - Browser: [e.g. Chrome, Safari]

--- a/.github/ISSUE_TEMPLATE/request-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-feature.md
@@ -1,13 +1,11 @@
 ---
+
 name: "\U0001F4E6 Request: Feature"
 about: An idea or request for new functionality
 title: ''
 labels: feature
 assignees: ''
-
----
-
-**Problem**
+---**Problem**
 A clear and concise description of what the problem is. (Eg. I'm always frustrated when [...])
 
 **Solution**

--- a/.github/ISSUE_TEMPLATE/request-improvement.md
+++ b/.github/ISSUE_TEMPLATE/request-improvement.md
@@ -1,13 +1,11 @@
 ---
+
 name: "\U0001F6E0 Request: Improvement"
 about: An improvement to existing functionality
 title: ''
 labels: improvement
 assignees: ''
-
----
-
-**Problem**
+---**Problem**
 A clear and concise description of what the problem is. (Eg. I'm always frustrated when [...])
 
 **Solution**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,8 @@ A GIF or video showing the old and new behaviors after this pull request is merg
 If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)
 
 **Checks**
+
 - [ ] The new code matches the existing patterns and styles.
 - [ ] The tests pass with `yarn test`.
 - [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
 - [ ] The relevant examples still work. (Run examples with `yarn start`.)
-- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.61.2 (2021-03-30)
+
+**Note:** Version bump only for package slate-packages
+
+## 0.61.1 (2021-03-29)
+
+**Note:** Version bump only for package slate-packages

--- a/package.json
+++ b/package.json
@@ -70,12 +70,8 @@
     "is-hotkey": "^0.1.6",
     "is-url": "^1.2.2",
     "lerna": "^3.19.0",
-<<<<<<< HEAD
     "lint-staged": ">=10",
-    "lodash": "^4.17.4",
-=======
     "lodash": "^4.17.21",
->>>>>>> 489669a4 (Fix linting issues)
     "mocha": "^6.2.0",
     "next": "^9.4.0",
     "npm-run-all": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,12 @@
     "is-hotkey": "^0.1.6",
     "is-url": "^1.2.2",
     "lerna": "^3.19.0",
+<<<<<<< HEAD
     "lint-staged": ">=10",
     "lodash": "^4.17.4",
+=======
+    "lodash": "^4.17.21",
+>>>>>>> 489669a4 (Fix linting issues)
     "mocha": "^6.2.0",
     "next": "^9.4.0",
     "npm-run-all": "^4.1.2",

--- a/packages/slate-history/CHANGELOG.md
+++ b/packages/slate-history/CHANGELOG.md
@@ -6,6 +6,6 @@
 
 - [#4154](https://github.com/ianstormtaylor/slate/pull/4154) [`7283c51f`](https://github.com/ianstormtaylor/slate/commit/7283c51feb83cb8522bc16efce09bb01c29400b9) Thanks [@ianstormtaylor](https://github.com/ianstormtaylor)! - **Start using [🦋 Changesets](https://github.com/atlassian/changesets) to manage releases.** Going forward, whenever a pull request is made that fixes or adds functionality to Slate, it will need to be accompanied by a changset Markdown file describing the change. These files will be automatically used in the release process when bump the versions of Slate and compiling the changelog.
 
-### Patch Changes
+## 0.61.1 (2021-03-29)
 
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) Thanks [@ianstormtaylor](https://github.com/ianstormtaylor)! - Fixed history logic to not store focus and blur selection changes in the history.
+**Note:** Version bump only for package slate-history

--- a/packages/slate-hyperscript/CHANGELOG.md
+++ b/packages/slate-hyperscript/CHANGELOG.md
@@ -4,4 +4,8 @@
 
 ### Minor Changes
 
-- [#4154](https://github.com/ianstormtaylor/slate/pull/4154) [`7283c51f`](https://github.com/ianstormtaylor/slate/commit/7283c51feb83cb8522bc16efce09bb01c29400b9) Thanks [@ianstormtaylor](https://github.com/ianstormtaylor)! - **Start using [🦋 Changesets](https://github.com/atlassian/changesets) to manage releases.** Going forward, whenever a pull request is made that fixes or adds functionality to Slate, it will need to be accompanied by a changset Markdown file describing the change. These files will be automatically used in the release process when bump the versions of Slate and compiling the changelog.
+**Note:** Version bump only for package slate-hyperscript
+
+## 0.61.1 (2021-03-29)
+
+**Note:** Version bump only for package slate-hyperscript

--- a/packages/slate-react/CHANGELOG.md
+++ b/packages/slate-react/CHANGELOG.md
@@ -8,42 +8,42 @@
 
 ## 0.61.1 (2021-03-29)
 
-* [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Updated placeholder styles to allow for wrapping long placeholder text.
+- [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Updated placeholder styles to allow for wrapping long placeholder text.
 
-- [#3698](https://github.com/ianstormtaylor/slate/pull/3698) [`bf83f333`](https://github.com/ianstormtaylor/slate/commit/bf83f333e689bc17b96504b497bb7fcdf6dc7fc1) Thanks [@pubuzhixing8](https://github.com/pubuzhixing8)! - Fixed selection updating with IME inputs in browsers that support `beforeinput`.
+* [#3698](https://github.com/ianstormtaylor/slate/pull/3698) [`bf83f333`](https://github.com/ianstormtaylor/slate/commit/bf83f333e689bc17b96504b497bb7fcdf6dc7fc1) Thanks [@pubuzhixing8](https://github.com/pubuzhixing8)! - Fixed selection updating with IME inputs in browsers that support `beforeinput`.
 
-* [#3652](https://github.com/ianstormtaylor/slate/pull/3652) [`f3fb40cc`](https://github.com/ianstormtaylor/slate/commit/f3fb40cce044b73b6da13013f90bd7018f2f5d8a) Thanks [@Andarist](https://github.com/Andarist)! - Fixed selection logic when a controlled editor's nodes change out from under it.
+- [#3652](https://github.com/ianstormtaylor/slate/pull/3652) [`f3fb40cc`](https://github.com/ianstormtaylor/slate/commit/f3fb40cce044b73b6da13013f90bd7018f2f5d8a) Thanks [@Andarist](https://github.com/Andarist)! - Fixed selection logic when a controlled editor's nodes change out from under it.
 
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug where memoization logic would prevent placeholders from re-rendering properly.
+* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug where memoization logic would prevent placeholders from re-rendering properly.
 
-* [#3326](https://github.com/ianstormtaylor/slate/pull/3326) [`d5b2d7f5`](https://github.com/ianstormtaylor/slate/commit/d5b2d7f55e2982019b246fdea1e9eb845d0e2fc2) Thanks [@rockettomatooo](https://github.com/rockettomatooo)! - Added invariants when passing invalud `value` or `editor` props to `<Editable>`.
+- [#3326](https://github.com/ianstormtaylor/slate/pull/3326) [`d5b2d7f5`](https://github.com/ianstormtaylor/slate/commit/d5b2d7f55e2982019b246fdea1e9eb845d0e2fc2) Thanks [@rockettomatooo](https://github.com/rockettomatooo)! - Added invariants when passing invalud `value` or `editor` props to `<Editable>`.
 
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed cursor movement in RTL text.
+* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed cursor movement in RTL text.
 
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug in the conversion of DOM points to Slate points.
+- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug in the conversion of DOM points to Slate points.
 
-- [#3746](https://github.com/ianstormtaylor/slate/pull/3746) [`f8be509e`](https://github.com/ianstormtaylor/slate/commit/f8be509e4d0b5c13bb791e0fd5702242319d114f) Thanks [@gztomas](https://github.com/gztomas)! - Fixed auto-scrolling behavior when a block is bigger than the viewport.
+* [#3746](https://github.com/ianstormtaylor/slate/pull/3746) [`f8be509e`](https://github.com/ianstormtaylor/slate/commit/f8be509e4d0b5c13bb791e0fd5702242319d114f) Thanks [@gztomas](https://github.com/gztomas)! - Fixed auto-scrolling behavior when a block is bigger than the viewport.
 
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug that occurred when using Babel's `loose` mode.
+- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug that occurred when using Babel's `loose` mode.
 
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed deleting void elements when using cut-and-paste.
+* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed deleting void elements when using cut-and-paste.
 
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug that crashed the editor when using IME input.
+- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug that crashed the editor when using IME input.
 
-- [#3396](https://github.com/ianstormtaylor/slate/pull/3396) [`469e6b26`](https://github.com/ianstormtaylor/slate/commit/469e6b26f50857ef0d68cdf5a54793f8fe9033fd) Thanks [@cvlmtg](https://github.com/cvlmtg)! - Fixed allowing the `onPaste` handler to be overridden in all browsers.
+* [#3396](https://github.com/ianstormtaylor/slate/pull/3396) [`469e6b26`](https://github.com/ianstormtaylor/slate/commit/469e6b26f50857ef0d68cdf5a54793f8fe9033fd) Thanks [@cvlmtg](https://github.com/cvlmtg)! - Fixed allowing the `onPaste` handler to be overridden in all browsers.
 
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed internal decoration logic to be faster and require fewer re-renders.
+- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed internal decoration logic to be faster and require fewer re-renders.
 
-- [#3894](https://github.com/ianstormtaylor/slate/pull/3894) [`7fe41f15`](https://github.com/ianstormtaylor/slate/commit/7fe41f156614453479cb9ea649fe5665b616d3a7) Thanks [@msc117](https://github.com/msc117)! - Fixed an error that happened when selecting void nodes in a read-only editor.
+* [#3894](https://github.com/ianstormtaylor/slate/pull/3894) [`7fe41f15`](https://github.com/ianstormtaylor/slate/commit/7fe41f156614453479cb9ea649fe5665b616d3a7) Thanks [@msc117](https://github.com/msc117)! - Fixed an error that happened when selecting void nodes in a read-only editor.
 
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed `move_node` operations to not always require a full re-render.
+- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed `move_node` operations to not always require a full re-render.
 
-- [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Fixed normalization of DOM points to be more accurate when triple-clicking.
+* [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Fixed normalization of DOM points to be more accurate when triple-clicking.
 
-* [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Fixed a bug that prevented `isFocused` from updating on certain focus changes.
+- [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Fixed a bug that prevented `isFocused` from updating on certain focus changes.
 
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed IME input to not insert repeated characters.
+* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed IME input to not insert repeated characters.
 
-* [#3749](https://github.com/ianstormtaylor/slate/pull/3749) [`0473d0bf`](https://github.com/ianstormtaylor/slate/commit/0473d0bf93808b0e4e98abe833b7f7f4f5aff3b1) Thanks [@davidruisinger](https://github.com/davidruisinger)! - Fixes Slate to work with the Shadow DOM.
+- [#3749](https://github.com/ianstormtaylor/slate/pull/3749) [`0473d0bf`](https://github.com/ianstormtaylor/slate/commit/0473d0bf93808b0e4e98abe833b7f7f4f5aff3b1) Thanks [@davidruisinger](https://github.com/davidruisinger)! - Fixes Slate to work with the Shadow DOM.
 
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed deleting by line to account for the line breaks in the browser.
+* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed deleting by line to account for the line breaks in the browser.

--- a/packages/slate-react/CHANGELOG.md
+++ b/packages/slate-react/CHANGELOG.md
@@ -6,15 +6,7 @@
 
 - [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - **Add directional awareness to `Editor.deleteFragment`.** This is an obscure change, but is a required distinction when implementing features that need to "fake delete" content (like Google Docs's suggestions). Previously deleting always collapsed to the end of a range, but now it can collapse forwards as well.
 
-* [#4154](https://github.com/ianstormtaylor/slate/pull/4154) [`7283c51f`](https://github.com/ianstormtaylor/slate/commit/7283c51feb83cb8522bc16efce09bb01c29400b9) Thanks [@ianstormtaylor](https://github.com/ianstormtaylor)! - **Start using [🦋 Changesets](https://github.com/atlassian/changesets) to manage releases.** Going forward, whenever a pull request is made that fixes or adds functionality to Slate, it will need to be accompanied by a changset Markdown file describing the change. These files will be automatically used in the release process when bump the versions of Slate and compiling the changelog.
-
-### Patch Changes
-
-- [#4150](https://github.com/ianstormtaylor/slate/pull/4150) [`bbd7d9c3`](https://github.com/ianstormtaylor/slate/commit/bbd7d9c33023add223ef9f1a33b657a468552caf) Thanks [@nivekithan](https://github.com/nivekithan)! - Added support for using the new `beforeInput` events in the latest Firefox.
-
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed spellcheck disabling logic to always work in older versions of Firefox.
-
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed browser-detection behavior to work with Deno.
+## 0.61.1 (2021-03-29)
 
 * [`d5589279`](https://github.com/ianstormtaylor/slate/commit/d5589279e8792185c1082af720a73f55b16797dd) - Updated placeholder styles to allow for wrapping long placeholder text.
 

--- a/packages/slate/CHANGELOG.md
+++ b/packages/slate/CHANGELOG.md
@@ -6,15 +6,7 @@
 
 - [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - **Updated `Text.equals` to deeply compare text node properties.** Previously it only did a shallow comparison, but this made it harder to keep track of more complex data structures at the text level.
 
-* [#4154](https://github.com/ianstormtaylor/slate/pull/4154) [`7283c51f`](https://github.com/ianstormtaylor/slate/commit/7283c51feb83cb8522bc16efce09bb01c29400b9) Thanks [@ianstormtaylor](https://github.com/ianstormtaylor)! - **Start using [🦋 Changesets](https://github.com/atlassian/changesets) to manage releases.** Going forward, whenever a pull request is made that fixes or adds functionality to Slate, it will need to be accompanied by a changset Markdown file describing the change. These files will be automatically used in the release process when bump the versions of Slate and compiling the changelog.
-
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - **Added support for custom selection properties.** Previously you could set custom properties on the selection objects but it was not a fully supported feature because there was no way to delete them later. Now custom properties are officially supported and deleting them once set is possible.
-
-### Patch Changes
-
-- [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed `move_node` operations to normalize the node in question.
-
-* [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Added memoization logic to `Node.isNodeList` and `Editor.isEditor` to speed up common code paths.
+## 0.61.1 (2021-03-29)
 
 - [`c6002024`](https://github.com/ianstormtaylor/slate/commit/c60020244b9d25094edb0ffcca8b49dead9b31dc) - Fixed a bug when merging deeply nested multi-child nodes.
 

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -18,6 +18,7 @@
     "esrever": "^0.2.0",
     "immer": "^7.0.0",
     "is-plain-object": "^3.0.0",
+    "lodash": "^4.17.21",
     "tiny-warning": "^1.0.3"
   },
   "keywords": [

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -18,7 +18,6 @@
     "esrever": "^0.2.0",
     "immer": "^7.0.0",
     "is-plain-object": "^3.0.0",
-    "lodash": "^4.17.21",
     "tiny-warning": "^1.0.3"
   },
   "keywords": [

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -18,7 +18,7 @@
     "esrever": "^0.2.0",
     "immer": "^7.0.0",
     "is-plain-object": "^3.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.21",
     "tiny-warning": "^1.0.3"
   },
   "keywords": [

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -1,4 +1,3 @@
-import { update } from 'lodash'
 import {
   Editor,
   Element,

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -1001,7 +1001,3 @@ const matchPath = (editor: Editor, path: Path): ((node: Node) => boolean) => {
   const [node] = Editor.node(editor, path)
   return n => n === node
 }
-
-const updateNode = (prevProps: NodeProps, updatedProps: Partial<Node>) => {
-  return { ...prevProps, ...updatedProps }
-}

--- a/packages/slate/test/transforms/setNodes/block/block-function-across.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-function-across.tsx
@@ -1,0 +1,38 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+const updateFunction = props => {
+  return { ...props, key: !props.key }
+}
+
+export const run = editor => {
+  Transforms.setNodes(editor, updateFunction, {
+    match: n => Editor.isBlock(editor, n),
+  })
+}
+
+export const input = (
+  <editor>
+    <block key={false}>
+      <anchor />
+      word
+    </block>
+    <block key={false}>
+      a<focus />
+      nother
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block key={true}>
+      <anchor />
+      word
+    </block>
+    <block key={true}>
+      a<focus />
+      nother
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/setNodes/block/block-function-across.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-function-across.tsx
@@ -26,11 +26,11 @@ export const input = (
 )
 export const output = (
   <editor>
-    <block key={true}>
+    <block key>
       <anchor />
       word
     </block>
-    <block key={true}>
+    <block key>
       a<focus />
       nother
     </block>

--- a/packages/slate/test/transforms/setNodes/inline/inline-function-nested.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-function-nested.tsx
@@ -33,7 +33,7 @@ export const output = (
       <text />
       <inline>
         <text />
-        <inline key={true}>
+        <inline key>
           <cursor />
           word
         </inline>

--- a/packages/slate/test/transforms/setNodes/inline/inline-function-nested.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-function-nested.tsx
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+const updateFunction = props => {
+  return { ...props, key: !props.key }
+}
+
+export const run = editor => {
+  Transforms.setNodes(editor, updateFunction, {
+    match: n => Editor.isInline(editor, n),
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        <text />
+        <inline key={false}>
+          <cursor />
+          word
+        </inline>
+        <text />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        <text />
+        <inline key={true}>
+          <cursor />
+          word
+        </inline>
+        <text />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7001,9 +7001,9 @@ lint-staged@>=10:
     stringify-object "^3.3.0"
 
 listr2@^3.2.2:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.4.4.tgz#5bb5e0107cc9a8787dcfb5d302c88cbddcdba248"
-  integrity sha512-okQwtieCHDX5erlxcEn2xwNfVQhV+/YiD+U0v+6DQamXnknE7mc6B5fopHl96v1PuZjTpaoChctf96PB6K4XRg==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.6.2.tgz#7260159f9108523eaa430d4a674db65b6c2d08cc"
+  integrity sha512-B2vlu7Zx/2OAMVUovJ7Tv1kQ2v2oXd0nZKzkSAcRCej269d8gkS/gupDEdNl23KQ3ZjVD8hQmifrrBFbx8F9LA==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7194,6 +7194,11 @@ lodash@^4.17.13, lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"


### PR DESCRIPTION
**Description**
This PR allows Transforms.setNodes to take either a Partial<Node> as it second argument to props (which we have before) which overrides the props on the node or a function that takes the existing props for the relevant node and returns a new set of props to attach to the node.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/3808

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

