### PR TITLE
Fix cursor movements when splitting nodes

### DIFF
--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -265,6 +265,12 @@ export const GeneralTransforms: GeneralTransforms = {
             ...(properties as Partial<Text>),
             text: after,
           }
+
+          if (newNode.text) {
+            parent.children.splice(index + 1, node.text ? 0 : 1, newNode)
+          } else {
+            parent.children.splice(index + 1, node.text ? 0 : 1)
+          }
         } else {
           const before = node.children.slice(0, position)
           const after = node.children.slice(position)
@@ -274,9 +280,8 @@ export const GeneralTransforms: GeneralTransforms = {
             ...(properties as Partial<Element>),
             children: after,
           }
+          parent.children.splice(index + 1, 0, newNode)
         }
-
-        parent.children.splice(index + 1, 0, newNode)
 
         if (selection) {
           for (const [point, key] of Range.points(selection)) {

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -266,15 +266,16 @@ export const GeneralTransforms: GeneralTransforms = {
             text: after,
           }
 
-          if (newNode.text) {
-            parent.children.splice(index + 1, node.text ? 0 : 1, newNode)
-          } else {
-            parent.children.splice(index + 1, node.text ? 0 : 1)
-          }
+          newNode.text && parent.children.splice(index + 1, 0, newNode)
+          !node.text && index && parent.children.splice(index, 1)
         } else {
           const before = node.children.slice(0, position)
           const after = node.children.slice(position)
           node.children = before
+
+          if (after.length === 0) {
+            after.push({ ...before[before.length - 1], text: '' })
+          }
 
           newNode = {
             ...(properties as Partial<Element>),


### PR DESCRIPTION
**Description**
In `split_node` operation sometimes there will be creation empty text node which then will cleared by default normalization function. 
This leads to bugs regarding cursor positions like 
- #4130 

This pr aims to solve problems like those by not creating those empty text nodes itself

**Issue**
- #4130 


## Before

From [example](https://www.slatejs.org/examples/richtext)

![gif](https://recordit.co/dCHBzOfGtA.gif)

## After

![gif](https://recordit.co/DX1WAKFu77.gif)


**Context**

[old code](https://github.com/ianstormtaylor/slate/blob/0b0328b2d0a595d48905b41c6afcc4f65bc352c6/packages/slate/src/transforms/general.ts#L261)  will create two new text node even if the text is empty

[new code](https://github.com/nivekithan/slate/blob/acc4051286474a647a02cb58658e3d340da9555e/packages/slate/src/transforms/general.ts#L269) will not add new text node if its empty and will remove the old text node if it became empty

Since we are not always creating text nodes sometime Element node might contain empty `children` array in that case we will create new empty text node and populate with previous text node properties 

I submitting this is as draft since still there are some errors like 

![bug](https://recordit.co/cunnwlozjo.gif)

where the `marks` are not transferred properly

And the also some tests are failing I will also take care of that,

Before doing those I just want to know opinions of maintainers since I am changing the behavior of an operation weather it is okay to do that or not

**Checks**
- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

