### PR TITLE
Fix unhangRange condition and make sure result not out of initial range.

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1507,7 +1507,7 @@ export const Editor: EditorInterface = {
     let [start, end] = Range.edges(range)
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if (start.offset !== 0 || end.offset !== 0 || Range.isCollapsed(range)) {
+    if (end.offset !== 0 || Range.isCollapsed(range)) {
       return range
     }
 
@@ -1535,6 +1535,9 @@ export const Editor: EditorInterface = {
         end = { path, offset: node.text.length }
         break
       }
+    }
+    if (Point.isBefore(end, start)) {
+      end = start
     }
 
     return { anchor: start, focus: end }


### PR DESCRIPTION
**Description**
This is a minor fix for unhangRange, one for no matter whether start.offset is zero, should always do unhangRange if end.offset is zero and not collapsed, one for make sure the result range is still inside the original range.

**Issue**
Fixes: 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

