### PR TITLE
fix: insert new node in advance to avoid ime double input with editor marks

### DIFF
--- a/.changeset/old-bees-design.md
+++ b/.changeset/old-bees-design.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix IME double input with editor mark

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -131,6 +131,7 @@ export const Editable = (props: EditableProps) => {
   const state = useMemo(
     () => ({
       isComposing: false,
+      hasInsertPrefixInCompositon: false,
       isDraggingInternally: false,
       isUpdatingSelection: false,
       latestElement: null as DOMElement | null,
@@ -717,6 +718,23 @@ export const Editable = (props: EditableProps) => {
                 if (!IS_SAFARI && !IS_FIREFOX_LEGACY && !IS_IOS && event.data) {
                   Editor.insertText(editor, event.data)
                 }
+
+                if (editor.selection && Range.isCollapsed(editor.selection)) {
+                  const leafPath = editor.selection.anchor.path
+                  const currentTextNode = Node.leaf(editor, leafPath)
+                  if (state.hasInsertPrefixInCompositon) {
+                    state.hasInsertPrefixInCompositon = false
+                    Editor.withoutNormalizing(editor, () => {
+                      // remove prefix added in onCompositionStart
+                      const text = currentTextNode.text.replace(/^\uFEFF/, '')
+                      Transforms.delete(editor, {
+                        distance: currentTextNode.text.length,
+                        reverse: true,
+                      })
+                      Transforms.insertText(editor, text)
+                    })
+                  }
+                }
               }
             },
             [attributes.onCompositionEnd]
@@ -739,9 +757,42 @@ export const Editable = (props: EditableProps) => {
                 hasEditableTarget(editor, event.target) &&
                 !isEventHandled(event, attributes.onCompositionStart)
               ) {
-                const { selection } = editor
-                if (selection && Range.isExpanded(selection)) {
-                  Editor.deleteFragment(editor)
+                const { selection, marks } = editor
+                if (selection) {
+                  if (Range.isExpanded(selection)) {
+                    Editor.deleteFragment(editor)
+                  } else {
+                    const inline = Editor.above(editor, {
+                      match: n => Editor.isInline(editor, n),
+                      mode: 'highest',
+                    })
+                    if (inline) {
+                      const [, inlinePath] = inline
+                      if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
+                        const point = Editor.after(editor, inlinePath)!
+                        Transforms.setSelection(editor, {
+                          anchor: point,
+                          focus: point,
+                        })
+                      }
+                    }
+                    // insert new node in advance to ensure composition text will insert
+                    // along with final input text
+                    // and add prefix text to avoid this node removed by normalize
+                    if (marks) {
+                      state.hasInsertPrefixInCompositon = true
+                      Transforms.insertNodes(
+                        editor,
+                        {
+                          text: '\uFEFF',
+                          ...marks,
+                        },
+                        {
+                          select: true,
+                        }
+                      )
+                    }
+                  }
                 }
               }
             },


### PR DESCRIPTION
**Description**

When the user enters text using the input method, the browser will trigger `composition` event sequentially and insert  composition text in the DOM. At the end of composition, the browser will remove the previously inserted composition text and insert the final IME output text.

But the problem is, if we type with editor mark, slate will create a new node and insert the final text into the new node, which will cause the position of the inserted final text is different from the position of the the previously inserted composition text, which will cause the browser can't remove the inserted composition text correctly, and React can't detect the change too.

This will result in inconsistent data structure and DOM rendering and slate will crash when select text that shouldn't exist

**Issue**

Fixes:  #4158 #3888

**Example**

![xx](https://user-images.githubusercontent.com/17848159/129345780-c064b760-2bcf-44fa-b6be-3088e0fd958f.gif)


**Context**

I used to force refresh all relevant string component to let `React` correct the wrong DOM node, but it led to more problems, such as the bug mentioned in [Issue] (https://github.com/ianstormtaylor/slate/pull/4158#issuecomment-886820923) that could not trigger the click event and this is hacky and looks stupid

Now I have a new way to implement it.  In `onCompositionStart`  event, we will move selection and insert a new node with mark in advance of `Editor.insertText`. To avoid nodes being deleted by `normalize` due to empty text, I set Text to '\uFEFF'  which will not be displayed in browser and remove it in `onCompositionEnd`  event, and in order to avoid unnecessary removal operations,  a new state `state.hasInsertPrefixInCompositon`  has been added.


**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

