### PR TITLE
Improve `props` argument type in `Transforms.setNodes()` 

### DIFF
--- a/.changeset/late-spoons-cheer.md
+++ b/.changeset/late-spoons-cheer.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Improve typescript type of `props` argument of `Transforms.setNodes()`

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -67,7 +67,7 @@ export interface NodeTransforms {
   ) => void
   setNodes: <T extends Node>(
     editor: Editor,
-    props: Partial<Node>,
+    props: Partial<T>,
     options?: {
       at?: Location
       match?: NodeMatch<T>

--- a/site/examples/embeds.tsx
+++ b/site/examples/embeds.tsx
@@ -73,7 +73,9 @@ const VideoElement = ({ attributes, children, element }) => {
             const newProperties: Partial<SlateElement> = {
               url: val,
             }
-            Transforms.setNodes(editor, newProperties, { at: path })
+            Transforms.setNodes<SlateElement>(editor, newProperties, {
+              at: path,
+            })
           }}
         />
       </div>

--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -37,7 +37,9 @@ const withLayout = editor => {
         const enforceType = type => {
           if (SlateElement.isElement(child) && child.type !== type) {
             const newProperties: Partial<SlateElement> = { type }
-            Transforms.setNodes(editor, newProperties, { at: childPath })
+            Transforms.setNodes<SlateElement>(editor, newProperties, {
+              at: childPath,
+            })
           }
         }
 

--- a/site/examples/markdown-shortcuts.tsx
+++ b/site/examples/markdown-shortcuts.tsx
@@ -67,7 +67,7 @@ const withShortcuts = editor => {
         const newProperties: Partial<SlateElement> = {
           type,
         }
-        Transforms.setNodes(editor, newProperties, {
+        Transforms.setNodes<SlateElement>(editor, newProperties, {
           match: n => Editor.isBlock(editor, n),
         })
 

--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -74,7 +74,7 @@ const toggleBlock = (editor, format) => {
   const newProperties: Partial<SlateElement> = {
     type: isActive ? 'paragraph' : isList ? 'list-item' : format,
   }
-  Transforms.setNodes(editor, newProperties)
+  Transforms.setNodes<SlateElement>(editor, newProperties)
 
   if (!isActive && isList) {
     const block = { type: format, children: [] }


### PR DESCRIPTION
**Description**

Because Typescript can know which type of nodes we are modifying thanks to the `T` type inferred from the `match` function, if available, it can also properly narrow down the `props` argument type.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

