### PR TITLE
Updates "Saving to a Database" example to distinguish content changes

### DIFF
--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -28,7 +28,7 @@ That will render a basic Slate editor on your page, and when you type things wil
 
 What we need to do is save the changes you make somewhere. For this example, we'll just be using [Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but it will give you an idea for where you'd need to add your own database hooks.
 
-So, in our `onChange` handler, we need to save the `value`:
+So, in our `onChange` handler, we need to save the `value` if anything besides the selection was changed:
 
 ```jsx
 const App = () => {
@@ -47,9 +47,12 @@ const App = () => {
       onChange={value => {
         setValue(value)
 
-        // Save the value to Local Storage.
-        const content = JSON.stringify(value)
-        localStorage.setItem('content', content)
+        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type);
+        if (isAstChange) {
+          // Save the value to Local Storage.
+          const content = JSON.stringify(value)
+          localStorage.setItem('content', content)
+        }
       }}
     >
       <Editable />
@@ -81,8 +84,12 @@ const App = () => {
       value={value}
       onChange={value => {
         setValue(value)
-        const content = JSON.stringify(value)
-        localStorage.setItem('content', content)
+        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type);
+        if (isAstChange) {
+          // Save the value to Local Storage.
+          const content = JSON.stringify(value)
+          localStorage.setItem('content', content)
+        }
       }}
     >
       <Editable />
@@ -135,8 +142,11 @@ const App = () => {
       value={value}
       onChange={value => {
         setValue(value)
-        // Serialize the value and save the string value to Local Storage.
-        localStorage.setItem('content', serialize(value))
+        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type);
+        if (isAstChange) {
+          // Serialize the value and save the string value to Local Storage.
+          localStorage.setItem('content', serialize(value))
+        }
       }}
     >
       <Editable />

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -84,7 +84,7 @@ const App = () => {
       value={value}
       onChange={value => {
         setValue(value)
-        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type);
+        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type)
         if (isAstChange) {
           // Save the value to Local Storage.
           const content = JSON.stringify(value)

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -47,7 +47,7 @@ const App = () => {
       onChange={value => {
         setValue(value)
 
-        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type);
+        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type)
         if (isAstChange) {
           // Save the value to Local Storage.
           const content = JSON.stringify(value)

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -47,7 +47,9 @@ const App = () => {
       onChange={value => {
         setValue(value)
 
-        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type)
+        const isAstChange = editor.operations.some(
+          op => 'set_selection' !== op.type
+        )
         if (isAstChange) {
           // Save the value to Local Storage.
           const content = JSON.stringify(value)
@@ -84,7 +86,9 @@ const App = () => {
       value={value}
       onChange={value => {
         setValue(value)
-        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type)
+        const isAstChange = editor.operations.some(
+          op => 'set_selection' !== op.type
+        )
         if (isAstChange) {
           // Save the value to Local Storage.
           const content = JSON.stringify(value)
@@ -142,7 +146,9 @@ const App = () => {
       value={value}
       onChange={value => {
         setValue(value)
-        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type)
+        const isAstChange = editor.operations.some(
+          op => 'set_selection' !== op.type
+        )
         if (isAstChange) {
           // Serialize the value and save the string value to Local Storage.
           localStorage.setItem('content', serialize(value))

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -142,7 +142,7 @@ const App = () => {
       value={value}
       onChange={value => {
         setValue(value)
-        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type);
+        const isAstChange = editor.operations.some(op => 'set_selection' !== op.type)
         if (isAstChange) {
           // Serialize the value and save the string value to Local Storage.
           localStorage.setItem('content', serialize(value))


### PR DESCRIPTION


**Description**
As written, the "Saving to a Database" examples save even when the editor content is unchanged.  This is inefficient and often undesirable.
