### PR TITLE
in examples, move withReact in front of withHistory

### DIFF
--- a/site/examples/check-lists.tsx
+++ b/site/examples/check-lists.tsx
@@ -69,7 +69,7 @@ const CheckListsExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const renderElement = useCallback(props => <Element {...props} />, [])
   const editor = useMemo(
-    () => withChecklists(withHistory(withReact(createEditor()))),
+    () => withReact(withChecklists(withHistory(createEditor()))),
     []
   )
 

--- a/site/examples/code-highlighting.tsx
+++ b/site/examples/code-highlighting.tsx
@@ -13,7 +13,7 @@ const CodeHighlightingExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const [language, setLanguage] = useState('html')
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
 
   // decorate function depends on the language selected
   const decorate = useCallback(
@@ -99,7 +99,7 @@ const Leaf = ({ attributes, children, leaf }) => {
         ${leaf.comment &&
           css`
             color: slategray;
-          `} 
+          `}
 
         ${(leaf.operator || leaf.url) &&
           css`

--- a/site/examples/custom-placeholder.tsx
+++ b/site/examples/custom-placeholder.tsx
@@ -5,7 +5,7 @@ import { withHistory } from 'slate-history'
 
 const PlainTextExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>
       <Editable

--- a/site/examples/editable-voids.tsx
+++ b/site/examples/editable-voids.tsx
@@ -11,7 +11,7 @@ import { EditableVoidElement } from './custom-types'
 const EditableVoidsExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const editor = useMemo(
-    () => withEditableVoids(withHistory(withReact(createEditor()))),
+    () => withReact(withEditableVoids(withHistory(createEditor()))),
     []
   )
 

--- a/site/examples/embeds.tsx
+++ b/site/examples/embeds.tsx
@@ -15,7 +15,7 @@ import {
 
 const EmbedsExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withEmbeds(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withEmbeds(createEditor())), [])
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>
       <Editable

--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -65,7 +65,7 @@ const ForcedLayoutExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const renderElement = useCallback(props => <Element {...props} />, [])
   const editor = useMemo(
-    () => withLayout(withHistory(withReact(createEditor()))),
+    () => withReact(withLayout(withHistory(createEditor()))),
     []
   )
   return (

--- a/site/examples/hovering-toolbar.tsx
+++ b/site/examples/hovering-toolbar.tsx
@@ -16,7 +16,7 @@ import { Button, Icon, Menu, Portal } from '../components'
 
 const HoveringMenuExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
 
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>

--- a/site/examples/iframe.tsx
+++ b/site/examples/iframe.tsx
@@ -21,7 +21,7 @@ const IFrameExample = () => {
     []
   )
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
 
   const handleBlur = useCallback(() => ReactEditor.deselect(editor), [editor])
 

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -19,7 +19,7 @@ import { ImageElement } from './custom-types'
 const ImagesExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const editor = useMemo(
-    () => withImages(withHistory(withReact(createEditor()))),
+    () => withImages(withReact(withHistory(createEditor()))),
     []
   )
 

--- a/site/examples/links.tsx
+++ b/site/examples/links.tsx
@@ -17,7 +17,7 @@ import { Button, Icon, Toolbar } from '../components'
 const LinkExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const editor = useMemo(
-    () => withLinks(withHistory(withReact(createEditor()))),
+    () => withLinks(withReact(withHistory(createEditor()))),
     []
   )
 

--- a/site/examples/markdown-preview.tsx
+++ b/site/examples/markdown-preview.tsx
@@ -11,7 +11,7 @@ import { css } from 'emotion'
 const MarkdownPreviewExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
   const decorate = useCallback(([node, path]) => {
     const ranges = []
 

--- a/site/examples/markdown-shortcuts.tsx
+++ b/site/examples/markdown-shortcuts.tsx
@@ -29,7 +29,7 @@ const MarkdownShortcutsExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const renderElement = useCallback(props => <Element {...props} />, [])
   const editor = useMemo(
-    () => withShortcuts(withReact(withHistory(createEditor()))),
+    () => withReact(withShortcuts(withHistory(createEditor()))),
     []
   )
   return (

--- a/site/examples/mentions.tsx
+++ b/site/examples/mentions.tsx
@@ -21,7 +21,7 @@ const MentionExample = () => {
   const [search, setSearch] = useState('')
   const renderElement = useCallback(props => <Element {...props} />, [])
   const editor = useMemo(
-    () => withMentions(withReact(withHistory(createEditor()))),
+    () => withReact(withMentions(withHistory(createEditor()))),
     []
   )
 

--- a/site/examples/plaintext.tsx
+++ b/site/examples/plaintext.tsx
@@ -5,7 +5,7 @@ import { withHistory } from 'slate-history'
 
 const PlainTextExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>
       <Editable placeholder="Enter some plain text..." />

--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -25,7 +25,7 @@ const RichTextExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const renderElement = useCallback(props => <Element {...props} />, [])
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
 
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>

--- a/site/examples/scroll-into-view.tsx
+++ b/site/examples/scroll-into-view.tsx
@@ -50,7 +50,7 @@ const ScrollIntoViewExample = () => {
 
 const PlainTextEditor = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>
       <Editable placeholder="Enter some plain text..." />

--- a/site/examples/search-highlighting.tsx
+++ b/site/examples/search-highlighting.tsx
@@ -9,7 +9,7 @@ import { Icon, Toolbar } from '../components'
 const SearchHighlightingExample = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
   const [search, setSearch] = useState<string | undefined>()
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
   const decorate = useCallback(
     ([node, path]) => {
       const ranges = []

--- a/site/examples/shadow-dom.tsx
+++ b/site/examples/shadow-dom.tsx
@@ -29,7 +29,7 @@ const ShadowDOM = () => {
 
 const ShadowEditor = () => {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(() => withReact(withHistory(createEditor())), [])
 
   return (
     <Slate editor={editor} value={value} onChange={value => setValue(value)}>

--- a/site/examples/tables.tsx
+++ b/site/examples/tables.tsx
@@ -15,7 +15,7 @@ const TablesExample = () => {
   const renderElement = useCallback(props => <Element {...props} />, [])
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
   const editor = useMemo(
-    () => withTables(withHistory(withReact(createEditor()))),
+    () => withReact(withTables(withHistory(createEditor()))),
     []
   )
   return (


### PR DESCRIPTION
**Description**
PR #3888 defers some operations in `editor.apply` via `withReact`. This interacts badly with the `editor.apply` in `withHistory` if `withHistory` is applied outside `withReact`. This change moves `withReact` outside `withHistory` in all the site examples.

For most examples I put `withReact` outside all the other plugins, but for a few (like the images example) the `withReact` override of `insertData` conflicts with the `insertData` in the examples plugin, so I put `withReact` inside the example's plugin.

**Issue**
Fixes: #4530

**Example**
Current behavior:
![](http://g.recordit.co/GpZltGaVRx.gif)

New behavior:
![](http://g.recordit.co/r7Oapv8trv.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

I didn't add a changeset because this isn't code that goes in released packages.

