### PR TITLE
Add missing insertFragmentData and insertTextData on the ReactEditor class

### DIFF
--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -231,6 +231,22 @@ export const ReactEditor = {
   },
 
   /**
+   * Insert fragment data from a `DataTransfer` into the editor.
+   */
+
+  insertFragmentData(editor: ReactEditor, data: DataTransfer): void {
+    editor.insertFragmentData(data)
+  },
+
+  /**
+   * Insert text data from a `DataTransfer` into the editor.
+   */
+
+  insertTextData(editor: ReactEditor, data: DataTransfer): void {
+    editor.insertTextData(data)
+  },
+
+  /**
    * Sets data from the currently selected fragment on a `DataTransfer`.
    */
 


### PR DESCRIPTION
This is a follow-up of https://github.com/ianstormtaylor/slate/pull/4614 to add missing public-facing method `insertFragmentData` and `insertTextData` on the ReactEditor class