### PR TITLE
Replaced empty text with null character

### DIFF
--- a/packages/slate/src/transforms/general.ts
+++ b/packages/slate/src/transforms/general.ts
@@ -272,7 +272,7 @@ const applyToDraft = (editor: Editor, selection: Selection, op: Operation) => {
         node.text = before
         newNode = {
           ...(properties as Partial<Text>),
-          text: after,
+          text: after || '\0',
         }
       } else {
         const before = node.children.slice(0, position)

--- a/packages/slate/test/operations/move_node/path-not-equals-new-path.tsx
+++ b/packages/slate/test/operations/move_node/path-not-equals-new-path.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>1</element>
+    <element>2</element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'move_node',
+    path: [0],
+    newPath: [1],
+  },
+]
+export const output = (
+  <editor>
+    <element>2</element>
+    <element>1</element>
+  </editor>
+)


### PR DESCRIPTION
**Description**
Earlier the cursor was unable to move to empty text, now it moves to the newly created `null character`.

**Issue**
Fixes: #4195

**Example**

### Before

![114385908-783c3000-9b88-11eb-8699-e979c1142e27](https://user-images.githubusercontent.com/43617894/124398062-4c68ba80-dd31-11eb-90db-b243a2939b36.gif)


### After

![ezgif com-gif-maker](https://user-images.githubusercontent.com/43617894/124398024-23482a00-dd31-11eb-9322-e8507291c5f0.gif)


<!-- **Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.) -->

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

