### PR TITLE
Moving in string containing unicode sequences does not work

### DIFF
--- a/config/rollup/rollup.config.js
+++ b/config/rollup/rollup.config.js
@@ -58,7 +58,6 @@ function configure(pkg, env, target) {
       // we have to manually specify named exports here for them to work.
       // https://github.com/rollup/rollup-plugin-commonjs#custom-named-exports
       namedExports: {
-        esrever: ['reverse'],
         'react-dom': ['findDOMNode'],
         'react-dom/server': ['renderToStaticMarkup'],
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "internal:release:next": "yarn prerelease && yarn changeset publish --tag next",
     "serve": "cd ./site && next",
     "start": "npm-run-all --parallel --print-label watch serve",
-    "test": "mocha --require ./config/babel/register.cjs ./packages/*/test/index.js",
+    "test": "mocha --require ./config/babel/register.cjs ./packages/*/test/**/*.{js,ts}",
     "test:custom": "mocha --require ./config/babel/register.cjs ./packages/slate/test/index.js",
     "test:inspect": "yarn test --inspect-brk",
     "test:integration": "run-p -r serve cypress:run",

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -14,8 +14,6 @@
     "dist/"
   ],
   "dependencies": {
-    "@types/esrever": "^0.2.0",
-    "esrever": "^0.2.0",
     "fast-deep-equal": "^3.1.3",
     "immer": "^8.0.1",
     "is-plain-object": "^3.0.0",

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1,5 +1,4 @@
 import isPlainObject from 'is-plain-object'
-import { reverse as reverseText } from 'esrever'
 
 import {
   Ancestor,

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -25,7 +25,7 @@ import {
   POINT_REFS,
   RANGE_REFS,
 } from '../utils/weak-maps'
-import { getWordDistance, getCharacterDistance } from '../utils/string'
+import { getWordDistance, getCharacterDistance, split } from '../utils/string'
 import { Descendant } from './node'
 import { Element } from './element'
 
@@ -1337,7 +1337,6 @@ export const Editor: EditorInterface = {
             : Editor.start(editor, path)
 
           blockText = Editor.string(editor, { anchor: s, focus: e }, { voids })
-          blockText = reverse ? reverseText(blockText) : blockText
           isNewBlock = true
         }
       }
@@ -1378,8 +1377,8 @@ export const Editor: EditorInterface = {
           // otherwise advance blockText forward by the new `distance`.
           if (distance === 0) {
             if (blockText === '') break
-            distance = calcDistance(blockText, unit)
-            blockText = blockText.slice(distance)
+            distance = calcDistance(blockText, unit, reverse)
+            blockText = split(blockText, distance, reverse)[1]
           }
 
           // Advance `leafText` by the current `distance`.
@@ -1410,11 +1409,11 @@ export const Editor: EditorInterface = {
 
     // Helper:
     // Return the distance in offsets for a step of size `unit` on given string.
-    function calcDistance(text: string, unit: string) {
+    function calcDistance(text: string, unit: string, reverse: boolean) {
       if (unit === 'character') {
-        return getCharacterDistance(text)
+        return getCharacterDistance(text, reverse)
       } else if (unit === 'word') {
-        return getWordDistance(text)
+        return getWordDistance(text, reverse)
       } else if (unit === 'line' || unit === 'block') {
         return text.length
       }

--- a/packages/slate/src/utils/string.ts
+++ b/packages/slate/src/utils/string.ts
@@ -5,9 +5,6 @@
 const SPACE = /\s/
 const PUNCTUATION = /[\u0021-\u0023\u0025-\u002A\u002C-\u002F\u003A\u003B\u003F\u0040\u005B-\u005D\u005F\u007B\u007D\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E3B\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/
 const CHAMELEON = /['\u2018\u2019]/
-const SURROGATE_START = 0xd800
-const SURROGATE_END = 0xdfff
-const ZERO_WIDTH_JOINER = 0x200d
 
 /**
  * Get the distance to the end of the first character in a string of text.
@@ -16,59 +13,119 @@ const ZERO_WIDTH_JOINER = 0x200d
 export const getCharacterDistance = (text: string): number => {
   let offset = 0
   // prev types:
-  // SURR: surrogate pair
-  // MOD: modifier (technically also surrogate pair)
+  // NSEQ: non sequenceable codepoint.
+  // MOD: modifier
   // ZWJ: zero width joiner
   // VAR: variation selector
-  // BMP: sequenceable character from basic multilingual plane
-  let prev: 'SURR' | 'MOD' | 'ZWJ' | 'VAR' | 'BMP' | null = null
-  let charCode = text.charCodeAt(0)
+  // BMP: sequenceable codepoint from basic multilingual plane
+  // RI: regional indicator
+  // KC: keycap
+  // Tag: tag
+  let prev:
+    | 'NSEQ'
+    | 'MOD'
+    | 'ZWJ'
+    | 'VAR'
+    | 'BMP'
+    | 'RI'
+    | 'KC'
+    | 'TAG'
+    | null = null
 
-  while (charCode) {
-    if (isSurrogate(charCode)) {
-      const modifier = isModifier(charCode, text, offset)
+  while (true) {
+    const code = text.codePointAt(offset)
+    if (!code) break
 
-      // Early returns are the heart of this function, where we decide if previous and current
-      // codepoints should form a single character (in terms of how many of them should selection
-      // jump over).
-      if (prev === 'SURR' || prev === 'BMP') {
+    // Check if code point is part of a sequence.
+    if (isZWJ(code)) {
+      offset += 1
+      prev = 'ZWJ'
+
+      continue
+    }
+
+    if (isKeycap(code)) {
+      if (prev === 'KC') {
+        break
+      }
+
+      offset += 1
+      prev = 'KC'
+      continue
+    }
+    if (isCombiningEnclosingKeycap(code)) {
+      offset += 1
+      break
+    }
+
+    if (isVariationSelector(code)) {
+      offset += 1
+
+      if (prev === 'BMP') {
+        break
+      }
+
+      prev = 'VAR'
+
+      continue
+    }
+
+    if (isBMPEmoji(code)) {
+      if (prev && prev !== 'ZWJ' && prev !== 'VAR') {
+        break
+      }
+
+      offset += 1
+      prev = 'BMP'
+
+      continue
+    }
+
+    if (isModifier(code)) {
+      offset += 2
+      prev = 'MOD'
+
+      continue
+    }
+
+    if (isBlackFlag(code)) {
+      if (prev === 'TAG') {
+        break
+      }
+      offset += 2
+      prev = 'TAG'
+      continue
+    }
+    if (prev === 'TAG' && isTag(code)) {
+      offset += 2
+
+      if (isCancelTag(code)) break
+
+      continue
+    }
+
+    if (isRegionalIndicator(code)) {
+      offset += 2
+
+      if (prev === 'RI') {
+        break
+      }
+
+      prev = 'RI'
+
+      continue
+    }
+
+    if (!isBMP(code)) {
+      // If previous code point is not sequenceable, it means we are not in a
+      // sequence.
+      if (prev === 'NSEQ') {
         break
       }
 
       offset += 2
-      prev = modifier ? 'MOD' : 'SURR'
-      charCode = text.charCodeAt(offset)
-      // Absolutely fine to `continue` without any checks because if `charCode` is NaN (which
-      // is the case when out of `text` range), next `while` loop won"t execute and we"re done.
-      continue
-    }
+      prev = 'NSEQ'
 
-    if (charCode === ZERO_WIDTH_JOINER) {
-      offset += 1
-      prev = 'ZWJ'
-      charCode = text.charCodeAt(offset)
-
-      continue
-    }
-
-    if (isBMPEmoji(charCode)) {
-      if (prev && prev !== 'ZWJ' && prev !== 'VAR') {
-        break
-      }
-      offset += 1
-      prev = 'BMP'
-      charCode = text.charCodeAt(offset)
-
-      continue
-    }
-
-    if (isVariationSelector(charCode)) {
-      if (prev && prev !== 'ZWJ') {
-        break
-      }
-      offset += 1
-      prev = 'VAR'
-      charCode = text.charCodeAt(offset)
       continue
     }
 
@@ -147,24 +204,13 @@ const isWordCharacter = (char: string, remaining: string): boolean => {
 }
 
 /**
- * Determines if `code` is a surrogate
- */
-
-const isSurrogate = (code: number): boolean =>
-  SURROGATE_START <= code && code <= SURROGATE_END
-
-/**
  * Does `code` form Modifier with next one.
  *
  * https://emojipedia.org/modifiers/
  */
 
-const isModifier = (code: number, text: string, offset: number): boolean => {
-  if (code === 0xd83c) {
-    const next = text.charCodeAt(offset + 1)
-    return next <= 0xdfff && next >= 0xdffb
-  }
-  return false
+const isModifier = (code: number): boolean => {
+  return code >= 0x1f3fb && code <= 0x1f3ff
 }
 
 /**
@@ -175,6 +221,30 @@ const isModifier = (code: number, text: string, offset: number): boolean => {
 
 const isVariationSelector = (code: number): boolean => {
   return code <= 0xfe0f && code >= 0xfe00
+}
+
+/**
+ * Is `code` a code point used in keycap sequence.
+ *
+ * https://emojipedia.org/emoji-keycap-sequence/
+ */
+
+const isKeycap = (code: number): boolean => {
+  return (
+    (code >= 0x30 && code <= 0x39) || // digits
+    code === 0x23 || // number sign
+    code === 0x2a
+  )
+}
+
+/**
+ * Is `code` a Combining Enclosing Keycap.
+ *
+ * https://emojipedia.org/combining-enclosing-keycap/
+ */
+
+const isCombiningEnclosingKeycap = (code: number): boolean => {
+  return code === 0x20e3
 }
 
 /**
@@ -195,6 +265,80 @@ const isBMPEmoji = (code: number): boolean => {
     code === 0x2620 || // scull (☠)
     code === 0x2695 || // medical (⚕)
     code === 0x2708 || // plane (✈️)
-    code === 0x25ef // large circle (◯)
+    code === 0x25ef || // large circle (◯)
+    code === 0x2b06 || // up arrow (⬆)
+    code === 0x2197 || // up-right arrow (↗)
+    code === 0x27a1 || // right arrow (➡)
+    code === 0x2198 || // down-right arrow (↘)
+    code === 0x2b07 || // down arrow (⬇)
+    code === 0x2199 || // down-left arrow (↙)
+    code === 0x2b05 || // left arrow (⬅)
+    code === 0x2196 || // up-left arrow (↖)
+    code === 0x2195 || // up-down arrow (↕)
+    code === 0x2194 || // left-right arrow (↔)
+    code === 0x21a9 || // right arrow curving left (↩)
+    code === 0x21aa || // left arrow curving right (↪)
+    code === 0x2934 || // right arrow curving up (⤴)
+    code === 0x2935 // right arrow curving down (⤵)
   )
+}
+
+/**
+ * Is `code` a Regional Indicator.
+ *
+ * https://en.wikipedia.org/wiki/Regional_indicator_symbol
+ */
+
+const isRegionalIndicator = (code: number): boolean => {
+  return code >= 0x1f1e6 && code <= 0x1f1ff
+}
+
+/**
+ * Is `code` from basic multilingual plane.
+ *
+ * https://codepoints.net/basic_multilingual_plane
+ */
+
+const isBMP = (code: number): boolean => {
+  return code <= 0xffff
+}
+
+/**
+ * Is `code` a Zero Width Joiner.
+ *
+ * https://emojipedia.org/zero-width-joiner/
+ */
+
+const isZWJ = (code: number): boolean => {
+  return code === 0x200d
+}
+
+/**
+ * Is `code` a Black Flag.
+ *
+ * https://emojipedia.org/black-flag/
+ */
+
+const isBlackFlag = (code: number): boolean => {
+  return code === 0x1f3f4
+}
+
+/**
+ * Is `code` a Tag.
+ *
+ * https://emojipedia.org/emoji-tag-sequence/
+ */
+
+const isTag = (code: number): boolean => {
+  return code >= 0xe0000 && code <= 0xe007f
+}
+
+/**
+ * Is `code` a Cancel Tag.
+ *
+ * https://emojipedia.org/cancel-tag/
+ */
+
+const isCancelTag = (code: number): boolean => {
+  return code === 0xe007f
 }

--- a/packages/slate/test/transforms/delete/emojis/inline-end-reverse.tsx
+++ b/packages/slate/test/transforms/delete/emojis/inline-end-reverse.tsx
@@ -10,7 +10,7 @@ export const input = (
     <block>
       <text />
       <inline>
-        word📛
+        word🇫🇷
         <cursor />
       </inline>
       <text />

--- a/packages/slate/test/transforms/move/emojis/keycap-reverse.tsx
+++ b/packages/slate/test/transforms/move/emojis/keycap-reverse.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor, { reverse: true })
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word5️⃣
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        5️⃣
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/keycap.tsx
+++ b/packages/slate/test/transforms/move/emojis/keycap.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        5️⃣
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word5️⃣
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/ri-reverse.tsx
+++ b/packages/slate/test/transforms/move/emojis/ri-reverse.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor, { reverse: true })
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word🇫🇷
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        🇫🇷
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/ri.tsx
+++ b/packages/slate/test/transforms/move/emojis/ri.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        🇫🇷
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word🇫🇷
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/tag-reverse.tsx
+++ b/packages/slate/test/transforms/move/emojis/tag-reverse.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor, { reverse: true })
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word🏴󠁧󠁢󠁳󠁣󠁴󠁿
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        🏴󠁧󠁢󠁳󠁣󠁴󠁿
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/tag.tsx
+++ b/packages/slate/test/transforms/move/emojis/tag.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        🏴󠁧󠁢󠁳󠁣󠁴󠁿
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word🏴󠁧󠁢󠁳󠁣󠁴󠁿
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/zwj-reverse.tsx
+++ b/packages/slate/test/transforms/move/emojis/zwj-reverse.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor, { reverse: true })
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word👨‍👩‍👧‍👧
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        👨‍👩‍👧‍👧
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/move/emojis/zwj.tsx
+++ b/packages/slate/test/transforms/move/emojis/zwj.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.move(editor)
+}
+export const input = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word
+        <cursor />
+        👨‍👩‍👧‍👧
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text />
+      <inline>
+        word👨‍👩‍👧‍👧
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/utils/string.ts
+++ b/packages/slate/test/utils/string.ts
@@ -1,0 +1,83 @@
+import assert from 'assert'
+import { getCharacterDistance } from '../../src/utils/string'
+
+const regularCases = [
+  // ['a', 1],
+  // ['0', 1],
+  // [' ', 1],
+  // ['🙂', 2],
+  // ['⬅️', 2],
+  ['🏴', 2],
+] as const
+
+const sequences = [
+  ['👁‍🗨', 5],
+  ['👨‍👩‍👧‍👧', 11],
+  ['👨🏿‍🦳', 7],
+] as const
+
+const regionalIndicators = [
+  '🇧🇪',
+  '🇧🇫',
+  '🇧🇬',
+  '🇧🇭',
+  '🇧🇮',
+  '🇧🇯',
+  '🇧🇱',
+  '🇧🇲',
+  '🇧🇳',
+  '🇧🇴',
+]
+
+const keycaps = [
+  '#️⃣',
+  '*️⃣',
+  '0️⃣',
+  '1️⃣',
+  '2️⃣',
+  '3️⃣',
+  '4️⃣',
+  '5️⃣',
+  '6️⃣',
+  '7️⃣',
+  '8️⃣',
+  '9️⃣',
+]
+
+const tags = [
+  ['🏴󠁧󠁢󠁥󠁮󠁧󠁿', 14],
+  ['🏴󠁧󠁢󠁳󠁣󠁴󠁿', 14],
+  ['🏴󠁧󠁢󠁷󠁬󠁳󠁿', 14],
+] as const
+
+describe('getCharacterDistance', () => {
+  regularCases.forEach(([str, length]) => {
+    it(`regular case ${str}`, () => {
+      assert.strictEqual(getCharacterDistance(str + str), length)
+    })
+  })
+
+  regionalIndicators.forEach(str => {
+    it(`regional indicator ${str}`, () => {
+      assert.strictEqual(getCharacterDistance(str + str), 4)
+    })
+  })
+
+  keycaps.forEach(str => {
+    it(`keycap ${str}`, () => {
+      assert.strictEqual(getCharacterDistance(str + str), 3)
+    })
+  })
+
+  tags.forEach(([str, length]) => {
+    it(`tag ${str}`, () => {
+      assert.strictEqual(getCharacterDistance(str + str), length)
+    })
+  })
+
+  sequences.forEach(([str, length]) => {
+    it(`sequence ${str}`, () => {
+      assert.strictEqual(getCharacterDistance(str + str), length)
+    })
+  })
+})

--- a/packages/slate/test/utils/string.ts
+++ b/packages/slate/test/utils/string.ts
@@ -2,11 +2,11 @@ import assert from 'assert'
 import { getCharacterDistance } from '../../src/utils/string'
 
 const regularCases = [
-  // ['a', 1],
-  // ['0', 1],
-  // [' ', 1],
-  // ['🙂', 2],
-  // ['⬅️', 2],
+  ['a', 1],
+  ['0', 1],
+  [' ', 1],
+  ['🙂', 2],
+  ['⬅️', 2],
   ['🏴', 2],
 ] as const
 

--- a/packages/slate/test/utils/string.ts
+++ b/packages/slate/test/utils/string.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
-import { getCharacterDistance } from '../../src/utils/string'
+import { getCharacterDistance, getWordDistance } from '../../src/utils/string'
 
-const regularCases = [
+const codepoints = [
   ['a', 1],
   ['0', 1],
   [' ', 1],
@@ -10,13 +10,13 @@ const regularCases = [
   ['🏴', 2],
 ] as const
 
-const sequences = [
+const zwjSequences = [
   ['👁‍🗨', 5],
   ['👨‍👩‍👧‍👧', 11],
   ['👨🏿‍🦳', 7],
 ] as const
 
-const regionalIndicators = [
+const regionalIndicatorSequences = [
   '🇧🇪',
   '🇧🇫',
   '🇧🇬',
@@ -29,7 +29,7 @@ const regionalIndicators = [
   '🇧🇴',
 ]
 
-const keycaps = [
+const keycapSequences = [
   '#️⃣',
   '*️⃣',
   '0️⃣',
@@ -44,40 +44,78 @@ const keycaps = [
   '9️⃣',
 ]
 
-const tags = [
+const tagSequences = [
   ['🏴󠁧󠁢󠁥󠁮󠁧󠁿', 14],
   ['🏴󠁧󠁢󠁳󠁣󠁴󠁿', 14],
   ['🏴󠁧󠁢󠁷󠁬󠁳󠁿', 14],
 ] as const
 
-describe('getCharacterDistance', () => {
-  regularCases.forEach(([str, length]) => {
-    it(`regular case ${str}`, () => {
-      assert.strictEqual(getCharacterDistance(str + str), length)
+const dirs = ['ltr', 'rtl']
+
+dirs.forEach(dir => {
+  const isRTL = dir === 'rtl'
+
+  describe(`getCharacterDistance - ${dir}`, () => {
+    codepoints.forEach(([str, dist]) => {
+      it(str, () => {
+        assert.strictEqual(getCharacterDistance(str + str, isRTL), dist)
+      })
+    })
+
+    zwjSequences.forEach(([str, dist]) => {
+      it(str, () => {
+        assert.strictEqual(getCharacterDistance(str + str, isRTL), dist)
+      })
+    })
+
+    regionalIndicatorSequences.forEach(str => {
+      it(str, () => {
+        assert.strictEqual(getCharacterDistance(str + str, isRTL), 4)
+      })
+    })
+
+    keycapSequences.forEach(str => {
+      it(str, () => {
+        assert.strictEqual(getCharacterDistance(str + str, isRTL), 3)
+      })
+    })
+
+    tagSequences.forEach(([str, dist]) => {
+      it(str, () => {
+        assert.strictEqual(getCharacterDistance(str + str, isRTL), dist)
+      })
     })
   })
+})
 
-  regionalIndicators.forEach(str => {
-    it(`regional indicator ${str}`, () => {
-      assert.strictEqual(getCharacterDistance(str + str), 4)
+const ltrCases = [
+  ['hello foobarbaz', 5],
+  ['🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁳󠁣󠁴󠁿 🏴󠁧󠁢󠁷󠁬󠁳󠁿', 28],
+  ["Don't do this", 5],
+  ["I'm ok", 3],
+] as const
+
+const rtlCases = [
+  ['hello foobarbaz', 9],
+  ['🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁳󠁣󠁴󠁿 🏴󠁧󠁢󠁷󠁬󠁳󠁿', 14],
+  ["Don't", 5],
+  ["Don't do this", 4],
+  ["I'm", 3],
+  ['Tags 🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁳󠁣󠁴󠁿', 28],
+] as const
+
+describe(`getWordDistance - ltr`, () => {
+  ltrCases.forEach(([str, dist]) => {
+    it(str, () => {
+      assert.strictEqual(getWordDistance(str), dist)
     })
   })
+})
 
-  keycaps.forEach(str => {
-    it(`keycap ${str}`, () => {
-      assert.strictEqual(getCharacterDistance(str + str), 3)
-    })
-  })
-
-  tags.forEach(([str, length]) => {
-    it(`tag ${str}`, () => {
-      assert.strictEqual(getCharacterDistance(str + str), length)
-    })
-  })
-
-  sequences.forEach(([str, length]) => {
-    it(`sequence ${str}`, () => {
-      assert.strictEqual(getCharacterDistance(str + str), length)
+describe(`getWordDistance - rtl`, () => {
+  rtlCases.forEach(([str, dist]) => {
+    it(str, () => {
+      assert.strictEqual(getWordDistance(str, true), dist)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,11 +2469,6 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/esrever@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@types/esrever/-/esrever-0.2.0.tgz#96404a2284b2c7527f08a1e957f8a31705f9880f"
-  integrity sha512-5NI6TeGzVEy/iBcuYtcPzzIC6EqlfQ2+UZ54vT0ulq8bPNGAy8UJD+XcsAyEOcnYFUjOVWuUV+k4/rVkxt9/XQ==
-
 "@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
@@ -5446,11 +5441,6 @@ esrecurse@^4.1.0:
   integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   dependencies:
     estraverse "^4.1.0"
-
-esrever@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/esrever/-/esrever-0.2.0.tgz#96e9d28f4f1b1a76784cd5d490eaae010e7407b8"
-  integrity sha1-lunSj08bGnZ4TNXUkOquAQ50B7g=
 
 estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.3.0"


### PR DESCRIPTION
Hi, this PR is not meant to be merge, I decided to open it as the code might be useful...

Tell me if you want me to close it and open an issue instead of it.

**Description**

I started this PR as I had a weird behavior when moving the cursor in a string containing a flag.

After digging into Slate code, reading https://emojipedia.org and skimming Unicode specs, I noticed that Slate does not handle [flag sequences](https://emojipedia.org/emoji-flag-sequence/) so started fixing it. While writing tests, I have noticed that [tag sequences](https://emojipedia.org/emoji-tag-sequence/) and [keycap sequences](https://emojipedia.org/emoji-keycap-sequence/) were not handled so I decided to improve `getCharacterDistance` so that moving the cursor works as expected.

When I tested my solution in the examples, I noticed that I only fixed 50% of the issue... With the changes I made, moving from left to write works as expected, but moving from right to left is still broken because Slate breaks the sequences by reversing the string when moving from right to left.  

I am wondering if there is a way to let the browser find the next cursor position. If this is not doable Slate will need to first split a string by grapheme clusters and then reverse the resulting array. It seems that https://github.com/orling/grapheme-splitter can help but I am not sure it is up to date and code is a bit scary...

**Video**

Recorded on https://www.slatejs.org.

![CleanShot 2021-05-31 at 18 44 00](https://user-images.githubusercontent.com/203411/120222470-466a5000-c240-11eb-833d-c086ee6b55d3.gif)

**Steps**

To reproduce the issue, paste this string in the editor and move left/right.

```
🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁳󠁣󠁴󠁿🏴󠁧󠁢󠁷󠁬󠁳󠁿🇧🇪🇧🇫🇧🇬🇧🇭🇧🇮🇧🇯🇧🇱🇧🇲🇧🇳🇧🇴
```



