### PR TITLE
Fix mergeNodes moving node into parent sibling

### DIFF
--- a/.changeset/orange-jeans-sing.md
+++ b/.changeset/orange-jeans-sing.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix mergeNodes moving node into parent sibling

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -150,7 +150,10 @@ const applyToDraft = (editor: Editor, selection: Selection, op: Operation) => {
               }
             }
 
-            if (prev) {
+            const preferNext =
+              prev && next && Path.common(prev[1], path).length === 0
+
+            if (prev && !preferNext) {
               point.path = prev[1]
               point.offset = prev[0].text.length
             } else if (next) {

--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -150,8 +150,16 @@ const applyToDraft = (editor: Editor, selection: Selection, op: Operation) => {
               }
             }
 
-            const preferNext =
-              prev && next && Path.common(prev[1], path).length === 0
+            let preferNext = false
+            if (prev && next) {
+              if (Path.equals(next[1], path)) {
+                preferNext = !Path.hasPrevious(next[1])
+              } else {
+                preferNext =
+                  Path.common(prev[1], path).length <
+                  Path.common(next[1], path).length
+              }
+            }
 
             if (prev && !preferNext) {
               point.path = prev[1]

--- a/packages/slate/test/normalization/text/merge-adjacent-empty-after-nested.tsx
+++ b/packages/slate/test/normalization/text/merge-adjacent-empty-after-nested.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text />
+    </block>
+    <block>
+      <block>
+        <cursor />
+        <text />
+      </block>
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+    </block>
+    <block>
+      <block>
+        <cursor />
+      </block>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/normalization/text/merge-adjacent-empty-after.tsx
+++ b/packages/slate/test/normalization/text/merge-adjacent-empty-after.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text />
+    </block>
+    <block>
+      <cursor />
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+    </block>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-nested.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-nested.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+    </element>
+    <element>
+      <element>
+        <cursor />
+        <text />
+      </element>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [1, 0, 0],
+    node: { text: '' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text />
+    </element>
+    <element>
+      <element>
+        <cursor />
+      </element>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor.tsx
+++ b/packages/slate/test/operations/remove_node/cursor.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+    </element>
+    <element>
+      <cursor />
+      <text />
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [1, 0],
+    node: { text: '' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text />
+    </element>
+    <element>
+      <cursor />
+    </element>
+  </editor>
+)

--- a/packages/slate/test/transforms/mergeNodes/path/text-hanging-nested.tsx
+++ b/packages/slate/test/transforms/mergeNodes/path/text-hanging-nested.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { Transforms, Text } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      <block>
+        <cursor />
+        <text />
+      </block>
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.mergeNodes(editor, { at: [1, 0, 1], match: Text.isText })
+}
+export const output = (
+  <editor>
+    <block>one</block>
+    <block>
+      <block>
+        <cursor />
+      </block>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/mergeNodes/path/text-hanging.tsx
+++ b/packages/slate/test/transforms/mergeNodes/path/text-hanging.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Transforms, Text } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      <cursor />
+      <text />
+      <text />
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.mergeNodes(editor, { at: [1], match: Text.isText })
+}
+export const output = (
+  <editor>
+    <block>one</block>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/mergeNodes/path/text-hanging.tsx
+++ b/packages/slate/test/transforms/mergeNodes/path/text-hanging.tsx
@@ -8,12 +8,11 @@ export const input = (
     <block>
       <cursor />
       <text />
-      <text />
     </block>
   </editor>
 )
 export const run = editor => {
-  Transforms.mergeNodes(editor, { at: [1], match: Text.isText })
+  Transforms.mergeNodes(editor, { at: [1, 1], match: Text.isText })
 }
 export const output = (
   <editor>


### PR DESCRIPTION
**Description**
This PR changes the point resolution of `remove_node` ops, such that if the previous point doesn't share a common ancestor and the next point is available, prefer the next one.

**Example**
see test cases

**Context**
I ran into this behavior when trying to write helpers that preserve cursor position. I insert empty text nodes like: `{ text: '', anchor: true }`. If a change deleted from the beginning of a line, I noticed the cursor would end up in the prior line.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

