### PR TITLE
Fix useTimeout type to use browser type instead of nodejs type

### DIFF
--- a/packages/slate-react/src/components/android/use-android-input-manager.ts
+++ b/packages/slate-react/src/components/android/use-android-input-manager.ts
@@ -17,7 +17,7 @@ export function useAndroidInputManager(node: RefObject<HTMLElement>) {
   const editor = useSlateStatic()
   const [inputManager] = useState(() => new AndroidInputManager(editor))
   const { receivedUserInput, onUserInput } = useTrackUserInput()
-  const timeoutId = useRef<NodeJS.Timeout | null>(null)
+  const timeoutId = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isReconciling = useRef(false)
   const flush = useCallback((mutations: MutationRecord[]) => {
     if (!receivedUserInput.current) {


### PR DESCRIPTION
**Description**
See https://github.com/ianstormtaylor/slate/pull/4417#discussion_r684247757

**Context**
https://github.com/ianstormtaylor/slate/pull/4417

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

