### PR TITLE
fix ime double input with mark

### DIFF
--- a/.changeset/lovely-walls-knock.md
+++ b/.changeset/lovely-walls-knock.md
@@ -1,5 +1,5 @@
 ---
-'slate-react': major
+'slate-react': patch
 ---
 
 Fixed a bug that resulted in doubly-input characters when using an IME.

--- a/.changeset/lovely-walls-knock.md
+++ b/.changeset/lovely-walls-knock.md
@@ -2,4 +2,4 @@
 'slate-react': major
 ---
 
-refresh String element to avoid double input using IME
+Fixed a bug that resulted in doubly-input characters when using an IME.

--- a/.changeset/lovely-walls-knock.md
+++ b/.changeset/lovely-walls-knock.md
@@ -1,0 +1,5 @@
+---
+'slate-react': major
+---
+
+refresh String element to avoid double input using IME

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -43,7 +43,13 @@ const Leaf = (props: {
   }, [placeholderRef])
 
   let children = (
-    <String isLast={isLast} leaf={leaf} parent={parent} text={text} />
+    <String
+      key={Math.random()}
+      isLast={isLast}
+      leaf={leaf}
+      parent={parent}
+      text={text}
+    />
   )
 
   if (leaf[PLACEHOLDER_SYMBOL]) {

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -4,6 +4,9 @@ import String from './string'
 import { PLACEHOLDER_SYMBOL } from '../utils/weak-maps'
 import { RenderLeafProps } from './editable'
 
+// auto-incrementing key for String component, force it refresh to
+// prevent inconsistent rendering by React with IME input
+let keyForString = 0
 /**
  * Individual leaves in a text node with unique formatting.
  */
@@ -44,7 +47,7 @@ const Leaf = (props: {
 
   let children = (
     <String
-      key={Math.random()}
+      key={keyForString++}
       isLast={isLast}
       leaf={leaf}
       parent={parent}


### PR DESCRIPTION
**Description**

this pr will force `String` element refresh it self to avoid ime double input

**Issue**

No

**Example**

![xx](https://user-images.githubusercontent.com/17848159/113268718-41555700-930a-11eb-9a5e-69fc65c3f82f.gif)



**Context**

![image](https://user-images.githubusercontent.com/17848159/113268836-6a75e780-930a-11eb-9535-78b352bf3131.png)

while we should get 

![image](https://user-images.githubusercontent.com/17848159/113268909-8083a800-930a-11eb-951d-0b4890c4d3c3.png)

this is becasue we memoizedLeaf to avoid refresh. now we will refresh all sibling leaf when a leaf changes

**Checks**
- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

