### PR TITLE
make editor.selection avaliable when editor is contenteditable false

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -513,7 +513,12 @@ export const Editable = (props: EditableProps) => {
           }
           data-slate-editor
           data-slate-node="value"
-          contentEditable={readOnly ? undefined : true}
+          // explicitly set this
+          contentEditable={!readOnly}
+          // in some cases, if use a decoration which range are relate with selection to decorate a text node,
+          // then you will select the whole text node when you select part of text
+          // and this magic zIndex="-1" will fix it
+          zindex={-1}
           suppressContentEditableWarning
           ref={ref}
           style={{

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -223,9 +223,12 @@ export const ReactEditor = {
 
     return (
       targetEl.closest(`[data-slate-editor]`) === editorEl &&
-      (!editable ||
-        targetEl.isContentEditable ||
-        !!targetEl.getAttribute('data-slate-zero-width'))
+      (!editable || targetEl.isContentEditable
+        ? true
+        : (typeof targetEl.isContentEditable === 'boolean' && // isContentEditable only on HTMLElement, and other node will be undefined
+            // this is the core logic that let you can got the right editor.selection instead of null when editor is contenteditable="false"(readOnly)
+            targetEl.closest('[contenteditable="false"]') === editorEl) ||
+          !!targetEl.getAttribute('data-slate-zero-width'))
     )
   },
 


### PR DESCRIPTION
Developer needs to access the selection in read-only mode in some cases. For example, when implementing the comment feature, the readonly mode can add comment in document, and I need to know the location of the selection in Slate in order to do the corresponding highlighting, referencing and location recording. But the current design, in read-only mode, editor.selection is always null.

And more, my understanding of read-only mode would be to allow only the editor API to modify the document while contenteditable="false" (for instance: in collaborative read-only mode), and not allow user modifications via events such as keydown, beforeinput, input, drag-and-drop input, etc. 

But I can't hide the keyboard on mobile if I prevent these events while keeping contenteditable="true" to achieve a fake "read-only".

I've tested this pr in my own project and in the readonly code in the example and it works fine.

@ianstormtaylor  Any idea?

