### PR TITLE
Fix display bug in GitBook

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -66,7 +66,7 @@ declare module 'slate' {
 }
 ```
 
-```typescript jsx
+```typescript
 // Also you must annotate `useState<Descendant[]>` and the editor's initial value.
 const App = () => {
   const initialValue: CustomElement = []


### PR DESCRIPTION
**Description**
The markup ` ```typescript jsx ` doesn't render properly on [https://docs.slatejs.org/walkthroughs/01-installing-slate](https://docs.slatejs.org/walkthroughs/01-installing-slate), because it's not supported by GitBook. This PR changes it to just  ` ```typescript ` (without the `jsx`) to fix the issue.

**Issue**
Fixes: n/a

**Example**
<img width="752" alt="GitBook" src="https://user-images.githubusercontent.com/83459976/127643810-00764629-4586-474b-8cf4-01423fc616bf.png">

**Context**
The change is trivial.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

