### PR TITLE
Fix: regression caused by triple click fix

### DIFF
--- a/.changeset/smart-pears-beam.md
+++ b/.changeset/smart-pears-beam.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix: regression caused by triple click fix

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -590,11 +590,15 @@ export const ReactEditor = {
             )
             const focusElement = tripleClickedBlock!.lastElementChild
             // Get the element node that holds the focus text node
+            // Not every Slate element node contains a child node with `data-slate-string`,
+            // such as void nodes, so the result below could be null.
             const innermostFocusElement = focusElement!.querySelector(
               '[data-slate-string]'
             )
-            const lastTextNode = innermostFocusElement!.childNodes[0]
-            focusNode = lastTextNode
+            if (innermostFocusElement) {
+              const lastTextNode = innermostFocusElement.childNodes[0]
+              focusNode = lastTextNode
+            }
           }
         }
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -565,13 +565,17 @@ export const ReactEditor = {
         // This will highlight the corresponding toolbar button for the sibling
         // block even though users just want to target the previous block.
         // (2021/08/24)
-        // Within the context of Slate and Chrome, if anchor and focus nodes don't have
-        //  the same nodeValue and focusOffset is 0, then it's definitely a triple click
-        // behaviour.
+        // Signs of a triple click in Chrome
+        // - anchor node will be a text node but focus node won't
+        // - both anchorOffset and focusOffset are 0
+        // - focusNode value will be null since Chrome tries to extend to just the
+        // beginning of the next block
         if (
           IS_CHROME &&
-          anchorNode?.nodeValue !== focusNode?.nodeValue &&
-          domRange.focusOffset === 0
+          anchorNode?.nodeType !== focusNode?.nodeType &&
+          domRange.anchorOffset === 0 &&
+          domRange.focusOffset === 0 &&
+          focusNode?.nodeValue == null
         ) {
           // If an anchorNode is an element node when triple clicked, then the focusNode
           //  should also be the same as anchorNode when triple clicked.


### PR DESCRIPTION
fixes #4490 

**Description**
Introducing fix for triple-click selection in this [PR](https://github.com/ianstormtaylor/slate/pull/4455#issuecomment-913821241) caused some regressions that I didn't expect.

This new PR will alleviate that.

**Issue**
Some of the issue caused by the triple click fix include, but not limited to:
- Crash when selecting void nodes #4490 
- Shift + down arrow then delete text doesn't delete it #4496 

**Context**
There are two problems with my triple-click fix:
- The condition for checking if an action is a triple-click is too broad.
- The logic for resetting `focusNode` of a selection is not fail-proof. The building block of the content component in a Slate editor are HTML element with attribute `data-slate-node="element"`. They may contain child elements `data-slate-string`, but not always. The current logic assumes that Element always contains String elements, which leads to the crash when selecting void nodes.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

