### PR TITLE
Fix handling of delete in Chrome when inline void node is selected

### DIFF
--- a/.changeset/delete-inline-void.md
+++ b/.changeset/delete-inline-void.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix deletion of selected inline void nodes in Chrome. Chrome does not fire a `beforeinput` event when deleting backwards within an inline void node, so we need to add special logic to handle this edge-case for Chrome only.


### PR DESCRIPTION
**Description**
This PR fixes deletion of selected inline void nodes in Chrome. Chrome does not fire a `beforeinput` event when deleting backwards within an inline void node, so we need to add special logic to handle this edge-case for Chrome only.

Both Firefox and Safari do not exhibit this behaviour, and fire the `deleteContentBackward` / `deleteContentForward` beforeinput event when deleting backward/forward in a void inline node.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/3456

**Example**

https://user-images.githubusercontent.com/1416436/120367264-a9aabf80-c2de-11eb-917c-98673f776800.mp4

https://user-images.githubusercontent.com/1416436/120368409-09559a80-c2e0-11eb-8f4c-63dd1c323335.mp4

https://user-images.githubusercontent.com/1416436/120367276-ab748300-c2de-11eb-8509-e7dcb0d1a76f.mp4

https://user-images.githubusercontent.com/1416436/120368294-e5925480-c2df-11eb-966d-e8b9fcc36d0a.mp4


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

