### PR TITLE
Fix broken plugins link in Editor documentation

### DIFF
--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -352,7 +352,7 @@ Call a function, deferring normalization until after it completes.
 
 ## Schema-specific instance methods to override
 
-Replace these methods to modify the original behavior of the editor when building [Plugins](https://github.com/ianstormtaylor/slate/tree/a02787539a460fb70730085e26df13cca959fabd/concepts/07-plugins/README.md). When modifying behavior, call the original method when appropriate. For example, a plugin that marks image nodes as "void":
+Replace these methods to modify the original behavior of the editor when building [Plugins](../../concepts/08-plugins.md). When modifying behavior, call the original method when appropriate. For example, a plugin that marks image nodes as "void":
 
 ```javascript
 const withImages = editor => {


### PR DESCRIPTION
**Description**
Fix broken link in docs.

I'm not sure if a changeset is needed for a simple broken link docs fix?

**Issue**
Fixes: https://docs.slatejs.org/api/nodes/editor was linking to https://github.com/ianstormtaylor/slate/tree/a02787539a460fb70730085e26df13cca959fabd/concepts/07-plugins/README.md which is incorrect. Fixed with the right relative path.

**Example**
Trivial: Broken link.

**Context**
Trivial

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

