### PR TITLE
Fix erroneous text after native insert

### DIFF
--- a/.changeset/light-gorillas-train.md
+++ b/.changeset/light-gorillas-train.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix erroneous text after native insert

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -308,10 +308,6 @@ export const Editable = (props: EditableProps) => {
           }
         }
 
-        if (!native) {
-          event.preventDefault()
-        }
-
         // COMPAT: For the deleting forward/backward input types we don't want
         // to change the selection because it is the range that will be deleted,
         // and those commands determine that for themselves.
@@ -425,7 +421,9 @@ export const Editable = (props: EditableProps) => {
               // Only insertText operations use the native functionality, for now.
               // Potentially expand to single character deletes, as well.
               if (native) {
-                asNative(editor, () => Editor.insertText(editor, data))
+                asNative(editor, () => Editor.insertText(editor, data), {
+                  onFlushed: () => (native = false),
+                })
               } else {
                 Editor.insertText(editor, data)
               }
@@ -433,6 +431,10 @@ export const Editable = (props: EditableProps) => {
 
             break
           }
+        }
+
+        if (!native) {
+          event.preventDefault()
         }
       }
     },


### PR DESCRIPTION
**Description**

The code was backing out of a native insert if there are ops other than insert_text, but at that point the decision to preventDefault was already made. The PR takes into account the flush as well, and does a prevent default in case a flush has occured.

**Issue**

Fixes: #4527

**Notes**

Refactored asNative to record previous state and reset it in a finally clause. A variable is set, so the function should clean up after itself, to put it tersely. Also, captured the previous state of AS_NATIVE, as to account for potential nesting of the calls.

**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

