### PR TITLE
Move hasRange to core

### DIFF
--- a/.changeset/dull-kiwis-drive.md
+++ b/.changeset/dull-kiwis-drive.md
@@ -1,0 +1,6 @@
+---
+'slate': minor
+'slate-react': minor
+---
+
+Move hasRange to core

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -188,7 +188,7 @@ export const Editable = (props: EditableProps) => {
     // then its children might just change - DOM responds to it on its own
     // but Slate's value is not being updated through any operation
     // and thus it doesn't transform selection on its own
-    if (selection && !ReactEditor.hasRange(editor, selection)) {
+    if (selection && !Editor.hasRange(editor, selection)) {
       editor.selection = ReactEditor.toSlateRange(editor, domSelection)
       return
     }

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -33,7 +33,6 @@ import { IS_CHROME } from '../utils/environment'
 export interface ReactEditor extends BaseEditor {
   insertData: (data: DataTransfer) => void
   setFragmentData: (data: DataTransfer) => void
-  hasRange: (editor: ReactEditor, range: Range) => boolean
 }
 
 export const ReactEditor = {
@@ -586,12 +585,5 @@ export const ReactEditor = {
       : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset])
 
     return { anchor, focus }
-  },
-
-  hasRange(editor: ReactEditor, range: Range): boolean {
-    const { anchor, focus } = range
-    return (
-      Editor.hasPath(editor, anchor.path) && Editor.hasPath(editor, focus.path)
-    )
   },
 }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -119,6 +119,7 @@ export interface EditorInterface {
   hasBlocks: (editor: Editor, element: Element) => boolean
   hasInlines: (editor: Editor, element: Element) => boolean
   hasPath: (editor: Editor, path: Path) => boolean
+  hasRange: (editor: Editor, range: Range) => boolean
   hasTexts: (editor: Editor, element: Element) => boolean
   insertBreak: (editor: Editor) => void
   insertFragment: (editor: Editor, fragment: Node[]) => void
@@ -485,6 +486,18 @@ export const Editor: EditorInterface = {
     const fragment = Node.fragment(editor, range)
     return fragment
   },
+
+  /**
+   * Check if range exists
+   */
+
+  hasRange(editor: Editor, range: Range): boolean {
+    const { anchor, focus } = range
+    return (
+      Editor.hasPath(editor, anchor.path) && Editor.hasPath(editor, focus.path)
+    )
+  },
+
   /**
    * Check if a node has block children.
    */


### PR DESCRIPTION
**Description**
Moves hasRange to core Editor, as described in https://github.com/ianstormtaylor/slate/issues/4160#issue-848635767

**Issue**
Fixes #4160

**Example**
n/a

**Context**
Moves `hasRange` from `ReactEditor` to `Editor`.
Non-breaking since ReactEditor inherits from Editor,

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

