### PR TITLE
Allow setFragmentData without clipboardData object

### DIFF
--- a/.changeset/quiet-teachers-kneel.md
+++ b/.changeset/quiet-teachers-kneel.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Allow setFragmentData to work without copy/paste or DnD data structure

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -96,7 +96,7 @@ export const withReact = <T extends Editor>(editor: T) => {
     }
   }
 
-  e.setFragmentData = (data: DataTransfer) => {
+  e.setFragmentData = (data: Pick<DataTransfer, 'getData' | 'setData'>) => {
     const { selection } = e
 
     if (!selection) {

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -179,6 +179,7 @@ export const withReact = <T extends Editor>(editor: T) => {
     data.setData('text/html', div.innerHTML)
     data.setData('text/plain', getPlainText(div))
     document.body.removeChild(div)
+    return data
   }
 
   e.insertData = (data: DataTransfer) => {


### PR DESCRIPTION
**Description**

It is highly useful to get a copy of the exact selection and it is available in slate-react as e.setFragmentData. Unfortunately the type definition currently requires a DataTransfer object which is difficult to stub as this object comes from ClipboardData or drag-n-drop events. In practice, the only requirement slate-react actually needs is getData/setData. Users could provide a data object that looks like this (let me know if this should be provided as a utility method):

```
  const getDataTransfer = () => {
    const storage = new Map()
    return {
      getData: (key: string) => storage.get(key),
      setData: (key: string, value: string) => storage.set(key, value),
    }
  }
```

**Issue**
Fixes: Allows an easy way to get access to the slate tree in `application/x-slate-fragment`, `'text/html'`, or `'text/plain'` without a copy/paste or DnD operation.

**Example**

The API footprint is exactly the same other than how the DataTransfer object gets passed in. Using the above method, users could do something like:

```
const data = ReactEditor.setFragmentData(getDataTransfer())
const fragment =  data.getData('application/x-slate-fragment')
if (fragment) {
  const decoded = decodeURIComponent(window.atob(fragment));
  const parsed = JSON.parse(decoded) as Node[];
  console.log(parsed) // see the slate tree for the selection
}
```

It's not 100% certain to me if setFragmentData should be async, so I've left it sync.


**Context**
See above. Let me know if this should work differently and I'll update accordingly.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.   (Note: I did not write a new test for this change)
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

