### PR TITLE
Do not try to disable Grammarly in Slate

### DIFF
--- a/.changeset/wet-lobsters-travel.md
+++ b/.changeset/wet-lobsters-travel.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Do not disable Grammarly extension in Slate editors

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -567,10 +567,6 @@ export const Editable = (props: EditableProps) => {
     <ReadOnlyContext.Provider value={readOnly}>
       <DecorateContext.Provider value={decorate}>
         <Component
-          // COMPAT: The Grammarly Chrome extension works by changing the DOM
-          // out from under `contenteditable` elements, which leads to weird
-          // behaviors so we have to disable it like editor. (2017/04/24)
-          data-gramm={false}
           role={readOnly ? undefined : 'textbox'}
           {...attributes}
           // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd


### PR DESCRIPTION
**Description**

Stop _trying_ to disable Grammarly extension from working in Slate editors.

**Issue**
Fixes: #4124 

**Example**

![Peek 2021-11-09 18-19](https://user-images.githubusercontent.com/370680/140962893-f2e1e02d-616d-4538-b536-5bc2a78fa3ed.gif)

**Context**

The Grammarly extension is not causing DOM issues anymore, as they have reworked their highlighting logic: 
https://www.grammarly.com/blog/engineering/making-grammarly-feel-native-on-every-website/

Also the `data-gramm` attribute (introduced in #733) is no longer working actually (see #4124), as the Grammarly team changed the name.

Though applying Grammarly suggestions is still broken: #4579 (but it does not break the editor, so it may be fine).

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

