### PR TITLE
feature(slate): Add isElementType utility function to Element Interface

### DIFF
--- a/.changeset/rich-wasps-leave.md
+++ b/.changeset/rich-wasps-leave.md
@@ -2,4 +2,4 @@
 'slate': patch
 ---
 
-Add isElementType utilit to Element interface
+Add isElementType utility to Element interface

--- a/.changeset/rich-wasps-leave.md
+++ b/.changeset/rich-wasps-leave.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Add isElementType utilit to Element interface

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -18,7 +18,22 @@ export interface ElementInterface {
   isElement: (value: any) => value is Element
   isElementList: (value: any) => value is Element[]
   isElementProps: (props: any) => props is Partial<Element>
+  isElementType: (
+    value: any,
+    type: string
+  ) => value is Element & { type: string }
   matches: (element: Element, props: Partial<Element>) => boolean
+}
+
+/**
+ * Shared the function with isElementType utility
+ */
+const isElement = (value: any): value is Element => {
+  return (
+    isPlainObject(value) &&
+    Node.isNodeList(value.children) &&
+    !Editor.isEditor(value)
+  )
 }
 
 export const Element: ElementInterface = {
@@ -34,14 +49,7 @@ export const Element: ElementInterface = {
    * Check if a value implements the `Element` interface.
    */
 
-  isElement(value: any): value is Element {
-    return (
-      isPlainObject(value) &&
-      Node.isNodeList(value.children) &&
-      !Editor.isEditor(value)
-    )
-  },
-
+  isElement,
   /**
    * Check if a value is an array of `Element` objects.
    */
@@ -56,6 +64,20 @@ export const Element: ElementInterface = {
 
   isElementProps(props: any): props is Partial<Element> {
     return (props as Partial<Element>).children !== undefined
+  },
+
+  /**
+   * Check if a value implements the `Element` interface and has type key
+   */
+
+  isElementType: (
+    value: any,
+    type: string
+  ): value is Element & { type: string } => {
+    if (value?.type === type && isElement(value)) {
+      return true
+    }
+    return false
   },
 
   /**

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -12,7 +12,6 @@ export interface BaseElement {
 }
 
 export type Element = ExtendedType<'Element', BaseElement>
-type DefaultElementType = Element & { type: string }
 
 export interface ElementInterface {
   isAncestor: (value: any) => value is Ancestor
@@ -69,10 +68,11 @@ export const Element: ElementInterface = {
   },
 
   /**
-   * Check if a value implements the `Element` interface and has type key
+   * Check if a value implements the `Element` interface and has elementKey with selected value.
+   * Default it check to `type` key value
    */
 
-  isElementType: <T extends Element = DefaultElementType>(
+  isElementType: <T extends Element>(
     value: any,
     elementVal: string,
     elementKey: string = 'type'

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -12,13 +12,14 @@ export interface BaseElement {
 }
 
 export type Element = ExtendedType<'Element', BaseElement>
+type DefaultElementType = Element & { type: string }
 
 export interface ElementInterface {
   isAncestor: (value: any) => value is Ancestor
   isElement: (value: any) => value is Element
   isElementList: (value: any) => value is Element[]
   isElementProps: (props: any) => props is Partial<Element>
-  isElementType: <T extends Element = Element & { type: string }>(
+  isElementType: <T extends Element>(
     value: any,
     elementVal: string,
     elementKey?: string
@@ -71,7 +72,7 @@ export const Element: ElementInterface = {
    * Check if a value implements the `Element` interface and has type key
    */
 
-  isElementType: <T extends Element = Element & { type: string }>(
+  isElementType: <T extends Element = DefaultElementType>(
     value: any,
     elementVal: string,
     elementKey: string = 'type'

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -18,10 +18,11 @@ export interface ElementInterface {
   isElement: (value: any) => value is Element
   isElementList: (value: any) => value is Element[]
   isElementProps: (props: any) => props is Partial<Element>
-  isElementType: (
+  isElementType: <T extends Element = Element & { type: string }>(
     value: any,
-    type: string
-  ) => value is Element & { type: string }
+    elementVal: string,
+    elementKey?: string
+  ) => value is T
   matches: (element: Element, props: Partial<Element>) => boolean
 }
 
@@ -70,14 +71,12 @@ export const Element: ElementInterface = {
    * Check if a value implements the `Element` interface and has type key
    */
 
-  isElementType: (
+  isElementType: <T extends Element = Element & { type: string }>(
     value: any,
-    type: string
-  ): value is Element & { type: string } => {
-    if (value?.type === type && isElement(value)) {
-      return true
-    }
-    return false
+    elementVal: string,
+    elementKey: string = 'type'
+  ): value is T => {
+    return isElement(value) && value[elementKey] === elementVal
   },
 
   /**

--- a/packages/slate/test/interfaces/Element/isElement/elementType.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/elementType.tsx
@@ -1,0 +1,11 @@
+import { Element } from 'slate'
+
+export const input = {
+  type: 'paragraph',
+  children: [{ text: '' }],
+}
+export const test = value => {
+  return Element.isElementType(value, 'heading-large')
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Element/isElement/isElementDiscriminant.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementDiscriminant.tsx
@@ -1,0 +1,11 @@
+import { Element } from 'slate'
+
+export const input = {
+  source: 'heading-large',
+  children: [{ text: '' }],
+}
+export const test = value => {
+  return Element.isElementType(value, 'heading-large', 'source')
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Element/isElement/isElementDiscriminant.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementDiscriminant.tsx
@@ -4,8 +4,7 @@ export const input = {
   source: 'heading-large',
   children: [{ text: '' }],
 }
-export const test = value => {
-  return Element.isElementType(value, 'heading-large', 'source')
-}
+export const test = value =>
+  Element.isElementType(value, 'heading-large', 'source')
 
 export const output = true

--- a/packages/slate/test/interfaces/Element/isElement/isElementDiscriminantFalse.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementDiscriminantFalse.tsx
@@ -1,11 +1,9 @@
 import { Element } from 'slate'
 
 export const input = {
-  source: 'heading-large',
+  type: 'heading-large',
   children: [{ text: '' }],
 }
-export const test = value => {
-  return Element.isElementType(value, 'paragraph', 'source')
-}
+export const test = value => Element.isElementType(value, 'paragraph', 'source')
 
 export const output = false

--- a/packages/slate/test/interfaces/Element/isElement/isElementDiscriminantFalse.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementDiscriminantFalse.tsx
@@ -1,11 +1,11 @@
 import { Element } from 'slate'
 
 export const input = {
-  type: 'paragraph',
+  source: 'heading-large',
   children: [{ text: '' }],
 }
 export const test = value => {
-  return Element.isElementType(value, 'heading-large')
+  return Element.isElementType(value, 'paragraph', 'source')
 }
 
-export const output = true
+export const output = false

--- a/packages/slate/test/interfaces/Element/isElement/isElementType.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementType.tsx
@@ -4,8 +4,6 @@ export const input = {
   type: 'paragraph',
   children: [{ text: '' }],
 }
-export const test = value => {
-  return Element.isElementType(value, 'paragraph')
-}
+export const test = value => Element.isElementType(value, 'paragraph')
 
 export const output = true

--- a/packages/slate/test/interfaces/Element/isElement/isElementType.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementType.tsx
@@ -1,0 +1,11 @@
+import { Element } from 'slate'
+
+export const input = {
+  type: 'paragraph',
+  children: [{ text: '' }],
+}
+export const test = value => {
+  return Element.isElementType(value, 'paragraph')
+}
+
+export const output = true

--- a/packages/slate/test/interfaces/Element/isElement/isElementTypeFalse.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementTypeFalse.tsx
@@ -4,8 +4,6 @@ export const input = {
   type: 'heading-large',
   children: [{ text: '' }],
 }
-export const test = value => {
-  return Element.isElementType(value, 'heading-large')
-}
+export const test = value => Element.isElementType(value, 'paragraph')
 
-export const output = true
+export const output = false

--- a/packages/slate/test/interfaces/Element/isElement/isElementTypeFalse.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/isElementTypeFalse.tsx
@@ -1,0 +1,11 @@
+import { Element } from 'slate'
+
+export const input = {
+  type: 'heading-large',
+  children: [{ text: '' }],
+}
+export const test = value => {
+  return Element.isElementType(value, 'heading-large')
+}
+
+export const output = true


### PR DESCRIPTION
**Description**
Trying to add isElementType function support like what suggested in the proposal

**Issue**
#4327 

**Example**

https://user-images.githubusercontent.com/16449020/123110300-87840780-d46e-11eb-965e-3e1c9d4666bd.mp4



**Context**
Not sure if this is the correct implementation like what suggested in proposal, since node.type will has type `string` instead of the string literal like implemented in CustomType. I hope there is a suggestion about how to make it become string literal

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

