### PR TITLE
Fix duplicated content and other bugs related to drag and drop handling

### DIFF
--- a/.changeset/drag-and-drop.md
+++ b/.changeset/drag-and-drop.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix duplicated content and other bugs related to drag and drop handling


### PR DESCRIPTION
**Description**
This PR fixes a number of different issues that happen today with drag and drop. 
It's loosely based off of this abandonned PR: https://github.com/ianstormtaylor/slate/pull/3562

**Issue**
Fixes: 
https://github.com/ianstormtaylor/slate/issues/4222
https://github.com/ianstormtaylor/slate/issues/3522
https://github.com/ianstormtaylor/slate/issues/3137
https://github.com/ianstormtaylor/slate/issues/2076

**Examples**

https://user-images.githubusercontent.com/1416436/117067981-b1d00900-acf8-11eb-9271-df09e50ed963.mp4

https://user-images.githubusercontent.com/1416436/117067990-b4326300-acf8-11eb-838f-feb8b49c23f3.mp4

https://user-images.githubusercontent.com/1416436/117202852-51a29b00-adbc-11eb-8f0e-b9f20718ee33.mp4

https://user-images.githubusercontent.com/1416436/117068035-c14f5200-acf8-11eb-9818-6bfaeb6c4c0d.mp4

https://user-images.githubusercontent.com/1416436/117068045-c4e2d900-acf8-11eb-9ba7-ebf41c1d9d76.mp4

https://user-images.githubusercontent.com/1416436/117068049-c7453300-acf8-11eb-890d-fae171d71774.mp4

https://user-images.githubusercontent.com/1416436/117068075-cc09e700-acf8-11eb-9dad-b1cf6dd74d3b.mp4


**Context**

The main things this PR does:

- Keeps track of whether the drag start event happened internally
- If the drag start event happened internally, the original dragged range needs to be deleted before inserting a new fragment
- It's better to use `insertFragment` and call `preventDefault()` in the `drop` event rather than letting the `beforeinput` event go through. This strategy works consistently across all browsers and would also work with other input reconciliation strategies once Android support lands.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

