### PR TITLE
Fix placeholder overflow

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -23,25 +23,6 @@ const Leaf = (props: {
     renderLeaf = (props: RenderLeafProps) => <DefaultLeaf {...props} />,
   } = props
 
-  const placeholderRef = useRef<HTMLSpanElement | null>(null)
-
-  useEffect(() => {
-    const placeholderEl = placeholderRef?.current
-    const editorEl = document.querySelector<HTMLDivElement>(
-      '[data-slate-editor="true"]'
-    )
-
-    if (!placeholderEl || !editorEl) {
-      return
-    }
-
-    editorEl.style.minHeight = `${placeholderEl.clientHeight}px`
-
-    return () => {
-      editorEl.style.minHeight = 'auto'
-    }
-  }, [placeholderRef])
-
   let children = (
     <String isLast={isLast} leaf={leaf} parent={parent} text={text} />
   )
@@ -50,20 +31,17 @@ const Leaf = (props: {
     children = (
       <React.Fragment>
         <span
-          ref={placeholderRef}
           contentEditable={false}
           style={{
             pointerEvents: 'none',
             display: 'inline-block',
             width: '100%',
             maxWidth: '100%',
-            whiteSpace: 'nowrap',
             opacity: '0.333',
             userSelect: 'none',
             fontStyle: 'normal',
             fontWeight: 'normal',
             textDecoration: 'none',
-            position: 'absolute',
           }}
         >
           {leaf.placeholder}


### PR DESCRIPTION
**Description**
Fix issue when placeholder horizontally overflows editor bounds.

**Issue**
Fixes: #4018, #2922

**Context**
@Glazy in his [PR](https://github.com/ianstormtaylor/slate/pull/4019) already fixed this issue, however it wasn't correctly [ported to master](https://github.com/Avizura/slate/commit/00393bb18548976d4e79c8bc46d54b2125bb6701). Specifically [this line](https://github.com/ianstormtaylor/slate/pull/4019/files#diff-18ef6af284404b1670857e562c183f2da6774d81bb65ed39d82fe124f769787bL40) wasn't ported for some reason. Also I didn't understand why we should dynamically set the editor `minHeight` and `position: absolute` (it brings vertical overflowing issue) instead of using static positioning.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

