### PR TITLE
Fix/text matches

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -92,7 +92,7 @@ const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
     next.renderLeaf === prev.renderLeaf &&
     next.text === prev.text &&
     next.leaf.text === prev.leaf.text &&
-    Text.matches(next.leaf, prev.leaf) &&
+    Text.matches(prev.leaf, next.leaf) &&
     next.leaf[PLACEHOLDER_SYMBOL] === prev.leaf[PLACEHOLDER_SYMBOL]
   )
 })

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -75,16 +75,22 @@ export const Text: TextInterface = {
    */
 
   matches(text: Text, props: Partial<Text>): boolean {
-    for (const key in props) {
+    const keySet = new Set<string>()
+    Object.keys(text).forEach(key => {
+      keySet.add(key)
+    })
+    Object.keys(props).forEach(key => {
+      keySet.add(key)
+    })
+    for (let key of keySet.keys()) {
       if (key === 'text') {
         continue
       }
 
-      if (!text.hasOwnProperty(key) || text[key] !== props[key]) {
+      if (text[key] !== props[key]) {
         return false
       }
     }
-
     return true
   },
 


### PR DESCRIPTION
**Description**
fix `Text` matches function

matches should compare all props include prev leaf and next leaf,

**Issue**

**Example**
```
  prev: { text: 'a' }
  next: { text: 'a', highlight: true }

  matches(text: Text, props: Partial<Text>): boolean {
    for (const key in props) {
      if (key === 'text') {
        continue
      }

      if (!text.hasOwnProperty(key) || text[key] !== props[key]) {
        return false
      }
    }

    return true
  },

  Text.matches(next.leaf, prev.leaf) // compare

  // in the matches function ,props do not include `highlight`. so it return true. but in fact ,it should return false
```

**Checks**
- [] The new code matches the existing patterns and styles.
- [] The tests pass with `yarn test`.
- [] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

