### PR TITLE
Don't set null in set_node newProperties when using unsetNodes

### DIFF
--- a/.changeset/spotty-squids-walk.md
+++ b/.changeset/spotty-squids-walk.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Don't set `null` in `set_node`'s `newProperties` object when using `Transforms.unsetNodes()`

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -632,19 +632,23 @@ export const NodeTransforms: NodeTransforms = {
           continue
         }
 
+        let hasChanges = false
+
         for (const k in props) {
           if (k === 'children' || k === 'text') {
             continue
           }
 
           if (props[k] !== node[k]) {
-            // Omit new properties from the old property list rather than set them to undefined
+            hasChanges = true
+            // Omit new properties from the old properties list
             if (node.hasOwnProperty(k)) properties[k] = node[k]
-            newProperties[k] = props[k]
+            // Omit properties that have been removed from the new properties list
+            if (props[k] != null) newProperties[k] = props[k]
           }
         }
 
-        if (Object.keys(newProperties).length !== 0) {
+        if (hasChanges) {
           editor.apply({
             type: 'set_node',
             path,

--- a/packages/slate/test/operations/set_node/remove-null.tsx
+++ b/packages/slate/test/operations/set_node/remove-null.tsx
@@ -10,6 +10,7 @@ export const input = (
   </editor>
 )
 
+// this is supported for backwards compatibility only; newProperties should omit removed values.
 export const operations = [
   {
     type: 'set_node',

--- a/packages/slate/test/operations/set_node/remove-undefined.tsx
+++ b/packages/slate/test/operations/set_node/remove-undefined.tsx
@@ -10,6 +10,7 @@ export const input = (
   </editor>
 )
 
+// this is supported for backwards compatibility only; newProperties should omit removed values.
 export const operations = [
   {
     type: 'set_node',

--- a/packages/slate/test/transforms/unsetNodes/operation-contents-check.tsx
+++ b/packages/slate/test/transforms/unsetNodes/operation-contents-check.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import assert from 'assert'
+import { Transforms, Text, Editor } from 'slate'
+import { jsx } from '../..'
+
+export const run = (editor: Editor) => {
+  Transforms.unsetNodes(editor, 'key', { at: [0] })
+
+  // unsetNodes uses null to remove properties, but that should not
+  // flow through to the operation
+  const [setNode] = editor.operations
+
+  if (setNode.type === 'set_node') {
+    assert.deepStrictEqual(setNode, {
+      type: 'set_node',
+      path: [0],
+      properties: { key: true },
+      newProperties: {},
+    })
+  } else {
+    // eslint-disable-next-line no-console
+    console.error('operations:', editor.operations)
+    assert.fail('operation was not a set node')
+  }
+}
+export const input = (
+  <editor>
+    <block key>word</block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>word</block>
+  </editor>
+)

--- a/packages/slate/test/transforms/unsetNodes/text.tsx
+++ b/packages/slate/test/transforms/unsetNodes/text.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { Transforms, Text } from 'slate'
-import { jsx } from '../../..'
+import { jsx } from '../..'
 
 export const run = editor => {
   Transforms.unsetNodes(editor, 'key', { match: Text.isText })


### PR DESCRIPTION
**Description**
Having `null` values in `set_node` operations is unnecessary, thanks to #4078, and adds complexity to collaboration transforms.

**Issue**
Follow up to #4078

**Context**
After #4078 was submitted @ianstormtaylor suggested omitting removed keys, rather than setting them to `null`, which was a much cleaner solution. This tidies up the last place that null values might be set.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

