### PR TITLE
Added test for 'move-node' operation

### DIFF
--- a/packages/slate/test/operations/move_node/path-not-equals-new-path.tsx
+++ b/packages/slate/test/operations/move_node/path-not-equals-new-path.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>1</element>
+    <element>2</element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'move_node',
+    path: [0],
+    newPath: [1],
+  },
+]
+export const output = (
+  <editor>
+    <element>2</element>
+    <element>1</element>
+  </editor>
+)


### PR DESCRIPTION
**Description**
Added test for the `move-node` operation when `path` is not equal to the `new path`.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
~- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)~

