### PR TITLE
Stop basic installation from throwing typescript errors

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -59,7 +59,7 @@ type CustomText = { text: string }
 
 declare module 'slate' {
   interface CustomTypes {
-    Editor: BaseEditor & ReactEditor & HistoryEditor
+    Editor: BaseEditor & ReactEditor
     Element: CustomElement
     Text: CustomText
   }


### PR DESCRIPTION
**Description**
Fix docs.

**Issue**
See commit.

Gotta say, the error I got with the current example is pretty non-trivial:
```
const editor = useMemo(() => withReact(createEditor()), []);
```
squiggly on `createEditor`:
```
Argument of type 'BaseEditor' is not assignable to parameter of type 'ReactEditor'.
  Type 'BaseEditor' is missing the following properties from type 'ReactEditor': insertData, setFragmentData, hasRange
```
Woah, that's some sideways error, thanks TypeScript.