### PR TITLE
Upgrade `is-plain-object` to v5.0.0

### DIFF
--- a/.changeset/gold-planets-pump.md
+++ b/.changeset/gold-planets-pump.md
@@ -1,0 +1,8 @@
+---
+'slate-history': patch
+'slate-hyperscript': patch
+'slate-react': patch
+'slate': patch
+---
+
+Upgrade `is-plain-object` to v5.0.0

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "dependencies": {
-    "is-plain-object": "^3.0.0"
+    "is-plain-object": "^5.0.0"
   },
   "devDependencies": {
     "@babel/runtime": "^7.7.4",

--- a/packages/slate-history/src/history.ts
+++ b/packages/slate-history/src/history.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 import { Operation } from 'slate'
 
 /**

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "dependencies": {
-    "is-plain-object": "^3.0.0"
+    "is-plain-object": "^5.0.0"
   },
   "devDependencies": {
     "@babel/runtime": "^7.7.4",

--- a/packages/slate-hyperscript/src/hyperscript.ts
+++ b/packages/slate-hyperscript/src/hyperscript.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 import { Element } from 'slate'
 import {
   createAnchor,

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -18,7 +18,7 @@
     "@types/lodash": "^4.14.149",
     "direction": "^1.0.3",
     "is-hotkey": "^0.1.6",
-    "is-plain-object": "^3.0.0",
+    "is-plain-object": "^5.0.0",
     "lodash": "^4.17.4",
     "scroll-into-view-if-needed": "^2.2.20",
     "tiny-invariant": "1.0.6"

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "immer": "^8.0.1",
-    "is-plain-object": "^3.0.0",
+    "is-plain-object": "^5.0.0",
     "tiny-warning": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 
 import {
   Ancestor,

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 import { Editor, Node, Path, Descendant, ExtendedType, Ancestor } from '..'
 
 /**

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -1,5 +1,5 @@
 import { ExtendedType, Node, Path, Range } from '..'
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 
 export type BaseInsertNodeOperation = {
   type: 'insert_node'

--- a/packages/slate/src/interfaces/point.ts
+++ b/packages/slate/src/interfaces/point.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 import { produce } from 'immer'
 import { ExtendedType, Operation, Path } from '..'
 

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -1,5 +1,5 @@
 import { produce } from 'immer'
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 import { ExtendedType, Operation, Path, Point, PointEntry } from '..'
 
 /**

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 import { Range } from '..'
 import { ExtendedType } from './custom-types'
 import { isDeepEqual } from '../utils/deep-equal'

--- a/packages/slate/src/utils/deep-equal.ts
+++ b/packages/slate/src/utils/deep-equal.ts
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-object'
+import { isPlainObject } from 'is-plain-object'
 
 /*
   Custom deep equal comparison for Slate nodes.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,13 +9191,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "is-plain-object@npm:3.0.1"
-  checksum: d13fe75db350d4ac669595cdfe0242ae87fcecddf2bca858d2dd443a6ed6eb1f69951fac8c2fa85b16106c6b0d7738fea86c2aca2ecee7fd61de15c1574f2cc5
-  languageName: node
-  linkType: hard
-
 "is-plain-object@npm:^5.0.0":
   version: 5.0.0
   resolution: "is-plain-object@npm:5.0.0"
@@ -14316,7 +14309,7 @@ resolve@^2.0.0-next.3:
   resolution: "slate-history@workspace:packages/slate-history"
   dependencies:
     "@babel/runtime": ^7.7.4
-    is-plain-object: ^3.0.0
+    is-plain-object: ^5.0.0
     lodash: ^4.17.21
     slate: ^0.65.3
     slate-hyperscript: ^0.62.0
@@ -14331,7 +14324,7 @@ resolve@^2.0.0-next.3:
   resolution: "slate-hyperscript@workspace:packages/slate-hyperscript"
   dependencies:
     "@babel/runtime": ^7.7.4
-    is-plain-object: ^3.0.0
+    is-plain-object: ^5.0.0
     slate: ^0.65.3
     source-map-loader: ^0.2.4
   peerDependencies:
@@ -14429,7 +14422,7 @@ resolve@^2.0.0-next.3:
     "@types/react-dom": ^16.9.4
     direction: ^1.0.3
     is-hotkey: ^0.1.6
-    is-plain-object: ^3.0.0
+    is-plain-object: ^5.0.0
     jsdom: ^16.6.0
     lodash: ^4.17.4
     react: ">=16.8.0"
@@ -14453,7 +14446,7 @@ resolve@^2.0.0-next.3:
   dependencies:
     "@babel/runtime": ^7.7.4
     immer: ^8.0.1
-    is-plain-object: ^3.0.0
+    is-plain-object: ^5.0.0
     lodash: ^4.17.21
     slate-hyperscript: ^0.62.0
     source-map-loader: ^0.2.4


### PR DESCRIPTION
**Description**
The `is-plain-object` package recently had a major version upgrade that broke libraries which import its default export, such as this one. This causes issues when other packages in the same application require a higher version of `is-plain-object`, resulting in an error originating in Slate's codebase. To remedy this, Slate is now depending on `is-plain-object@^5.0.0` and its import references across the codebase have been updated.

**Issue**
Fixes: #4499

**Example**
See issue

**Context**
See issue

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)