### PR TITLE
Update IS_FIREFOX_LEGACY flag to prevent FF crash

### DIFF
--- a/.changeset/forty-mails-roll.md
+++ b/.changeset/forty-mails-roll.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fixed text insertion logic to prevent crashing in newer Firefox versions.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -17,7 +17,7 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 import useChildren from '../hooks/use-children'
 import Hotkeys from '../utils/hotkeys'
 import {
-  IS_FIREFOX,
+  IS_FIREFOX_LEGACY,
   IS_SAFARI,
   IS_EDGE_LEGACY,
   IS_CHROME_LEGACY,

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -653,7 +653,7 @@ export const Editable = (props: EditableProps) => {
                 // aren't correct and never fire the "insertFromComposition"
                 // type that we need. So instead, insert whenever a composition
                 // ends since it will already have been committed to the DOM.
-                if (!IS_SAFARI && !IS_FIREFOX && event.data) {
+                if (!IS_SAFARI && !IS_FIREFOX_LEGACY && event.data) {
                   Editor.insertText(editor, event.data)
                 }
               }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -17,6 +17,7 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 import useChildren from '../hooks/use-children'
 import Hotkeys from '../utils/hotkeys'
 import {
+  IS_FIREFOX,
   IS_FIREFOX_LEGACY,
   IS_SAFARI,
   IS_EDGE_LEGACY,


### PR DESCRIPTION
#4118 and #4150 introduced IS_FIREFOX_LEGACY, but this block of code was not updated to reflect that. This breaks insertion of emoji and unicode characters in slate-react. This change fixes #3855.

**Description**
As noted in #3855, Firefox crashes when inserting emoji using the emoji keyboard.

**Issue**
Fixes: #3855

**Example**
This fixes an obviously overlooked update/typo. The example in #3855 shows the issue before this change. With this fix, the editor behaves as expected (doesn't crash when inserting an emoji)

**Context**
Correct a typo

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)