### PR TITLE
Fix - delete selected inline void in chrome

### DIFF
--- a/.changeset/loud-planets-count.md
+++ b/.changeset/loud-planets-count.md
@@ -1,0 +1,5 @@
+---
+"slate-react": patch
+---
+
+Fix - delete selected inline void in chrome

--- a/.changeset/loud-planets-count.md
+++ b/.changeset/loud-planets-count.md
@@ -1,5 +1,5 @@
 ---
-"slate-react": patch
+'slate-react': patch
 ---
 
 Fix - delete selected inline void in chrome

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1213,7 +1213,7 @@ export const Editable = (props: EditableProps) => {
                         Editor.isInline(editor, currentNode)
                       ) {
                         event.preventDefault()
-                        Transforms.delete(editor, { unit: 'block' })
+                        Editor.deleteBackward(editor, { unit: 'block' })
 
                         return
                       }


### PR DESCRIPTION
**Description**
When you select an inline void element, and delete it (press "backspace"), no editor command are fired.
A `Transform.deleteBackward` is called instead.
[Ref in the code](https://github.com/ianstormtaylor/slate/blob/35b722cadd8ae594e6f83e2195682ba64bc79850/packages/slate-react/src/components/editable.tsx#L1196)
The problem: when you want to override default Editor's commands: that obviously doesn't work.

**Expectation**
Call `Editor.deleteBackward` instead of `Transforms.deleteBackward`.

**Environment**
- Slate React Version: 0.65.3
- Browser: Chrome, Safari

**Context**
[Issue 4525](https://github.com/ianstormtaylor/slate/issues/4525)