### PR TITLE
Allow control of Slate's event handler execution in custom event handler API

### DIFF
--- a/.changeset/chilly-gifts-dance.md
+++ b/.changeset/chilly-gifts-dance.md
@@ -1,5 +1,5 @@
 ---
-'slate-react': patch
+'slate-react': minor
 ---
 
 Allow custom event handlers on Editable component to return boolean flag to specify whether the event can be treated as being handled

--- a/.changeset/chilly-gifts-dance.md
+++ b/.changeset/chilly-gifts-dance.md
@@ -1,5 +1,0 @@
----
-'slate-react': minor
----
-
-Allow custom event handlers on Editable component to return boolean flag to specify whether the event can be treated as being handled

--- a/.changeset/chilly-gifts-dance.md
+++ b/.changeset/chilly-gifts-dance.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Allow custom event handlers on Editable component to return boolean flag to specify whether the event can be treated as being handled

--- a/.changeset/override-event-handlers.md
+++ b/.changeset/override-event-handlers.md
@@ -1,0 +1,49 @@
+---
+'slate-react': minor
+---
+
+Allow custom event handlers on Editable component to return boolean flag to specify whether the event can be treated as being handled.
+
+By default, the `Editable` component comes with a set of event handlers that handle typical rich-text editing behaviors (for example, it implements its own `onCopy`, `onPaste`, `onDrop`, and `onKeyDown` handlers).
+
+In some cases you may want to extend or override Slate's default behavior, which can be done by passing your own event handler(s) to the `Editable` component.
+
+Your custom event handler can control whether or not Slate should execute its own event handling for a given event after your handler runs depending on the return value of your event handler as described below.
+
+```jsx
+import {Editable} from 'slate-react';
+
+function MyEditor() {
+  const onClick = event => {
+    // Implement custom event logic...
+
+    // When no value is returned, Slate will execute its own event handler when
+    // neither isDefaultPrevented nor isPropagationStopped was set on the event
+  };
+
+  const onDrop = event => {
+    // Implement custom event logic...
+
+    // No matter the state of the event, treat it as being handled by returning
+    // true here, Slate will skip its own event handler
+    return true;
+  };
+
+  const onDragStart = event => {
+    // Implement custom event logic...
+
+    // No matter the status of the event, treat event as *not* being handled by
+    // returning false, Slate will exectue its own event handler afterward
+    return false;
+  };
+
+  return (
+    <Editable
+      onClick={onClick}
+      onDrop={onDrop}
+      onDragStart={onDragStart}
+      {/*...*/}
+    />
+  )
+}
+```

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -20,9 +20,11 @@ The main Slate editor.
 
 #### Event Handling
 
-By default, the `Editable` component comes with a set of event handlers that realize typical rich-text editing behavior (e.g., among others `Editable` implements its own `onCopy`, `onPaste`, `onDrop`, and `onKeyDown`). In some cases you may want to extend or overwrite Slate's default behavior, which can be done by passing your own event handler to the `Editable` component.
+By default, the `Editable` component comes with a set of event handlers that handle typical rich-text editing behaviors (for example, it implements its own `onCopy`, `onPaste`, `onDrop`, and `onKeyDown` handlers). 
 
