### PR TITLE
Do not needlessly JSON.stringify() the whole editor

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -22,12 +22,15 @@ export const Slate = (props: {
   const [key, setKey] = useState(0)
   const context: [ReactEditor] = useMemo(() => {
     if (!Node.isNodeList(value)) {
-      throw new Error(`[Slate] value is invalid! Expected a list of elements` + 
-        `but got: ${JSON.stringify(value)}`)
+      throw new Error(
+        `[Slate] value is invalid! Expected a list of elements` +
+          `but got: ${JSON.stringify(value)}`
+      )
     }
     if (!Editor.isEditor(editor)) {
-      throw new Error(`[Slate] editor is invalid! you passed:` +
-      `${JSON.stringify(editor)}`)
+      throw new Error(
+        `[Slate] editor is invalid! you passed:` + `${JSON.stringify(editor)}`
+      )
     }
     editor.children = value
     Object.assign(editor, rest)

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -22,10 +22,12 @@ export const Slate = (props: {
   const [key, setKey] = useState(0)
   const context: [ReactEditor] = useMemo(() => {
     if (!Node.isNodeList(value)) {
-      throw new Error(`[Slate] value is invalid! Expected a list of elements but got: ${JSON.stringify(value)}`)
+      throw new Error(`[Slate] value is invalid! Expected a list of elements` + 
+        `but got: ${JSON.stringify(value)}`)
     }
     if (!Editor.isEditor(editor)) {
-      throw new Error(`[Slate] editor is invalid! you passed: ${JSON.stringify(editor)}`)
+      throw new Error(`[Slate] editor is invalid! you passed:` +
+      `${JSON.stringify(editor)}`)
     }
     editor.children = value
     Object.assign(editor, rest)

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo, useState, useCallback, useEffect } from 'react'
 import { Editor, Node, Element, Descendant } from 'slate'
-import invariant from 'tiny-invariant'
-
 import { ReactEditor } from '../plugin/react-editor'
 import { FocusedContext } from '../hooks/use-focused'
 import { EditorContext } from '../hooks/use-slate-static'
@@ -23,9 +21,12 @@ export const Slate = (props: {
   const { editor, children, onChange, value, ...rest } = props
   const [key, setKey] = useState(0)
   const context: [ReactEditor] = useMemo(() => {
-    invariant(Node.isNodeList(value), `[Slate] value is invalid.`)
-    invariant(Editor.isEditor(editor), `[Slate] editor is invalid.`)
-
+    if (!Node.isNodeList(value)) {
+      throw new Error(`[Slate] value is invalid! Expected a list of elements but got: ${JSON.stringify(value)}`)
+    }
+    if (!Editor.isEditor(editor)) {
+      throw new Error(`[Slate] editor is invalid! you passed: ${JSON.stringify(editor)}`)
+    }
     editor.children = value
     Object.assign(editor, rest)
     return [editor]

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -23,16 +23,8 @@ export const Slate = (props: {
   const { editor, children, onChange, value, ...rest } = props
   const [key, setKey] = useState(0)
   const context: [ReactEditor] = useMemo(() => {
-    invariant(
-      Node.isNodeList(value),
-      `[Slate] value is invalid! Expected a list of elements but got: ${JSON.stringify(
-        value
-      )}`
-    )
-    invariant(
-      Editor.isEditor(editor),
-      `[Slate] editor is invalid! you passed: ${JSON.stringify(editor)}`
-    )
+    invariant(Node.isNodeList(value), `[Slate] value is invalid.`)
+    invariant(Editor.isEditor(editor), `[Slate] editor is invalid.`)
 
     editor.children = value
     Object.assign(editor, rest)


### PR DESCRIPTION
The `value` and `editor` passed to the `<Slate>` component can be big. The `useMemo()` which creates the context is invoked whenever the value changes. This means the code would JSON.stringify() both the value and editor (which through .children also contains the value), just for the `invariant()` message which may not be used most of the time.

A lazy version of `invariant` would be nice to have (eg. `invariant(false, () => "<expensive string builder>")`). But to be honest I'd prefer dumping the object into the console via console.log/info/error, because then I can actually see and inspect it.