### PR TITLE
Add element prop to leaf node

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -81,8 +81,9 @@ const Leaf = (props: {
   } = {
     'data-slate-leaf': true,
   }
+  let element = parent
 
-  return renderLeaf({ attributes, children, leaf, text })
+  return renderLeaf({ attributes, children, leaf, text, element })
 }
 
 const MemoizedLeaf = React.memo(Leaf, (prev, next) => {


### PR DESCRIPTION
**Description**
This allows the element's data model and relevant information to be passed down to the `renderLeaf` callback


