### PR TITLE
Update package.json to include repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "workspaces": [
     "packages/*"
   ],
+   "repository": {
+    "type": "git",
+    "url": "https://github.com/ianstormtaylor/slate.git"
+  },
   "scripts": {
     "build": "yarn build:rollup && yarn build:next",
     "build:next": "cd ./site && next build && next export",


### PR DESCRIPTION
**Description**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
*slate-react-placeholder

