### PR TITLE
Correcting the splitting logic in setNodes

### DIFF
--- a/.changeset/two-lies-appear.md
+++ b/.changeset/two-lies-appear.md
@@ -1,0 +1,5 @@
+---
+"slate": patch
+---
+
+Fixed a bug in splitting and applying overlapping marks to text nodes.

--- a/.changeset/two-lies-appear.md
+++ b/.changeset/two-lies-appear.md
@@ -1,5 +1,5 @@
 ---
-"slate": patch
+slate: patch
 ---
 
 Fixed a bug in splitting and applying overlapping marks to text nodes.

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -224,8 +224,10 @@ export const createEditor = (): Editor => {
       let n = 0
 
       for (let i = 0; i < node.children.length; i++, n++) {
+        const currentNode = Node.get(editor, path)
+        if (Text.isText(currentNode)) continue
         const child = node.children[i] as Descendant
-        const prev = node.children[i - 1] as Descendant
+        const prev = currentNode.children[n - 1] as Descendant
         const isLast = i === node.children.length - 1
         const isInlineOrText =
           Text.isText(child) ||

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -592,17 +592,21 @@ export const NodeTransforms: NodeTransforms = {
         const rangeRef = Editor.rangeRef(editor, at, { affinity: 'inward' })
         const [start, end] = Range.edges(at)
         const splitMode = mode === 'lowest' ? 'lowest' : 'highest'
+        const endAtEndOfNode = Editor.isEnd(editor, end, end.path)
         Transforms.splitNodes(editor, {
           at: end,
           match,
           mode: splitMode,
           voids,
+          always: !endAtEndOfNode,
         })
+        const startAtStartOfNode = Editor.isStart(editor, start, start.path)
         Transforms.splitNodes(editor, {
           at: start,
           match,
           mode: splitMode,
           voids,
+          always: !startAtStartOfNode,
         })
         at = rangeRef.unref()!
 

--- a/packages/slate/test/transforms/setNodes/text/merge-across.tsx
+++ b/packages/slate/test/transforms/setNodes/text/merge-across.tsx
@@ -1,0 +1,41 @@
+/** @jsx jsx */
+import { Transforms, Text } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.setNodes(
+    editor,
+    { key: true },
+    { match: Text.isText, split: true }
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      <text>
+        One
+        <anchor />
+      </text>
+      <text key>Two</text>
+      <text>
+        <focus />
+        Three
+      </text>
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text>
+        One
+        <anchor />
+      </text>
+      <text key>
+        Two
+        <focus />
+      </text>
+      <text>Three</text>
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**

This pull request aims to solves a couple of things:
- In setNodes, if splitting has to happen, it should be set to always at :
  - [start](https://github.com/ridhambhat/slate/blob/d808c4ba6f36829064dc2cce42bcb502502343ca/packages/slate/src/transforms/node.ts#L603-L610) if anchor is not at the start of the node
  - [end](https://github.com/ridhambhat/slate/blob/d808c4ba6f36829064dc2cce42bcb502502343ca/packages/slate/src/transforms/node.ts#L595-L602) if focus is not at the end of the node
- In [normalizeNode](https://github.com/ridhambhat/slate/blob/d808c4ba6f36829064dc2cce42bcb502502343ca/packages/slate/src/create-editor.ts#L195), while iterating through children, the variable [prev](https://github.com/ridhambhat/slate/blob/d808c4ba6f36829064dc2cce42bcb502502343ca/packages/slate/src/create-editor.ts#L230) pointed towards wrong node in some cases. Fixed that by getting value of prev from updated node. 

**Issue**

Fixes: [#4038](https://github.com/ianstormtaylor/slate/issues/4038)

**Example**

*Old behavior*
![Old behavior](https://i.imgur.com/WtHzKe8.gif)
*New behavior*
![New Behaviour](https://i.imgur.com/We2SpuK.gif)

**Context**

For the splitting logic, if always is not set for the mentioned conditions, then for the case where anchor is at the end of one node and focus is at the start of another node, the selection bleeds through and properties is applied on nodes where it is not intended. It is safer to split nodes and have empty nodes which will be normalized later.

For the normalization, in particular conditions when a text node was sandwiched between two empty text nodes, then due to the way previous variable was calculated in logic before, it pointed to the wrong node, not taking in account that it could have been merged/deleted. To correct this behavior, now prev is taken from an updated copy of the base node at each iteration.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

