### PR TITLE
Updates outdated TypeScript link in first walkthrough document

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -47,7 +47,7 @@ const App = () => {
 
 Of course we haven't rendered anything, so you won't see any changes.
 
-> If you are using TypeScript, you will also need to extend the `Editor` with `ReactEditor` as per the documentation on [TypeScript](../concepts/11-typescript/README.md). The example below also includes the custom types required for the rest of this example.
+> If you are using TypeScript, you will also need to extend the `Editor` with `ReactEditor` as per the documentation on [TypeScript](../concepts/12-typescript.md). The example below also includes the custom types required for the rest of this example.
 
 ```typescript
 // TypeScript Users only add this code


### PR DESCRIPTION
**Description**
This PR updates TypeScript link in the `Installing Slate` documentation for new users to a valid reference. Looks like this URL changed in the past, so this is just fixing a 404. Thanks!