### PR TITLE
feat(react-slate): Ability to add multiple placeholders.

### DIFF
--- a/.changeset/nine-llamas-hope.md
+++ b/.changeset/nine-llamas-hope.md
@@ -1,0 +1,14 @@
+---
+'slate-react': minor
+'slate': patch
+---
+
+ReactNode previews and ability to customize it.
+
+- Now previews can be any of ReactNode or ReactNodeArray
+- Leaf component is fully refactored, no effects used anymore, just straight render.
+- Preview styling moved to `DefaultLeaf` component so users now able to change it on their need via `Editable.renderLeaf`.
+- `Editable` component has proper typing now.
+
+BREAKING CHANGE: anyone using `Editable.renderLeaf` and not calling `DefaultLeaf` on placeholder leaves wont have placeholder displayed.
+Sadly this is the only way to allow placeholder customisation.

--- a/.changeset/silly-deers-guess.md
+++ b/.changeset/silly-deers-guess.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Add ability to specify multiple placeholders.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1,13 +1,20 @@
-import React, { useEffect, useRef, useMemo, useCallback } from 'react'
+import React, {
+  ReactNode,
+  ReactNodeArray,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import {
   Editor,
   Element,
-  NodeEntry,
   Node,
+  NodeEntry,
+  Path,
   Range,
   Text,
   Transforms,
-  Path,
 } from 'slate'
 import getDirection from 'direction'
 import { HistoryEditor } from 'slate-history'
@@ -17,11 +24,11 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 import useChildren from '../hooks/use-children'
 import Hotkeys from '../utils/hotkeys'
 import {
-  IS_FIREFOX,
-  IS_SAFARI,
-  IS_EDGE_LEGACY,
   IS_CHROME_LEGACY,
+  IS_EDGE_LEGACY,
+  IS_FIREFOX,
   IS_FIREFOX_LEGACY,
+  IS_SAFARI,
 } from '../utils/environment'
 import { ReactEditor } from '..'
 import { ReadOnlyContext } from '../hooks/use-read-only'
@@ -35,17 +42,16 @@ import {
   getDefaultView,
   isDOMElement,
   isDOMNode,
-  DOMStaticRange,
   isPlainTextOnlyPaste,
 } from '../utils/dom'
 import {
   EDITOR_TO_ELEMENT,
+  EDITOR_TO_WINDOW,
   ELEMENT_TO_NODE,
+  IS_FOCUSED,
   IS_READ_ONLY,
   NODE_TO_ELEMENT,
-  IS_FOCUSED,
   PLACEHOLDER_SYMBOL,
-  EDITOR_TO_WINDOW,
 } from '../utils/weak-maps'
 
 // COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
@@ -85,39 +91,36 @@ export interface RenderLeafProps {
   }
 }
 
-/**
- * `EditableProps` are passed to the `<Editable>` component.
- */
-
-export type EditableProps = {
+type IEditableProps = {
   decorate?: (entry: NodeEntry) => Range[]
   onDOMBeforeInput?: (event: InputEvent) => void
-  placeholder?: string
+  placeholder?: ReactNode | ReactNodeArray
   readOnly?: boolean
   role?: string
   style?: React.CSSProperties
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   as?: React.ElementType
-} & React.TextareaHTMLAttributes<HTMLDivElement>
+}
 
 /**
- * Editable.
+ * `EditableProps` are passed to the `<Editable>` component.
  */
+type EditableProps = IEditableProps &
+  Omit<React.TextareaHTMLAttributes<HTMLDivElement>, keyof IEditableProps>
 
