### PR TITLE
Fix the problem of text being inserted in the wrong place in IME mode

### DIFF
--- a/.changeset/khaki-eels-exist.md
+++ b/.changeset/khaki-eels-exist.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fixed the problem of text being inserted in the wrong place in IME mode.

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -23,6 +23,7 @@ import {
   isDOMSelection,
   normalizeDOMPoint,
   hasShadowRoot,
+  isDOMText,
 } from '../utils/dom'
 import { IS_CHROME } from '../utils/environment'
 
@@ -466,7 +467,7 @@ export const ReactEditor = {
       // The parent of TEXT_NODE must have `date-slate-string`.
       if (
         !voidNode &&
-        nearestNode.nodeType === 3 &&
+        isDOMText(nearestNode) &&
         !parentNode.hasAttribute('data-slate-string')
       ) {
         parentNode.removeChild(nearestNode)

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -463,6 +463,15 @@ export const ReactEditor = {
       let leafNode = parentNode.closest('[data-slate-leaf]')
       let domNode: DOMElement | null = null
 
+      // The parent of TEXT_NODE must have `date-slate-string`.
+      if (
+        !voidNode &&
+        nearestNode.nodeType === 3 &&
+        !parentNode.hasAttribute('data-slate-string')
+      ) {
+        parentNode.removeChild(nearestNode)
+      }
+
       // Calculate how far into the text node the `nearestNode` is, so that we
       // can determine what the offset relative to the text node is.
       if (leafNode) {


### PR DESCRIPTION
**Description**

In IME mode, if you try to type text right after an inline element, it will be inserted in the wrong place.
(A string will be inserted directly as a child of `data-slate-node="element"`)

![before](https://user-images.githubusercontent.com/26650149/117469207-6c2d6d80-af90-11eb-9431-85939ef23926.gif)
![Text is inserted in the wrong place](https://user-images.githubusercontent.com/26650149/116888320-45a4c500-ac66-11eb-9b37-0d043065b094.png)

Therefore, I fixed it so that text inserted in the wrong place will be removed.

![after](https://user-images.githubusercontent.com/26650149/117469584-dd6d2080-af90-11eb-85a5-e365de95be2c.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

