### PR TITLE
feat: sync selection to extactly matched DOM selection

### DIFF
--- a/.changeset/four-poets-move.md
+++ b/.changeset/four-poets-move.md
@@ -1,5 +1,5 @@
 ---
-'slate-react': major
+'slate-react': patch
 ---
 
-sync to extractly matched DOM selection with editor.selection
+Fixed a bug when syncing the selection for IME-based editing.

--- a/.changeset/four-poets-move.md
+++ b/.changeset/four-poets-move.md
@@ -1,0 +1,5 @@
+---
+'slate-react': major
+---
+
+sync to extractly matched DOM selection with editor.selection

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -177,7 +177,7 @@ export const Editable = (props: EditableProps) => {
     // If the DOM selection is in the editor and the editor selection is already correct, we're done.
     if (hasDomSelection && hasDomSelectionInEditor && selection) {
       const slateRange = ReactEditor.toSlateRange(editor, domSelection, {
-        extractMatch: true,
+        exactMatch: true,
       })
       if (slateRange && Range.equals(slateRange, selection)) {
         return
@@ -190,7 +190,7 @@ export const Editable = (props: EditableProps) => {
     // and thus it doesn't transform selection on its own
     if (selection && !ReactEditor.hasRange(editor, selection)) {
       editor.selection = ReactEditor.toSlateRange(editor, domSelection, {
-        extractMatch: false,
+        exactMatch: false,
       })
       return
     }
@@ -283,7 +283,7 @@ export const Editable = (props: EditableProps) => {
 
           if (targetRange) {
             const range = ReactEditor.toSlateRange(editor, targetRange, {
-              extractMatch: false,
+              exactMatch: false,
             })
 
             if (!selection || !Range.equals(selection, range)) {
@@ -449,7 +449,7 @@ export const Editable = (props: EditableProps) => {
 
         if (anchorNodeSelectable && focusNodeSelectable) {
           const range = ReactEditor.toSlateRange(editor, domSelection, {
-            extractMatch: false,
+            exactMatch: false,
           })
           Transforms.select(editor, range)
         } else {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -175,13 +175,13 @@ export const Editable = (props: EditableProps) => {
     }
 
     // If the DOM selection is in the editor and the editor selection is already correct, we're done.
-    if (
-      hasDomSelection &&
-      hasDomSelectionInEditor &&
-      selection &&
-      Range.equals(ReactEditor.toSlateRange(editor, domSelection), selection)
-    ) {
-      return
+    if (hasDomSelection && hasDomSelectionInEditor && selection) {
+      const slateRange = ReactEditor.toSlateRange(editor, domSelection, {
+        extractMatch: true,
+      })
+      if (slateRange && Range.equals(slateRange, selection)) {
+        return
+      }
     }
 
     // when <Editable/> is being controlled through external value
@@ -189,7 +189,9 @@ export const Editable = (props: EditableProps) => {
     // but Slate's value is not being updated through any operation
     // and thus it doesn't transform selection on its own
     if (selection && !ReactEditor.hasRange(editor, selection)) {
-      editor.selection = ReactEditor.toSlateRange(editor, domSelection)
+      editor.selection = ReactEditor.toSlateRange(editor, domSelection, {
+        extractMatch: false,
+      })
       return
     }
 
@@ -280,7 +282,9 @@ export const Editable = (props: EditableProps) => {
           const [targetRange] = (event as any).getTargetRanges()
 
           if (targetRange) {
-            const range = ReactEditor.toSlateRange(editor, targetRange)
+            const range = ReactEditor.toSlateRange(editor, targetRange, {
+              extractMatch: false,
+            })
 
             if (!selection || !Range.equals(selection, range)) {
               Transforms.select(editor, range)
@@ -444,7 +448,9 @@ export const Editable = (props: EditableProps) => {
           isTargetInsideVoid(editor, focusNode)
 
         if (anchorNodeSelectable && focusNodeSelectable) {
-          const range = ReactEditor.toSlateRange(editor, domSelection)
+          const range = ReactEditor.toSlateRange(editor, domSelection, {
+            extractMatch: false,
+          })
           Transforms.select(editor, range)
         } else {
           Transforms.deselect(editor)

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -544,11 +544,11 @@ export const ReactEditor = {
   toSlateRange<T extends boolean>(
     editor: ReactEditor,
     domRange: DOMRange | DOMStaticRange | DOMSelection,
-    option: {
+    options: {
       exactMatch: T
     }
   ): T extends true ? Range | null : Range {
-    const { exactMatch } = option
+    const { exactMatch } = options
     const el = isDOMSelection(domRange)
       ? domRange.anchorNode
       : domRange.startContainer

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -521,7 +521,12 @@ export const ReactEditor = {
     }
 
     if (!textNode) {
-      return null as T extends true ? Point | null : Point
+      if (extractMatch) {
+        return null as T extends true ? Point | null : Point
+      }
+      throw new Error(
+        `Cannot resolve a Slate point from DOM point: ${domPoint}`
+      )
     }
 
     // COMPAT: If someone is clicking from one Slate editor into another,

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -433,7 +433,7 @@ export const ReactEditor = {
 
     // Resolve a Slate range from the DOM range.
     const range = ReactEditor.toSlateRange(editor, domRange, {
-      extractMatch: false,
+      exactMatch: false,
     })
     return range
   },
@@ -545,10 +545,10 @@ export const ReactEditor = {
     editor: ReactEditor,
     domRange: DOMRange | DOMStaticRange | DOMSelection,
     option: {
-      extractMatch: T
+      exactMatch: T
     }
   ): T extends true ? Range | null : Range {
-    const { extractMatch } = option
+    const { exactMatch } = option
     const el = isDOMSelection(domRange)
       ? domRange.anchorNode
       : domRange.startContainer
@@ -598,7 +598,7 @@ export const ReactEditor = {
     const anchor = ReactEditor.toSlatePoint(
       editor,
       [anchorNode, anchorOffset],
-      extractMatch
+      exactMatch
     )
     if (!anchor) {
       return null as T extends true ? Range | null : Range
@@ -606,7 +606,7 @@ export const ReactEditor = {
 
     const focus = isCollapsed
       ? anchor
-      : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset], extractMatch)
+      : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset], exactMatch)
     if (!focus) {
       return null as T extends true ? Range | null : Range
     }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -276,7 +276,6 @@ export interface EditorInterface {
       voids?: boolean
     }
   ) => NodeEntry<Element> | undefined
-
   withoutNormalizing: (editor: Editor, fn: () => void) => void
 }
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -276,6 +276,7 @@ export interface EditorInterface {
       voids?: boolean
     }
   ) => NodeEntry<Element> | undefined
+
   withoutNormalizing: (editor: Editor, fn: () => void) => void
 }
 


### PR DESCRIPTION
**Description**

We will return if DOM selection is equal to `editor.selection` when we  sync DOM selection state as below

```ts
   if (
      hasDomSelection &&
      hasDomSelectionInEditor &&
      selection &&
      Range.equals(ReactEditor.toSlateRange(editor, domSelection), selection)
    ) {
      return
    }
```

`ReactEditor.toSlateRange`  will call `normalizeDOMPoint(domPoint)` to normalize a DOM point so that it always refers to a text node nearby as comment says.

think of DOM structure below

```
<span>
  <span contentEditable={false}></span>
  <cursor>
  <span data-slate-node="text">
    <span data-slate-leaf="true" >
      <span data-slate-string="true">xx</span>
    </span>
</span>
```

there is no need to sync DOM selection without this PR。but if typing `测试` using IME it will result in 

```
<span>
  <span contentEditable={false}></span>
  测试
  <span data-slate-node="text">
    <span data-slate-leaf="true" >
      <span data-slate-string="true">测试<cursor>xx</span>
    </span>
</span>
```

**Issue**

Fixes: https://github.com/ianstormtaylor/slate/issues/4142

**Example**

```ts
toSlateRange<T extends boolean>(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection, option: {
    extractMatch: T;
}): T extends true ? Range | null : Range
``` 

add `extractMatch` to `ReactEditor.toSlateRange`，it will return `Range | null` when using `extractMatch`


**Checks**
- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

