### PR TITLE
Save some remove_text calls if the text is zero length

### DIFF
--- a/.changeset/giant-adults-matter.md
+++ b/.changeset/giant-adults-matter.md
@@ -1,0 +1,5 @@
+---
+slate: patch
+---
+
+Fixed insert and remove text operations to no-op without any text.

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -44,6 +44,7 @@ export const GeneralTransforms: GeneralTransforms = {
 
       case 'insert_text': {
         const { path, offset, text } = op
+        if (text.length === 0) break
         const node = Node.leaf(editor, path)
         const before = node.text.slice(0, offset)
         const after = node.text.slice(offset)
@@ -167,7 +168,7 @@ export const GeneralTransforms: GeneralTransforms = {
 
       case 'remove_text': {
         const { path, offset, text } = op
-        if (!text || text.length === 0) break
+        if (text.length === 0) break
         const node = Node.leaf(editor, path)
         const before = node.text.slice(0, offset)
         const after = node.text.slice(offset + text.length)

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -167,6 +167,7 @@ export const GeneralTransforms: GeneralTransforms = {
 
       case 'remove_text': {
         const { path, offset, text } = op
+        if (!text || text.length === 0) break
         const node = Node.leaf(editor, path)
         const before = node.text.slice(0, offset)
         const after = node.text.slice(offset + text.length)

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -177,7 +177,8 @@ export const TextTransforms: TextTransforms = {
         const { path } = point
         const { offset } = start
         const text = node.text.slice(offset)
-        editor.apply({ type: 'remove_text', path, offset, text })
+        if (text.length > 0)
+          editor.apply({ type: 'remove_text', path, offset, text })
       }
 
       for (const pathRef of pathRefs) {
@@ -191,7 +192,8 @@ export const TextTransforms: TextTransforms = {
         const { path } = point
         const offset = isSingleText ? start.offset : 0
         const text = node.text.slice(offset, end.offset)
-        editor.apply({ type: 'remove_text', path, offset, text })
+        if (text.length > 0)
+          editor.apply({ type: 'remove_text', path, offset, text })
       }
 
       if (
@@ -476,7 +478,8 @@ export const TextTransforms: TextTransforms = {
       }
 
       const { path, offset } = at
-      editor.apply({ type: 'insert_text', path, offset, text })
+      if (text.length > 0)
+        editor.apply({ type: 'insert_text', path, offset, text })
     })
   },
 }


### PR DESCRIPTION
There's no need to remove_text of 0 length, so prevent that from happening.

It's arguably an optimization, and some plugins that hook into editor.apply may balk this happening.  So, it seems like a good idea to do in general.  If you don't agree with this, then just close this PR.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

