### PR TITLE
Revert to using matrix for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   release:
+    name: ${{ matrix.channel }}
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        channel:
+          - latest
+          - dev
 
     steps:
       - name: Checkout repo
@@ -29,6 +36,7 @@ jobs:
 
       # https://github.com/changesets/action
       - name: Create release pull request or Publish to npm
+        if: matrix.channel == 'latest'
         uses: changesets/action@master
         with:
           publish: yarn changeset publish
@@ -39,6 +47,7 @@ jobs:
 
       # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
       - name: Release to @dev channel
+        if: matrix.channel == 'dev'
         run: |
           yarn changeset version --snapshot
           yarn changeset publish --tag dev


### PR DESCRIPTION
**Description**
Setting max parallel number of jobs to 1 and updated the job order so that the `latest` job runs before the `dev` job.

The `yarn changeset publish` command deletes files in the .changesets folder, so it's not safe to run two changeset steps in the same job.
<img width="347" alt="Screen Shot 2021-05-26 at 10 14 41 AM" src="https://user-images.githubusercontent.com/1416436/119675640-39e29380-be0b-11eb-82da-4518d7c4fb6b.png">

Which means that by the time the `snapshot` release command runs, there are no changesets found and it exits early:
<img width="642" alt="Screen Shot 2021-05-26 at 10 14 52 AM" src="https://user-images.githubusercontent.com/1416436/119675724-4a930980-be0b-11eb-9b24-8bbfc1bd6725.png">


**Issue**
Follows-up on #4291 and #4274 
