### PR TITLE
Read data-slate-fragment when application/x-slate-fragment is missing

### DIFF
--- a/.changeset/nervous-planes-wonder.md
+++ b/.changeset/nervous-planes-wonder.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix to read fragment from data-slate-fragment when application/x-slate-fragment is missing

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -453,8 +453,9 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
           )}
           onPaste={useCallback(
             (event: React.ClipboardEvent<HTMLDivElement>) => {
-              // This unfortunately needs to be handled with paste events instead.
+              // this will make application/x-slate-fragment exist when onPaste attributes is passed
               event.clipboardData = getClipboardData(event.clipboardData)
+              // This unfortunately needs to be handled with paste events instead.
               if (
                 hasEditableTarget(editor, event.target) &&
                 !isEventHandled(event, attributes.onPaste) &&

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -9,7 +9,11 @@ import {
   NATIVE_OPERATIONS,
   flushNativeEvents,
 } from '../utils/native'
-import { isDOMText, getPlainText } from '../utils/dom'
+import {
+  isDOMText,
+  getPlainText,
+  getSlateFragmentAttribute,
+} from '../utils/dom'
 import { findCurrentLineRange } from '../utils/lines'
 
 /**
@@ -213,7 +217,12 @@ export const withReact = <T extends Editor>(editor: T) => {
   }
 
   e.insertData = (data: DataTransfer) => {
-    const fragment = data.getData('application/x-slate-fragment')
+    /**
+     * Checking copied fragment from application/x-slate-fragment or data-slate-fragment
+     */
+    const fragment =
+      data.getData('application/x-slate-fragment') ||
+      getSlateFragmentAttribute(data)
 
     if (fragment) {
       const decoded = decodeURIComponent(window.atob(fragment))

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -234,11 +234,25 @@ export const getPlainText = (domNode: DOMNode) => {
   return text
 }
 
+/**
+ * Get x-slate-fragment attribute from data-slate-fragment
+ */
 const catchSlateFragment = /data-slate-fragment="(.+?)"/m
+export const getSlateFragmentAttribute = (
+  dataTransfer: DataTransfer
+): string | void => {
+  const htmlData = dataTransfer.getData('text/html')
+  const [, fragment] = htmlData.match(catchSlateFragment) || []
+  return fragment
+}
+
+/**
+ * Get the x-slate-fragment attribute that exist in text/html data
+ * and append it to the DataTransfer object
+ */
 export const getClipboardData = (dataTransfer: DataTransfer): DataTransfer => {
   if (!dataTransfer.getData('application/x-slate-fragment')) {
-    const htmlData = dataTransfer.getData('text/html')
-    const [, fragment] = htmlData.match(catchSlateFragment) || []
+    const fragment = getSlateFragmentAttribute(dataTransfer)
     if (fragment) {
       const clipboardData = new DataTransfer()
       dataTransfer.types.forEach(type => {


### PR DESCRIPTION
**Description**
From what im understand, the mutation should be detected from beforeInput event and only using onPaste as the fallback. But im found out, window.DataTransfer is not holding the slate-fragment data. For now, im only found out it missing when using safari on mac (safari version 14).

**Issue**
#3589, #4217

**Example**
![fix-slate-fragment](https://user-images.githubusercontent.com/16449020/129384788-023e4375-465c-42f2-b66a-c5a209f35929.gif)

**Context**
When try to debug this, im found out the application/x-slate-fragment is exist in onPaste clipboard but not in window data transfer that used in beforeInput event. Since `data-slate-fragment` also hold the same data,  i think its better to check to it as the fallback when `application/x-slate-fragment ` is missing. This also what i did in #4433 for android. Im using safari 14 and macos catalina.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

