### PR TITLE
Fix typescript docs

### DIFF
--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -2,7 +2,7 @@
 
 Slate supports typing of one Slate document model \(ie. one set of custom `Editor`, `Element` and `Text` types\). If you need to support more than one document model, see the section Multiple Document Models.
 
-**Warning:** You must define `CustomTypes` when using TypeScript or Slate will display typing errors.
+**Warning:** You must define `CustomTypes`, annotate `useState`, and annotate the editor's initial state when using TypeScript or Slate will display typing errors.
 
 ## Migrating from 0.47.x
 
@@ -21,14 +21,45 @@ import { BaseEditor } from 'slate'
 import { ReactEditor } from 'slate-react'
 import { HistoryEditor } from 'slate-history'
 
-type CustomText = { text: string; bold: boolean; italic: boolean }
+type CustomElement = { type: 'paragraph'; children: CustomText[] }
+type CustomText = { text: string; bold?: boolean; italic?: boolean }
 
 declare module 'slate' {
   interface CustomTypes {
     Editor: BaseEditor & ReactEditor & HistoryEditor
-    Element: { type: 'paragraph'; children: CustomText[] }
+    Element: CustomElement
     Text: CustomText
   }
+}
+```
+
+## Annotations in the Editor
+
+To avoid typing errors annotate `useState` w/ `<Descendant[]>` and the editor's initial value w/ your custom Element type.
+
+```typescript jsx
+import React, { useMemo, useState } from 'react'
+import { createEditor, Descendant } from 'slate'
+import { Slate, Editable, withReact } from 'slate-react'
+
+const App = () => {
+  const initialValue: CustomElement[] = [
+    {
+      type: 'paragraph',
+      children: [{ text: 'A line of text in a paragraph.' }],
+    },
+  ];
+  const editor = useMemo(() => withReact(createEditor()), [])
+  const [value, setValue] = useState<Descendant[]>([])
+  return (
+    <Slate
+      editor={editor}
+      value={value}
+      onChange={setValue}
+    >
+      <Editable />
+    </Slate>
+  )
 }
 ```
 
@@ -59,7 +90,7 @@ export type HeadingElement = {
 
 export type CustomElement = ParagraphElement | HeadingElement
 
-export type FormattedText = { text: string; bold: boolean; italic: boolean }
+export type FormattedText = { text: string; bold?: boolean; italic?: boolean }
 
 export type CustomText = FormattedText
 

--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -50,7 +50,7 @@ const App = () => {
     },
   ];
   const editor = useMemo(() => withReact(createEditor()), [])
-  const [value, setValue] = useState<Descendant[]>([])
+  const [value, setValue] = useState<Descendant[]>(initialValue)
   return (
     <Slate
       editor={editor}

--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -47,10 +47,10 @@ const App = () => {
 
 Of course we haven't rendered anything, so you won't see any changes.
 
-> If you are using TypeScript, you will also need to extend the `Editor` with `ReactEditor` as per the documentation on [TypeScript](../concepts/12-typescript.md). The example below also includes the custom types required for the rest of this example.
+> If you are using TypeScript, you will also need to extend the `Editor` with `ReactEditor` and add annotations as per the documentation on [TypeScript](../concepts/12-typescript.md). The example below also includes the custom types required for the rest of this example.
 
 ```typescript
-// TypeScript Users only add this code
+// TypeScript users only add this code
 import { BaseEditor } from 'slate'
 import { ReactEditor } from 'slate-react'
 
@@ -63,6 +63,14 @@ declare module 'slate' {
     Element: CustomElement
     Text: CustomText
   }
+}
+```
+```typescript jsx
+// Also you must annotate `useState<Descendant[]>` and the editor's initial value.
+const App = () => {
+  const initialValue : CustomElement = [];
+  const [value, setValue] = useState<Descendant[]>(initialValue)
+  return <Slate value={value} onChange={setValue}>...</Slate>
 }
 ```
 


### PR DESCRIPTION
**Description**
In the docs, this adds annotations to `useState` and the editor's initial values to avoid typing errors.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4280

**Before**
![image](https://user-images.githubusercontent.com/15849320/120137221-1152f480-c191-11eb-9a9c-80341d2a0d97.png)
![image](https://user-images.githubusercontent.com/15849320/120137235-19129900-c191-11eb-900f-36fc12c82a64.png)


**After**
![image](https://user-images.githubusercontent.com/15849320/120137147-e5d00a00-c190-11eb-94f2-d63fe9bc534d.png)
