### PR TITLE
Increase timeout for markdown-shortcuts integration test for now

### DIFF
--- a/cypress/integration/examples/markdown-shortcuts.ts
+++ b/cypress/integration/examples/markdown-shortcuts.ts
@@ -15,8 +15,8 @@ describe('On markdown-shortcuts example', () => {
       .should('not.exist')
 
     cy.findByRole('textbox')
-      // need wait(0) here otherwise the page is not loaded yet correctly
-      .wait(0)
+      // need wait() here otherwise the slate component is not fully mounted yet sometimes
+      .wait(1000)
       .type(
         '{movetostart}* 1st Item{enter}2nd Item{enter}3rd Item{enter}{backspace}'
       )


### PR DESCRIPTION
**Description**
Apparently the `markdown-shortcuts` test still fails sometimes in the CI. As a quick fix for now, just increasing the timeout.

For a better solution to this altogether maybe we should look into adding `@cypress/react` (https://github.com/cypress-io/cypress/tree/master/npm/react#readme). It looks like that can wait for the component to be mounted fully. I just had a shot at setting it up without success.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

