### PR TITLE
FIX warnings related to `autoCorrect` and `autoCapitalize`

### DIFF
--- a/.changeset/metal-suits-reply.md
+++ b/.changeset/metal-suits-reply.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+FIX warnings related to autoCorrect and autoCapitalize

--- a/.changeset/metal-suits-reply.md
+++ b/.changeset/metal-suits-reply.md
@@ -2,4 +2,4 @@
 'slate-react': patch
 ---
 
-FIX warnings related to autoCorrect and autoCapitalize
+Fix React warnings related to `autoCorrect` and `autoCapitalize` attributes being passed as a boolean instead of a string.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -507,10 +507,10 @@ export const Editable = (props: EditableProps) => {
           // have to use hacks to make these replacement-based features work.
           spellCheck={!HAS_BEFORE_INPUT_SUPPORT ? false : attributes.spellCheck}
           autoCorrect={
-            !HAS_BEFORE_INPUT_SUPPORT ? false : attributes.autoCorrect
+            !HAS_BEFORE_INPUT_SUPPORT ? 'false' : attributes.autoCorrect
           }
           autoCapitalize={
-            !HAS_BEFORE_INPUT_SUPPORT ? false : attributes.autoCapitalize
+            !HAS_BEFORE_INPUT_SUPPORT ? 'false' : attributes.autoCapitalize
           }
           data-slate-editor
           data-slate-node="value"


### PR DESCRIPTION
**Description**
A clear and concise description of what this pull request solves. (Please do not just link to a long issue thread. Instead include a clear description here or your pull request will likely not be reviewed as quickly.)

Wile running tets in Jest, I received multiple warning related to issues on `autoCorrect` and `autoCapitalize`. It appears there was already an opened issue on this subject.

Related warnings are:

```txt
Warning: Received `false` for a non-boolean attribute `autoCorrect`.
Warning: Received `false` for a non-boolean attribute `autoCapitalize`.
```

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4248

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

