### PR TITLE
Fix iframe crash

### DIFF
--- a/.changeset/thick-apricots-fly.md
+++ b/.changeset/thick-apricots-fly.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fixes error thrown when Editor is rendered inside iframe

--- a/.changeset/thick-apricots-fly.md
+++ b/.changeset/thick-apricots-fly.md
@@ -2,4 +2,4 @@
 'slate-react': patch
 ---
 
-Fixes error thrown when Editor is rendered inside iframe
+Fixes error that occurs when Editor is rendered inside iframe

--- a/cypress/integration/iframe.ts
+++ b/cypress/integration/iframe.ts
@@ -1,0 +1,31 @@
+// Taken from https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
+const getIframeDocument = () => {
+  return cy
+    .get('iframe')
+    .its('0.contentDocument')
+    .should('exist')
+}
+
+const getIframeBody = () => {
+  return (
+    getIframeDocument()
+      .its('body')
+      // automatically retries until body is loaded
+      .should('not.be.undefined')
+      .then(cy.wrap)
+  )
+}
+
+describe('iframe editor', () => {
+  beforeEach(() => {
+    cy.visit('examples/iframe')
+  })
+
+  it('should be editable', () => {
+    getIframeBody()
+      .findByRole('textbox')
+      .type('{movetostart}')
+      .type('Hello World')
+      .should('contain.text', 'Hello World')
+  })
+})

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -106,6 +106,10 @@ export const ReactEditor = {
     const el = ReactEditor.toDOMNode(editor, editor)
     const root = el.getRootNode()
 
+    // The below exception will always be thrown for iframes because the document inside an iframe
+    // does not inherit it's prototype from the parent document, therefore we return early
+    if (el.ownerDocument !== document) return el.ownerDocument
+
     if (!(root instanceof Document || root instanceof ShadowRoot))
       throw new Error(
         `Unable to find DocumentOrShadowRoot for editor element: ${el}`


### PR DESCRIPTION
**Description**
Fixes iframe crashes

Context: The exception is thrown if an editor root element does not inherit from `Document`. However an document inside iframe will never inherit the same prototype as `window.document`, this change prevents triggering this exception if we are inside an iframe

**Issue**
Fixes: #4170

**Example**
Currently the iframe example crashes with the exception `Unable to find DocumentOrShadowRoot for editor element ...`
![image](https://user-images.githubusercontent.com/1188186/115838745-e77c1480-a411-11eb-957b-ec7911e1f820.png)

With this change it works again:
![iframe-slate-fix](https://user-images.githubusercontent.com/1188186/115839039-2a3dec80-a412-11eb-8cda-cb27e81d3859.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

