### PR TITLE
fix: fix deletion in safari when inline node is selected

### DIFF
--- a/.changeset/safari-delete-inlinevoid.md
+++ b/.changeset/safari-delete-inlinevoid.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix deletion of selected inline void nodes in Safari when presssing `backspace` or `delete`. This is a bug that [was originally fixed only for Google Chrome](https://github.com/ianstormtaylor/slate/issues/3456), but the fix also needs to be applied in Safari.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1066,8 +1066,8 @@ export const Editable = (props: EditableProps) => {
                     return
                   }
                 } else {
-                  if (IS_CHROME) {
-                    // COMPAT: Chrome supports `beforeinput` event but does not fire
+                  if (IS_CHROME || IS_SAFARI) {
+                    // COMPAT: Chrome and Safari support `beforeinput` event but do not fire
                     // an event when deleting backwards in a selected void inline node
                     if (
                       selection &&


### PR DESCRIPTION
**Description**

This PR fixes the deletion of inline void nodes on Safari. It's basically an extension of #4307, so it applies also in Safari.

**Issue**
Fixes: #4330 

**Example**
![safari-mention-before](https://user-images.githubusercontent.com/37072867/121382549-00e80a00-c947-11eb-82d9-edeba273ae5b.gif)
![safari-mention-after](https://user-images.githubusercontent.com/37072867/121382557-0180a080-c947-11eb-9ff1-12bf4b1211be.gif)


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

