### PR TITLE
Add DefaultEditable and AndroidEditable to exports

### DIFF
--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -26,3 +26,4 @@ export { useSlate } from './hooks/use-slate'
 export { ReactEditor } from './plugin/react-editor'
 export { withReact } from './plugin/with-react'
 export const Editable = !IS_ANDROID ? DefaultEditable : AndroidEditable
+export { DefaultEditable, AndroidEditable }


### PR DESCRIPTION
**Description**
The `Editable` and `AndroidEditable` are not exported. Some people need access to these as exports.

**Issue**
n/a

**Example**
n/a

**Context**
@clauderic has mentioned they need access to the default `Editable`.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

