### PR TITLE
Only apply Firefox `toSlatePoint()` offset fix when the cloned contents end in `\n\n`

### DIFF
--- a/.changeset/firefox-newline-fix.md
+++ b/.changeset/firefox-newline-fix.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Only apply Firefox `toSlatePoint()` offset fix when the cloned contents end in `\n\n` instead of just `\n`.

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -515,7 +515,7 @@ export const ReactEditor = {
           // COMPAT: In Firefox, `range.cloneContents()` returns an extra trailing '\n'
           // when the document ends with a new-line character. This results in the offset
           // length being off by one, so we need to subtract one to account for this.
-          (IS_FIREFOX && domNode.textContent?.endsWith('\n')))
+          (IS_FIREFOX && domNode.textContent?.endsWith('\n\n')))
       ) {
         offset--
       }


### PR DESCRIPTION
**Description**
This PR follows up on #4547.

**Context**
I meant to update the PR to only apply the offset fix when the cloned textContent ends in `\n\n` instead of `\n` but didn't get a chance to push that up before it was merged.

The rationale for this change is that we only need to apply this fix for the specific edge-case where Firefox returns `\n\n` for the `textContent` of the cloned range. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

