### PR TITLE
[Small-Fix] Small UI fix for the search icon and placeholder of the search highlighting

### DIFF
--- a/site/examples/search-highlighting.tsx
+++ b/site/examples/search-highlighting.tsx
@@ -48,8 +48,8 @@ const SearchHighlightingExample = () => {
           <Icon
             className={css`
               position: absolute;
-              top: 0.5em;
-              left: 0.5em;
+              top: 0.3em;
+              left: 0.4em;
               color: #ccc;
             `}
           >
@@ -60,7 +60,7 @@ const SearchHighlightingExample = () => {
             placeholder="Search the text..."
             onChange={e => setSearch(e.target.value)}
             className={css`
-              padding-left: 2em;
+              padding-left: 2.5em;
               width: 100%;
             `}
           />


### PR DESCRIPTION

**Description**

The Ui for the search highlighting example had a search icon and a placeholder. They were overlapping and were not aligned with each other.
This small PR fixes this and ensures that they don't overlap.


BEFORE THE CHANGE:-

![image](https://user-images.githubusercontent.com/59202075/128595936-f5551bc4-8c47-43d4-95df-d0c4bc2e360c.png)


AFTER THE CHANGE:-

![image](https://user-images.githubusercontent.com/59202075/128595940-ea145aed-acca-4ebb-8383-ad90a0203340.png)


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

