### PR TITLE
Normalization: Nonempty to empty to inline should remove empty node

### DIFF
--- a/.changeset/seven-fishes-check.md
+++ b/.changeset/seven-fishes-check.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Normalization now removes empty text nodes after nonempty nodes with differing styles, but before inline nodes.

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -273,7 +273,7 @@ export const createEditor = (): Editor => {
                 voids: true,
               })
               n--
-            } else if (isLast && child.text === '') {
+            } else if (child.text === '') {
               Transforms.removeNodes(editor, {
                 at: path.concat(n),
                 voids: true,

--- a/packages/slate/test/normalization/text/merge-adjacent-empty-before-inline.tsx
+++ b/packages/slate/test/normalization/text/merge-adjacent-empty-before-inline.tsx
@@ -5,7 +5,7 @@ export const input = (
   <editor>
     <block>
       <text>not empty</text>
-      <text a/>
+      <text a />
       <inline>inline</inline>
       <text />
     </block>

--- a/packages/slate/test/normalization/text/merge-adjacent-empty-before-inline.tsx
+++ b/packages/slate/test/normalization/text/merge-adjacent-empty-before-inline.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>not empty</text>
+      <text a/>
+      <inline>inline</inline>
+      <text />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text>not empty</text>
+      <inline>inline</inline>
+      <text />
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
As the code exists today, if you have an empty text node before an inline node, the empty text node will not be removed if it has a nonempty node before it with differing attributes.

The issue is that we consider pairs of text nodes, and generally only remove the earlier node if that node is empty. The only time we remove the current node is if it is the last node in the block. This fails to behave correctly when the current node is the last node before an inline object, and leaves the empty text node lingering.

This PR aims to fix that edge case.

**Example**
This is just a copy/paste of the test case, but the test really exemplifies this better than anything else I can think of:

As things stand today, this input:
```
<editor>
  <block>
    <text>not empty</text>
    <text a/>
    <inline>inline</inline>
    <text />
  </block>
</editor>
```
Will leave the `<text a/>` node lingering after normalization.

With the fix, the normalization will remove the `<text a/>` node and produce:
```
<editor>
  <block>
    <text>not empty</text>
    <inline>inline</inline>
    <text />
  </block>
</editor>
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

