### PR TITLE
Double character insert regression

### DIFF
--- a/.changeset/nine-windows-rush.md
+++ b/.changeset/nine-windows-rush.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix double character insertion regression due to unnecessary memo

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -55,32 +55,26 @@ const String = (props: {
 /**
  * Leaf strings with text in them.
  */
-const TextString = React.memo(
-  (props: { text: string; isTrailing?: boolean }) => {
-    const { text, isTrailing = false } = props
+const TextString = (props: { text: string; isTrailing?: boolean }) => {
+  const { text, isTrailing = false } = props
 
-    const ref = useRef<HTMLSpanElement>(null)
-    const forceUpdateFlag = useRef(false)
+  const ref = useRef<HTMLSpanElement>(null)
+  const forceUpdateFlag = useRef(false)
 
-    if (ref.current && ref.current.textContent !== text) {
-      forceUpdateFlag.current = !forceUpdateFlag.current
-    }
-
-    // This component may have skipped rendering due to native operations being
-    // applied. If an undo is performed React will see the old and new shadow DOM
-    // match and not apply an update. Forces each render to actually reconcile.
-    return (
-      <span
-        data-slate-string
-        ref={ref}
-        key={forceUpdateFlag.current ? 'A' : 'B'}
-      >
-        {text}
-        {isTrailing ? '\n' : null}
-      </span>
-    )
+  if (ref.current && ref.current.textContent !== text) {
+    forceUpdateFlag.current = !forceUpdateFlag.current
   }
-)
+
+  // This component may have skipped rendering due to native operations being
+  // applied. If an undo is performed React will see the old and new shadow DOM
+  // match and not apply an update. Forces each render to actually reconcile.
+  return (
+    <span data-slate-string ref={ref} key={forceUpdateFlag.current ? 'A' : 'B'}>
+      {text}
+      {isTrailing ? '\n' : null}
+    </span>
+  )
+}
 
 /**
  * Leaf strings without text, render as zero-width strings.


### PR DESCRIPTION
**Description**
An unnecessary React.memo wrapper introduced in #3888 /  25afbd4 was causing a double character insertion

**Issue**
Fixes: #4445

**Example**
See #4445

**Context**
See #4445

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

