### PR TITLE
Remove unused slate-history dependency on immer

### DIFF
--- a/.changeset/itchy-poems-lie.md
+++ b/.changeset/itchy-poems-lie.md
@@ -1,0 +1,5 @@
+---
+'slate-history': patch
+---
+
+Removed unnecessary (and outdated) dependency on `immer`

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -14,7 +14,6 @@
     "dist/"
   ],
   "dependencies": {
-    "immer": "^8.0.1",
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description**
As discussed in https://github.com/ianstormtaylor/slate/pull/4050#issuecomment-887904120 immer was upgraded in slate-history but it was not published (this was before the changeset auto-publish system was introduced). Merging this means the package will be included in the next publish.

**Issue**
Follow up to: #4050

**Context**
I can't find any reference to `immer` in the current `slate-history` code so this should be safe.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

