### PR TITLE
Don't import slate-history to slate-react

### DIFF
--- a/.changeset/bright-cameras-drum.md
+++ b/.changeset/bright-cameras-drum.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Removed accidental bundling of `slate-history` inside `slate-react`

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "slate": "^0.63.0",
-    "slate-history": "^0.62.0",
     "slate-hyperscript": "^0.62.0"
   },
   "peerDependencies": {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -10,7 +10,6 @@ import {
   Path,
 } from 'slate'
 import getDirection from 'direction'
-import { HistoryEditor } from 'slate-history'
 import throttle from 'lodash/throttle'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
@@ -874,9 +873,10 @@ export const Editable = (props: EditableProps) => {
                 // hotkeys ourselves. (2019/11/06)
                 if (Hotkeys.isRedo(nativeEvent)) {
                   event.preventDefault()
+                  const maybeHistoryEditor: any = editor
 
-                  if (HistoryEditor.isHistoryEditor(editor)) {
-                    editor.redo()
+                  if (typeof maybeHistoryEditor.redo === 'function') {
+                    maybeHistoryEditor.redo()
                   }
 
                   return
@@ -884,9 +884,10 @@ export const Editable = (props: EditableProps) => {
 
                 if (Hotkeys.isUndo(nativeEvent)) {
                   event.preventDefault()
+                  const maybeHistoryEditor: any = editor
 
-                  if (HistoryEditor.isHistoryEditor(editor)) {
-                    editor.undo()
+                  if (typeof maybeHistoryEditor.undo === 'function') {
+                    maybeHistoryEditor.undo()
                   }
 
                   return


### PR DESCRIPTION
**Description**
#3835 accidentally started bundling a chunk of `slate-history` inside `slate-react` ([this change](https://github.com/ianstormtaylor/slate/pull/3835/files#diff-1d0c52ec4c5562d96965f789988bd4efd4a6d24b88527918987d06bcc43d15adL769-R770)). The fix for now is to revert the change (plus some TypeScript shenanigans now that `ReactEditor` is more strictly typed). A more complete fix would require either:

* Moving the history type and `isHistoryEditor` code into core (not ideal)
* Exporting events that would allow `slate-history` to hook into the keyboard events itself (see [slack thread](https://slate-js.slack.com/archives/CC58ZGGU9/p1621280180168400))

**Issue**
Fixes: Bundle regression caused by #3835

**Example**
It's easy to confirm; after `yarn build:rollup` open `packages/slate-react/dist/index.js` (or `index.es.js`) and search for `history`.

Before:
```
-rw-r--r--  1 spyder staff  88034 May 18 09:40 index.es.js
-rw-r--r--  1 spyder staff 107845 May 18 09:40 index.js
```
After:
```
-rw-r--r--  1 spyder staff  86482 May 18 09:47 index.es.js
-rw-r--r--  1 spyder staff 106183 May 18 09:47 index.js
```

These are unminified, but 1.5kb is still nothing to sneeze at.

**Context**
In theory we should be able to make importing across packages a compile failure but I couldn't quite figure that out. Removing `slate-history` from the `slate-react` package.json does, at least, trigger a lint failure on an accidental import.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

