### PR TITLE
fix: shadow-dom example not found in examples

### DIFF
--- a/site/examples/shadow-dom.tsx
+++ b/site/examples/shadow-dom.tsx
@@ -1,17 +1,17 @@
 import ReactDOM from 'react-dom'
 import React, { useState, useMemo, useRef, useEffect } from 'react'
-import { createEditor } from 'slate'
+import { createEditor, Descendant } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 import { withHistory } from 'slate-history'
 
 const ShadowDOM = () => {
-  const container = useRef(null)
+  const container = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (container.current.shadowRoot) return
+    if (container.current!.shadowRoot) return
 
     // Create a shadow DOM
-    const outerShadowRoot = container.current.attachShadow({ mode: 'open' })
+    const outerShadowRoot = container.current!.attachShadow({ mode: 'open' })
     const host = document.createElement('div')
     outerShadowRoot.appendChild(host)
 
@@ -28,7 +28,7 @@ const ShadowDOM = () => {
 }
 
 const ShadowEditor = () => {
-  const [value, setValue] = useState(initialValue)
+  const [value, setValue] = useState<Descendant[]>(initialValue)
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
 
   return (
@@ -38,8 +38,9 @@ const ShadowEditor = () => {
   )
 }
 
-const initialValue = [
+const initialValue: Descendant[] = [
   {
+    type: 'paragraph',
     children: [{ text: 'This Editor is rendered within a nested Shadow DOM.' }],
   },
 ]


### PR DESCRIPTION
**Description**
Fix 404 page not fuond when I access to `examples/shadow-dom`.

**Issue**
I couldn't find the related issue.

**Example**

Before:
![image](https://user-images.githubusercontent.com/2446460/115987528-5adb7d00-a5f0-11eb-8e63-1a57c2728fbb.png)

After:
![image](https://user-images.githubusercontent.com/2446460/115987486-413a3580-a5f0-11eb-99c6-86430a6e4f50.png)


**Context**
rename `shadow-dom.js` to `shadow-dom.tsx`,  
then update type hints to compile successfully.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

