### PR TITLE
Remove unused useEffect import

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -18,7 +18,7 @@ Once you've installed Slate, you'll need to import it.
 
 ```jsx
 // Import React dependencies.
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 // Import the Slate editor factory.
 import { createEditor } from 'slate'
 


### PR DESCRIPTION
**Description**
The useEffect Hook is imported, but is not actually being used in any of the examples on the page. The import is redundant; there's no reason to keep it.

**Issue**
Fixes: n/a

**Example**
![useEffect](https://user-images.githubusercontent.com/83459976/127667228-41d421ae-b0f6-49b3-94e3-7bf978e60e47.png)

**Context**
The change is trivial.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

