### PR TITLE
cypress: shadow-dom example test

### DIFF
--- a/cypress/integration/examples/shadow-dom.ts
+++ b/cypress/integration/examples/shadow-dom.ts
@@ -1,0 +1,10 @@
+describe('shadow-dom example', () => {
+  beforeEach(() => cy.visit('examples/shadow-dom'))
+
+  it('renders slate editor inside nested shadow', () => {
+    const outerShadow = cy.dataCy('outer-shadow-root').shadow()
+    const innerShadow = outerShadow.find('> div').shadow()
+
+    innerShadow.findByRole('textbox').should('exist')
+  })
+})

--- a/site/examples/shadow-dom.tsx
+++ b/site/examples/shadow-dom.tsx
@@ -24,7 +24,7 @@ const ShadowDOM = () => {
     ReactDOM.render(<ShadowEditor />, reactRoot)
   })
 
-  return <div ref={container} />
+  return <div ref={container} data-cy="outer-shadow-root" />
 }
 
 const ShadowEditor = () => {


### PR DESCRIPTION
**Description**
Adds a cypress test for the shadow dom examples

**Video**

https://user-images.githubusercontent.com/2987087/128340496-7ad85e5f-5a2e-4ad3-9638-f05ef4e2d998.mp4



**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

