### PR TITLE
Fix setNodes when called with 'split' and a collapsed range

### DIFF
--- a/.changeset/sharp-donkeys-sparkle.md
+++ b/.changeset/sharp-donkeys-sparkle.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix setNodes when called with 'split' and a collapsed range

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -222,12 +222,16 @@ export const Range: RangeInterface = {
       let affinityFocus: 'forward' | 'backward' | null
 
       if (affinity === 'inward') {
+        // If the range is collapsed, make sure to use the same affinity to
+        // avoid the two points passing each other and expanding in the opposite
+        // direction
+        const isCollapsed = Range.isCollapsed(r)
         if (Range.isForward(r)) {
           affinityAnchor = 'forward'
-          affinityFocus = 'backward'
+          affinityFocus = isCollapsed ? affinityAnchor : 'backward'
         } else {
           affinityAnchor = 'backward'
-          affinityFocus = 'forward'
+          affinityFocus = isCollapsed ? affinityAnchor : 'forward'
         }
       } else if (affinity === 'outward') {
         if (Range.isForward(r)) {

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -594,9 +594,12 @@ export const NodeTransforms: NodeTransforms = {
       }
 
       if (split && Range.isRange(at)) {
-        if (Range.isCollapsed(at)) {
-          // If the range is collapsed and 'split' is true, there's nothing to
-          // style that won't get normalized away
+        if (
+          Range.isCollapsed(at) &&
+          Editor.leaf(editor, at.anchor)[0].text.length > 0
+        ) {
+          // If the range is collapsed in a non-empty node and 'split' is true in a non, there's nothing to
+          // set that won't get normalized away
           return
         }
         const rangeRef = Editor.rangeRef(editor, at, { affinity: 'inward' })

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -594,6 +594,11 @@ export const NodeTransforms: NodeTransforms = {
       }
 
       if (split && Range.isRange(at)) {
+        if (Range.isCollapsed(at)) {
+          // If the range is collapsed and 'split' is true, there's nothing to
+          // style that won't get normalized away
+          return
+        }
         const rangeRef = Editor.rangeRef(editor, at, { affinity: 'inward' })
         const [start, end] = Range.edges(at)
         const splitMode = mode === 'lowest' ? 'lowest' : 'highest'

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -598,7 +598,7 @@ export const NodeTransforms: NodeTransforms = {
           Range.isCollapsed(at) &&
           Editor.leaf(editor, at.anchor)[0].text.length > 0
         ) {
-          // If the range is collapsed in a non-empty node and 'split' is true in a non, there's nothing to
+          // If the range is collapsed in a non-empty node and 'split' is true, there's nothing to
           // set that won't get normalized away
           return
         }

--- a/packages/slate/test/interfaces/Range/transform/inward-collapsed.tsx
+++ b/packages/slate/test/interfaces/Range/transform/inward-collapsed.tsx
@@ -1,0 +1,34 @@
+import { Range } from 'slate'
+
+export const input = {
+  anchor: {
+    path: [0, 0],
+    offset: 1,
+  },
+  focus: {
+    path: [0, 0],
+    offset: 1,
+  },
+}
+export const test = value => {
+  return Range.transform(
+    value,
+    {
+      type: 'split_node',
+      path: [0, 0],
+      position: 1,
+      properties: {},
+    },
+    { affinity: 'inward' }
+  )
+}
+export const output = {
+  anchor: {
+    path: [0, 1],
+    offset: 0,
+  },
+  focus: {
+    path: [0, 1],
+    offset: 0,
+  },
+}

--- a/packages/slate/test/transforms/setNodes/split/noop-collapsed.tsx
+++ b/packages/slate/test/transforms/setNodes/split/noop-collapsed.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { Transforms, Text } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.setNodes(
+    editor,
+    { someKey: true },
+    { match: Text.isText, split: true }
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      w<cursor />
+      ord
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      w<cursor />
+      ord
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
When calling 'setNodes' with a collapsed range, and `split: true`, what should happen is nothing, (`split` means we want to style whatever is in between the two points, which will be nothing), however we were seeing a full node get styled as if a split never occurred. Tracked it down to two issues:

- When a range is already collapsed and the affinity was 'inward' (the default), it was possible to end up going too far 'inward' and have the anchor push past the focus. This change detects that case and just leaves it collapsed, preferring whichever direction the anchor would be moving. 
- setNodes uses this transform as part of a rangeRef to track edits while it splits the nodes at the provided range. Because the range was collapsed the rangeRef would end up outside the target of the split, and set properties on the whole node, even with the above fix to 'inward' affinity because we don't have enough context to know which direction to move in the collapsed case for the two splits. Since it should be a noop anyway for non-empty text nodes, just early return when we detect that case

Technically only the 2nd fix is needed to prevent setNodes from doing the wrong thing, but the range transform seemed incorrect either way

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

