### PR TITLE
Fix addMark/removeMark caused unexpected onChange.

### DIFF
--- a/.changeset/three-parrots-remember.md
+++ b/.changeset/three-parrots-remember.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fixed a bug that would allow multiple changes to be scheduled at the same time.

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -106,7 +106,9 @@ export const createEditor = (): Editor => {
           }
 
           editor.marks = marks
-          editor.onChange()
+          if (!FLUSHING.get(editor)) {
+            editor.onChange()
+          }
         }
       }
     },
@@ -296,7 +298,9 @@ export const createEditor = (): Editor => {
           const marks = { ...(Editor.marks(editor) || {}) }
           delete marks[key]
           editor.marks = marks
-          editor.onChange()
+          if (!FLUSHING.get(editor)) {
+            editor.onChange()
+          }
         }
       }
     },


### PR DESCRIPTION
**Description**
Collaborate editor relies on onChange and editor.operations, but in editor.addMark and editor.removeMark, onChange is called directly without check it was already scheduled by editor.apply method. which will cause onChange with same group or part of same group of editor.operations be called twice, then cause problem with collaborate editors.

**Issue**
Fixes: (link to issue)

**Context**
This PR simply check whether there was already a scheduled onChange, if so, do not call onChange in addMark and removeMark.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

