### PR TITLE
fix decorate bug (#4277) without adding extra layers of render tree

### DIFF
--- a/.changeset/real-jobs-bow.md
+++ b/.changeset/real-jobs-bow.md
@@ -1,0 +1,6 @@
+---
+'slate-react': patch
+'slate': patch
+---
+
+fix decorate bug (#4277) without adding extra layers of render tree

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useMemo, useCallback, useState } from 'react'
 import {
+  Ancestor,
   Editor,
   Element,
   NodeEntry,
@@ -46,6 +47,10 @@ import {
   PLACEHOLDER_SYMBOL,
   EDITOR_TO_WINDOW,
 } from '../utils/weak-maps'
+
+const Children = (props: Parameters<typeof useChildren>[0]) => (
+  <React.Fragment>{useChildren(props)}</React.Fragment>
+)
 
 /**
  * `RenderElementProps` are passed to the `renderElement` handler.
@@ -1125,14 +1130,14 @@ export const Editable = (props: EditableProps) => {
             [readOnly, attributes.onPaste]
           )}
         >
-          {useChildren({
-            decorations,
-            node: editor,
-            renderElement,
-            renderPlaceholder,
-            renderLeaf,
-            selection: editor.selection,
-          })}
+          <Children
+            decorations={decorations}
+            node={editor}
+            renderElement={renderElement}
+            renderPlaceholder={renderPlaceholder}
+            renderLeaf={renderLeaf}
+            selection={editor.selection}
+          />
         </Component>
       </DecorateContext.Provider>
     </ReadOnlyContext.Provider>

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useMemo, useCallback, useState } from 'react'
 import {
-  Ancestor,
   Editor,
   Element,
   NodeEntry,

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Editor, Range, Element, Path, Ancestor, Descendant } from 'slate'
+import { Editor, Range, Element, NodeEntry, Ancestor, Descendant } from 'slate'
 
 import ElementComponent from '../components/element'
 import TextComponent from '../components/text'
@@ -17,67 +17,6 @@ import {
  * Children.
  */
 
-const Child = (props: {
-  decorations: Range[]
-  parent: Ancestor
-  path: Path
-  child: Descendant
-  isLast: boolean
-  renderElement?: (props: RenderElementProps) => JSX.Element
-  renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
-  renderLeaf?: (props: RenderLeafProps) => JSX.Element
-  selection: Range | null
-}) => {
-  const {
-    decorations,
-    parent,
-    path,
-    child,
-    isLast,
-    renderElement,
-    renderPlaceholder,
-    renderLeaf,
-    selection,
-  } = props
-  const decorate = useDecorate()
-  const editor = useSlateStatic()
-
-  const range = Editor.range(editor, path)
-  const sel = selection && Range.intersection(range, selection)
-  const ds = decorate([child, path])
-
-  for (const dec of decorations) {
-    const d = Range.intersection(dec, range)
-
-    if (d) {
-      ds.push(d)
-    }
-  }
-
-  if (Element.isElement(child)) {
-    return (
-      <ElementComponent
-        decorations={ds}
-        element={child}
-        renderElement={renderElement}
-        renderPlaceholder={renderPlaceholder}
-        renderLeaf={renderLeaf}
-        selection={sel}
-      />
-    )
-  }
-  return (
-    <TextComponent
-      decorations={ds}
-      isLast={isLast}
-      parent={parent}
-      renderPlaceholder={renderPlaceholder}
-      renderLeaf={renderLeaf}
-      text={child}
-    />
-  )
-}
-
 const useChildren = (props: {
   decorations: Range[]
   node: Ancestor
@@ -94,6 +33,7 @@ const useChildren = (props: {
     renderLeaf,
     selection,
   } = props
+  const decorate = useDecorate()
   const editor = useSlateStatic()
   const path = ReactEditor.findPath(editor, node)
   const children = []
@@ -106,21 +46,43 @@ const useChildren = (props: {
     const p = path.concat(i)
     const n = node.children[i] as Descendant
     const key = ReactEditor.findKey(editor, n)
+    const range = Editor.range(editor, p)
+    const sel = selection && Range.intersection(range, selection)
+    const ds = decorate([n, p])
 
-    children.push(
-      <Child
-        decorations={decorations}
-        parent={node}
-        path={p}
-        child={n}
-        key={key.id}
-        isLast={isLeafBlock && i === node.children.length - 1}
-        renderElement={renderElement}
-        renderPlaceholder={renderPlaceholder}
-        renderLeaf={renderLeaf}
-        selection={selection}
-      />
-    )
+    for (const dec of decorations) {
+      const d = Range.intersection(dec, range)
+
+      if (d) {
+        ds.push(d)
+      }
+    }
+
+    if (Element.isElement(n)) {
+      children.push(
+        <ElementComponent
+          decorations={ds}
+          element={n}
+          key={key.id}
+          renderElement={renderElement}
+          renderPlaceholder={renderPlaceholder}
+          renderLeaf={renderLeaf}
+          selection={sel}
+        />
+      )
+    } else {
+      children.push(
+        <TextComponent
+          decorations={ds}
+          key={key.id}
+          isLast={isLeafBlock && i === node.children.length - 1}
+          parent={node}
+          renderPlaceholder={renderPlaceholder}
+          renderLeaf={renderLeaf}
+          text={n}
+        />
+      )
+    }
 
     NODE_TO_INDEX.set(n, i)
     NODE_TO_PARENT.set(n, node)


### PR DESCRIPTION
**Description**
The combination of #4152 and #4138 broke decoration in `Editable`: the `decorate` function is not called on immediate children of the editor (because the function is retrieved from a React context before the context is set).

I fixed this in #4394 by adding a wrapper component around each child in `useChildren`, so the context is set by the time we retrieve the `decorate` function.

But after some discussion with @ulion (on #4277 and #4394) I think it's better not to wrap every child, but only the immediate children of `Editable`; this achieves the same thing without adding extra layers to the render tree. And since the immediate children of `Editable` are not passed to `renderLeaf`, it's not necessary to wrap them individually for #4152. So this change reverts the changes to `use-children.tsx` from #4394, and adds back a `Children` component in `Editable` in order to defer the call to `useDecorate`.

**Issue**
Fixes: #4277

**Example**
See test—`decorate` is called on all children of editor.

**Context**
As above, the issue is that a React context (added in #4138) is used before being set (because #4152 replaced the `Children` component with a call to `useChildren`). In order to fix the bug without defeating the goals of these two changes, we wrap a `Children` component around the `useChildren` call in `Editable` to defer the use of the context.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.) **No changeset needed; no functionality is affected by this change.**
