### PR TITLE
Add changeset for triple click fix

### DIFF
--- a/.changeset/old-planes-trade.md
+++ b/.changeset/old-planes-trade.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix incorrect selection when triple clicking blocks in Editable component

--- a/.changeset/smart-pears-beam.md
+++ b/.changeset/smart-pears-beam.md
@@ -1,5 +1,0 @@
----
-'slate-react': patch
----
-
-Fix: regression caused by triple click fix


### PR DESCRIPTION
**Description**
In this PR, I added changeset for the fix for the triple click [here ](https://github.com/ianstormtaylor/slate/pull/4455) and removed changeset for this related [PR](https://github.com/ianstormtaylor/slate/pull/4498)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

