### PR TITLE
Ensure round-trip tests don't mutate output before checking against it => reveals 4 tests are broken

### DIFF
--- a/packages/slate-history/test/undo/delete_backward/block-text.tsx
+++ b/packages/slate-history/test/undo/delete_backward/block-text.tsx
@@ -15,4 +15,5 @@ export const input = (
     </block>
   </editor>
 )
+export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
 export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/block-text.tsx
+++ b/packages/slate-history/test/undo/delete_backward/block-text.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Transforms } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor)
@@ -14,4 +15,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/custom-prop.tsx
+++ b/packages/slate-history/test/undo/delete_backward/custom-prop.tsx
@@ -18,4 +18,5 @@ export const input = (
     </block>
   </editor>
 )
+export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
 export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/custom-prop.tsx
+++ b/packages/slate-history/test/undo/delete_backward/custom-prop.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Transforms } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor)
@@ -17,4 +18,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/inline-across.tsx
+++ b/packages/slate-history/test/undo/delete_backward/inline-across.tsx
@@ -26,4 +26,5 @@ export const input = (
     </block>
   </editor>
 )
+export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
 export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/inline-across.tsx
+++ b/packages/slate-history/test/undo/delete_backward/inline-across.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Transforms } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor)
@@ -25,4 +26,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_break/basic.tsx
+++ b/packages/slate-history/test/undo/insert_break/basic.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Editor } from 'slate'
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   editor.insertBreak()
@@ -16,4 +17,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_fragment/basic.tsx
+++ b/packages/slate-history/test/undo/insert_fragment/basic.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 const fragment = (
   <block type="d">
@@ -33,5 +34,5 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)
 export const skip = true

