### PR TITLE
fix typo - rename extractMatch to exactMatch

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -449,9 +449,9 @@ export const ReactEditor = {
   toSlatePoint<T extends boolean>(
     editor: ReactEditor,
     domPoint: DOMPoint,
-    extractMatch: T
+    exactMatch: T
   ): T extends true ? Point | null : Point {
-    const [nearestNode, nearestOffset] = extractMatch
+    const [nearestNode, nearestOffset] = exactMatch
       ? domPoint
       : normalizeDOMPoint(domPoint)
     const parentNode = nearestNode.parentNode as DOMElement
@@ -525,7 +525,7 @@ export const ReactEditor = {
     }
 
     if (!textNode) {
-      if (extractMatch) {
+      if (exactMatch) {
         return null as T extends true ? Point | null : Point
       }
       throw new Error(


### PR DESCRIPTION
**Description**
This PR renames one parameter of `toSlatePoint` to be consistent with the rest of the codebase. 
`extractMatch` parameter is renamed as `exactMatch`

**Issue**
Fixes: (link to issue)

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

