### PR TITLE
Create .gitattributes and explicitly set the line breaks to be LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
**Description**
In windows git will convert the LF line breaks to CRLF by default and due to eslint configuration the eslint will throw error. If you are using eslint plugin in vscode this leads to whole screen becoming red.  Which should be avoided.

Thats why we will set the EOL to be LF in `.gitattributes ` so that git wont convert the LF to CRLF.

For reference 

- [eslint]( https://eslint.org/docs/rules/linebreak-style)
- [stackoverflow](https://stackoverflow.com/a/42135910)

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
