### PR TITLE
Do NOT use exact match when updating dom selection

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -170,7 +170,7 @@ export const Editable = (props: EditableProps) => {
     // If the DOM selection is in the editor and the editor selection is already correct, we're done.
     if (hasDomSelection && hasDomSelectionInEditor && selection) {
       const slateRange = ReactEditor.toSlateRange(editor, domSelection, {
-        exactMatch: true,
+        exactMatch: false,
       })
       if (slateRange && Range.equals(slateRange, selection)) {
         return


### PR DESCRIPTION
**Description**
When there is NO text, yet within a nested, editable void Slate Editor (see [editable voids example](https://www.slatejs.org/examples/editable-voids), starting to type some text leads to backwards typing.

**Issue**
Fixes: #4293 

**Example**
Before:
![khkYcJF2rp](https://user-images.githubusercontent.com/5305150/120163582-f072b980-c1f9-11eb-8ef5-6824bd613105.gif)

After:
![ayoBo1dHIj](https://user-images.githubusercontent.com/5305150/120163880-42b3da80-c1fa-11eb-8ba0-55a40999689e.gif)

**Context**
TBD

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

