### PR TITLE
feat(docs): mention third parameter to `toSlateRange` method in the docs

### DIFF
--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -168,7 +168,7 @@ Get the target range from a DOM `event`.
 
 Find a Slate point from a DOM selection's `domNode` and `domOffset`.
 
-### `toSlateRange(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection, options: { exactMach?: boolean } = {})`
+### `toSlateRange(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection, options?: { exactMatch?: boolean } = {})`
 
 Find a Slate range from a DOM range or selection.
 

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -168,7 +168,7 @@ Get the target range from a DOM `event`.
 
 Find a Slate point from a DOM selection's `domNode` and `domOffset`.
 
-### `toSlateRange(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection)`
+### `toSlateRange(editor: ReactEditor, domRange: DOMRange | DOMStaticRange | DOMSelection, options: { exactMach?: boolean } = {})`
 
 Find a Slate range from a DOM range or selection.
 


### PR DESCRIPTION
**Description**
This is a small addition to the documentation of the sub-library Slate React.

Slate React implements a React and DOM-specific version of the `Editor` interface called `ReactEditor`.

It has a method named `toSlateRange` for translating a Slate range from a DOM range. This method accepts up to three parameters:
- editor: ReactEditor (required)
- domRange (required)
- an optional third parameter that is an object with property `exactMatch` and value is a boolean.

However, the current version of the documentation doesn't mention this parameter.

**Example**
Example of this implementation can be found at the `Editable` component of `slate-react`, inside the custom `onDOMSelectionChange`.

```
const onDOMSelectionChange = useCallback(
  throttle(() => {
    if (...) {
      const root = ReactEditor.findDocumentOrShadowRoot(editor)
      const domSelection = root.getSelection()
      const range = ReactEditor.toSlateRange(editor, domSelection, { exactMatch: false })
    }
  })
)
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

