### PR TITLE
fix(react-editor): reset focus offset when triple clicking

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -572,36 +572,52 @@ export const ReactEditor = {
         // beginning of the next block
         if (
           IS_CHROME &&
-          anchorNode?.nodeType !== focusNode?.nodeType &&
+          anchorNode &&
+          focusNode &&
+          anchorNode.nodeType !== focusNode.nodeType &&
           domRange.anchorOffset === 0 &&
           domRange.focusOffset === 0 &&
-          focusNode?.nodeValue == null
+          focusNode.nodeValue == null
         ) {
           // If an anchorNode is an element node when triple clicked, then the focusNode
           //  should also be the same as anchorNode when triple clicked.
-          if (anchorNode!.nodeType === 1) {
-            focusNode = anchorNode
-          } else {
-            // Otherwise, anchorNode is a text node and we need to
-            // - climb up the DOM tree to get the farthest element node that receives
-            // triple click. It should have atribute 'data-slate-node' = "element"
-            // - get the last child of that element node
-            // - climb down the DOM tree to get the text node of the last child
-            // - this is also the end of the selection aka the focusNode
-            const anchorElement = anchorNode!.parentNode as HTMLElement
-            const tripleClickedBlock = anchorElement.closest(
-              '[data-slate-node="element"]'
-            )
-            const focusElement = tripleClickedBlock!.lastElementChild
-            // Get the element node that holds the focus text node
-            // Not every Slate element node contains a child node with `data-slate-string`,
-            // such as void nodes, so the result below could be null.
-            const innermostFocusElement = focusElement!.querySelector(
-              '[data-slate-string]'
-            )
-            if (innermostFocusElement) {
-              const lastTextNode = innermostFocusElement.childNodes[0]
-              focusNode = lastTextNode
+          // if (anchorNode!.nodeType === 1) {
+          //   focusNode = anchorNode
+          // } else {
+          //   // Otherwise, anchorNode is a text node and we need to
+          //   // - climb up the DOM tree to get the farthest element node that receives
+          //   // triple click. It should have atribute 'data-slate-node' = "element"
+          //   // - get the last child of that element node
+          //   // - climb down the DOM tree to get the text node of the last child
+          //   // - this is also the end of the selection aka the focusNode
+          const anchorElement = anchorNode.parentNode as HTMLElement
+          const selectedBlock = anchorElement.closest(
+            '[data-slate-node="element"]'
+          )
+          if (selectedBlock) {
+            // The Slate Text nodes are leaf-level and contains document's text.
+            // However, when represented in the DOM, they are actually Element nodes
+            // and different from the DOM's Text nodes
+            const { childElementCount: slateTextNodeCount } = selectedBlock
+            if (slateTextNodeCount === 1) {
+              focusNode = anchorNode as Text
+              focusOffset = focusNode.length
+            } else if (slateTextNodeCount > 1) {
+              // A element with attribute data-slate-node="element" can have multiple
+              // children with attribute data-slate-node="text". But these children only have
+              // one child at each level.
+              // <span data-slate-node="text">
+              //   <span data-slate-leaf="">
+              //     <span data-slate-string=""></span>
+              //   </span>
+              // </span>
+              const focusElement = selectedBlock.lastElementChild as HTMLElement
+              const nodeIterator = document.createNodeIterator(
+                focusElement,
+                NodeFilter.SHOW_TEXT
+              )
+              focusNode = nodeIterator.nextNode() as Text
+              focusOffset = focusNode.length
             }
           }
         }

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -581,15 +581,12 @@ export const ReactEditor = {
         ) {
           // If an anchorNode is an element node when triple clicked, then the focusNode
           //  should also be the same as anchorNode when triple clicked.
-          // if (anchorNode!.nodeType === 1) {
-          //   focusNode = anchorNode
-          // } else {
-          //   // Otherwise, anchorNode is a text node and we need to
-          //   // - climb up the DOM tree to get the farthest element node that receives
-          //   // triple click. It should have atribute 'data-slate-node' = "element"
-          //   // - get the last child of that element node
-          //   // - climb down the DOM tree to get the text node of the last child
-          //   // - this is also the end of the selection aka the focusNode
+          // Otherwise, anchorNode is a text node and we need to
+          // - climb up the DOM tree to get the farthest element node that receives
+          //   triple click. It should have atribute 'data-slate-node' = "element"
+          // - get the last child of that element node
+          // - climb down the DOM tree to get the text node of the last child
+          // - this is also the end of the selection aka the focusNode
           const anchorElement = anchorNode.parentNode as HTMLElement
           const selectedBlock = anchorElement.closest(
             '[data-slate-node="element"]'


### PR DESCRIPTION
**Description**

In my triple click fix, I reset the `focusNode` but forgot to reset the related `focusOffset` value. As a result, the Slate range computed from DOM selection is still not correct and cause a number of issues when users try to transform a block by applying formatting or deleting. 

**Issue**
Fixes: #4492 

**Example**
Before the fix

https://user-images.githubusercontent.com/28924121/133071690-27d21192-b86c-4b6a-9741-0f2f1ff53218.mp4

After the fix

- Selecting a block by clicking and dragging, then hitting Backspace should remove that block.

https://user-images.githubusercontent.com/28924121/133098079-78fdccd1-3eef-42a3-b852-ca0ba55453d9.mp4

- Selecting a block through clicking and hitting Shift + Arrow down, then hitting Backspace should remove that block.

https://user-images.githubusercontent.com/28924121/133098140-5d2963af-0014-4501-a117-b4b6d71f1d91.mp4

- Triple click at the beginning of a Mark should delete the whole block that contains that Mark.

https://user-images.githubusercontent.com/28924121/133098182-1198893c-aa2c-4291-b777-ab5c44f06643.mp4

**Context**
Here's what I did:
- Refactor the condition for checking for triple clicking or Shift + down arrow. Chrome seems to have issue with selection that is not clicking and dragging.
- Rewrite the code for getting `focusNode` to avoid error thrown when accessing property of a potentially null value.
- Add logic for getting the DOM Text node of the `focusNode` object.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

