### PR TITLE
Fix paste to empty node losing structure of first block

### DIFF
--- a/.changeset/cool-rings-help.md
+++ b/.changeset/cool-rings-help.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Fix paste to empty node losing structure of first block

--- a/packages/slate/test/transforms/insertFragment/of-blocks/block-empty.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-blocks/block-empty.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <block>
+        <block>one</block>
+      </block>
+      <block>two</block>
+      <block>three</block>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>word</block>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>word</block>
+    <block>
+      <block>one</block>
+    </block>
+    <block>two</block>
+    <block>
+      three
+      <cursor />
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**

When pasting into an empty block, insert the entire fragment as-is, thereby preserving the structure of the first block.

**Issue**

Fixes: #4486

**Example**

Right - current, left - PR.

![Peek 2021-09-03 22-39](https://user-images.githubusercontent.com/10130001/132063248-6ef6a902-87eb-4850-9730-e93d81f1108f.gif)

**Caveat**

Since the first node is not handled in a special way anymore, there will be a change to how complex structures like lists behave (GIF below). I feel that slate cannot handle this well on it's own without knowing the semantics of those elements (is it a list, is it a table, how does one paste a table into a table etc), and it should be up to the "plugin" that defines what a list is to define that behavior. If this is not acceptable, i propose we allow the clients to choose between two insert strategies, as we really need the PR behavior to work and list behavior for us is solved by [plate](https://plate.udecode.io).

Note however that slate handles pasting to a list (a flat list too) nicely, whereas pasting outside of a list is not good, whereas the PR is the opposite - pasting outside the list looks good, whereas pasting into a list introduces a sublist.

Right - current, left - PR.

![Peek 2021-09-03 22-47](https://user-images.githubusercontent.com/10130001/132064030-3a933b35-cff4-4a2f-844b-f24f2ee37d14.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

