### PR TITLE
Fix scroll into view to scroll parent scrollables

### DIFF
--- a/.changeset/poor-moose-approve.md
+++ b/.changeset/poor-moose-approve.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Scroll when inserting new text will now scroll parent scrollables

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -216,7 +216,6 @@ export const Editable = (props: EditableProps) => {
       )
       scrollIntoView(leafEl, {
         scrollMode: 'if-needed',
-        boundary: el,
       })
       // @ts-ignore
       delete leafEl.getBoundingClientRect

--- a/site/examples/scroll-into-view.tsx
+++ b/site/examples/scroll-into-view.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useMemo } from 'react'
+import { createEditor, Descendant } from 'slate'
+import { Slate, Editable, withReact } from 'slate-react'
+import { withHistory } from 'slate-history'
+import { css } from 'emotion'
+import range from 'lodash/range'
+
+/**
+ * This is an example we can use to test the scrollIntoView functionality in
+ * `Editable`. Keeping it here for now as we may need it to make sure it is
+ * working properly after adding it.
+ *
+ * If all is good, we can remove this example.
+ *
+ * Note:
+ * The example needs to be added to `[example].tsx` before it can be used.
+ */
+
+const ScrollIntoViewExample = () => {
+  return (
+    <div
+      className={css`
+        height: 320px;
+        overflow-y: scroll;
+      `}
+    >
+      <div
+        className={css`
+          height: 160px;
+          background: #e0e0e0;
+        `}
+      />
+      <div
+        className={css`
+          height: 320px;
+          overflow-y: scroll;
+        `}
+      >
+        <PlainTextEditor />
+      </div>
+      <div
+        className={css`
+          height: 160px;
+          background: #e0e0e0;
+        `}
+      />
+    </div>
+  )
+}
+
+const PlainTextEditor = () => {
+  const [value, setValue] = useState<Descendant[]>(initialValue)
+  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  return (
+    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+      <Editable placeholder="Enter some plain text..." />
+    </Slate>
+  )
+}
+
+const initialValue: Descendant[] = range(5).map(() => ({
+  type: 'paragraph',
+  children: [
+    {
+      text: `There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.`,
+    },
+  ],
+}))
+
+export default ScrollIntoViewExample


### PR DESCRIPTION
**Description**
When typing at the bottom of the Editor, the editor will always scroll into view; however, the parent scrollable containers won't scroll into view.

**Issue**
Noticed this issue independently but I think it may resolve the below issue as well.

Fixes:
https://github.com/ianstormtaylor/slate/issues/3750

**Example**
See https://github.com/ianstormtaylor/slate/issues/3750

**Context**
This is a very small change that removes the `boundary` option of `scrollIntoVIew` which limits the scrolling to the editor.

```ts
      scrollIntoView(leafEl, {
        scrollMode: 'if-needed',
        // boundary: el,
      })
```

Note: I added an examples to the `examples` folder to see this in action. I kept it there so that if there were issues with the solution, the framework to look at the issue doesn't have to be recreated; however, eventually, I think it can be removed if we are satisfied with the solution.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

