### PR TITLE
[docs] Prune import that is never used

### DIFF
--- a/docs/concepts/09-serializing.md
+++ b/docs/concepts/09-serializing.md
@@ -53,7 +53,7 @@ For example, here's a similar `serialize` function for HTML:
 
 ```js
 import escapeHtml from 'escape-html'
-import { Node, Text } from 'slate'
+import { Text } from 'slate'
 
 const serialize = node => {
   if (Text.isText(node)) {

--- a/docs/concepts/11-typescript.md
+++ b/docs/concepts/11-typescript.md
@@ -4,7 +4,6 @@ Slate supports typing of one Slate document model (ie. one set of custom `Editor
 
 **Warning:** You must define `CustomTypes` when using TypeScript or Slate will display typing errors.
 
-
 ## Defining `Editor`, `Element` and `Text` Types
 
 To define a custom `Element` or `Text` type, extend the `CustomTypes` interface in the `slate` module like this.


### PR DESCRIPTION
**Description**

In the Serializing docs, for the `serialize` function for HTML example,
we import `Node` but never use it in the scope of the example. 

Remove it to eliminate the possibility for confusion.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

