### PR TITLE
replace lodash depency in slate

### DIFF
--- a/.changeset/red-bears-cry.md
+++ b/.changeset/red-bears-cry.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Removed lodash dependecy to reduce bundled footprint

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -16,10 +16,13 @@
   "dependencies": {
     "@types/esrever": "^0.2.0",
     "esrever": "^0.2.0",
+    "fast-deep-equal": "^3.1.3",
     "immer": "^8.0.1",
     "is-plain-object": "^3.0.0",
-    "lodash": "^4.17.4",
     "tiny-warning": "^1.0.3"
+  },
+  "devDependencies": {
+    "lodash": "^4.17.21"
   },
   "keywords": [
     "canvas",

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -36,15 +36,15 @@ export const Text: TextInterface = {
   ): boolean {
     const { loose = false } = options
 
-    function omit(obj: Record<any, any>, key: string) {
-      const { [key]: _, ...rest } = obj
+    function omitText(obj: Record<any, any>) {
+      const { text, ...rest } = obj
 
       return rest
     }
 
     return isEqual(
-      loose ? omit(text, 'text') : text,
-      loose ? omit(another, 'text') : another
+      loose ? omitText(text) : text,
+      loose ? omitText(another) : another
     )
   },
 

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -1,5 +1,5 @@
 import isPlainObject from 'is-plain-object'
-import isEqual from 'lodash/isEqual'
+import isEqual from 'fast-deep-equal'
 import { Range } from '..'
 import { ExtendedType } from './custom-types'
 

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -1,6 +1,5 @@
 import isPlainObject from 'is-plain-object'
 import isEqual from 'lodash/isEqual'
-import omit from 'lodash/omit'
 import { Range } from '..'
 import { ExtendedType } from './custom-types'
 
@@ -36,6 +35,12 @@ export const Text: TextInterface = {
     options: { loose?: boolean } = {}
   ): boolean {
     const { loose = false } = options
+
+    function omit(obj: Record<any, any>, key: string) {
+      const { [key]: _, ...rest } = obj
+
+      return rest
+    }
 
     return isEqual(
       loose ? omit(text, 'text') : text,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5656,7 +5656,7 @@ faker@^4.1.0:
   resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
   integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
**Description**
This PR removes the dependency on `loadsh/omit` reducing bundle size by ~50Kb

> Edit: The scope of this has expanded to replace all usages of lodash, see below

**Example**
Before
<img width="897" alt="Bildschirmfoto 2021-05-06 um 13 20 47" src="https://user-images.githubusercontent.com/25329995/117290350-fd57f380-ae6d-11eb-8b18-b1de8333b27b.png">

After
<img width="838" alt="Bildschirmfoto 2021-05-06 um 13 18 46" src="https://user-images.githubusercontent.com/25329995/117290371-047f0180-ae6e-11eb-9262-29ee281cfd13.png">

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

