### PR TITLE
Fix unhangRange to respect voids

### DIFF
--- a/.changeset/metal-tomatoes-beg.md
+++ b/.changeset/metal-tomatoes-beg.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+unhangRange treats void elements as having content

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1620,7 +1620,6 @@ export const Editor: EditorInterface = {
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
     if (
-      start.offset !== 0 ||
       end.offset !== 0 ||
       Boolean(Editor.void(editor, { at: end.path })) ||
       Range.isCollapsed(range)

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -105,7 +105,7 @@ export const TextTransforms: TextTransforms = {
         const endOfDoc = Editor.end(editor, [])
 
         if (!Point.equals(end, endOfDoc)) {
-          at = Editor.unhangRange(editor, at, { voids })
+          at = Editor.unhangRange(editor, at)
         }
       }
 

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-void.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-void.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block void>
+      <text />
+    </block>
+  </editor>
+)
+export const test = editor => {
+  const range = {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [1, 0], offset: 0 },
+  }
+  return {
+    voidsTrue: Editor.unhangRange(editor, range, { voids: true }),
+    voidsFalse: Editor.unhangRange(editor, range),
+  }
+}
+export const output = {
+  voidsTrue: {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [1, 0], offset: 0 },
+  },
+  voidsFalse: {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 0], offset: 3 },
+  },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-void.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-void.tsx
@@ -11,22 +11,12 @@ export const input = (
   </editor>
 )
 export const test = editor => {
-  const range = {
+  return Editor.unhangRange(editor, {
     anchor: { path: [0, 0], offset: 0 },
     focus: { path: [1, 0], offset: 0 },
-  }
-  return {
-    voidsTrue: Editor.unhangRange(editor, range, { voids: true }),
-    voidsFalse: Editor.unhangRange(editor, range),
-  }
+  })
 }
 export const output = {
-  voidsTrue: {
-    anchor: { path: [0, 0], offset: 0 },
-    focus: { path: [1, 0], offset: 0 },
-  },
-  voidsFalse: {
-    anchor: { path: [0, 0], offset: 0 },
-    focus: { path: [0, 0], offset: 3 },
-  },
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 0 },
 }

--- a/packages/slate/test/interfaces/Editor/unhangRange/block.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block.tsx
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>one</block>
+    <block>
+      <text />
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [1, 0], offset: 0 },
+  })
+}
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/inline-void.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/inline-void.tsx
@@ -14,22 +14,12 @@ export const input = (
   </editor>
 )
 export const test = editor => {
-  const range = {
+  return Editor.unhangRange(editor, {
     anchor: { path: [0, 0], offset: 0 },
     focus: { path: [0, 2], offset: 0 },
-  }
-  return {
-    voidsTrue: Editor.unhangRange(editor, range, { voids: true }),
-    voidsFalse: Editor.unhangRange(editor, range),
-  }
+  })
 }
 export const output = {
-  voidsTrue: {
-    anchor: { path: [0, 0], offset: 0 },
-    focus: { path: [0, 1, 0], offset: 0 },
-  },
-  voidsFalse: {
-    anchor: { path: [0, 0], offset: 0 },
-    focus: { path: [0, 0], offset: 3 },
-  },
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 1, 0], offset: 0 },
 }

--- a/packages/slate/test/interfaces/Editor/unhangRange/inline-void.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/inline-void.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>one</text>
+      <inline void>
+        <text />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const test = editor => {
+  const range = {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 2], offset: 0 },
+  }
+  return {
+    voidsTrue: Editor.unhangRange(editor, range, { voids: true }),
+    voidsFalse: Editor.unhangRange(editor, range),
+  }
+}
+export const output = {
+  voidsTrue: {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 1, 0], offset: 0 },
+  },
+  voidsFalse: {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 0], offset: 3 },
+  },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/inline.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/inline.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>one</text>
+      <inline>
+        <text />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.unhangRange(editor, {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 2], offset: 0 },
+  })
+}
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/start-in-middle.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/start-in-middle.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>notbold</text>
+      <text bold>bold</text>
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.unhangRange(editor, {
+    anchor: { path: [0, 0], offset: 2 },
+    focus: { path: [0, 1], offset: 0 },
+  })
+}
+export const output = {
+  anchor: { path: [0, 0], offset: 2 },
+  focus: { path: [0, 0], offset: 7 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/text.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/text.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>notbold</text>
+      <text bold>bold</text>
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.unhangRange(editor, {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 1], offset: 0 },
+  })
+}
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 7 },
+}

