### PR TITLE
Fix errors accessing `globalThis` in browsers that do not implement it

### DIFF
--- a/.changeset/fix-globalthis-errors.md
+++ b/.changeset/fix-globalthis-errors.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix errors accessing `globalThis` in browsers that do not implement it

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -17,11 +17,10 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 import useChildren from '../hooks/use-children'
 import Hotkeys from '../utils/hotkeys'
 import {
+  HAS_BEFORE_INPUT_SUPPORT,
   IS_FIREFOX,
   IS_FIREFOX_LEGACY,
   IS_SAFARI,
-  IS_EDGE_LEGACY,
-  IS_CHROME_LEGACY,
 } from '../utils/environment'
 import { ReactEditor } from '..'
 import { ReadOnlyContext } from '../hooks/use-read-only'
@@ -47,15 +46,6 @@ import {
   PLACEHOLDER_SYMBOL,
   EDITOR_TO_WINDOW,
 } from '../utils/weak-maps'
-
-// COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
-// Chrome Legacy doesn't support `beforeinput` correctly
-const HAS_BEFORE_INPUT_SUPPORT =
-  !IS_CHROME_LEGACY &&
-  !IS_EDGE_LEGACY &&
-  globalThis.InputEvent &&
-  // @ts-ignore The `getTargetRanges` property isn't recognized.
-  typeof globalThis.InputEvent.prototype.getTargetRanges === 'function'
 
 /**
  * `RenderElementProps` are passed to the `renderElement` handler.

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -46,3 +46,14 @@ export const CAN_USE_DOM = !!(
   typeof window.document !== 'undefined' &&
   typeof window.document.createElement !== 'undefined'
 )
+
+// COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
+// Chrome Legacy doesn't support `beforeinput` correctly
+export const HAS_BEFORE_INPUT_SUPPORT =
+  !IS_CHROME_LEGACY &&
+  !IS_EDGE_LEGACY &&
+  // globalThis is undefined in older browsers
+  typeof globalThis !== 'undefined' &&
+  globalThis.InputEvent &&
+  // @ts-ignore The `getTargetRanges` property isn't recognized.
+  typeof globalThis.InputEvent.prototype.getTargetRanges === 'function'


### PR DESCRIPTION
**Description**
This PR fixes errors thrown in [browsers that do not implement](https://caniuse.com/mdn-javascript_builtins_globalthis) the [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) global object.

**Issue**
I could not find any open issues related to this. This is a fairly recent issue introduced by this commit https://github.com/ianstormtaylor/slate/commit/6a1376332bbd2567336c444c57c1e64fdf706feb

**Example**
Before:
![Screen Shot 2021-05-20 at 11 17 39 AM](https://user-images.githubusercontent.com/1416436/119005884-d87b7a00-b95d-11eb-9909-ff0fd74b103f.png)

After:
![Screen Shot 2021-05-20 at 11 18 03 AM](https://user-images.githubusercontent.com/1416436/119005876-d6b1b680-b95d-11eb-9bc3-fe5c1283439f.png)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

