### PR TITLE
fix(android): Fix editors mark is not inserted on insert text in android

### DIFF
--- a/.changeset/thick-geckos-kick.md
+++ b/.changeset/thick-geckos-kick.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix editor mark is not inserted on android

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -1,5 +1,5 @@
 import { ReactEditor } from '../../plugin/react-editor'
-import { Editor, Range, Transforms } from 'slate'
+import { Editor, Range, Transforms, Text } from 'slate'
 
 import { DOMNode } from '../../utils/dom'
 
@@ -102,13 +102,25 @@ export class AndroidInputManager {
   private insertText = (insertedText: TextInsertion[]) => {
     debug('insertText')
 
-    const { selection } = this.editor
+    const { selection, marks } = this.editor
 
     // Insert the batched text diffs
     insertedText.forEach(insertion => {
-      Transforms.insertText(this.editor, insertion.text.insertText, {
-        at: normalizeTextInsertionRange(this.editor, selection, insertion),
-      })
+      const text = insertion.text.insertText
+      const at = normalizeTextInsertionRange(this.editor, selection, insertion)
+      if (marks) {
+        const node = { text, ...marks }
+        Transforms.insertNodes(this.editor, node, {
+          match: Text.isText,
+          at,
+          select: true,
+        })
+      } else {
+        Transforms.insertText(this.editor, text, {
+          at,
+        })
+      }
+      this.editor.marks = null
     })
   }
 

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -115,12 +115,12 @@ export class AndroidInputManager {
           at,
           select: true,
         })
+        this.editor.marks = null
       } else {
         Transforms.insertText(this.editor, text, {
           at,
         })
       }
-      this.editor.marks = null
     })
   }
 


### PR DESCRIPTION
**Description**
Currently on rich text example, the mark is not inserted on the inserted text.
step to replicate:
* toggle mark button
* insert some text
* text inserted without the mark
expected: mark should be inserted with the text

**Issue**
#4405 

**Example**
current example: 

![bug-mark](https://user-images.githubusercontent.com/16449020/122640473-62bc2700-d132-11eb-9102-0fd1f49d5223.gif)

fix example:

![fix](https://user-images.githubusercontent.com/16449020/122640499-7ebfc880-d132-11eb-9d9b-9c09f06a8f2e.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

