### PR TITLE
Fix issue with Unicode 1.1 smileys

### DIFF
--- a/.changeset/bright-seahorses-share.md
+++ b/.changeset/bright-seahorses-share.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Fix issue with unicode 1.1 smileys followed by a variation selector.

--- a/packages/slate/test/utils/string.ts
+++ b/packages/slate/test/utils/string.ts
@@ -10,13 +10,26 @@ const codepoints = [
   ['0', 1],
   [' ', 1],
   ['🙂', 2],
+  ['☺️', 2],
+  ['☺️', 2],
   ['⬅️', 2],
   ['🏴', 2],
+  ['☺️a', 2, 1],
+  ['🏁🇨🇳', 2, 4],
+  ['🎌🇩🇪', 2, 4],
+  ['🚩🇺🇸', 2, 4],
+  ['🇨🇳🎌', 4, 2],
+  ['🏴🏳️', 2, 3],
+  ['🇷🇺🚩', 4, 2],
 ] as const
 
 const zwjSequences = [
   ['👁‍🗨', 5],
   ['👨‍👩‍👧‍👧', 11],
+  ['👩‍❤️‍👨', 8],
+  ['🙋🏽‍♂️', 7],
+  ['🙋‍♂️', 5],
+  ['🕵️‍♀️', 6],
   ['👨🏿‍🦳', 7],
 ] as const
 
@@ -60,7 +73,9 @@ dirs.forEach(dir => {
   const isRTL = dir === 'rtl'
 
   describe(`getCharacterDistance - ${dir}`, () => {
-    codepoints.forEach(([str, dist]) => {
+    codepoints.forEach(([str, ltrDist, rtlDist]) => {
+      const dist = isRTL && rtlDist != null ? rtlDist : ltrDist
+
       it(str, () => {
         assert.strictEqual(getCharacterDistance(str + str, isRTL), dist)
       })


### PR DESCRIPTION
**Description**

This PR follows up on #4326. @gitcatrat found an issue with some older Unicode 1.1 smileys.

**Example**

Before:

https://user-images.githubusercontent.com/203411/135591426-237a9c26-1515-437e-a76c-6a9ac1dc03db.mp4

After:

https://user-images.githubusercontent.com/203411/135591553-53e61645-fa65-4692-a0cd-179af364469d.mp4

**Context**

`getCharacterDistance` does not use a whitelist anymore. If a character is followed by a variation selector, it is considered a sequence no matter what the character is. Also I tried to make the function more readable by reorganizing the code and adding a few comments.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

