### PR TITLE
Do not remove empty node in merge operation if it is first children i…

### DIFF
--- a/.changeset/merge-nodes-issue
+++ b/.changeset/merge-nodes-issue
@@ -1,0 +1,5 @@
+---
+"slate": patch
+---
+
+Do not remove empty node in merge operation if it is first children in it's parent.

--- a/.changeset/merge-nodes-issue
+++ b/.changeset/merge-nodes-issue
@@ -2,4 +2,4 @@
 "slate": patch
 ---
 
-Do not remove empty node in merge operation if it is first children in it's parent.
+Do not remove empty node in merge operation if it is first children in its parent.

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -422,9 +422,12 @@ export const NodeTransforms: NodeTransforms = {
       // of merging the two. This is a common rich text editor behavior to
       // prevent losing formatting when deleting entire nodes when you have a
       // hanging selection.
+      // if prevNode is first child in parent,don't remove it.
       if (
         (Element.isElement(prevNode) && Editor.isEmpty(editor, prevNode)) ||
-        (Text.isText(prevNode) && prevNode.text === '')
+        (Text.isText(prevNode) &&
+          prevNode.text === '' &&
+          prevPath[prevPath.length - 1] !== 0)
       ) {
         Transforms.removeNodes(editor, { at: prevPath, voids })
       } else {


### PR DESCRIPTION
…n parent(#4228)

**Description**
see issue.

**Issue**
Fixes: (#4228)

**Example**
in richtext example.select the line and delete it. see issue video pls.

**Context**
one line has bold node or other node,not just one textnode.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
- [x] The tests pass with `yarn test`. 

