### PR TITLE
[slate-react]: fix selection bugs when multiple editors share value

### DIFF
--- a/.changeset/calm-books-applaud.md
+++ b/.changeset/calm-books-applaud.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+[slate-react]: fix selection bugs when multiple editors share value

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -11,7 +11,7 @@ import {
   ELEMENT_TO_NODE,
   NODE_TO_PARENT,
   NODE_TO_INDEX,
-  KEY_TO_ELEMENT,
+  EDITOR_TO_KEY_TO_ELEMENT,
 } from '../utils/weak-maps'
 import { isDecoratorRangeListEqual } from '../utils/range-list'
 import {
@@ -120,12 +120,13 @@ const Element = (props: {
 
   // Update element-related weak maps with the DOM element ref.
   useIsomorphicLayoutEffect(() => {
+    const KEY_TO_ELEMENT = EDITOR_TO_KEY_TO_ELEMENT.get(editor)
     if (ref.current) {
-      KEY_TO_ELEMENT.set(key, ref.current)
+      KEY_TO_ELEMENT?.set(key, ref.current)
       NODE_TO_ELEMENT.set(element, ref.current)
       ELEMENT_TO_NODE.set(ref.current, element)
     } else {
-      KEY_TO_ELEMENT.delete(key)
+      KEY_TO_ELEMENT?.delete(key)
       NODE_TO_ELEMENT.delete(element)
     }
   })

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -6,9 +6,9 @@ import { ReactEditor, useSlateStatic } from '..'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 import {
-  KEY_TO_ELEMENT,
   NODE_TO_ELEMENT,
   ELEMENT_TO_NODE,
+  EDITOR_TO_KEY_TO_ELEMENT,
 } from '../utils/weak-maps'
 import { isDecoratorRangeListEqual } from '../utils/range-list'
 
@@ -56,12 +56,13 @@ const Text = (props: {
 
   // Update element-related weak maps with the DOM element ref.
   useIsomorphicLayoutEffect(() => {
+    const KEY_TO_ELEMENT = EDITOR_TO_KEY_TO_ELEMENT.get(editor)
     if (ref.current) {
-      KEY_TO_ELEMENT.set(key, ref.current)
+      KEY_TO_ELEMENT?.set(key, ref.current)
       NODE_TO_ELEMENT.set(text, ref.current)
       ELEMENT_TO_NODE.set(ref.current, text)
     } else {
-      KEY_TO_ELEMENT.delete(key)
+      KEY_TO_ELEMENT?.delete(key)
       NODE_TO_ELEMENT.delete(text)
     }
   })

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -6,11 +6,11 @@ import {
   ELEMENT_TO_NODE,
   IS_FOCUSED,
   IS_READ_ONLY,
-  KEY_TO_ELEMENT,
   NODE_TO_INDEX,
   NODE_TO_KEY,
   NODE_TO_PARENT,
   EDITOR_TO_WINDOW,
+  EDITOR_TO_KEY_TO_ELEMENT,
 } from '../utils/weak-maps'
 import {
   DOMElement,
@@ -241,9 +241,10 @@ export const ReactEditor = {
    */
 
   toDOMNode(editor: ReactEditor, node: Node): HTMLElement {
+    const KEY_TO_ELEMENT = EDITOR_TO_KEY_TO_ELEMENT.get(editor)
     const domNode = Editor.isEditor(node)
       ? EDITOR_TO_ELEMENT.get(editor)
-      : KEY_TO_ELEMENT.get(ReactEditor.findKey(editor, node))
+      : KEY_TO_ELEMENT?.get(ReactEditor.findKey(editor, node))
 
     if (!domNode) {
       throw new Error(

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -3,7 +3,11 @@ import { Editor, Node, Path, Operation, Transforms, Range } from 'slate'
 
 import { ReactEditor } from './react-editor'
 import { Key } from '../utils/key'
-import { EDITOR_TO_ON_CHANGE, NODE_TO_KEY } from '../utils/weak-maps'
+import {
+  EDITOR_TO_KEY_TO_ELEMENT,
+  EDITOR_TO_ON_CHANGE,
+  NODE_TO_KEY,
+} from '../utils/weak-maps'
 import {
   AS_NATIVE,
   NATIVE_OPERATIONS,
@@ -28,6 +32,10 @@ import { findCurrentLineRange } from '../utils/lines'
 export const withReact = <T extends Editor>(editor: T) => {
   const e = editor as T & ReactEditor
   const { apply, onChange, deleteBackward } = e
+
+  // The WeakMap which maps a key to a specific HTMLElement must be scoped to the editor instance to
+  // avoid collisions between editors in the DOM that share the same value.
+  EDITOR_TO_KEY_TO_ELEMENT.set(e, new WeakMap())
 
   e.deleteBackward = unit => {
     if (unit !== 'line') {

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -18,9 +18,12 @@ export const EDITOR_TO_WINDOW: WeakMap<Editor, Window> = new WeakMap()
 export const EDITOR_TO_ELEMENT: WeakMap<Editor, HTMLElement> = new WeakMap()
 export const EDITOR_TO_PLACEHOLDER: WeakMap<Editor, string> = new WeakMap()
 export const ELEMENT_TO_NODE: WeakMap<HTMLElement, Node> = new WeakMap()
-export const KEY_TO_ELEMENT: WeakMap<Key, HTMLElement> = new WeakMap()
 export const NODE_TO_ELEMENT: WeakMap<Node, HTMLElement> = new WeakMap()
 export const NODE_TO_KEY: WeakMap<Node, Key> = new WeakMap()
+export const EDITOR_TO_KEY_TO_ELEMENT: WeakMap<
+  Editor,
+  WeakMap<Key, HTMLElement>
+> = new WeakMap()
 
 /**
  * Weak maps for storing editor-related state.


### PR DESCRIPTION
**Description**
The `KEY_TO_ELEMENT` WeakMap must be scoped to the editor instance to avoid collisions between multiple editors in the same DOM that share the same editor value (object equality on `Node`).

This is solved by wrapping it in another WeakMap keyed on the editor object, that returns the `KEY_TO_ELEMENT` WeakMap for that editor.

It could also be solved by just putting the `KEY_TO_ELEMENT` Weakmap directly on the editor instance, but I didn't want to tangle the `ReactEditor` interface with these (internal) things and keep using weak-maps only for this logic.


**Issue**
Fixes:
https://github.com/ianstormtaylor/slate/issues/3380
https://github.com/ianstormtaylor/slate/issues/3997
https://github.com/ianstormtaylor/slate/issues/4129


**Example**

This will illustrate the problem:

1) Go to the current main branch deployment: https://deploy-preview-4469--slatejs.netlify.app/examples/editable-voids
2) Click the + Button on top of the page to add another editor.
3) Click in the middle of bold word "rich" in the *top editor*.
4) Move the cursor one char to the right with arrow right key.
5) Cursor is moved and focused on *bottom editor* word "rich"

Then try the same on the deployed preview: https://deploy-preview-4475--slatejs.netlify.app/examples/editable-voids to confirm the fix.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

