### PR TITLE
Collapse expanded selection before move word hotkey

### DIFF
--- a/.changeset/move-word-collapse.md
+++ b/.changeset/move-word-collapse.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Collapse expanded selection before handling `moveWordBackward` (`alt + left`) and `moveWordForward` (`alt + right`) hotkeys.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -912,12 +912,22 @@ export const Editable = (props: EditableProps) => {
 
                 if (Hotkeys.isMoveWordBackward(nativeEvent)) {
                   event.preventDefault()
+
+                  if (selection && Range.isExpanded(selection)) {
+                    Transforms.collapse(editor, { edge: 'focus' })
+                  }
+
                   Transforms.move(editor, { unit: 'word', reverse: !isRTL })
                   return
                 }
 
                 if (Hotkeys.isMoveWordForward(nativeEvent)) {
                   event.preventDefault()
+
+                  if (selection && Range.isExpanded(selection)) {
+                    Transforms.collapse(editor, { edge: 'focus' })
+                  }
+
                   Transforms.move(editor, { unit: 'word', reverse: isRTL })
                   return
                 }


### PR DESCRIPTION
**Description**
This PR fixes the `moveWordBackward` / `moveWordForward` hotkey handling of `slate-react`. 

**Issue**
I could not find any existing related open issues.

The  `moveWordBackward` / `moveWordForward` hotkeys need to collapse expanded selections before moving the selection by word. The current behaviour is not aligned with how selection is moved in unmanaged `contenteditable` elements nor is it aligned with how other text editors work.

**Example**

_Before:_

https://user-images.githubusercontent.com/1416436/115253692-9eb71980-a0fa-11eb-83a8-e20eca5f4a06.mp4


_After:_

https://user-images.githubusercontent.com/1416436/116178116-fa793800-a6e2-11eb-9cbc-c6520d25407d.mp4

Slate above, native Textarea element below for reference


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

