### PR TITLE
Re-render leaf when new properties were added to it

### DIFF
--- a/.changeset/sixty-ties-fetch.md
+++ b/.changeset/sixty-ties-fetch.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Re-render leaf when new properties were added to it

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -105,7 +105,7 @@ const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
     next.renderPlaceholder === prev.renderPlaceholder &&
     next.text === prev.text &&
     next.leaf.text === prev.leaf.text &&
-    Text.matches(next.leaf, prev.leaf) &&
+    Text.equals(next.leaf, prev.leaf) &&
     next.leaf[PLACEHOLDER_SYMBOL] === prev.leaf[PLACEHOLDER_SYMBOL]
   )
 })


### PR DESCRIPTION
**Description**

Currently memoization uses `Text.matches` to compare new and previous leaf. This means that any new property added to a leaf — for example a decoration — will not cause the leaf to be re-rendered.

**Example**

Our editor supports a “tracking changes” mode. Among other things this means that when you delete text it's not removed from the editor, but marked as deleted. The problem occurs when user tries to remove an entire paragraph:

![Peek 2021-06-22 15-21](https://user-images.githubusercontent.com/385442/122932999-8370c080-d36e-11eb-92a6-307f0578eaf3.gif)

while paragraph is marked as removed, this is not reflected in the UI. This is because the decoration spans whole paragraph, and so the only change is addition of a new property to the leaf, which is not considered a change by `Text.matches`. When using `Text.equals` this works fine:

![Peek 2021-06-22 15-28](https://user-images.githubusercontent.com/385442/122933021-88ce0b00-d36e-11eb-9f75-c87b5cc6d01e.gif)

Note that I've tested this change on 0.59, but it should work the same on master, as leaf memoization hasn't changed. This is why I haven't checked _The relevant examples still work_ (I did run cypress tests though, and they pass).

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

