### PR TITLE
cypress: fix flaky code highlight test

### DIFF
--- a/cypress/integration/examples/code-highlighting.ts
+++ b/cypress/integration/examples/code-highlighting.ts
@@ -24,6 +24,7 @@ describe('code highlighting', () => {
     () => {
       const JSCode = 'const slateVar = 30;{enter}'
       cy.get('select').select('JavaScript') // Select the 'JavaScript' option
+      cy.get('select').should('have.value', 'js') // Confirm value to avoid race conditin
 
       cy.get(slateEditor)
         .type('{movetostart}')
@@ -34,8 +35,7 @@ describe('code highlighting', () => {
         .eq(0)
         .find(leafNode)
         .eq(0)
-        // test is failing in CI, but is not actually due to breaking behavior
-        //.should('contain', 'const')
+        .should('contain', 'const')
         .should('have.css', 'color', 'rgb(0, 119, 170)')
     }
   )

--- a/cypress/integration/examples/code-highlighting.ts
+++ b/cypress/integration/examples/code-highlighting.ts
@@ -24,7 +24,7 @@ describe('code highlighting', () => {
     () => {
       const JSCode = 'const slateVar = 30;{enter}'
       cy.get('select').select('JavaScript') // Select the 'JavaScript' option
-      cy.get('select').should('have.value', 'js') // Confirm value to avoid race conditin
+      cy.get('select').should('have.value', 'js') // Confirm value to avoid race condition
 
       cy.get(slateEditor)
         .type('{movetostart}')


### PR DESCRIPTION
**Description**
The code highlighting example test fails intermittently even after https://github.com/ianstormtaylor/slate/pull/4423.
From the post [here](https://www.cypress.io/blog/2020/07/22/do-not-get-too-detached/), it seems like toggling the select box can result in a race condition. Hence, in this patch I try to confirm that the select value is changed and only then perform subsequent actions

I've tried running this on https://github.com/MLH-Fellowship/slate twice, it seems to work. But since I can't simulate the CI environment locally, there's no guarantee.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

