### PR TITLE
add `renderChildren` callback to `renderElement`

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -81,6 +81,20 @@ export interface RenderElementProps {
 }
 
 /**
+ * `RenderTextProps` are passed to the `renderText` handler.
+ */
+
+export interface RenderTextProps {
+  renderChildren: (props?: RenderChildrenProps) => React.ReactNode
+  path: Path
+  text: Text
+  attributes: {
+    'data-slate-node': 'text'
+    ref: any
+  }
+}
+
+/**
  * `RenderLeafProps` are passed to the `renderLeaf` handler.
  */
 
@@ -105,6 +119,7 @@ export type EditableProps = {
   role?: string
   style?: React.CSSProperties
   renderElement?: (props: RenderElementProps) => JSX.Element
+  renderText?: (props: RenderTextProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   renderPlaceholder?: (props: RenderPlaceholderProps) => JSX.Element
   scrollSelectionIntoView?: (editor: ReactEditor, domRange: DOMRange) => void
@@ -123,6 +138,7 @@ export const Editable = (props: EditableProps) => {
     placeholder,
     readOnly = false,
     renderElement,
+    renderText,
     renderLeaf,
     renderPlaceholder = props => <DefaultPlaceholder {...props} />,
     scrollSelectionIntoView = defaultScrollSelectionIntoView,
@@ -1262,6 +1278,7 @@ export const Editable = (props: EditableProps) => {
             node={editor}
             renderElement={renderElement}
             renderPlaceholder={renderPlaceholder}
+            renderText={renderText}
             renderLeaf={renderLeaf}
             selection={editor.selection}
           />

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -55,11 +55,21 @@ const Children = (props: Parameters<typeof useChildren>[0]) => (
 )
 
 /**
+ * `RenderChildrenProps` are passed to the `renderChildren` callback.
+ */
+
+export interface RenderChildrenProps {
+  decorations?: Range[]
+}
+
+/**
  * `RenderElementProps` are passed to the `renderElement` handler.
  */
 
 export interface RenderElementProps {
   children: any
+  renderChildren: (props?: RenderChildrenProps) => React.ReactNode
+  path: Path
   element: Element
   attributes: {
     'data-slate-node': 'element'

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import getDirection from 'direction'
-import { Editor, Node, Range, NodeEntry, Element as SlateElement } from 'slate'
+import { Editor, Node, Range, Path, Element as SlateElement } from 'slate'
 
 import Text from './text'
 import useChildren from '../hooks/use-children'
@@ -15,6 +15,7 @@ import {
 } from '../utils/weak-maps'
 import { isDecoratorRangeListEqual } from '../utils/range-list'
 import {
+  RenderChildrenProps,
   RenderElementProps,
   RenderLeafProps,
   RenderPlaceholderProps,
@@ -27,6 +28,7 @@ import {
 const Element = (props: {
   decorations: Range[]
   element: SlateElement
+  path: Path
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
@@ -35,6 +37,7 @@ const Element = (props: {
   const {
     decorations,
     element,
+    path,
     renderElement = (p: RenderElementProps) => <DefaultElement {...p} />,
     renderPlaceholder,
     renderLeaf,
@@ -53,6 +56,19 @@ const Element = (props: {
     renderLeaf,
     selection,
   })
+
+  const renderChildren = (props?: RenderChildrenProps) =>
+    useChildren({
+      decorations:
+        props && props.decorations
+          ? [...decorations, ...props.decorations]
+          : decorations,
+      node: element,
+      renderElement,
+      renderPlaceholder,
+      renderLeaf,
+      selection,
+    })
 
   // Attributes that the developer must mix into the element in their
   // custom node renderer component.
@@ -131,7 +147,7 @@ const Element = (props: {
     }
   })
 
-  return renderElement({ attributes, children, element })
+  return renderElement({ attributes, children, element, path, renderChildren })
 }
 
 const MemoizedElement = React.memo(Element, (prev, next) => {

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -9,6 +9,7 @@ import { useDecorate } from './use-decorate'
 import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
 import {
   RenderElementProps,
+  RenderTextProps,
   RenderLeafProps,
   RenderPlaceholderProps,
 } from '../components/editable'
@@ -22,6 +23,7 @@ const useChildren = (props: {
   decorations: Range[]
   node: Ancestor
   renderElement?: (props: RenderElementProps) => JSX.Element
+  renderText?: (props: RenderTextProps) => JSX.Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   selection: Range | null
@@ -31,6 +33,7 @@ const useChildren = (props: {
     node,
     renderElement,
     renderPlaceholder,
+    renderText,
     renderLeaf,
     selection,
   } = props
@@ -69,6 +72,7 @@ const useChildren = (props: {
             key={key.id}
             renderElement={renderElement}
             renderPlaceholder={renderPlaceholder}
+            renderText={renderText}
             renderLeaf={renderLeaf}
             selection={sel}
           />
@@ -82,8 +86,10 @@ const useChildren = (props: {
           isLast={isLeafBlock && i === node.children.length - 1}
           parent={node}
           renderPlaceholder={renderPlaceholder}
+          renderText={renderText}
           renderLeaf={renderLeaf}
           text={n}
+          path={p}
         />
       )
     }

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -65,6 +65,7 @@ const useChildren = (props: {
           <ElementComponent
             decorations={ds}
             element={n}
+            path={p}
             key={key.id}
             renderElement={renderElement}
             renderPlaceholder={renderPlaceholder}

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -7,7 +7,9 @@ import { IS_ANDROID } from './utils/environment'
 export const Editable = IS_ANDROID ? AndroidEditable : DefaultEditable
 export {
   Editable as DefaultEditable,
+  RenderChildrenProps,
   RenderElementProps,
+  RenderTextProps,
   RenderLeafProps,
   RenderPlaceholderProps,
   DefaultPlaceholder,

--- a/site/examples/richtext-with-code-highlighting-renderChildren.tsx
+++ b/site/examples/richtext-with-code-highlighting-renderChildren.tsx
@@ -1,0 +1,405 @@
+import Prism from 'prismjs'
+import 'prismjs/components/prism-python'
+import 'prismjs/components/prism-php'
+import 'prismjs/components/prism-sql'
+import 'prismjs/components/prism-java'
+import React, { useCallback, useMemo, useState } from 'react'
+import faker from 'faker'
+import isHotkey from 'is-hotkey'
+import {
+  Editable,
+  withReact,
+  useSlate,
+  RenderTextProps,
+  Slate,
+} from 'slate-react'
+import {
+  Editor,
+  Transforms,
+  createEditor,
+  Descendant,
+  Element as SlateElement,
+  Text,
+} from 'slate'
+import { withHistory } from 'slate-history'
+import { css } from 'emotion'
+
+import { Button, Icon, Toolbar } from '../components'
+
+const HOTKEYS = {
+  'mod+b': 'bold',
+  'mod+i': 'italic',
+  'mod+u': 'underline',
+  'mod+`': 'code',
+}
+
+const LIST_TYPES = ['numbered-list', 'bulleted-list']
+
+const HEADINGS = 100
+const PARAGRAPHS = 7
+const initialValue: Descendant[] = []
+
+for (let h = 0; h < HEADINGS; h++) {
+  initialValue.push({
+    type: 'heading',
+    children: [{ text: faker.lorem.sentence() }],
+  })
+
+  for (let p = 0; p < PARAGRAPHS; p++) {
+    initialValue.push({
+      type: 'paragraph',
+      children: [{ text: faker.lorem.paragraph() }],
+    })
+  }
+}
+
+const LanguageContext = React.createContext('html')
+
+const RichTextWithCodeHighlightingRenderChildrenExample = () => {
+  const [value, setValue] = useState<Descendant[]>(initialValue)
+  const [language, setLanguage] = useState('html')
+  const renderElement = useCallback(props => <Element {...props} />, [])
+  const renderLeaf = useCallback(props => <Leaf {...props} />, [])
+  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+
+  const renderText = useCallback((props: RenderTextProps) => {
+    const { attributes, renderChildren, path, text } = props
+    const decorations = []
+    if ('code' in text) {
+      const language = React.useContext(LanguageContext)
+      const tokens = Prism.tokenize(text.text, Prism.languages[language])
+      let start = 0
+
+      for (const token of tokens) {
+        const length = getLength(token)
+        const end = start + length
+
+        if (typeof token !== 'string') {
+          decorations.push({
+            [token.type]: true,
+            anchor: { path, offset: start },
+            focus: { path, offset: end },
+          })
+        }
+
+        start = end
+      }
+    }
+    return <span {...attributes}>{renderChildren({ decorations })}</span>
+  }, [])
+
+  return (
+    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+      <div
+        contentEditable={false}
+        style={{ position: 'relative', top: '5px', right: '5px' }}
+      >
+        <h3>
+          Select a language
+          <select
+            value={language}
+            style={{ float: 'right' }}
+            onChange={e => setLanguage(e.target.value)}
+          >
+            <option value="js">JavaScript</option>
+            <option value="css">CSS</option>
+            <option value="html">HTML</option>
+            <option value="python">Python</option>
+            <option value="sql">SQL</option>
+            <option value="java">Java</option>
+            <option value="php">PHP</option>
+          </select>
+        </h3>
+      </div>
+      <Toolbar>
+        <MarkButton format="bold" icon="format_bold" />
+        <MarkButton format="italic" icon="format_italic" />
+        <MarkButton format="underline" icon="format_underlined" />
+        <MarkButton format="code" icon="code" />
+        <BlockButton format="heading-one" icon="looks_one" />
+        <BlockButton format="heading-two" icon="looks_two" />
+        <BlockButton format="block-quote" icon="format_quote" />
+        <BlockButton format="numbered-list" icon="format_list_numbered" />
+        <BlockButton format="bulleted-list" icon="format_list_bulleted" />
+      </Toolbar>
+      <LanguageContext.Provider value={language}>
+        <Editable
+          renderElement={renderElement}
+          renderText={renderText}
+          renderLeaf={renderLeaf}
+          placeholder="Enter some rich text…"
+          spellCheck
+          autoFocus
+          onKeyDown={event => {
+            for (const hotkey in HOTKEYS) {
+              if (isHotkey(hotkey, event as any)) {
+                event.preventDefault()
+                const mark = HOTKEYS[hotkey]
+                toggleMark(editor, mark)
+              }
+            }
+          }}
+        />
+      </LanguageContext.Provider>
+    </Slate>
+  )
+}
+
+const toggleBlock = (editor, format) => {
+  const isActive = isBlockActive(editor, format)
+  const isList = LIST_TYPES.includes(format)
+
+  Transforms.unwrapNodes(editor, {
+    match: n =>
+      LIST_TYPES.includes(
+        !Editor.isEditor(n) && SlateElement.isElement(n) && n.type
+      ),
+    split: true,
+  })
+  const newProperties: Partial<SlateElement> = {
+    type: isActive ? 'paragraph' : isList ? 'list-item' : format,
+  }
+  Transforms.setNodes(editor, newProperties)
+
+  if (!isActive && isList) {
+    const block = { type: format, children: [] }
+    Transforms.wrapNodes(editor, block)
+  }
+}
+
+const toggleMark = (editor, format) => {
+  const isActive = isMarkActive(editor, format)
+
+  if (isActive) {
+    Editor.removeMark(editor, format)
+  } else {
+    Editor.addMark(editor, format, true)
+  }
+}
+
+const isBlockActive = (editor, format) => {
+  const [match] = Editor.nodes(editor, {
+    match: n =>
+      !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === format,
+  })
+
+  return !!match
+}
+
+const isMarkActive = (editor, format) => {
+  const marks = Editor.marks(editor)
+  return marks ? marks[format] === true : false
+}
+
+const Element = ({ attributes, children, element }) => {
+  switch (element.type) {
+    case 'block-quote':
+      return <blockquote {...attributes}>{children}</blockquote>
+    case 'bulleted-list':
+      return <ul {...attributes}>{children}</ul>
+    case 'heading-one':
+      return <h1 {...attributes}>{children}</h1>
+    case 'heading-two':
+      return <h2 {...attributes}>{children}</h2>
+    case 'list-item':
+      return <li {...attributes}>{children}</li>
+    case 'numbered-list':
+      return <ol {...attributes}>{children}</ol>
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+const getLength = token => {
+  if (typeof token === 'string') {
+    return token.length
+  } else if (typeof token.content === 'string') {
+    return token.content.length
+  } else {
+    return token.content.reduce((l, t) => l + getLength(t), 0)
+  }
+}
+
+const Leaf = ({ attributes, children, leaf }) => {
+  if (leaf.bold) {
+    children = <strong>{children}</strong>
+  }
+
+  if (leaf.code) {
+    children = (
+      <span
+        {...attributes}
+        className={css`
+            font-family: monospace;
+            background: hsla(0, 0%, 100%, .5);
+
+        ${leaf.comment &&
+          css`
+            color: slategray;
+          `}
+
+        ${(leaf.operator || leaf.url) &&
+          css`
+            color: #9a6e3a;
+          `}
+        ${leaf.keyword &&
+          css`
+            color: #07a;
+          `}
+        ${(leaf.variable || leaf.regex) &&
+          css`
+            color: #e90;
+          `}
+        ${(leaf.number ||
+          leaf.boolean ||
+          leaf.tag ||
+          leaf.constant ||
+          leaf.symbol ||
+          leaf['attr-name'] ||
+          leaf.selector) &&
+          css`
+            color: #905;
+          `}
+        ${leaf.punctuation &&
+          css`
+            color: #999;
+          `}
+        ${(leaf.string || leaf.char) &&
+          css`
+            color: #690;
+          `}
+        ${(leaf.function || leaf['class-name']) &&
+          css`
+            color: #dd4a68;
+          `}
+        `}
+      >
+        {children}
+      </span>
+    )
+  }
+
+  if (leaf.italic) {
+    children = <em>{children}</em>
+  }
+
+  if (leaf.underline) {
+    children = <u>{children}</u>
+  }
+
+  return <span {...attributes}>{children}</span>
+}
+
+const BlockButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isBlockActive(editor, format)}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleBlock(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+const MarkButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isMarkActive(editor, format)}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleMark(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+// modifications and additions to prism library
+
+Prism.languages.python = Prism.languages.extend('python', {})
+Prism.languages.insertBefore('python', 'prolog', {
+  comment: { pattern: /##[^\n]*/, alias: 'comment' },
+})
+Prism.languages.javascript = Prism.languages.extend('javascript', {})
+Prism.languages.insertBefore('javascript', 'prolog', {
+  comment: { pattern: /\/\/[^\n]*/, alias: 'comment' },
+})
+Prism.languages.html = Prism.languages.extend('html', {})
+Prism.languages.insertBefore('html', 'prolog', {
+  comment: { pattern: /<!--[^\n]*-->/, alias: 'comment' },
+})
+Prism.languages.markdown = Prism.languages.extend('markup', {})
+Prism.languages.insertBefore('markdown', 'prolog', {
+  blockquote: { pattern: /^>(?:[\t ]*>)*/m, alias: 'punctuation' },
+  code: [
+    { pattern: /^(?: {4}|\t).+/m, alias: 'keyword' },
+    { pattern: /``.+?``|`[^`\n]+`/, alias: 'keyword' },
+  ],
+  title: [
+    {
+      pattern: /\w+.*(?:\r?\n|\r)(?:==+|--+)/,
+      alias: 'important',
+      inside: { punctuation: /==+$|--+$/ },
+    },
+    {
+      pattern: /(^\s*)#+.+/m,
+      lookbehind: !0,
+      alias: 'important',
+      inside: { punctuation: /^#+|#+$/ },
+    },
+  ],
+  hr: {
+    pattern: /(^\s*)([*-])([\t ]*\2){2,}(?=\s*$)/m,
+    lookbehind: !0,
+    alias: 'punctuation',
+  },
+  list: {
+    pattern: /(^\s*)(?:[*+-]|\d+\.)(?=[\t ].)/m,
+    lookbehind: !0,
+    alias: 'punctuation',
+  },
+  'url-reference': {
+    pattern: /!?\[[^\]]+\]:[\t ]+(?:\S+|<(?:\\.|[^>\\])+>)(?:[\t ]+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\)))?/,
+    inside: {
+      variable: { pattern: /^(!?\[)[^\]]+/, lookbehind: !0 },
+      string: /(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/,
+      punctuation: /^[\[\]!:]|[<>]/,
+    },
+    alias: 'url',
+  },
+  bold: {
+    pattern: /(^|[^\\])(\*\*|__)(?:(?:\r?\n|\r)(?!\r?\n|\r)|.)+?\2/,
+    lookbehind: !0,
+    inside: { punctuation: /^\*\*|^__|\*\*$|__$/ },
+  },
+  italic: {
+    pattern: /(^|[^\\])([*_])(?:(?:\r?\n|\r)(?!\r?\n|\r)|.)+?\2/,
+    lookbehind: !0,
+    inside: { punctuation: /^[*_]|[*_]$/ },
+  },
+  url: {
+    pattern: /!?\[[^\]]+\](?:\([^\s)]+(?:[\t ]+"(?:\\.|[^"\\])*")?\)| ?\[[^\]\n]*\])/,
+    inside: {
+      variable: { pattern: /(!?\[)[^\]]+(?=\]$)/, lookbehind: !0 },
+      string: { pattern: /"(?:\\.|[^"\\])*"(?=\)$)/ },
+    },
+  },
+})
+Prism.languages.markdown.bold.inside.url = Prism.util.clone(
+  Prism.languages.markdown.url
+)
+Prism.languages.markdown.italic.inside.url = Prism.util.clone(
+  Prism.languages.markdown.url
+)
+Prism.languages.markdown.bold.inside.italic = Prism.util.clone(
+  Prism.languages.markdown.italic
+)
+Prism.languages.markdown.italic.inside.bold = Prism.util.clone(Prism.languages.markdown.bold); // prettier-ignore
+
+export default RichTextWithCodeHighlightingRenderChildrenExample

--- a/site/examples/richtext-with-code-highlighting.tsx
+++ b/site/examples/richtext-with-code-highlighting.tsx
@@ -1,0 +1,398 @@
+import Prism from 'prismjs'
+import 'prismjs/components/prism-python'
+import 'prismjs/components/prism-php'
+import 'prismjs/components/prism-sql'
+import 'prismjs/components/prism-java'
+import React, { useCallback, useMemo, useState } from 'react'
+import faker from 'faker'
+import isHotkey from 'is-hotkey'
+import { Editable, withReact, useSlate, Slate } from 'slate-react'
+import {
+  Editor,
+  Transforms,
+  createEditor,
+  Descendant,
+  Element as SlateElement,
+  Text,
+} from 'slate'
+import { withHistory } from 'slate-history'
+import { css } from 'emotion'
+
+import { Button, Icon, Toolbar } from '../components'
+
+const HOTKEYS = {
+  'mod+b': 'bold',
+  'mod+i': 'italic',
+  'mod+u': 'underline',
+  'mod+`': 'code',
+}
+
+const LIST_TYPES = ['numbered-list', 'bulleted-list']
+
+const HEADINGS = 100
+const PARAGRAPHS = 7
+const initialValue: Descendant[] = []
+
+for (let h = 0; h < HEADINGS; h++) {
+  initialValue.push({
+    type: 'heading',
+    children: [{ text: faker.lorem.sentence() }],
+  })
+
+  for (let p = 0; p < PARAGRAPHS; p++) {
+    initialValue.push({
+      type: 'paragraph',
+      children: [{ text: faker.lorem.paragraph() }],
+    })
+  }
+}
+
+const RichTextWithCodeHighlightingExample = () => {
+  const [value, setValue] = useState<Descendant[]>(initialValue)
+  const [language, setLanguage] = useState('html')
+  const renderElement = useCallback(props => <Element {...props} />, [])
+  const renderLeaf = useCallback(props => <Leaf {...props} />, [])
+  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+
+  const decorate = useCallback(
+    ([node, path]) => {
+      const ranges = []
+      if (!(Text.isText(node) && 'code' in node)) {
+        return ranges
+      }
+      const tokens = Prism.tokenize(node.text, Prism.languages[language])
+      let start = 0
+
+      for (const token of tokens) {
+        const length = getLength(token)
+        const end = start + length
+
+        if (typeof token !== 'string') {
+          ranges.push({
+            [token.type]: true,
+            anchor: { path, offset: start },
+            focus: { path, offset: end },
+          })
+        }
+
+        start = end
+      }
+
+      return ranges
+    },
+    [language]
+  )
+
+  return (
+    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+      <div
+        contentEditable={false}
+        style={{ position: 'relative', top: '5px', right: '5px' }}
+      >
+        <h3>
+          Select a language
+          <select
+            value={language}
+            style={{ float: 'right' }}
+            onChange={e => setLanguage(e.target.value)}
+          >
+            <option value="js">JavaScript</option>
+            <option value="css">CSS</option>
+            <option value="html">HTML</option>
+            <option value="python">Python</option>
+            <option value="sql">SQL</option>
+            <option value="java">Java</option>
+            <option value="php">PHP</option>
+          </select>
+        </h3>
+      </div>
+      <Toolbar>
+        <MarkButton format="bold" icon="format_bold" />
+        <MarkButton format="italic" icon="format_italic" />
+        <MarkButton format="underline" icon="format_underlined" />
+        <MarkButton format="code" icon="code" />
+        <BlockButton format="heading-one" icon="looks_one" />
+        <BlockButton format="heading-two" icon="looks_two" />
+        <BlockButton format="block-quote" icon="format_quote" />
+        <BlockButton format="numbered-list" icon="format_list_numbered" />
+        <BlockButton format="bulleted-list" icon="format_list_bulleted" />
+      </Toolbar>
+      <Editable
+        decorate={decorate}
+        renderElement={renderElement}
+        renderLeaf={renderLeaf}
+        placeholder="Enter some rich text…"
+        spellCheck
+        autoFocus
+        onKeyDown={event => {
+          for (const hotkey in HOTKEYS) {
+            if (isHotkey(hotkey, event as any)) {
+              event.preventDefault()
+              const mark = HOTKEYS[hotkey]
+              toggleMark(editor, mark)
+            }
+          }
+        }}
+      />
+    </Slate>
+  )
+}
+
+const toggleBlock = (editor, format) => {
+  const isActive = isBlockActive(editor, format)
+  const isList = LIST_TYPES.includes(format)
+
+  Transforms.unwrapNodes(editor, {
+    match: n =>
+      LIST_TYPES.includes(
+        !Editor.isEditor(n) && SlateElement.isElement(n) && n.type
+      ),
+    split: true,
+  })
+  const newProperties: Partial<SlateElement> = {
+    type: isActive ? 'paragraph' : isList ? 'list-item' : format,
+  }
+  Transforms.setNodes(editor, newProperties)
+
+  if (!isActive && isList) {
+    const block = { type: format, children: [] }
+    Transforms.wrapNodes(editor, block)
+  }
+}
+
+const toggleMark = (editor, format) => {
+  const isActive = isMarkActive(editor, format)
+
+  if (isActive) {
+    Editor.removeMark(editor, format)
+  } else {
+    Editor.addMark(editor, format, true)
+  }
+}
+
+const isBlockActive = (editor, format) => {
+  const [match] = Editor.nodes(editor, {
+    match: n =>
+      !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === format,
+  })
+
+  return !!match
+}
+
+const isMarkActive = (editor, format) => {
+  const marks = Editor.marks(editor)
+  return marks ? marks[format] === true : false
+}
+
+const Element = ({ attributes, children, element }) => {
+  switch (element.type) {
+    case 'block-quote':
+      return <blockquote {...attributes}>{children}</blockquote>
+    case 'bulleted-list':
+      return <ul {...attributes}>{children}</ul>
+    case 'heading-one':
+      return <h1 {...attributes}>{children}</h1>
+    case 'heading-two':
+      return <h2 {...attributes}>{children}</h2>
+    case 'list-item':
+      return <li {...attributes}>{children}</li>
+    case 'numbered-list':
+      return <ol {...attributes}>{children}</ol>
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+const getLength = token => {
+  if (typeof token === 'string') {
+    return token.length
+  } else if (typeof token.content === 'string') {
+    return token.content.length
+  } else {
+    return token.content.reduce((l, t) => l + getLength(t), 0)
+  }
+}
+
+const Leaf = ({ attributes, children, leaf }) => {
+  if (leaf.bold) {
+    children = <strong>{children}</strong>
+  }
+
+  if (leaf.code) {
+    children = (
+      <span
+        {...attributes}
+        className={css`
+            font-family: monospace;
+            background: hsla(0, 0%, 100%, .5);
+
+        ${leaf.comment &&
+          css`
+            color: slategray;
+          `}
+
+        ${(leaf.operator || leaf.url) &&
+          css`
+            color: #9a6e3a;
+          `}
+        ${leaf.keyword &&
+          css`
+            color: #07a;
+          `}
+        ${(leaf.variable || leaf.regex) &&
+          css`
+            color: #e90;
+          `}
+        ${(leaf.number ||
+          leaf.boolean ||
+          leaf.tag ||
+          leaf.constant ||
+          leaf.symbol ||
+          leaf['attr-name'] ||
+          leaf.selector) &&
+          css`
+            color: #905;
+          `}
+        ${leaf.punctuation &&
+          css`
+            color: #999;
+          `}
+        ${(leaf.string || leaf.char) &&
+          css`
+            color: #690;
+          `}
+        ${(leaf.function || leaf['class-name']) &&
+          css`
+            color: #dd4a68;
+          `}
+        `}
+      >
+        {children}
+      </span>
+    )
+  }
+
+  if (leaf.italic) {
+    children = <em>{children}</em>
+  }
+
+  if (leaf.underline) {
+    children = <u>{children}</u>
+  }
+
+  return <span {...attributes}>{children}</span>
+}
+
+const BlockButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isBlockActive(editor, format)}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleBlock(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+const MarkButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isMarkActive(editor, format)}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleMark(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+// modifications and additions to prism library
+
+Prism.languages.python = Prism.languages.extend('python', {})
+Prism.languages.insertBefore('python', 'prolog', {
+  comment: { pattern: /##[^\n]*/, alias: 'comment' },
+})
+Prism.languages.javascript = Prism.languages.extend('javascript', {})
+Prism.languages.insertBefore('javascript', 'prolog', {
+  comment: { pattern: /\/\/[^\n]*/, alias: 'comment' },
+})
+Prism.languages.html = Prism.languages.extend('html', {})
+Prism.languages.insertBefore('html', 'prolog', {
+  comment: { pattern: /<!--[^\n]*-->/, alias: 'comment' },
+})
+Prism.languages.markdown = Prism.languages.extend('markup', {})
+Prism.languages.insertBefore('markdown', 'prolog', {
+  blockquote: { pattern: /^>(?:[\t ]*>)*/m, alias: 'punctuation' },
+  code: [
+    { pattern: /^(?: {4}|\t).+/m, alias: 'keyword' },
+    { pattern: /``.+?``|`[^`\n]+`/, alias: 'keyword' },
+  ],
+  title: [
+    {
+      pattern: /\w+.*(?:\r?\n|\r)(?:==+|--+)/,
+      alias: 'important',
+      inside: { punctuation: /==+$|--+$/ },
+    },
+    {
+      pattern: /(^\s*)#+.+/m,
+      lookbehind: !0,
+      alias: 'important',
+      inside: { punctuation: /^#+|#+$/ },
+    },
+  ],
+  hr: {
+    pattern: /(^\s*)([*-])([\t ]*\2){2,}(?=\s*$)/m,
+    lookbehind: !0,
+    alias: 'punctuation',
+  },
+  list: {
+    pattern: /(^\s*)(?:[*+-]|\d+\.)(?=[\t ].)/m,
+    lookbehind: !0,
+    alias: 'punctuation',
+  },
+  'url-reference': {
+    pattern: /!?\[[^\]]+\]:[\t ]+(?:\S+|<(?:\\.|[^>\\])+>)(?:[\t ]+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\)))?/,
+    inside: {
+      variable: { pattern: /^(!?\[)[^\]]+/, lookbehind: !0 },
+      string: /(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/,
+      punctuation: /^[\[\]!:]|[<>]/,
+    },
+    alias: 'url',
+  },
+  bold: {
+    pattern: /(^|[^\\])(\*\*|__)(?:(?:\r?\n|\r)(?!\r?\n|\r)|.)+?\2/,
+    lookbehind: !0,
+    inside: { punctuation: /^\*\*|^__|\*\*$|__$/ },
+  },
+  italic: {
+    pattern: /(^|[^\\])([*_])(?:(?:\r?\n|\r)(?!\r?\n|\r)|.)+?\2/,
+    lookbehind: !0,
+    inside: { punctuation: /^[*_]|[*_]$/ },
+  },
+  url: {
+    pattern: /!?\[[^\]]+\](?:\([^\s)]+(?:[\t ]+"(?:\\.|[^"\\])*")?\)| ?\[[^\]\n]*\])/,
+    inside: {
+      variable: { pattern: /(!?\[)[^\]]+(?=\]$)/, lookbehind: !0 },
+      string: { pattern: /"(?:\\.|[^"\\])*"(?=\)$)/ },
+    },
+  },
+})
+Prism.languages.markdown.bold.inside.url = Prism.util.clone(
+  Prism.languages.markdown.url
+)
+Prism.languages.markdown.italic.inside.url = Prism.util.clone(
+  Prism.languages.markdown.url
+)
+Prism.languages.markdown.bold.inside.italic = Prism.util.clone(
+  Prism.languages.markdown.italic
+)
+Prism.languages.markdown.italic.inside.bold = Prism.util.clone(Prism.languages.markdown.bold); // prettier-ignore
+
+export default RichTextWithCodeHighlightingExample

--- a/site/pages/examples/[example].tsx
+++ b/site/pages/examples/[example].tsx
@@ -23,6 +23,8 @@ import PasteHtml from '../../examples/paste-html'
 import PlainText from '../../examples/plaintext'
 import ReadOnly from '../../examples/read-only'
 import RichText from '../../examples/richtext'
+import RichTextWithCodeHighlighting from '../../examples/richtext-with-code-highlighting'
+import RichTextWithCodeHighlightingRenderChildren from '../../examples/richtext-with-code-highlighting-renderChildren'
 import SearchHighlighting from '../../examples/search-highlighting'
 import ShadowDOM from '../../examples/shadow-dom'
 import Tables from '../../examples/tables'
@@ -49,6 +51,16 @@ const EXAMPLES = [
   ['Plain Text', PlainText, 'plaintext'],
   ['Read-only', ReadOnly, 'read-only'],
   ['Rich Text', RichText, 'richtext'],
+  [
+    'Rich Text with Code Highlighting',
+    RichTextWithCodeHighlighting,
+    'richtext-with-code-highlighting',
+  ],
+  [
+    'Rich Text with Code Highlighting (renderChildren)',
+    RichTextWithCodeHighlightingRenderChildren,
+    'richtext-with-code-highlighting-renderChildren',
+  ],
   ['Search Highlighting', SearchHighlighting, 'search-highlighting'],
   ['Shadow DOM', ShadowDOM, 'shadow-dom'],
   ['Tables', Tables, 'tables'],


### PR DESCRIPTION
Add a `renderChildren` argument to `renderElement` that takes decorations to be applied to the element's children, so
dynamic decorations may be rendered without a global re-render.

**Description**
With the existing decorations mechanism, it is not easy to make decorations dynamic, so they're recomputed based on external state. Currently the only way to do it is to change the `decorate` function, which causes every element in the document to re-render.

A small change to the `renderElement` API can greatly improve the situation: pass a new `renderChildren` argument, which takes a `decorations` argument. These decorations are added to any existing decorations when rendering the children.

(This is a first cut PR for discussion.)

**Issue**
Fixes: #4483

**Example**
```ts
const renderElement = (props: RenderElementProps) => {
  switch (props.element.type) {
    case 'code':
      const decorations = ... // syntax highlighting
      return <code>{props.renderChildren({ decorations })}</code>
    ...
```

**Context**
See #4483 for some alternatives.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

