### PR TITLE
Fixed link to contribution page in Readme.md header

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@
   <a href="http://slatejs.org"><strong>Demo</strong></a> ·
   <a href="#examples"><strong>Examples</strong></a> ·
   <a href="http://docs.slatejs.org"><strong>Documentation</strong></a> ·
-  <a href="./Contributing.md"><strong>Contributing!</strong></a>
+  <a href="./docs/general/contributing.md"><strong>Contributing!</strong></a>
 </p>
 <br/>
 


### PR DESCRIPTION
**Description**
Just a small link fix

**Issue**

**Example**
This was not the correct link:
![image](https://user-images.githubusercontent.com/11338472/124564257-2b8f8a80-de41-11eb-9874-83fd4b10bc23.png)

This is:
![image](https://user-images.githubusercontent.com/11338472/124564318-3b0ed380-de41-11eb-824e-b59db41bfbf7.png)

**Context**

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

