### PR TITLE
Skip wrapping nodes when the only match is an editor

### DIFF
--- a/.changeset/khaki-readers-battle.md
+++ b/.changeset/khaki-readers-battle.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix `Transforms.wrapNodes` crashing when the `match` function matched only the editor

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -940,11 +940,11 @@ export const NodeTransforms: NodeTransforms = {
         if (matches.length > 0) {
           const [first] = matches
           const last = matches[matches.length - 1]
-          const [firstNode, firstPath] = first
-          const [lastNode, lastPath] = last
+          const [, firstPath] = first
+          const [, lastPath] = last
 
-          if (firstNode === lastNode && Editor.isEditor(firstNode)) {
-            // if the only matching node is an editor, no nodes matched
+          if (firstPath.length === 0 && lastPath.length === 0) {
+            // if there's no matching parent - usually means the node is an editor - don't do anything
             continue
           }
 

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -940,8 +940,14 @@ export const NodeTransforms: NodeTransforms = {
         if (matches.length > 0) {
           const [first] = matches
           const last = matches[matches.length - 1]
-          const [, firstPath] = first
-          const [, lastPath] = last
+          const [firstNode, firstPath] = first
+          const [lastNode, lastPath] = last
+
+          if (firstNode === lastNode && Editor.isEditor(firstNode)) {
+            // if the only matching node is an editor, no nodes matched
+            continue
+          }
+
           const commonPath = Path.equals(firstPath, lastPath)
             ? Path.parent(firstPath)
             : Path.common(firstPath, lastPath)

--- a/packages/slate/test/transforms/wrapNodes/block/omit-all.tsx
+++ b/packages/slate/test/transforms/wrapNodes/block/omit-all.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Editor, Node, Text, Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.wrapNodes(editor, <block a />, {
+    match: (node, currentPath) => {
+      // reject all nodes inside blocks tagged `noneditable`. Which is everything.
+      if (node.noneditable) return false
+      for (const [node, _] of Node.ancestors(editor, currentPath)) {
+        if (node.noneditable) return false
+      }
+      return true
+    },
+  })
+}
+export const input = (
+  <editor>
+    <block noneditable>
+      <cursor />
+      word
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block noneditable>
+      <cursor />
+      word
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
`Transforms.wrapNodes` attempts to detect when zero nodes match, but it missed an edge case where one node matches - the editor. The function very quickly throws `Error: Cannot get the parent path of the root path []` when this happens.

**Example**
The test shows the failure condition. The editor I'm working on supports `contenteditable=false` sections in document content, and while we are able to handle most of the filtering outside of slate this is one case that is difficult to handle without a lot of extra code.

**Context**
There are a few other ways I can think of to fix this - such as wrapping the supplied `match` function to enforce `!Editor.isEditor` - but this seemed like the least invasive way to deal with it.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

