### PR TITLE
call `decorate` for a node inside render of node's component

### DIFF
--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -1,9 +1,10 @@
 import React, { useRef } from 'react'
 import getDirection from 'direction'
-import { Editor, Node, Range, NodeEntry, Element as SlateElement } from 'slate'
+import { Editor, Node, Path, Range, Element as SlateElement } from 'slate'
 
 import Text from './text'
 import useChildren from '../hooks/use-children'
+import { useDecorate } from '../hooks/use-decorate'
 import { ReactEditor, useSlateStatic, useReadOnly } from '..'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 import {
@@ -27,6 +28,7 @@ import {
 const Element = (props: {
   decorations: Range[]
   element: SlateElement
+  path: Path
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
@@ -35,18 +37,23 @@ const Element = (props: {
   const {
     decorations,
     element,
+    path,
     renderElement = (p: RenderElementProps) => <DefaultElement {...p} />,
     renderPlaceholder,
     renderLeaf,
     selection,
   } = props
   const ref = useRef<HTMLElement>(null)
+  const decorate = useDecorate()
   const editor = useSlateStatic()
   const readOnly = useReadOnly()
   const isInline = editor.isInline(element)
   const key = ReactEditor.findKey(editor, element)
+  const ds = decorate([element, path])
+  ds.splice(ds.length, 0, ...decorations)
+
   let children: React.ReactNode = useChildren({
-    decorations,
+    decorations: ds,
     node: element,
     renderElement,
     renderPlaceholder,
@@ -92,7 +99,7 @@ const Element = (props: {
     }
 
     const Tag = isInline ? 'span' : 'div'
-    const [[text]] = Node.texts(element)
+    const [[text, path]] = Node.texts(element)
 
     children = readOnly ? null : (
       <Tag
@@ -110,6 +117,7 @@ const Element = (props: {
           isLast={false}
           parent={element}
           text={text}
+          path={path}
         />
       </Tag>
     )

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -1,9 +1,10 @@
 import React, { useRef } from 'react'
-import { Range, Element, Text as SlateText } from 'slate'
+import { Element, Path, Range, Text as SlateText } from 'slate'
 
 import Leaf from './leaf'
 import { ReactEditor, useSlateStatic } from '..'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
+import { useDecorate } from '../hooks/use-decorate'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 import {
   NODE_TO_ELEMENT,
@@ -23,6 +24,7 @@ const Text = (props: {
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   text: SlateText
+  path: Path
 }) => {
   const {
     decorations,
@@ -31,10 +33,14 @@ const Text = (props: {
     renderPlaceholder,
     renderLeaf,
     text,
+    path,
   } = props
-  const editor = useSlateStatic()
   const ref = useRef<HTMLSpanElement>(null)
-  const leaves = SlateText.decorations(text, decorations)
+  const decorate = useDecorate()
+  const editor = useSlateStatic()
+  const ds = decorate([text, path])
+  ds.splice(ds.length, 0, ...decorations)
+  const leaves = SlateText.decorations(text, ds)
   const key = ReactEditor.findKey(editor, text)
   const children = []
 

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -5,7 +5,6 @@ import ElementComponent from '../components/element'
 import TextComponent from '../components/text'
 import { ReactEditor } from '..'
 import { useSlateStatic } from './use-slate-static'
-import { useDecorate } from './use-decorate'
 import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
 import {
   RenderElementProps,
@@ -34,7 +33,6 @@ const useChildren = (props: {
     renderLeaf,
     selection,
   } = props
-  const decorate = useDecorate()
   const editor = useSlateStatic()
   const path = ReactEditor.findPath(editor, node)
   const children = []
@@ -49,8 +47,8 @@ const useChildren = (props: {
     const key = ReactEditor.findKey(editor, n)
     const range = Editor.range(editor, p)
     const sel = selection && Range.intersection(range, selection)
-    const ds = decorate([n, p])
 
+    const ds: Range[] = []
     for (const dec of decorations) {
       const d = Range.intersection(dec, range)
 
@@ -65,6 +63,7 @@ const useChildren = (props: {
           <ElementComponent
             decorations={ds}
             element={n}
+            path={p}
             key={key.id}
             renderElement={renderElement}
             renderPlaceholder={renderPlaceholder}
@@ -83,6 +82,7 @@ const useChildren = (props: {
           renderPlaceholder={renderPlaceholder}
           renderLeaf={renderLeaf}
           text={n}
+          path={p}
         />
       )
     }


### PR DESCRIPTION
**Description**
One way to implement dynamic decorations is to pass a different
`decorate` function on every decoration change. But this is very
expensive, because it triggers a render of every `Element`.

Another way to implement dynamic decorations is to call a React hook
inside the `decorate` function, so rendering is triggered when the
hook fires. By selectively calling the hook, you can arrange to render
only components that actually need to be updated.

However, in the existing code, the `decorate` call for a node runs in
the render of the node's parent component, so more of the tree is
rendered than necessary when a hook fires. This change moves the
`decorate` call for a node into the component for that node, so only
affected components are rendered.

**Issue**
Fixes: #4483

**Example**
Suppose you want to do syntax highlighting with themes. You can write a `decorate` function like so:
```ts
function decorate(([node, path])) => {
  if (Element.isElement(node) && node.type === 'code') {
    const theme = React.useContext(ThemeContext);
    return highlight(node, theme);
  }
}
```
Now when `ThemeContext` changes, the hook fires and `code` nodes are re-rendered, but non-`code` nodes are not re-rendered.

**Context**
See description. I made another attempt to address this problem in #4484, but I think this way is better because it doesn't change the API, and keeps decorations separate from other rendering.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