--- a/packages/slate-history/test/undo/insert_text/basic.tsx
+++ b/packages/slate-history/test/undo/insert_text/basic.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   editor.insertText('text')
@@ -12,4 +13,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_text/contiguous.tsx
+++ b/packages/slate-history/test/undo/insert_text/contiguous.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   editor.insertText('t')
@@ -14,4 +15,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate/test/interfaces/Node/ancestor/success.tsx
+++ b/packages/slate/test/interfaces/Node/ancestor/success.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx  */
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -12,4 +13,4 @@ export const input = (
 export const test = value => {
   return Node.ancestor(value, [0])
 }
-export const output = input.children[0]
+export const output = cloneDeep(input.children[0])

--- a/packages/slate/test/interfaces/Node/child/success.tsx
+++ b/packages/slate/test/interfaces/Node/child/success.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx  */
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -12,4 +13,4 @@ export const input = (
 export const test = value => {
   return Node.child(value, 0)
 }
-export const output = input.children[0]
+export const output = cloneDeep(input.children[0])

--- a/packages/slate/test/interfaces/Node/descendant/success.tsx
+++ b/packages/slate/test/interfaces/Node/descendant/success.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx  */
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -12,4 +13,4 @@ export const input = (
 export const test = value => {
   return Node.descendant(value, [0])
 }
-export const output = input.children[0]
+export const output = cloneDeep(input.children[0])

--- a/packages/slate/test/interfaces/Node/get/root.tsx
+++ b/packages/slate/test/interfaces/Node/get/root.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx  */
 import { Node } from 'slate'
 import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
 
 export const input = (
   <editor>
@@ -12,4 +13,4 @@ export const input = (
 export const test = value => {
   return Node.get(value, [])
 }
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate/test/interfaces/Node/get/root.tsx
+++ b/packages/slate/test/interfaces/Node/get/root.tsx
@@ -13,4 +13,5 @@ export const input = (
 export const test = value => {
   return Node.get(value, [])
 }
+export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
 export const output = cloneDeep(input)

--- a/packages/slate/test/transforms/delete/unit-line/text-end.tsx
+++ b/packages/slate/test/transforms/delete/unit-line/text-end.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Transforms } from 'slate'
 import { jsx } from '../../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor, { unit: 'line' })
@@ -13,4 +14,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)

--- a/packages/slate/test/transforms/delete/unit-line/text-start-reverse.tsx
+++ b/packages/slate/test/transforms/delete/unit-line/text-start-reverse.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Transforms } from 'slate'
 import { jsx } from '../../..'
+import { cloneDeep } from 'lodash'
 
 export const run = editor => {
   Transforms.delete(editor, { unit: 'line', reverse: true })
@@ -13,4 +14,4 @@ export const input = (
     </block>
   </editor>
 )
-export const output = input
+export const output = cloneDeep(input)


### PR DESCRIPTION
[ This was previously reported as PR #3718 last June, but never merged.  I closed that PR in favor of this. ]

Several round-trip tests, tests that check that the output is the same as the input, set `output = input`, which means both input and output point to the same object.  By the looks of it, when the input is modified the output is as well, making the tests no-ops.

We need to do deep copy instead of shallow/reference copy, and when this is done by this PR, 4 tests, that by the looks of it previously should have failed, now start to fail:

- slate-history / undo / delete_backward / block-text
- slate-history / undo / delete_backward / custom-prop
- slate-history / undo / delete_backward / inline-across
- slate / interfaces / Node / get / root

This PR converts `const output = input` to `const output = cloneDeep(input)` AND adds a `const skip = true` for the tests that are broken and needs to be fixed.  An alternative might be to, in the test system, automatically do a deepClone of output or input if they are found to be reference to the same object (or in all cases), ensuring that they can be mutated safely; but this is a bit automagical perhaps.

I don't know what the correct procedure is to report this as it's adding failing tests instead of fixing them, and I don't pretend to be able to fix all of the below failing tests in this PR - I just want to report that the tests themselves are broken, and so there may be bugs lurking there.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`. => **4 TESTS ARE BROKEN AND SET TO skip=true**
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.) => many seem to be broken in node_moduels
- [X] The relevant examples still work. (Run examples with `yarn start`.)

# Tests that fail (and are now skipped)

- slate-history / undo / delete_backward / block-text
- slate-history / undo / delete_backward / custom-prop
- slate-history / undo / delete_backward / inline-across
- slate / interfaces / Node / get / root

Here's the full output:
```
  908 passing (7s)
  9 pending
  4 failing

  1) slate-history
       undo
         delete_backward
           block-text :

      AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

{
  anchor: {
    offset: 3,
    path: [
      0,
      0
    ]
  },
  focus: {
    offset: 3,
    path: [
      0,
      0
    ]
  }
}

should loosely deep-equal

{
  anchor: {
    offset: 2,
    path: [
      0,
      0
    ]
  },
  focus: {
    offset: 2,
    path: [
      0,
      0
    ]
  }
}
      + expected - actual

       {
         "anchor": {
      -    "offset": 3
      +    "offset": 2
           "path": [
             0
             0
           ]
         }
         "focus": {
      -    "offset": 3
      +    "offset": 2
           "path": [
             0
             0
           ]
      
      at fn (packages/slate-history/test/index.js:13:12)
      at Context.<anonymous> (support/fixtures.js:49:11)
      at processImmediate (internal/timers.js:458:21)

  2) slate-history
       undo
         delete_backward
           custom-prop :

      AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

{
  anchor: {
    offset: 3,
    path: [
      0,
      0
    ]
  },
  focus: {
    offset: 2,
    path: [
      1,
      0
    ]
  }
}

should loosely deep-equal

{
  anchor: {
    offset: 1,
    path: [
      0,
      0
    ]
  },
  focus: {
    offset: 2,
    path: [
      1,
      0
    ]
  }
}
      + expected - actual

       {
         "anchor": {
      -    "offset": 3
      +    "offset": 1
           "path": [
             0
             0
           ]
      
      at fn (packages/slate-history/test/index.js:13:12)
      at Context.<anonymous> (support/fixtures.js:49:11)
      at processImmediate (internal/timers.js:458:21)

  3) slate-history
       undo
         delete_backward
           inline-across :

      AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

{
  anchor: {
    offset: 3,
    path: [
      0,
      1,
      0
    ]
  },
  focus: {
    offset: 2,
    path: [
      1,
      1,
      0
    ]
  }
}

should loosely deep-equal

{
  anchor: {
    offset: 1,
    path: [
      0,
      1,
      0
    ]
  },
  focus: {
    offset: 2,
    path: [
      1,
      1,
      0
    ]
  }
}
      + expected - actual

       {
         "anchor": {
      -    "offset": 3
      +    "offset": 1
           "path": [
             0
             1
             0
      
      at fn (packages/slate-history/test/index.js:13:12)
      at Context.<anonymous> (support/fixtures.js:49:11)
      at processImmediate (internal/timers.js:458:21)

  4) slate
       interfaces
         Node
           get
             root :

      AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

{
  addMark: [Function: addMark],
  apply: [Function: apply],
  children: [
    {
      children: [
        {
          text: ''
        }
      ]
    }
  ],
  deleteBackward: [Function: deleteBackward],
  deleteForward: [Function: deleteForward],
  deleteFragment: [Function: deleteFragment],
  getFragment: [Function: getFragment],
  insertBreak: [Function: insertBreak],
  insertFragment: [Function: insertFragment],
  insertNode: [Function: insertNode],
  insertText: [Function: insertText],
  isInline: [...

should loosely deep-equal

{
  addMark: [Function: addMark],
  apply: [Function: apply],
  children: [
    {
      children: [
        {
          text: ''
        }
      ]
    }
  ],
  deleteBackward: [Function: deleteBackward],
  deleteForward: [Function: deleteForward],
  deleteFragment: [Function: deleteFragment],
  getFragment: [Function: getFragment],
  insertBreak: [Function: insertBreak],
  insertFragment: [Function: insertFragment],
  insertNode: [Function: insertNode],
  insertText: [Function: insertText],
  isInline: [...
      + expected - actual


      at fn (packages/slate/test/index.js:13:12)
      at Context.<anonymous> (support/fixtures.js:49:11)
      at processImmediate (internal/timers.js:458:21)
```
