### PR TITLE
Fix contributing link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@
   <a href="http://slatejs.org"><strong>Demo</strong></a> ·
   <a href="#examples"><strong>Examples</strong></a> ·
   <a href="http://docs.slatejs.org"><strong>Documentation</strong></a> ·
-  <a href="./Contributing.md"><strong>Contributing!</strong></a>
+  <a href="#contributing"><strong>Contributing!</strong></a>
 </p>
 <br/>
 


### PR DESCRIPTION
**Description**
The contribution heading on `ReadMe.md` refers to a file that doesn't exist, This Pull Request aims to solve that issue.
![image](https://user-images.githubusercontent.com/37709578/122747250-4b04b000-d2a4-11eb-8e4d-3007b41906cc.png)


**Example**
Currently, it takes you to [this page](https://github.com/ianstormtaylor/slate/blob/main/Contributing.md) (which obviously doesn't exist).
This Pull Request will change the link to the [contribution](https://github.com/ianstormtaylor/slate#contributing) part on `README.md`

