### PR TITLE
fix: image disappears when the drag fails

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -941,7 +941,11 @@ export const Editable = (props: EditableProps) => {
                 Transforms.select(editor, range)
 
                 if (state.isDraggingInternally) {
-                  if (draggedRange) {
+                  if (
+                    draggedRange &&
+                    !Range.equals(draggedRange, range) &&
+                    !Editor.void(editor, { at: range, voids: true })
+                  ) {
                     Transforms.delete(editor, {
                       at: draggedRange,
                     })


### PR DESCRIPTION
**Description**
image disappears when the drag fails

**Example**
before
![Kapture 2021-10-26 at 18 53 46](https://user-images.githubusercontent.com/42615243/138864024-85a0387c-61e8-47b1-b5e4-676ef09ee904.gif)

after
![Kapture 2021-10-26 at 19 01 41](https://user-images.githubusercontent.com/42615243/138865136-324093a6-8ef5-497d-98ba-63855c27ef21.gif)

**Context**
drag the failed image to stay in place

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

