### PR TITLE
Fixed nested object comparison

### DIFF
--- a/.changeset/eleven-taxis-hear.md
+++ b/.changeset/eleven-taxis-hear.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fixed flaw in deep-equal algorithm when dealing with nested mark objects

--- a/packages/slate/src/utils/deep-equal.ts
+++ b/packages/slate/src/utils/deep-equal.ts
@@ -17,7 +17,7 @@ export const isDeepEqual = (
   for (const key in node) {
     const a = node[key]
     const b = another[key]
-    if (isPlainObject(a)) {
+    if (isPlainObject(a) && isPlainObject(b)) {
       if (!isDeepEqual(a, b)) return false
     } else if (Array.isArray(a) && Array.isArray(b)) {
       if (a.length !== b.length) return false

--- a/packages/slate/test/utils/deep-equal/deep-not-equal-nested-undefined.js
+++ b/packages/slate/test/utils/deep-equal/deep-not-equal-nested-undefined.js
@@ -1,0 +1,21 @@
+import { isDeepEqual } from '../../../src/utils/deep-equal'
+
+export const input = {
+  objectA: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: true },
+    underline: { origin: 'inherited', value: false },
+  },
+  objectB: {
+    text: 'same text',
+    bold: true,
+    italic: { origin: 'inherited', value: true },
+  },
+}
+
+export const test = ({ objectA, objectB }) => {
+  return isDeepEqual(objectA, objectB)
+}
+
+export const output = false


### PR DESCRIPTION
I added this function in #4276 but missed a test case. When the second value doesn't have the key it triggers an exception.

This isn't critical for simple use cases, but my team just started using nested objects as mark values and we instantly hit the bug.
