### PR TITLE
Fix deletion of expanded range

### DIFF
--- a/.changeset/modern-toes-invent.md
+++ b/.changeset/modern-toes-invent.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix deletion of expanded range (#4546)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -310,6 +310,10 @@ export const Editable = (props: EditableProps) => {
           }
         }
 
+        if (!native) {
+          event.preventDefault()
+        }
+
         // COMPAT: For the deleting forward/backward input types we don't want
         // to change the selection because it is the range that will be deleted,
         // and those commands determine that for themselves.
@@ -424,7 +428,7 @@ export const Editable = (props: EditableProps) => {
               // Potentially expand to single character deletes, as well.
               if (native) {
                 asNative(editor, () => Editor.insertText(editor, data), {
-                  onFlushed: () => (native = false),
+                  onFlushed: () => event.preventDefault(),
                 })
               } else {
                 Editor.insertText(editor, data)
@@ -433,10 +437,6 @@ export const Editable = (props: EditableProps) => {
 
             break
           }
-        }
-
-        if (!native) {
-          event.preventDefault()
         }
       }
     },


### PR DESCRIPTION
**Context**

In #4529, i wanted to have a single `event.preventDefault()` for the entire callback, but missed an early return. Here, I've put the `preventDefault` call back to where it was, and called it again from the `onFlushed` callback.

**Issue**
Fixes: #4546 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

