### PR TITLE
prevent code highlighting test failure due to timeout

### DIFF
--- a/cypress/integration/examples/code-highlighting.ts
+++ b/cypress/integration/examples/code-highlighting.ts
@@ -16,20 +16,26 @@ describe('code highlighting', () => {
       .should('have.css', 'color', 'rgb(153, 0, 85)')
   })
 
-  it('highlights javascript syntax', () => {
-    const JSCode = 'const slateVar = 30;{enter}'
-    cy.get('select').select('JavaScript') // Select the 'JavaScript' option
+  it(
+    'highlights javascript syntax',
+    {
+      defaultCommandTimeout: 10000, // test was not passing within 4s default
+    },
+    () => {
+      const JSCode = 'const slateVar = 30;{enter}'
+      cy.get('select').select('JavaScript') // Select the 'JavaScript' option
 
-    cy.get(slateEditor)
-      .type('{movetostart}')
-      .type(JSCode) // Type JavaScript code
+      cy.get(slateEditor)
+        .type('{movetostart}')
+        .type(JSCode) // Type JavaScript code
 
-    cy.get(slateEditor)
-      .find('span')
-      .eq(0)
-      .find(leafNode)
-      .eq(0)
-      .should('contain', 'const')
-      .should('have.css', 'color', 'rgb(0, 119, 170)')
-  })
+      cy.get(slateEditor)
+        .find('span')
+        .eq(0)
+        .find(leafNode)
+        .eq(0)
+        .should('contain', 'const')
+        .should('have.css', 'color', 'rgb(0, 119, 170)')
+    }
+  )
 })


### PR DESCRIPTION
**Description**

The introduction of a test in #4409 was not allowing sufficient time for the test to succeed. This test was causing failures in unrelated PRs such as #4037 and #3888.

**Issue**
Fixes: Failing test due to insufficient default timeout.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

No changeset as this lives outside the packages covered by changesets.