-export const Editable = (props: EditableProps) => {
-  const {
-    autoFocus,
-    decorate = defaultDecorate,
-    onDOMBeforeInput: propsOnDOMBeforeInput,
-    placeholder,
-    readOnly = false,
-    renderElement,
-    renderLeaf,
-    style = {},
-    as: Component = 'div',
-    ...attributes
-  } = props
+export const Editable: React.FC<EditableProps> = ({
+  autoFocus,
+  decorate = defaultDecorate,
+  onDOMBeforeInput: propsOnDOMBeforeInput,
+  placeholder,
+  readOnly = false,
+  renderElement,
+  renderLeaf,
+  style = {},
+  as: Component = 'div',
+  ...attributes
+}) => {
   const editor = useSlate()
   const ref = useRef<HTMLDivElement>(null)
 

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -1,105 +1,111 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import { Element, Text } from 'slate'
 import String from './string'
 import { PLACEHOLDER_SYMBOL } from '../utils/weak-maps'
 import { RenderLeafProps } from './editable'
 
-/**
- * Individual leaves in a text node with unique formatting.
- */
+export type DefaultLeafProps = RenderLeafProps &
+  Omit<React.HTMLAttributes<HTMLSpanElement>, keyof RenderLeafProps>
 
-const Leaf = (props: {
-  isLast: boolean
-  leaf: Text
-  parent: Element
-  renderLeaf?: (props: RenderLeafProps) => JSX.Element
-  text: Text
+export const DefaultLeaf: React.FC<DefaultLeafProps> = ({
+  attributes,
+  children,
+  leaf,
+  text,
+  ...props
 }) => {
-  const {
-    leaf,
-    isLast,
-    text,
-    parent,
-    renderLeaf = (props: RenderLeafProps) => <DefaultLeaf {...props} />,
-  } = props
-
-  const placeholderRef = useRef<HTMLSpanElement | null>(null)
-
-  useEffect(() => {
-    const placeholderEl = placeholderRef?.current
-    const editorEl = document.querySelector<HTMLDivElement>(
-      '[data-slate-editor="true"]'
-    )
-
-    if (!placeholderEl || !editorEl) {
-      return
-    }
-
-    editorEl.style.minHeight = `${placeholderEl.clientHeight}px`
-
-    return () => {
-      editorEl.style.minHeight = 'auto'
-    }
-  }, [placeholderRef])
-
-  let children = (
-    <String isLast={isLast} leaf={leaf} parent={parent} text={text} />
-  )
-
   if (leaf[PLACEHOLDER_SYMBOL]) {
-    children = (
-      <React.Fragment>
+    return (
+      <span
+        {...props}
+        {...attributes}
+        style={{
+          position: 'relative',
+          display: 'inline-block',
+          minWidth: '100%',
+          width: '100%',
+        }}
+      >
         <span
-          ref={placeholderRef}
           contentEditable={false}
           style={{
-            pointerEvents: 'none',
             display: 'inline-block',
-            width: '100%',
-            maxWidth: '100%',
-            whiteSpace: 'nowrap',
-            opacity: '0.333',
+            pointerEvents: 'none',
             userSelect: 'none',
-            fontStyle: 'normal',
-            fontWeight: 'normal',
-            textDecoration: 'none',
-            position: 'absolute',
+            minWidth: '100%',
+            width: '100%',
+            opacity: 0.45,
           }}
         >
           {leaf.placeholder}
         </span>
-        {children}
-      </React.Fragment>
+
+        <span
+          style={{
+            display: 'inline-block',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+          }}
+        >
+          {children}
+        </span>
+      </span>
     )
   }
 
-  // COMPAT: Having the `data-` attributes on these leaf elements ensures that
-  // in certain misbehaving browsers they aren't weirdly cloned/destroyed by
-  // contenteditable behaviors. (2019/05/08)
-  const attributes: {
-    'data-slate-leaf': true
-  } = {
-    'data-slate-leaf': true,
-  }
-
-  return renderLeaf({ attributes, children, leaf, text })
+  return (
+    <span {...props} {...attributes}>
+      {children}
+    </span>
+  )
 }
+DefaultLeaf.displayName = 'DefaultLeaf'
+
+interface LeafProps {
+  isLast: boolean
+  leaf: Text
+  text: Text
+  parent: Element
+  renderLeaf?: (props: RenderLeafProps) => JSX.Element
+}
+
+const renderDefaultLeaf: LeafProps['renderLeaf'] = props => (
+  <DefaultLeaf {...props} />
+)
+
+const Leaf: React.FC<LeafProps> = ({
+  isLast,
+  leaf,
+  text,
+  parent,
+  renderLeaf = renderDefaultLeaf,
+}) => {
+  return renderLeaf({
+    attributes: {
+      'data-slate-leaf': true,
+    },
+    leaf,
+    text,
+    children: (
+      <String isLast={isLast} leaf={leaf} parent={parent} text={text} />
+    ),
+  })
+}
+Leaf.displayName = 'Leaf'
 
 const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
   return (
     next.parent === prev.parent &&
     next.isLast === prev.isLast &&
-    next.renderLeaf === prev.renderLeaf &&
     next.text === prev.text &&
     next.leaf.text === prev.leaf.text &&
-    Text.matches(next.leaf, prev.leaf) &&
-    next.leaf[PLACEHOLDER_SYMBOL] === prev.leaf[PLACEHOLDER_SYMBOL]
+    next.leaf[PLACEHOLDER_SYMBOL] === prev.leaf[PLACEHOLDER_SYMBOL] &&
+    next.renderLeaf === prev.renderLeaf &&
+    Text.matches(next.leaf, prev.leaf)
   )
 })
-
-export const DefaultLeaf = (props: RenderLeafProps) => {
-  const { attributes, children } = props
-  return <span {...attributes}>{children}</span>
-}
 
 export default MemoizedLeaf

--- a/packages/slate-react/src/custom-types.ts
+++ b/packages/slate-react/src/custom-types.ts
@@ -1,14 +1,15 @@
 import { BaseRange, BaseText } from 'slate'
 import { ReactEditor } from './plugin/react-editor'
+import { ReactNode, ReactNodeArray } from 'react'
 
 declare module 'slate' {
   interface CustomTypes {
     Editor: ReactEditor
     Text: BaseText & {
-      placeholder: string
+      placeholder: ReactNode | ReactNodeArray
     }
     Range: BaseRange & {
-      placeholder?: string
+      placeholder?: ReactNode | ReactNodeArray
     }
   }
 }


### PR DESCRIPTION
**Description**
As for my case i had a need to add multiple placeholders for a single editable, that are hidden separately as content fills.

**Example**
![123](https://user-images.githubusercontent.com/6178739/114281853-70c23d00-9a49-11eb-964f-5ef8800c81ac.gif)
Above example has such `placeholder` property:
```ts
placeholder={[
  'Summarize your issue.',
  <>
    And describe it in details here.
    <br />
    Try to avoid using languages not supported by interface, it will significantly improve
    and speed up our work.
  </>,
]}
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

