### PR TITLE
respect reverse option in Editor.nodes

### DIFF
--- a/.changeset/forty-carrots-look.md
+++ b/.changeset/forty-carrots-look.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+`reverse` option in `Editor.nodes` will not be ignored if the type of `at` is `Span`

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -885,8 +885,8 @@ export const Editor: EditorInterface = {
     let to
 
     if (Span.isSpan(at)) {
-      from = at[0]
-      to = at[1]
+      from = reverse ? at[1] : at[0]
+      to = reverse ? at[0] : at[1]
     } else {
       const first = Editor.path(editor, at, { edge: 'start' })
       const last = Editor.path(editor, at, { edge: 'end' })


### PR DESCRIPTION
**Description**
As of now `reverse` option in `Editor.nodes` will be ignored if the type of `at` is `Span`, I dont think this is intentional

**Checks**
- [X] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

