### PR TITLE
Fix: IME bug when typing in the input value empty

### DIFF
--- a/.changeset/lucky-melons-laugh.md
+++ b/.changeset/lucky-melons-laugh.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix IME bug when typing in the inputValue empty

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -124,6 +124,11 @@ export const Editable = (props: EditableProps) => {
   const editor = useSlate()
   const ref = useRef<HTMLDivElement>(null)
 
+  const noInputValue =
+    placeholder &&
+    editor.children.length === 1 &&
+    Array.from(Node.texts(editor)).length === 1 &&
+    Node.string(editor) === ''
   // Update internal state on each render.
   IS_READ_ONLY.set(editor, readOnly)
 
@@ -489,12 +494,7 @@ export const Editable = (props: EditableProps) => {
 
   const decorations = decorate([editor, []])
 
-  if (
-    placeholder &&
-    editor.children.length === 1 &&
-    Array.from(Node.texts(editor)).length === 1 &&
-    Node.string(editor) === ''
-  ) {
+  if (noInputValue) {
     const start = Editor.start(editor, [])
     decorations.push({
       [PLACEHOLDER_SYMBOL]: true,
@@ -540,6 +540,12 @@ export const Editable = (props: EditableProps) => {
             // Allow for passed-in styles to override anything.
             ...style,
           }}
+          onInput={useCallback(() => {
+            const placeholderDOM = document.getElementById('slate-placeholder')
+            if (noInputValue && placeholderDOM) {
+              placeholderDOM.style.display = 'none'
+            }
+          }, [noInputValue])}
           onBeforeInput={useCallback(
             (event: React.FormEvent<HTMLDivElement>) => {
               // COMPAT: Certain browsers don't support the `beforeinput` event, so we
@@ -1116,6 +1122,7 @@ export const Editable = (props: EditableProps) => {
 export type RenderPlaceholderProps = {
   children: any
   attributes: {
+    id: string
     'data-slate-placeholder': boolean
     dir?: 'rtl'
     contentEditable: boolean

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -61,6 +61,7 @@ const Leaf = (props: {
     const placeholderProps: RenderPlaceholderProps = {
       children: leaf.placeholder,
       attributes: {
+        id: 'slate-placeholder',
         'data-slate-placeholder': true,
         style: {
           position: 'absolute',


### PR DESCRIPTION
**Reason**
When use IME input(such as Chinese, Japanese, ......) spelling, cursor position will suspension in placeholder. So, when input value equal empty text, placeholder dom hidden.

![image](https://user-images.githubusercontent.com/36876080/117294665-7aeb2600-aea5-11eb-9b3c-075ccad6246b.png)

**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

