### PR TITLE
Fixed regression in #4208 where normalization on empty block nodes could not be overridden

### DIFF
--- a/.changeset/popular-ways-fail.md
+++ b/.changeset/popular-ways-fail.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Fixed regression in #4208 where normalization on empty block nodes could not be overridden

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -997,16 +997,18 @@ export const Editor: EditorInterface = {
       */
       for (const dirtyPath of getDirtyPaths(editor)) {
         if (Node.has(editor, dirtyPath)) {
-          const [node, _] = Editor.node(editor, dirtyPath)
+          const entry = Editor.node(editor, dirtyPath)
+          const [node, _] = entry
 
-          // Add a text child to elements with no children.
-          // This is safe to do in any order, by definition it can't cause other paths to change.
+          /*
+            The default normalizer inserts an empty text node in this scenario, but it can be customised.
+            So there is some risk here.
+
+            As long as the normalizer only inserts child nodes for this case it is safe to do in any order;
+            by definition adding children to an empty node can't cause other paths to change.
+          */
           if (Element.isElement(node) && node.children.length === 0) {
-            const child = { text: '' }
-            Transforms.insertNodes(editor, child, {
-              at: dirtyPath.concat(0),
-              voids: true,
-            })
+            editor.normalizeNode(entry)
           }
         }
       }

--- a/packages/slate/test/normalization/block/insert-custom-block.tsx
+++ b/packages/slate/test/normalization/block/insert-custom-block.tsx
@@ -1,0 +1,40 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+import { Editor, Element, Transforms } from 'slate'
+
+export const input = (
+  <editor>
+    <element type="body" />
+  </editor>
+)
+
+// patch in a custom normalizer that inserts empty paragraphs in the body instead of text nodes
+// this test also verifies the new node itself is also normalized, because it's inserting a non-normalized node
+const editor = (input as unknown) as Editor
+const defaultNormalize = editor.normalizeNode
+editor.normalizeNode = entry => {
+  const [node, path] = entry
+  if (
+    Element.isElement(node) &&
+    node.children.length === 0 &&
+    (node as any).type === 'body'
+  ) {
+    const child = { type: 'paragraph', children: [] }
+    Transforms.insertNodes(editor, child, {
+      at: path.concat(0),
+      voids: true,
+    })
+  } else {
+    defaultNormalize(entry)
+  }
+}
+
+export const output = (
+  <editor>
+    <element type="body">
+      <element type="paragraph">
+        <text />
+      </element>
+    </element>
+  </editor>
+)


### PR DESCRIPTION
**Description**
My change in #4208 caused problems for anyone wanting to fix empty block nodes with custom behaviour, instead of the Slate default that inserts an empty text node.

**Issue**
Improves: #4208

**Example**
I have written a test for the desired behaviour that fails with my previous fix.

**Context**
It turns out just calling `editor.normalizeNode()` in the pre-normalization pass fixes both my initial test cases and the new test. There may be other edge cases that don't work so I've made this a minor level change.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

