### PR TITLE
Don't show the placeholder when composing

### DIFF
--- a/.changeset/tricky-moles-battle.md
+++ b/.changeset/tricky-moles-battle.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Do not display placeholder when composing

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, useCallback } from 'react'
+import React, { useEffect, useRef, useMemo, useCallback, useState } from 'react'
 import {
   Editor,
   Element,
@@ -112,6 +112,8 @@ export const Editable = (props: EditableProps) => {
     ...attributes
   } = props
   const editor = useSlate()
+  // Rerender editor when composition status changed
+  const [isComposing, setIsComposing] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
   // Update internal state on each render.
@@ -371,6 +373,7 @@ export const Editable = (props: EditableProps) => {
               // then we will abort because we're still composing and the selection
               // won't be updated properly.
               // https://www.w3.org/TR/input-events-2/
+              state.isComposing && setIsComposing(false)
               state.isComposing = false
             }
 
@@ -482,7 +485,8 @@ export const Editable = (props: EditableProps) => {
     placeholder &&
     editor.children.length === 1 &&
     Array.from(Node.texts(editor)).length === 1 &&
-    Node.string(editor) === ''
+    Node.string(editor) === '' &&
+    !isComposing
   ) {
     const start = Editor.start(editor, [])
     decorations.push({
@@ -649,6 +653,7 @@ export const Editable = (props: EditableProps) => {
                 hasEditableTarget(editor, event.target) &&
                 !isEventHandled(event, attributes.onCompositionEnd)
               ) {
+                state.isComposing && setIsComposing(false)
                 state.isComposing = false
 
                 // COMPAT: In Chrome, `beforeinput` events for compositions
@@ -668,6 +673,7 @@ export const Editable = (props: EditableProps) => {
                 hasEditableTarget(editor, event.target) &&
                 !isEventHandled(event, attributes.onCompositionUpdate)
               ) {
+                !state.isComposing && setIsComposing(true)
                 state.isComposing = true
               }
             },


### PR DESCRIPTION
**Description**
Don't show the placeholder when composing.

**Issue**
I found a related issue #4306 but it's closed. I think this issue should be handled inside the editable component because hiding placeholder when composing is an expected behavior.

**Example**
Old behavior:

https://user-images.githubusercontent.com/13460383/123546900-27a0a000-d791-11eb-967c-b188a9a927a2.mov

New behavior:

https://user-images.githubusercontent.com/13460383/123546923-3edf8d80-d791-11eb-8b9a-9490d862bfdd.mov

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

