### PR TITLE
Update release workflow to ensure that the `latest` job runs before the `dev` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,9 @@ on:
       - main
 
 jobs:
-  release:
-    name: ${{ matrix.channel }}
+  setup:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        channel:
-          - dev
-          - latest
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -32,9 +27,13 @@ jobs:
       - name: Prepare release
         run: yarn prerelease
 
+  latest:
+    needs: setup
+    runs-on: ubuntu-latest
+
+    steps:
       # https://github.com/changesets/action
-      - name: Create release pull request
-        if: matrix.channel == 'latest'
+      - name: Create release pull request or Publish to npm
         uses: changesets/action@master
         with:
           publish: yarn changeset publish
@@ -43,12 +42,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  dev:
+    needs: latest
+    runs-on: ubuntu-latest
+
+    steps:
       # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
       - name: Release to @dev channel
-        if: matrix.channel == 'dev'
         run: |
           yarn changeset version --snapshot
           yarn changeset publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description**
There was an issue with the `0.64.0` release of `slate-react` not properly being tagged under `latest` on npm. 

**Example**
![Screen Shot 2021-05-20 at 11 39 14 AM](https://user-images.githubusercontent.com/1416436/119020405-30b97880-b96c-11eb-958a-e7aeccd0f701.png)
![Screen Shot 2021-05-20 at 11 39 39 AM](https://user-images.githubusercontent.com/1416436/119020413-32833c00-b96c-11eb-9ebe-bc3c7f291840.png)

**Context**
This happened because the `dev` workflow ran before the `latest` workflow, and it noticed that `slate-react@0.64.0` hadn't been published yet and decided to publish it. 

By the time the `latest` workflow ran, the `dev` workflow had already released 0.64.0 so it resulted in a no-op.

This could arguably be a bug in changesets, though I think this PR is still the right solution, we should run the `latest` workflow before the `dev` workflow.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] This PR does not require a changeset

cc @circlingthesun