### PR TITLE
Fix(editable component): reselect the range created by triple click

### DIFF
--- a/cypress/integration/examples/select.ts
+++ b/cypress/integration/examples/select.ts
@@ -1,0 +1,62 @@
+describe('selection', () => {
+  // Currently, testing color property always yields rgb() value, even when stored
+  // as hex.
+  // Hence, we'll overwrite Cypress `should` command, in which we use
+  // `getComputedStyle` on both the subject element and creates a temp element
+  // to get the computed color and compares.
+  // Code by Nicholas Boll at https://github.com/cypress-io/cypress/issues/2186
+  // 2021/08/27
+  type CssStyleObject = Partial<CSSStyleDeclaration> &
+    Record<string, string | null>
+  const compareColor = (color: string, property: string) => (
+    targetElement: NodeListOf<Element>
+  ) => {
+    const tempElement = document.createElement('div')
+    tempElement.style.color = color
+    tempElement.style.display = 'none' // make sure it doesn't actually render
+    document.body.appendChild(tempElement) // append so that `getComputedStyle` actually works
+
+    const tempColor = getComputedStyle(tempElement).color
+    // Calling window.getComputedStyle(element) returns `CSSStyleDeclaration`
+    // object which has numeric index signature with string keys.
+    // We need to declare a new object which retains the typings of
+    // CSSStyleDeclaration and yet is relaxed enough to accept an
+    // arbitrary property name.
+
+    const targetStyle = getComputedStyle(targetElement[0]) as CssStyleObject
+    const targetColor = targetStyle[property]
+
+    document.body.removeChild(tempElement) // remove it because we're done with it
+
+    expect(tempColor).to.equal(targetColor)
+  }
+  Cypress.Commands.overwrite(
+    'should',
+    (originalFn, subject, expectation, ...args) => {
+      const customMatchers: { [key: string]: any } = {
+        'have.backgroundColor': compareColor(args[0], 'backgroundColor'),
+        'have.color': compareColor(args[0], 'color'),
+      }
+
+      // See if the expectation is a string and if it is a member of Jest's expect
+      if (typeof expectation === 'string' && customMatchers[expectation]) {
+        return originalFn(subject, customMatchers[expectation])
+      }
+      return originalFn(subject, expectation, ...args)
+    }
+  )
+  const slateEditor = '[data-slate-node="element"]'
+  beforeEach(() => cy.visit('examples/richtext'))
+  it('select the correct block when triple clicking', () => {
+    // triple clicking the second block (paragraph) shouldn't highlight the
+    // quote button
+    for (let i = 0; i < 3; i++) {
+      cy.get(slateEditor)
+        .eq(1)
+        .click()
+    }
+    cy.contains('.material-icons', /format_quote/)
+      .parent()
+      .should('have.color', '#ccc')
+  })
+})

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -624,52 +624,19 @@ export const Editable = (props: EditableProps) => {
               ) {
                 const node = ReactEditor.toSlateNode(editor, event.target)
                 const path = ReactEditor.findPath(editor, node)
-                // Check if user clicks thrice
-                if (event.detail === 3) {
-                  // Check the closest element block above the selection
-                  const elem = Editor.above(editor, {
-                    at: path,
-                    match: n => Editor.isBlock(editor, n),
-                  })
-                  if (elem) {
-                    // Get all the children of the element above
-                    const children = Node.children(editor, elem[1])
-                    const childrenPath = []
-                    // Loop through the generator of element children and create a list of their respective paths.
-                    for (const [, childPath] of children) {
-                      childrenPath.push(childPath)
-                    }
-                    // Triple-click selection is equal to click and drag from the begining to the end of a block.
-                    // Its anchor will be the first child and focus being the last child of the block.
-                    const anchorPath = childrenPath[0]
-                    const focusPath = childrenPath[childrenPath.length - 1]
-                    // In a triple-click selection, the anchor offset will always be 0 and focus offset will be the end point of the last child of the block.
-                    const { offset: focusOffset } = Editor.end(
-                      editor,
-                      focusPath
-                    )
-                    const range = Editor.range(
-                      editor,
-                      { path: anchorPath, offset: 0 },
-                      { path: focusPath, offset: focusOffset }
-                    )
-                    Transforms.select(editor, range)
-                  }
-                } else {
-                  const start = Editor.start(editor, path)
-                  const end = Editor.end(editor, path)
+                const start = Editor.start(editor, path)
+                const end = Editor.end(editor, path)
 
-                  const startVoid = Editor.void(editor, { at: start })
-                  const endVoid = Editor.void(editor, { at: end })
+                const startVoid = Editor.void(editor, { at: start })
+                const endVoid = Editor.void(editor, { at: end })
 
-                  if (
-                    startVoid &&
-                    endVoid &&
-                    Path.equals(startVoid[1], endVoid[1])
-                  ) {
-                    const range = Editor.range(editor, start)
-                    Transforms.select(editor, range)
-                  }
+                if (
+                  startVoid &&
+                  endVoid &&
+                  Path.equals(startVoid[1], endVoid[1])
+                ) {
+                  const range = Editor.range(editor, start)
+                  Transforms.select(editor, range)
                 }
               }
             },

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -624,19 +624,52 @@ export const Editable = (props: EditableProps) => {
               ) {
                 const node = ReactEditor.toSlateNode(editor, event.target)
                 const path = ReactEditor.findPath(editor, node)
-                const start = Editor.start(editor, path)
-                const end = Editor.end(editor, path)
+                // Check if user clicks thrice
+                if (event.detail === 3) {
+                  // Check the closest element block above the selection
+                  const elem = Editor.above(editor, {
+                    at: path,
+                    match: n => Editor.isBlock(editor, n),
+                  })
+                  if (elem) {
+                    // Get all the children of the element above
+                    const children = Node.children(editor, elem[1])
+                    const childrenPath = []
+                    // Loop through the generator of element children and create a list of their respective paths.
+                    for (const [, childPath] of children) {
+                      childrenPath.push(childPath)
+                    }
+                    // Triple-click selection is equal to click and drag from the begining to the end of a block.
+                    // Its anchor will be the first child and focus being the last child of the block.
+                    const anchorPath = childrenPath[0]
+                    const focusPath = childrenPath[childrenPath.length - 1]
+                    // In a triple-click selection, the anchor offset will always be 0 and focus offset will be the end point of the last child of the block.
+                    const { offset: focusOffset } = Editor.end(
+                      editor,
+                      focusPath
+                    )
+                    const range = Editor.range(
+                      editor,
+                      { path: anchorPath, offset: 0 },
+                      { path: focusPath, offset: focusOffset }
+                    )
+                    Transforms.select(editor, range)
+                  }
+                } else {
+                  const start = Editor.start(editor, path)
+                  const end = Editor.end(editor, path)
 
-                const startVoid = Editor.void(editor, { at: start })
-                const endVoid = Editor.void(editor, { at: end })
+                  const startVoid = Editor.void(editor, { at: start })
+                  const endVoid = Editor.void(editor, { at: end })
 
-                if (
-                  startVoid &&
-                  endVoid &&
-                  Path.equals(startVoid[1], endVoid[1])
-                ) {
-                  const range = Editor.range(editor, start)
-                  Transforms.select(editor, range)
+                  if (
+                    startVoid &&
+                    endVoid &&
+                    Path.equals(startVoid[1], endVoid[1])
+                  ) {
+                    const range = Editor.range(editor, start)
+                    Transforms.select(editor, range)
+                  }
                 }
               }
             },

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -568,6 +568,44 @@ export const ReactEditor = {
         anchorOffset = domRange.anchorOffset
         focusNode = domRange.focusNode
         focusOffset = domRange.focusOffset
+        // When triple clicking a block, Chrome will return a selection object whose
+        // focus node is the next element sibling and focusOffset is 0.
+        // This will highlight the corresponding toolbar button for the sibling
+        // block even though users just want to target the previous block.
+        // (2021/08/24)
+        // Within the context of Slate and Chrome, if anchor and focus nodes don't have
+        //  the same nodeValue and focusOffset is 0, then it's definitely a triple click
+        // behaviour.
+        if (
+          IS_CHROME &&
+          anchorNode?.nodeValue !== focusNode?.nodeValue &&
+          domRange.focusOffset === 0
+        ) {
+          // If an anchorNode is an element node when triple clicked, then the focusNode
+          //  should also be the same as anchorNode when triple clicked.
+          if (anchorNode!.nodeType === 1) {
+            focusNode = anchorNode
+          } else {
+            // Otherwise, anchorNode is a text node and we need to
+            // - climb up the DOM tree to get the farthest element node that receives
+            // triple click. It should have atribute 'data-slate-node' = "element"
+            // - get the last child of that element node
+            // - climb down the DOM tree to get the text node of the last child
+            // - this is also the end of the selection aka the focusNode
+            const anchorElement = anchorNode!.parentNode as HTMLElement
+            const tripleClickedBlock = anchorElement.closest(
+              '[data-slate-node="element"]'
+            )
+            const focusElement = tripleClickedBlock!.lastElementChild
+            // Get the element node that holds the focus text node
+            const innermostFocusElement = focusElement!.querySelector(
+              '[data-slate-string]'
+            )
+            const lastTextNode = innermostFocusElement!.childNodes[0]
+            focusNode = lastTextNode
+          }
+        }
+
         // COMPAT: There's a bug in chrome that always returns `true` for
         // `isCollapsed` for a Selection that comes from a ShadowRoot.
         // (2020/08/08)


### PR DESCRIPTION
**Description**
When triple clicking inside the editable component of Slate, it doesn't select the correct block. This poses two problems when Slate is to be used as a rich text editor:
- Give false visual feedback, e.g. the wrong toolbar button will be highlighted which leads to confusion
- Unable to apply new style to the selected block only.

This PR tries to select the correct block that users triple click on.

**Issue**
Fixes #4329 

**Example**

Before the fix:

![triple-click-before](https://user-images.githubusercontent.com/28924121/129546926-7fd38c6a-7468-44b4-8303-7f9a08d636af.png)

After the fix:

![triple-click-after](https://user-images.githubusercontent.com/28924121/129546960-a2ecb914-4919-48c6-8a28-97dff9a51976.png)

**Context**

Given a node at path [1].

```js
const editor = {
  children: [
    { // first node
    }
    {
      type: 'paragraph', // the node that receives triple click
      children: [
        { text: "Since it's rich text, you can do things like turn a selection of text " }, // path: [1, 0]
        { text: "bold", bold: true }, // path: [1, 1]
        { text: ", or add a semantically rendered block quote in the middle of the page, like this:" // path: [1, 2]
      ]
    }
  ]
}
```
Suppose we triple click just before the letter "S" of the paragraph.

- Inside the `onClick` event check if there is triple click with `event.detail === 3`.
- By design, the node that users click on will be the text node at path [1, 0]. Call `Editor.above()` to retrieve the closest element ancestor of that text node.
- If the element exists, get all the children of the element. Create an array of their respective path. It should be
[[1, 0], [1, 1], [1, 2]]
- Create a range whose anchor is the first child and focus is the third child. Its anchor offset is 0 (because the selection starts from the very start of the block) and focus offset is the end point of the third child (82) in this case.
- Calling `Transforms.select(range)` to select that range.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

