### PR TITLE
Fix backward typing bug in Safari by ensuring the selection is removed on blur

### DIFF
--- a/.changeset/safari-backwards-typing.md
+++ b/.changeset/safari-backwards-typing.md
@@ -1,0 +1,8 @@
+---
+'slate-react': patch
+---
+
+Fix backward typing bug in Safari by ensuring the selection is always removed on blur.
+Safari doesn't always remove the selection, even if the contenteditable element no longer has focus.
+In this scenario, we need to forcefully remove the selection on blur.
+Refer to https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -560,8 +560,6 @@ export const Editable = (props: EditableProps) => {
                 return
               }
 
-              const window = ReactEditor.getWindow(editor)
-
               // COMPAT: If the current `activeElement` is still the previous
               // one, this is due to the window being blurred when the tab
               // itself becomes unfocused, so we want to abort early to allow to
@@ -603,6 +601,14 @@ export const Editable = (props: EditableProps) => {
                 if (Element.isElement(node) && !editor.isVoid(node)) {
                   return
                 }
+              }
+
+              // COMPAT: Safari doesn't always remove the selection even if the content-
+              // editable element no longer has focus. Refer to:
+              // https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web
+              if (IS_SAFARI) {
+                const domSelection = root.getSelection()
+                domSelection?.removeAllRanges()
               }
 
               IS_FOCUSED.delete(editor)


### PR DESCRIPTION
**Description**
Safari doesn't always remove the selection, even if the contenteditable element no longer has focus. In this scenario, we need to forcefully remove the selection on blur https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web

**Issue**
I could not find any open issues related to this specific bug. There are other issues open with regards to backwards typing bugs but they are unrelated.

**Example**

To replicate, I simply added a button in the toolbar that calls `ReactEditor.blur(editor)` when clicked:

https://user-images.githubusercontent.com/1416436/121074881-75ce0f00-c7a2-11eb-94e7-9f3fb3356943.mp4


https://user-images.githubusercontent.com/1416436/121074888-7797d280-c7a2-11eb-8a80-122ec2754b0b.mp4



**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

