### PR TITLE
Added functionality for setNode to take a function as props argument

### DIFF
--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -635,3 +635,7 @@ export type NodeProps =
   | Omit<Editor, 'children'>
   | Omit<Element, 'children'>
   | Omit<Text, 'text'>
+
+// export type NodeProps<T extends Node> = T extends Element
+//   ? Omit<T, 'children'>
+//   : Omit<T, 'text'>

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -631,11 +631,6 @@ export type NodeEntry<T extends Node = Node> = [T, Path]
 /**
  * Convenience type for returning the props of a node.
  */
-export type NodeProps =
-  | Omit<Editor, 'children'>
-  | Omit<Element, 'children'>
-  | Omit<Text, 'text'>
-
-// export type NodeProps<T extends Node> = T extends Element
-//   ? Omit<T, 'children'>
-//   : Omit<T, 'text'>
+export type NodeProps<T extends Node = Node> = T extends Element
+  ? Omit<T, 'children'>
+  : Omit<T, 'text'>

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -12,6 +12,7 @@ import {
   Ancestor,
 } from '..'
 import { NodeMatch } from '../interfaces/editor'
+import { NodeProps } from '../interfaces/node'
 
 export interface NodeTransforms {
   insertNodes: <T extends Node>(
@@ -67,7 +68,7 @@ export interface NodeTransforms {
   ) => void
   setNodes: <T extends Node>(
     editor: Editor,
-    props: Partial<Node>,
+    props: Partial<T> | ((existingProps: NodeProps) => Partial<T>),
     options?: {
       at?: Location
       match?: NodeMatch<T>
@@ -555,7 +556,7 @@ export const NodeTransforms: NodeTransforms = {
 
   setNodes<T extends Node>(
     editor: Editor,
-    props: Partial<Node>,
+    props: Partial<T> | ((existingProps: NodeProps) => Partial<T>),
     options: {
       at?: Location
       match?: NodeMatch<T>
@@ -621,23 +622,24 @@ export const NodeTransforms: NodeTransforms = {
         mode,
         voids,
       })) {
-        const properties: Partial<Node> = {}
-        const newProperties: Partial<Node> = {}
+        const properties: Partial<T> = {}
+        const newProperties: Partial<T> = {}
+        const propsToApply = typeof props === 'function' ? props(node) : props
 
         // You can't set properties on the editor node.
         if (path.length === 0) {
           continue
         }
 
-        for (const k in props) {
+        for (const k in propsToApply) {
           if (k === 'children' || k === 'text') {
             continue
           }
 
-          if (props[k] !== node[k]) {
+          if (propsToApply[k] !== node[k]) {
             // Omit new properties from the old property list rather than set them to undefined
             if (node.hasOwnProperty(k)) properties[k] = node[k]
-            newProperties[k] = props[k]
+            newProperties[k] = propsToApply[k]
           }
         }
 

--- a/packages/slate/test/transforms/setNodes/block/block-function-across.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-function-across.tsx
@@ -1,0 +1,38 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+const updateFunction = props => {
+  return { ...props, key: !props.key }
+}
+
+export const run = editor => {
+  Transforms.setNodes(editor, updateFunction, {
+    match: n => Editor.isBlock(editor, n),
+  })
+}
+
+export const input = (
+  <editor>
+    <block key={false}>
+      <anchor />
+      word
+    </block>
+    <block key={false}>
+      a<focus />
+      nother
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block key>
+      <anchor />
+      word
+    </block>
+    <block key>
+      a<focus />
+      nother
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/setNodes/inline/inline-function-nested.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-function-nested.tsx
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+const updateFunction = props => {
+  return { ...props, key: !props.key }
+}
+
+export const run = editor => {
+  Transforms.setNodes(editor, updateFunction, {
+    match: n => Editor.isInline(editor, n),
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        <text />
+        <inline key={false}>
+          <cursor />
+          word
+        </inline>
+        <text />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        <text />
+        <inline key>
+          <cursor />
+          word
+        </inline>
+        <text />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3669,9 +3669,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001111, caniuse-lite@^1.0.30001113:
-  version "1.0.30001205"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz#d79bf6a6fb13196b4bb46e5143a22ca0242e0ef8"
-  integrity sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==
+  version "1.0.30001209"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz"
+  integrity sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
**Description**
This PR allows Transforms.setNodes to take either a Partial as it second argument to props (which we have before) which overrides the props on the node or a function that takes the existing props for the relevant node and returns a new set of props to attach to the node.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/3808

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

