### PR TITLE
fix forced update in TextString in case of double render

### DIFF
--- a/.changeset/smart-eyes-enjoy.md
+++ b/.changeset/smart-eyes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix forced update in TextString in case of double render

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -59,17 +59,17 @@ const TextString = (props: { text: string; isTrailing?: boolean }) => {
   const { text, isTrailing = false } = props
 
   const ref = useRef<HTMLSpanElement>(null)
-  const forceUpdateFlag = useRef(false)
+  const forceUpdateCount = useRef(0)
 
   if (ref.current && ref.current.textContent !== text) {
-    forceUpdateFlag.current = !forceUpdateFlag.current
+    forceUpdateCount.current += 1
   }
 
   // This component may have skipped rendering due to native operations being
   // applied. If an undo is performed React will see the old and new shadow DOM
   // match and not apply an update. Forces each render to actually reconcile.
   return (
-    <span data-slate-string ref={ref} key={forceUpdateFlag.current ? 'A' : 'B'}>
+    <span data-slate-string ref={ref} key={forceUpdateCount.current}>
       {text}
       {isTrailing ? '\n' : null}
     </span>


### PR DESCRIPTION
**Description**
In #3888 the following code was added to force a re-render when an operation has been applied to the DOM but not reflected in the Slate representation:
``` ts
const TextString = (props: { text: string; isTrailing?: boolean }) => {
  ...

  if (ref.current && ref.current.textContent !== text) {
    forceUpdateFlag.current = !forceUpdateFlag.current
  }

  // This component may have skipped rendering due to native operations being
  // applied. If an undo is performed React will see the old and new shadow DOM
  // match and not apply an update. Forces each render to actually reconcile.
  return (
    <span data-slate-string ref={ref} key={forceUpdateFlag.current ? 'A' : 'B'}>
    ...
```

However, in certain cases (e.g. running in React dev mode under a `<React.StrictMode>`) the render function may be called twice; when this happens, the `forceUpdateFlag` is flipped twice, producing the same `key`, so the `<span>` is not redrawn when it should be. This can result in doubled characters with decorations (see #4445).

To fix it, instead of keeping a flag and setting the `key` to `'A'` or `'B'`, we keep a count, increment it (instead of flipping the flag), and use its value as the `key`; this still works when the render function is called twice.

**Issue**
Fixes: #4445 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

