### PR TITLE
fix cursor not correct when insert multiple nodes using insertNodes

### DIFF
--- a/.changeset/neat-flies-eat.md
+++ b/.changeset/neat-flies-eat.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix cursor not correct issue after insert multiple nodes with `Transform.insertNodes`

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -228,7 +228,9 @@ export const NodeTransforms: NodeTransforms = {
         const path = parentPath.concat(index)
         index++
         editor.apply({ type: 'insert_node', path, node })
+        at = Path.next(at)
       }
+      at = Path.previous(at)
 
       if (select) {
         const point = Editor.end(editor, at)

--- a/packages/slate/test/transforms/insertNodes/path/multiple-inline-not-end.tsx
+++ b/packages/slate/test/transforms/insertNodes/path/multiple-inline-not-end.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      hel
+      <cursor />
+      lo
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.insertNodes(
+    editor,
+    [
+      <inline>
+        <text />
+      </inline>,
+      <text>world</text>
+    ],
+  )
+}
+export const output = (
+  <editor>
+    <block>
+      hel
+      <inline>
+        <text />
+      </inline>
+      world
+      <cursor />
+      lo
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertNodes/path/multiple-inline-not-end.tsx
+++ b/packages/slate/test/transforms/insertNodes/path/multiple-inline-not-end.tsx
@@ -12,15 +12,12 @@ export const input = (
   </editor>
 )
 export const run = editor => {
-  Transforms.insertNodes(
-    editor,
-    [
-      <inline>
-        <text />
-      </inline>,
-      <text>world</text>
-    ],
-  )
+  Transforms.insertNodes(editor, [
+    <inline>
+      <text />
+    </inline>,
+    <text>world</text>,
+  ])
 }
 export const output = (
   <editor>

--- a/packages/slate/test/transforms/insertNodes/path/multiple-inline.tsx
+++ b/packages/slate/test/transforms/insertNodes/path/multiple-inline.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      hello
+      <cursor />
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.insertNodes(
+    editor,
+    [
+      <inline>
+        <text />
+      </inline>,
+      <text>world</text>
+    ],
+  )
+}
+export const output = (
+  <editor>
+    <block>
+      hello
+      <inline>
+        <text />
+      </inline>
+      world
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertNodes/path/multiple-inline.tsx
+++ b/packages/slate/test/transforms/insertNodes/path/multiple-inline.tsx
@@ -11,15 +11,12 @@ export const input = (
   </editor>
 )
 export const run = editor => {
-  Transforms.insertNodes(
-    editor,
-    [
-      <inline>
-        <text />
-      </inline>,
-      <text>world</text>
-    ],
-  )
+  Transforms.insertNodes(editor, [
+    <inline>
+      <text />
+    </inline>,
+    <text>world</text>,
+  ])
 }
 export const output = (
   <editor>


### PR DESCRIPTION
**Description**
When using `Transforms.insertNodes` to insert multiple nodes, the cursor will be placed only after the first inserted node. This mainly because we only move `at` to next path once, key code below:
```js
at = isAtEnd ? Path.next(path) : path
// ...
const point = Editor.end(editor, at)

if (point) {
  Transforms.select(editor, point)
}
```
The `Path.next` will only invoke once which means the cursor only move after one node.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/3816

**Example**
before
![old](https://user-images.githubusercontent.com/2088642/131512917-206f38cb-1d74-40c6-b4d5-bb8a386e5420.gif)

after
![Aug-31-2021 21-38-11](https://user-images.githubusercontent.com/2088642/131512959-360082ed-0a25-4f3d-885c-afccc577fac4.gif)


**Context**
I just move the cursor every time a node is inserted, and because we go to next at first, so we need to go back at last.

Also I added two test cases for this situation, both cases are failed at the previous version.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

Actually I can build the site and server it under `http-server`, but when I run `yarn start` I can not view anything in my browser, it keep loading forever, I don't have time to figure the reason now, but I suppose I can build and server it success then it means *The relevant examples still work*.