--- a/packages/slate/test/transforms/delete/selection/block-across-nested.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-across-nested.tsx
@@ -3,7 +3,7 @@ import { Transforms } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.delete(editor)
+  Transforms.delete(editor, { hanging: true })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/delete/selection/block-depths-nested.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-depths-nested.tsx
@@ -3,7 +3,7 @@ import { Transforms } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.delete(editor)
+  Transforms.delete(editor, { hanging: true })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/delete/selection/block-join-edges.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-join-edges.tsx
@@ -3,7 +3,7 @@ import { Transforms } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.delete(editor)
+  Transforms.delete(editor, { hanging: true })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/delete/selection/block-join-inline.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-join-inline.tsx
@@ -3,7 +3,7 @@ import { Transforms } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.delete(editor)
+  Transforms.delete(editor, { hanging: true })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/delete/selection/block-join-nested.tsx
+++ b/packages/slate/test/transforms/delete/selection/block-join-nested.tsx
@@ -3,7 +3,7 @@ import { Transforms } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.delete(editor)
+  Transforms.delete(editor, { hanging: true })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/delete/voids-false/block-hanging-into.tsx
+++ b/packages/slate/test/transforms/delete/voids-false/block-hanging-into.tsx
@@ -23,6 +23,7 @@ export const output = (
     <block>
       <cursor />
     </block>
+    <block void>two</block>
     <block>three</block>
   </editor>
 )

--- a/packages/slate/test/transforms/delete/voids-false/block-hanging-into.tsx
+++ b/packages/slate/test/transforms/delete/voids-false/block-hanging-into.tsx
@@ -23,7 +23,6 @@ export const output = (
     <block>
       <cursor />
     </block>
-    <block void>two</block>
     <block>three</block>
   </editor>
 )


### PR DESCRIPTION
**Description**
When dealing with void elements, unhangRange would treat a range in a void the same as any other element. Conceptually since a void only has that single point to represent content, it shouldn't be treated as hanging in that case. 

In addition, this updated the method to fix two other issues that cropped up when writing the tests for it.
1. Drop the `voids` option entirely, and just perform the above behavior. The reason for that change is that it's somewhat unclear what this option even means for 'unhanging' a range. `voids` is a property of what is traversed/fetched _at_ a location, while the range itself _is_ a location. 

    For example if I pass `voids: false`, but the range I pass in has focus sitting inside a void, what should happen? The range isn't considered 'hanging' by the new definition above, but should we still move the focus because it's in a void? 

    This is also supported by the fact that:
     - A previous version I made of this change (See just the first commit) tried to respect the flag, however this pre-existing [test](https://github.com/ianstormtaylor/slate/blob/main/packages/slate/test/transforms/delete/voids-false/block-hanging-into.tsx#L15) has a range ending in a void, and the expected output is actually that the range does _not_ get modified. This test only passed because we were passing `voids: false` to our traversal and also skipping the first node due to the `skip = true` flag, effectively skipping 2 nodes instead of just 1. Fixing that 'bug' caused the test to fail and not have the desired behavior. 
     - We only ever actually forwarded the 'voids' option to this method in one place, most locations that call it do not pass a voids option, despite having an upstream param for it. 
2. Remove the 'start !== 0' optimization, since the code only unhangs the 'end', it was actually excluding ranges that were hanging, because the start was in the middle of a node.

**Example**

If you had the following situation today
```
<block>
  <text>Some text<anchor></text>
  <inline void><text/></inline void>
  <text><focus></text>
</block>

```
and wanted to perform an operation that included the void node but did not include the trailing empty text, (i.e., unhang the range), that would not be possible since we would skip over the empty text 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

