### PR TITLE
Layout example fix

### DIFF
--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -32,26 +32,25 @@ const withLayout = editor => {
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
-        let type: string;
-        const slateIndex = childPath[0];
-
-        switch (slateIndex) {
-          case 0:
-            type = 'title';
-            enforceType(type);
-            break;
-          case 1:
-            type = 'paragraph';
-            enforceType(type);
-          default:
-            break;
-        }
-
-        function enforceType(type) {
+        let type: string
+        const slateIndex = childPath[0]
+        const enforceType = type => {
           if (SlateElement.isElement(child) && child.type !== type) {
             const newProperties: Partial<SlateElement> = { type }
             Transforms.setNodes(editor, newProperties, { at: childPath })
           }
+        }
+
+        switch (slateIndex) {
+          case 0:
+            type = 'title'
+            enforceType(type)
+            break
+          case 1:
+            type = 'paragraph'
+            enforceType(type)
+          default:
+            break
         }
       }
     }

--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -32,6 +32,7 @@ const withLayout = editor => {
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
+        let type: string;
         const slateIndex = childPath[0];
 
         switch (slateIndex) {

--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -32,11 +32,25 @@ const withLayout = editor => {
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
-        const type = childPath[0] === 0 ? 'title' : 'paragraph'
+        const slateIndex = childPath[0];
 
-        if (SlateElement.isElement(child) && child.type !== type) {
-          const newProperties: Partial<SlateElement> = { type }
-          Transforms.setNodes(editor, newProperties, { at: childPath })
+        switch (slateIndex) {
+          case 0:
+            type = 'title';
+            enforceType(type);
+            break;
+          case 1:
+            type = 'paragraph';
+            enforceType(type);
+          default:
+            break;
+        }
+
+        function enforceType(type) {
+          if (SlateElement.isElement(child) && child.type !== type) {
+            const newProperties: Partial<SlateElement> = { type }
+            Transforms.setNodes(editor, newProperties, { at: childPath })
+          }
         }
       }
     }


### PR DESCRIPTION
**Description**
Fixes the original PR in #4388 to comply with lint/code structure guidelines.

Change the forced-layout example to enforce layout to an explicit block index to allow for block types beyond 'paragraph'.

Building from the current forced-layout example seems to prevent all types other than 'paragraph' from being used. The solution implemented here is to enforce the layout by an explicit block index. This way will not enforce subsequent blocks to be type 'paragraph.'

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

No changeset as it's just an update to an example