### PR TITLE
Apply no-children normalization fix before normalization

### DIFF
--- a/.changeset/silver-snakes-perform.md
+++ b/.changeset/silver-snakes-perform.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix `Error: Cannot get the start point in the node at path [...] because it has no start text node` caused by normalizing a document where some elements have no children

--- a/packages/slate/test/transforms/normalization/move_node.tsx
+++ b/packages/slate/test/transforms/normalization/move_node.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.moveNodes(editor, { at: [0, 0], to: [1, 0] })
+}
+export const output = (
+  <editor>
+    <block>
+      <text />
+    </block>
+    <block>onetwo</block>
+  </editor>
+)

--- a/packages/slate/test/transforms/normalization/split_node-and-insert_node.tsx
+++ b/packages/slate/test/transforms/normalization/split_node-and-insert_node.tsx
@@ -1,0 +1,84 @@
+/** @jsx jsx */
+import { Editor, Transforms } from 'slate'
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>one</inline>
+      <text />
+    </block>
+    <block>
+      <text />
+      <inline>two</inline>
+      <text />
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Editor.withoutNormalizing(editor, () => {
+    const operations = [
+      {
+        type: 'split_node',
+        path: [0, 1],
+        position: 0,
+        properties: { inline: true },
+      },
+      {
+        type: 'split_node',
+        path: [0],
+        position: 1,
+        properties: {},
+      },
+      {
+        type: 'split_node',
+        path: [2, 1, 0],
+        position: 0,
+        properties: {},
+      },
+      {
+        type: 'split_node',
+        path: [2, 1],
+        position: 0,
+        properties: { inline: true },
+      },
+      {
+        type: 'split_node',
+        path: [2],
+        position: 1,
+        properties: {},
+      },
+      { type: 'insert_node', path: [2, 1], node: { text: '' } },
+    ]
+    operations.forEach(editor.apply)
+  })
+}
+export const output = (
+  <editor>
+    <block>
+      <text />
+    </block>
+    <block>
+      <text />
+      <inline>
+        <text />
+      </inline>
+      <text />
+      <inline>one</inline>
+      <text />
+    </block>
+    <block>
+      <text />
+    </block>
+    <block>
+      <text />
+      <inline>
+        <text />
+      </inline>
+      <text />
+      <inline>two</inline>
+      <text />
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
There are some edge cases in Slate that result in `editor.normalizeNode()` triggering the exception `Error: Cannot get the start point in the node at path [...] because it has no start text node` after a valid action.

**Example**
There aren't any features of `slate-react` that trigger this but it's quite easy to replicate in a collaborative editor. I've added two test cases; `move_node` is the simplest code I could find that replicates the bug, `split_node` is the one that came up in my production code.

**Context**
The problem stems from normalization fixes that depend on valid document state. The normalization logic attempts to fix problems in an order that prevents this from being a problem, but sometimes it just isn't possible. The specific normalization fix that these tests use to trigger the exception is [merging adjacent equal text nodes](https://github.com/ianstormtaylor/slate/blob/95f402c59414331b2eeca9a19bd2c73c0ab6cd6c/packages/slate/src/create-editor.ts#L266). `Transforms.mergeNodes()` uses `Editor.previous()` which relies on `Editor.before()`, and that code walks the document from the editor root using `Editor.positions()`. If somewhere between the root and the target node is an element with no children, an exception occurs.

I've had a couple of conversations about this fix in Slack #contributing; I wasn't sure if it was appropriate for Slate or just something my team needed to deal with in our collaborative editor. Ian encouraged me to contribute it.

The major downside to this change is that unlike `editor.normalizeNode()` the code can't be overridden by an integrating developer. However given how critical having child elements is to Slate logic, I think it is acceptable for this specific fix.

The only alternative would be to use a tree navigation approach that is relative, instead of iterating from the document root every time. If that is later added this pre-normalization pass can be removed.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)