### PR TITLE
fix: chinese input double in qq browser

### DIFF
--- a/.changeset/flat-carpets-sort.md
+++ b/.changeset/flat-carpets-sort.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+double ime support for qq browser

--- a/.changeset/flat-carpets-sort.md
+++ b/.changeset/flat-carpets-sort.md
@@ -2,4 +2,4 @@
 'slate-react': patch
 ---
 
-double ime support for qq browser
+double ime fix for qq browser

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -21,6 +21,7 @@ import {
   IS_CHROME,
   IS_FIREFOX,
   IS_FIREFOX_LEGACY,
+  IS_QQBROWSER,
   IS_SAFARI,
 } from '../utils/environment'
 import { ReactEditor } from '..'
@@ -714,7 +715,13 @@ export const Editable = (props: EditableProps) => {
                 // aren't correct and never fire the "insertFromComposition"
                 // type that we need. So instead, insert whenever a composition
                 // ends since it will already have been committed to the DOM.
-                if (!IS_SAFARI && !IS_FIREFOX_LEGACY && !IS_IOS && event.data) {
+                if (
+                  !IS_SAFARI &&
+                  !IS_FIREFOX_LEGACY &&
+                  !IS_IOS &&
+                  !IS_QQBROWSER &&
+                  event.data
+                ) {
                   Editor.insertText(editor, event.data)
                 }
               }

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -39,6 +39,10 @@ export const IS_FIREFOX_LEGACY =
     navigator.userAgent
   )
 
+// qq browser
+export const IS_QQBROWSER =
+  typeof navigator !== 'undefined' && /.*QQBrowser/.test(navigator.userAgent)
+
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js
 export const CAN_USE_DOM = !!(


### PR DESCRIPTION
**Description**
Fixes Double IME issue in QQ browser (original PR in #3730, this rebases the PR against main)

**Issue**
Fixes: Several browsers require this fix to prevent double IME. This adds the QQ browser to that list.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

