### PR TITLE
Update error message for useSlate

### DIFF
--- a/.changeset/curly-mails-allow.md
+++ b/.changeset/curly-mails-allow.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Update error message for useSlate

--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -18,7 +18,7 @@ export const useSlate = (): Editor => {
 
   if (!context) {
     throw new Error(
-      `The \`useSlate\` hook must be used inside the <SlateProvider> component's context.`
+      `The \`useSlate\` hook must be used inside the <Slate> component's context.`
     )
   }
 


### PR DESCRIPTION
**Description**

Error message for useSlate is stale and points to an old API.

**Issue**
Fixes: #4479

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

