### PR TITLE
Don't remove selection when hovering over a non-selectable node

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -505,8 +505,6 @@ export const Editable = (props: EditableProps) => {
             exactMatch: false,
           })
           Transforms.select(editor, range)
-        } else {
-          Transforms.deselect(editor)
         }
       }
     }, 100),


### PR DESCRIPTION
**Description**

To reproduce the buggy behavior:

1. Go to https://codepen.io/jameshfisher/pen/OJgoeYw, or create a page that renders a Slate element with a `contentEditable: false` element in it.
2. Start selecting some text with the mouse.
3. During the drag, mouseover the `contentEditable: false` element.

Expected behavior: After doing a drag-to-select with the mouse, from a valid anchor point on mousedown to a valid focus point on mouseup, the selection is set to those anchor and focus points.

Actual behavior: your selection is removed as soon as your mouse hits the `contentEditable: false` element. This is because the current behavior clears the selection if it is momentarily not a valid Slate location.

**Recording of buggy behavior**

https://user-images.githubusercontent.com/166966/134682439-8bd7dcbf-5ee0-45bb-a2ea-545582a28f3a.mp4

**Issue**
Fixes https://github.com/ianstormtaylor/slate/issues/4545

**Context**
If the focus is momentarily not 

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)