### PR TITLE
Adds an example to the docs for Transforms.select

### DIFF
--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -115,6 +115,15 @@ Options: `{edge?: 'anchor' | 'focus' | 'start' | 'end'}`
 
 Set the selection to a new value specified by `target`. When a selection already exists, this method is just a proxy for `setSelection` and will update the existing value.
 
+For example, to set the selection to the entire contents of the editor:
+
+```javascript
+Transforms.select(editor, {
+  anchor: Editor.start(editor, []),
+  focus: Editor.end(editor, []),
+})
+```
+
 #### `Transforms.deselect(editor: Editor)`
 
 Unset the selection.


### PR DESCRIPTION
**Description**
While developers can look up the definition of a Location, it's far from clear how to select from the beginning of the editor content, or to the end of editor content.
