### PR TITLE
Fix boolean not assignable to string typescript error

### DIFF
--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -66,9 +66,9 @@ const toggleBlock = (editor, format) => {
 
   Transforms.unwrapNodes(editor, {
     match: n =>
-      LIST_TYPES.includes(
-        !Editor.isEditor(n) && SlateElement.isElement(n) && n.type
-      ),
+      !Editor.isEditor(n) &&
+      SlateElement.isElement(n) &&
+      LIST_TYPES.includes(n.type),
     split: true,
   })
   const newProperties: Partial<SlateElement> = {


### PR DESCRIPTION
**Description**
This PR fixes the following error thrown on `match: n => LIST_TYPES.includes(!Editor.isEditor(n) && SlateElement.isElement(n) && n.type)` when attempting to run the [richtext](https://github.com/ianstormtaylor/slate/blob/main/site/examples/richtext.tsx) example code in Typescript:
```
Argument of type 'string | boolean' is not assignable to parameter of type 'string'.
  Type 'boolean' is not assignable to type 'string'
```
Since `LIST_TYPES` is a list of strings, Typescript expects the argument of `includes` to be a `string` as well. I've moved the other conditions outside the `includes` function to fix it.

**Example**
![error_screenshot](https://user-images.githubusercontent.com/12792882/135973036-76eaeea1-c27f-4188-8fe4-cdd37f7ea957.png)

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

