### PR TITLE
[WIP]fix(slate-react): prevent a crash when typing in IME mode after an inline element

### DIFF
--- a/.changeset/short-flowers-flash.md
+++ b/.changeset/short-flowers-flash.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Prevent a crash when typing in IME mode after an inline element.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -267,12 +267,31 @@ export const Editable = (props: EditableProps) => {
         const { inputType: type } = event
         const data = (event as any).dataTransfer || event.data || undefined
 
-        // These two types occur while a user is composing text and can't be
-        // cancelled. Let them through and wait for the composition to end.
-        if (
-          type === 'insertCompositionText' ||
-          type === 'deleteCompositionText'
-        ) {
+        // `insertCompositionText` and 'deleteCompositionText' occur
+        // while a user is composing text and can't be cancelled.
+        // Let them through and wait for the composition to end.
+        if (type === 'insertCompositionText') {
+          if (selection && Range.isCollapsed(selection)) {
+            const inline = Editor.above(editor, {
+              match: n => Editor.isInline(editor, n),
+              mode: 'highest',
+            })
+
+            if (inline) {
+              const [, inlinePath] = inline
+
+              if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
+                const point = Editor.after(editor, inlinePath)
+                Transforms.setSelection(editor, {
+                  anchor: point,
+                  focus: point,
+                })
+              }
+            }
+          }
+          return
+        }
+        if (type === 'deleteCompositionText') {
           return
         }
 


### PR DESCRIPTION
**Description**

When text is entered without IME mode, the `insertText` function will adjust the insertion point of the text after the inline element.

However, in IME mode, the text is inserted before the process is executed, as shown in the image below, so the text is inserted in the wrong place.

![Text is inserted in the wrong place](https://user-images.githubusercontent.com/26650149/116888320-45a4c500-ac66-11eb-9b37-0d043065b094.png)

To fix the above problem, the listener of the beforeInput event will now adjust the text insertion point after the appropriate inline element.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4136#issuecomment-826478544

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

