### PR TITLE
Fix `toSlatePoint()` when text node ends in `\n` in Firefox

### DIFF
--- a/.changeset/firefox-newline-bug.md
+++ b/.changeset/firefox-newline-bug.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fixed a bug that caused the editor to be unable to resolve a Slate point from a DOM point when selecting an entire document that ended in a new line in Firefox.


### PR DESCRIPTION
### Description
In Firefox, selecting the entire contents of a document via <kbd>Ctrl+A</kbd> causes the editor to crash when the document ends with a `\n` character.

Refer to the issue below for more specific replication steps.

### Issue
Fixes: https://github.com/ianstormtaylor/slate/issues/4373

### Example

#### Before

https://user-images.githubusercontent.com/1416436/134738138-60a927c6-ea82-429e-9aac-cbf46e3515bf.mp4

#### After

https://user-images.githubusercontent.com/1416436/134738159-4367050d-3bfc-454a-8a3c-9d37aefc5869.mp4


### Context
In Firefox, `range.cloneContents()` returns an extra trailing `\n`, when the document ends with a new-line character. This results in the offset length being off by one, so we need to subtract one to account for this.

#### Chrome:

<img width="1031" alt="Screen Shot 2021-09-24 at 4 44 44 PM" src="https://user-images.githubusercontent.com/1416436/134737701-0b594285-4493-4707-b582-ef274e628d14.png">

#### Firefox

<img width="1208" alt="Screen Shot 2021-09-24 at 4 45 38 PM" src="https://user-images.githubusercontent.com/1416436/134737709-139de4a2-b593-441a-87f8-a7e920c78c5a.png">


### Checks
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