-Your custom event handler can control whether or not Slate will execute its own event handler after yours depending on the return value of your event handler as described below.
+In some cases you may want to extend or override Slate's default behavior, which can be done by passing your own event handler(s) to the `Editable` component.
+
+Your custom event handler can control whether or not Slate should execute its own event handling for a given event after your handler runs depending on the return value of your event handler as described below.
 
 ```javascript
 const onClick = useCallback(event => {

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -26,36 +26,42 @@ In some cases you may want to extend or override Slate's default behavior, which
 
 Your custom event handler can control whether or not Slate should execute its own event handling for a given event after your handler runs depending on the return value of your event handler as described below.
 
-```javascript
-const onClick = event => {
-  // Implement custom event logic...
+```jsx
+import {Editable} from 'slate-react';
 
-  // When no value is returned, Slate will execute its own event handler when neither
-  // isDefaultPrevented nor isPropagationStopped was set on the event
-};
+function MyEditor() {
+  const onClick = event => {
+    // Implement custom event logic...
 
-const onDrop = event => {
-  // Implement custom event logic...
+    // When no value is returned, Slate will execute its own event handler when
+    // neither isDefaultPrevented nor isPropagationStopped was set on the event
+  };
 
-  // No matter the state of the event, treat it as being handled by returning true here
-  // -> Slate will skip its own event handler
-  return true;
-};
+  const onDrop = event => {
+    // Implement custom event logic...
 
-const onDragStart = event => {
-  // Implement custom event logic...
+    // No matter the state of the event, treat it as being handled by returning
+    // true here, Slate will skip its own event handler
+    return true;
+  };
 
-  // No matter the status of the event, treat event as *not* being handled by returning false
-  // -> Slate will exectue its own event handler afterward
-  return false;
-};
+  const onDragStart = event => {
+    // Implement custom event logic...
 
-<Editable
-    onClick={onClick}
-    onDrop={onDrop}
-    onDragStart={onDragStart
-    {/*...*/}
-/>
+    // No matter the status of the event, treat event as *not* being handled by
+    // returning false, Slate will exectue its own event handler afterward
+    return false;
+  };
+
+  return (
+    <Editable
+      onClick={onClick}
+      onDrop={onDrop}
+      onDragStart={onDragStart}
+      {/*...*/}
+    />
+  )
+}
 ```
 
 ### `DefaultElement(props: RenderElementProps)`

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -18,6 +18,44 @@ React components for rendering Slate editors
 
 The main Slate editor.
 
+#### Event Handling
+
+By default, the `Editable` component comes with a set of event handlers that realize typical rich-text editing behavior (e.g., among others `Editable` implements its own `onCopy`, `onPaste`, `onDrop`, and `onKeyDown`). In some cases you may want to extend or overwrite Slate's default behavior, which can be done by passing your own event handler to the `Editable` component.
+
+Your custom event handler can control whether or not Slate will execute its own event handler after yours depending on the return value of your event handler as described below.
+
+```javascript
+const onClick = useCallback(event => {
+  // Implement custom event logic...
+
+  // When no value is returned, Slate will execute its own event handler if neither
+  // isDefaultPrevented or isPropagationStopped was set on the event
+}, []);
+
+const onDrop = useCallback(event => {
+  // Implement custom event logic...
+
+  // No matter the state of the event, treat it as being handled by returning true here
+  // -> Slate will skip its own event handler
+  return true;
+}, []);
+
+const onDragStart = useCallback(event => {
+  // Implement custom event logic...
+
+  // No matter the status of the event, treat event as *not* being handled by returning false
+  // -> Slate will exectue its own event handler afterward
+  return false;
+}, []);
+
+<Editable
+    onClick={onClick}
+    onDrop={onDrop}
+    onDragStart={onDragStart
+    {/*...*/}
+/>
+```
+
 ### `DefaultElement(props: RenderElementProps)`
 
 The default element renderer.

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -20,35 +20,35 @@ The main Slate editor.
 
 #### Event Handling
 
-By default, the `Editable` component comes with a set of event handlers that handle typical rich-text editing behaviors (for example, it implements its own `onCopy`, `onPaste`, `onDrop`, and `onKeyDown` handlers). 
+By default, the `Editable` component comes with a set of event handlers that handle typical rich-text editing behaviors (for example, it implements its own `onCopy`, `onPaste`, `onDrop`, and `onKeyDown` handlers).
 
 In some cases you may want to extend or override Slate's default behavior, which can be done by passing your own event handler(s) to the `Editable` component.
 
 Your custom event handler can control whether or not Slate should execute its own event handling for a given event after your handler runs depending on the return value of your event handler as described below.
 
 ```javascript
-const onClick = useCallback(event => {
+const onClick = event => {
   // Implement custom event logic...
 
-  // When no value is returned, Slate will execute its own event handler if neither
-  // isDefaultPrevented or isPropagationStopped was set on the event
-}, []);
+  // When no value is returned, Slate will execute its own event handler when neither
+  // isDefaultPrevented nor isPropagationStopped was set on the event
+};
 
-const onDrop = useCallback(event => {
+const onDrop = event => {
   // Implement custom event logic...
 
   // No matter the state of the event, treat it as being handled by returning true here
   // -> Slate will skip its own event handler
   return true;
-}, []);
+};
 
-const onDragStart = useCallback(event => {
+const onDragStart = event => {
   // Implement custom event logic...
 
   // No matter the status of the event, treat event as *not* being handled by returning false
   // -> Slate will exectue its own event handler afterward
   return false;
-}, []);
+};
 
 <Editable
     onClick={onClick}

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1200,12 +1200,11 @@ export const isEventHandled = <
   // shall be treated as being handled or not.
   const shouldTreatEventAsHandled = handler(event)
 
-  return (
-    (shouldTreatEventAsHandled === true ||
-      event.isDefaultPrevented() ||
-      event.isPropagationStopped()) &&
-    shouldTreatEventAsHandled !== false
-  )
+  if (shouldTreatEventAsHandled != null) {
+    return shouldTreatEventAsHandled
+  }
+  
+  return event.isDefaultPrevented() || event.isPropagationStopped()
 }
 
 /**

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1191,14 +1191,21 @@ export const isEventHandled = <
   EventType extends React.SyntheticEvent<unknown, unknown>
 >(
   event: EventType,
-  handler?: (event: EventType) => void
+  handler?: (event: EventType) => void | boolean
 ) => {
   if (!handler) {
     return false
   }
+  // The custom event handler may return a boolean to specify whether the event
+  // shall be treated as being handled or not.
+  const shouldTreatEventAsHandled = handler(event)
 
-  handler(event)
-  return event.isDefaultPrevented() || event.isPropagationStopped()
+  return (
+    (shouldTreatEventAsHandled === true ||
+      event.isDefaultPrevented() ||
+      event.isPropagationStopped()) &&
+    shouldTreatEventAsHandled !== false
+  )
 }
 
 /**

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1203,7 +1203,7 @@ export const isEventHandled = <
   if (shouldTreatEventAsHandled != null) {
     return shouldTreatEventAsHandled
   }
-  
+
   return event.isDefaultPrevented() || event.isPropagationStopped()
 }
 
@@ -1213,12 +1213,19 @@ export const isEventHandled = <
 
 export const isDOMEventHandled = <E extends Event>(
   event: E,
-  handler?: (event: E) => void
+  handler?: (event: E) => void | boolean
 ) => {
   if (!handler) {
     return false
   }
 
-  handler(event)
+  // The custom event handler may return a boolean to specify whether the event
+  // shall be treated as being handled or not.
+  const shouldTreatEventAsHandled = handler(event)
+
+  if (shouldTreatEventAsHandled != null) {
+    return shouldTreatEventAsHandled
+  }
+
   return event.defaultPrevented
 }


### PR DESCRIPTION
**Description**
From the [Slate Slack channel](https://slate-js.slack.com/archives/CC58ZGGU9/p1622124885032100):
We noticed that our own custom dnd behavior broke with the upgrade to 0.63 due to the changes introduced in this [PR](https://github.com/ianstormtaylor/slate/pull/4238). For some context: We use react-dnd to enable users, among other things, to drag Nodes next to each other to automatically set up column layouts. Thus, while we want to use Slate's internal dnd logic in some cases, we need to prevent the default logic in others.
The root cause of the issue lies within the `state.isDraggingInternally` property that was introduced and that is set in the `onDragStart` handler. Unfortunately, it is not possible to overwrite `onDragStart` and prevent the default logic on the Editable component without having to call `preventDefault` or `stopPropgation` on the event (which in turn would break react-dnd behavior). Otherwise, Slate's default handler is still executed.
It is limiting and confusing that the differentiator whether or not an event was handled is solely based on isDefaultPrevented or isPropagationStopped.
This PR introduces an escape hatch for custom event handlers to specify whether or not the event should be treated as handled and, therefore, further processed by Slate's own handler.

**Issue**
Fixes: issue described above

**Example**
```javascript
const onClick = useCallback(event => {
  // Implement custom event logic...

  // Not returning a value resembles the current state where isEventHandled depends on
  // preventDefault and stopPropgation
}, []);

const onDrop = useCallback(event => {
  // Implement custom event logic...

  // No matter the status of the event, treat it as being handled by returning true here
  // -> Slate will skip its own event handler
  return true;
}, []);

const onDragStart = useCallback(event => {
  // Implement custom event logic...

  // No matter the status of the event, treat event as *not* being handled by returning false
  // -> Slate will continue with its own handler
  return false;
}, []);

<Editable
    renderElement={renderElement}
    renderLeaf={renderLeaf}
    onClick={onClick}
    onDrop={onDrop}
    onDragStart={onDragStart
    {/*...*/}
/>
```

**Context**
This PR suggests the following change: Optionally, all custom event handlers can return a boolean to control the execution of Slate's default handler logic:
`void` - Currently the only supported option and there is no change in this existing behavior. (thus, no breaking change for existing Slate editors)
`true` - Explicitly treat event as handled -> Do not execute Slate's default event handler
`false` - Explicitly do not treat event as handled -> Execute Slate's default event handler

The boolean flags will take precedence over the existing `preventDefault` and `stopPropgation` checks and will, therefore, allow for more flexibility in adjusting Slate's behavior.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

