### PR TITLE
Add key for Children SelectedContext.Provider

### DIFF
--- a/.changeset/healthy-ads-trade.md
+++ b/.changeset/healthy-ads-trade.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Add key for Children SelectedContext.Provider

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -61,7 +61,7 @@ const useChildren = (props: {
 
     if (Element.isElement(n)) {
       children.push(
-        <SelectedContext.Provider value={!!sel}>
+        <SelectedContext.Provider key={`provider-${key.id}`} value={!!sel}>
           <ElementComponent
             decorations={ds}
             element={n}


### PR DESCRIPTION
**Description**
Adding key for SelectedContext.Provider in Children to remove warning from react in development mode.

**Issue**
Fixes: #4464

**Example**
<img width="1440" alt="Screen Shot 2021-08-31 at 11 29 17" src="https://user-images.githubusercontent.com/16449020/131437243-a5517cc3-aae1-4f13-a7fc-3d449d10169e.png">

<img width="1440" alt="Screen Shot 2021-08-31 at 11 31 18" src="https://user-images.githubusercontent.com/16449020/131437361-6cd74b4a-e7fc-4b05-9c5f-41e50a7daf18.png">


**Context**
key will be `provider-` followed by children id. example `provider-0`

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

