### PR TITLE
Check minHeight before overriding with placeholder height

### DIFF
--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -36,7 +36,7 @@ const Leaf = (props: {
       '[data-slate-editor="true"]'
     )
 
-    if (!placeholderEl || !editorEl) {
+    if (!placeholderEl || !editorEl || editorEl.style.minHeight) {
       return
     }
 


### PR DESCRIPTION
**Description**
Currently `leaf.tsx` overrides any minHeight styles added to `Editable` via the styles prop with a height of the placeholder.

I added a check to see if the minHeight already has a value before using the placeholder height.

- [ ] Check how it interacts with classNames and min-heights set via stylesheet

**Issue**
Fixes: 
https://github.com/ianstormtaylor/slate/issues/4233
https://github.com/ianstormtaylor/slate/issues/4314

**Example**
Before with `<Editable style={{ minHeight = 500 }} ...`
![image](https://user-images.githubusercontent.com/67913063/122113798-2f9f2e00-cde8-11eb-8e5f-d0c7ea96a213.png)

After with  `<Editable style={{ minHeight = 500 }} ...`
![image](https://user-images.githubusercontent.com/67913063/122113947-59f0eb80-cde8-11eb-858d-2fe5a5ccdc32.png)




**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

