### PR TITLE
Fix typo in TypeScript concepts documentation

### DIFF
--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -37,7 +37,7 @@ declare module 'slate' {
 
 Annotate `useState` w/ `<Descendant[]>` and the editor's initial value w/ your custom Element type.
 
-```typescript jsx
+```tsx
 import React, { useMemo, useState } from 'react'
 import { createEditor, Descendant } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'


### PR DESCRIPTION
Fixed #4467

**Description**

Small syntax typo in documentation

**Issue**
Fixes: #4467 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

docs only, no changeset