### PR TITLE
Allow unhang when the range start offset is not zero

### DIFF
--- a/.changeset/good-hairs-allow.md
+++ b/.changeset/good-hairs-allow.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Selection across the end of a paragraph now more consistently excludes the following paragraph from modifications

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1648,16 +1648,16 @@ export const Editor: EditorInterface = {
 
     for (const [node, path] of Editor.nodes(editor, {
       at: before,
-      match: Text.isText,
+      match: n => Text.isText(n) || (editor.isInline(n) && editor.isVoid(n)),
       reverse: true,
       voids,
     })) {
       if (skip) {
         skip = false
         continue
-      }
-
-      if (node.text !== '' || Path.isBefore(path, blockPath)) {
+      } else if (!Text.isText(node)) {
+        break
+      } else if (node.text !== '' || Path.isBefore(path, blockPath)) {
         end = { path, offset: node.text.length }
         break
       }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1633,7 +1633,7 @@ export const Editor: EditorInterface = {
     let [start, end] = Range.edges(range)
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if (start.offset !== 0 || end.offset !== 0 || Range.isCollapsed(range)) {
+    if (end.offset !== 0 || Range.isCollapsed(range)) {
       return range
     }
 

--- a/packages/slate/test/interfaces/Editor/range/unhang-inline-end.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-inline-end.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>
+      <text />
+      <inline>two</inline>
+      <text />
+    </block>
+  </editor>
+)
+
+export const inputCursor = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputCursor)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-inline-start.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-inline-start.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>
+      one
+      <inline>two</inline>
+    </block>
+    <block>three</block>
+  </editor>
+)
+
+export const inputCursor = {
+  anchor: { path: [0, 1, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputCursor)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 1, 0], offset: 0 },
+  focus: { path: [0, 1, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-into-inline.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-into-inline.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>
+      <text />
+      <inline>two</inline>
+      three
+    </block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 2], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 1, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-mark-start.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-mark-start.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>
+      one
+      <text a>two</text>
+    </block>
+    <block>three</block>
+  </editor>
+)
+
+export const inputCursor = {
+  anchor: { path: [0, 1], offset: 0 },
+  focus: { path: [1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputCursor)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 1], offset: 0 },
+  focus: { path: [0, 1], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-plain-nochange.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-plain-nochange.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 1 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 1 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-plain.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-plain.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-single-text-nochange.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-single-text-nochange.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [1, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 3 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [1, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-span-two-blocks.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-span-two-blocks.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+    <block>three</block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [2, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-text-before-inline.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-text-before-inline.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>
+      <text />
+      <inline>two</inline>
+      <text />
+    </block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-text-middle.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-text-middle.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 2 },
+  focus: { path: [1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 2 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-void-end.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-void-end.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>
+      one
+      <inline void />
+      <text />
+    </block>
+    <block>two</block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 2], offset: 0 },
+}

--- a/packages/slate/test/interfaces/Editor/range/unhang-void.tsx
+++ b/packages/slate/test/interfaces/Editor/range/unhang-void.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input: Editor = (
+  <editor>
+    <block>
+      one
+      <inline void />
+      two
+    </block>
+  </editor>
+)
+
+export const inputRange = {
+  anchor: { path: [0, 0], offset: 3 },
+  focus: { path: [0, 2], offset: 0 },
+}
+
+export const test = editor => {
+  Transforms.select(editor, inputRange)
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 3 },
+  focus: { path: [0, 2], offset: 0 },
+}

--- a/packages/slate/test/transforms/delete/selection/block-across-nested.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-across-nested.tsx
@@ -16,6 +16,7 @@ export const input = (
     </block>
     <block>
       <block>
+        extra text
         <focus />
         three
       </block>

--- a/packages/slate/test/transforms/delete/selection/block-depths-nested.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-depths-nested.tsx
@@ -14,6 +14,7 @@ export const input = (
       </block>
     </block>
     <block>
+      extra text
       <focus />
       two
     </block>

--- a/packages/slate/test/transforms/delete/selection/block-join-edges.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-join-edges.tsx
@@ -12,6 +12,7 @@ export const input = (
       <anchor />
     </block>
     <block>
+      extra text
       <focus />
       another
     </block>

--- a/packages/slate/test/transforms/delete/selection/block-join-inline.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-join-inline.tsx
@@ -12,6 +12,7 @@ export const input = (
       <anchor />
     </block>
     <block>
+      extra text
       <focus />
       two<inline>three</inline>four
     </block>

--- a/packages/slate/test/transforms/delete/selection/block-join-nested.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-join-nested.tsx
@@ -14,6 +14,7 @@ export const input = (
           <anchor />
         </block>
         <block>
+          extra text
           <focus />
           another
         </block>


### PR DESCRIPTION
**Description**

The `unhangRange` implementation produces inconsistent user actions. It has an early exit if the start of the selection is not at the start of a node, but that seems like an arbitrary decision.

The result from a user perspective is that if they get into a range hang situation, whether the following paragraph is included in their next action is seemingly random. 

**Issue**
Fixes: #4148 (I've also incorporated the inline void change)

**Example**

* `<p>[ab</p><p>]c</p>` becomes `<p>[ab]</p><p>c</p>` ✅ 
* `<p>a<bold>[b</bold></p><p>]c</p>` becomes `<p>a<bold>[b]</bold></p><p>c</p>` ✅ 
* `<p>a[b</p><p>]c</p>` is not adjusted ❌ 


**Context**
I've added a bunch of tests for the existing behaviour, the test that fails without my fix is `unhang-text-middle.tsx`.

I'm not 100% sure if this is a good idea, because the selection delete tests depend on `<p>ab[</p><p>]c</p>` which my change now unhangs to `<p>ab[]</p><p>c</p>`. Adding extra text to the tests allows them to pass but I'm concerned it might have changed the intention of the tests.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
