### PR TITLE
cypress: test for paste html example

### DIFF
--- a/cypress/integration/examples/paste-html.ts
+++ b/cypress/integration/examples/paste-html.ts
@@ -1,0 +1,29 @@
+describe('paste html example', () => {
+  beforeEach(() => cy.visit('examples/paste-html'))
+
+  const createHtmlPasteEvent = (htmlContent: string) =>
+    Object.assign(new Event('paste', { bubbles: true, cancelable: true }), {
+      clipboardData: {
+        getData: (type = 'text/html') => htmlContent,
+        types: ['text/html'],
+      },
+    })
+
+  const cyNewPasteHtml = (htmlContent: string) =>
+    cy
+      .findByRole('textbox')
+      .type('{selectall}')
+      .trigger('paste', createHtmlPasteEvent(htmlContent))
+
+  it('pasted bold text uses <strong>', () => {
+    cyNewPasteHtml('<strong>Hello Bold</strong>')
+      .get('strong')
+      .should('contain.text', 'Hello')
+  })
+
+  it('pasted code uses <code>', () => {
+    cyNewPasteHtml('<code>console.log("hello from slate!")</code>')
+      .get('code')
+      .should('contain.text', 'slate!')
+  })
+})


### PR DESCRIPTION
**Description**
Adds cypress integration test for paste html example

**Video**

https://user-images.githubusercontent.com/2987087/129034226-3664ab7d-e11a-40a2-b8f6-09f871f5f4b1.mp4



**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

