### PR TITLE
Update forced-layout example

### DIFF
--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -32,6 +32,7 @@ const withLayout = editor => {
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
+        let type: string;
         const slateIndex = childPath[0];
 
         switch (slateIndex) {

--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -32,11 +32,25 @@ const withLayout = editor => {
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
-        const type = childPath[0] === 0 ? 'title' : 'paragraph'
+        const slateIndex = childPath[0];
 
-        if (SlateElement.isElement(child) && child.type !== type) {
-          const newProperties: Partial<SlateElement> = { type }
-          Transforms.setNodes(editor, newProperties, { at: childPath })
+        switch (slateIndex) {
+          case 0:
+            type = 'title';
+            enforceType(type);
+            break;
+          case 1:
+            type = 'paragraph';
+            enforceType(type);
+          default:
+            break;
+        }
+
+        function enforceType(type) {
+          if (SlateElement.isElement(child) && child.type !== type) {
+            const newProperties: Partial<SlateElement> = { type }
+            Transforms.setNodes(editor, newProperties, { at: childPath })
+          }
         }
       }
     }


### PR DESCRIPTION
Change the forced-layout example to enforce layout to an explicit block index to allow for block types beyond 'paragraph'.

**Description**
Building from the current forced-layout example seems to prevent all types other than 'paragraph' from being used. The solution implemented here is to enforce the layout by an explicit block index. This way will not enforce subsequent blocks to be type 'paragraph.'

**Checks**
- Newbie dev, the `enforceType()` implementation smells a bit and likely needs to be refactored.
- edit: Also, I do not know what the Typescript implementation looks like
