### PR TITLE
fix: weak guard on DataTransfer to not rely on current window

### DIFF
--- a/.changeset/beige-hotels-vanish.md
+++ b/.changeset/beige-hotels-vanish.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+weak guard on DataTransfer to not rely on current window

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -429,9 +429,11 @@ export const Editable = (props: EditableProps) => {
               state.isComposing = false
             }
 
-            const window = ReactEditor.getWindow(editor)
-            if (data instanceof window.DataTransfer) {
-              ReactEditor.insertData(editor, data as DataTransfer)
+            // use a weak comparison instead of 'instanceof' to allow
+            // programmatic access of paste events coming from external windows
+            // like cypress where cy.window does not work realibly
+            if (data?.constructor.name === 'DataTransfer') {
+              ReactEditor.insertData(editor, data)
             } else if (typeof data === 'string') {
               // Only insertText operations use the native functionality, for now.
               // Potentially expand to single character deletes, as well.


### PR DESCRIPTION
**Description**
As previously asked in [Slack](https://slate-js.slack.com/archives/C1RH7AXSS/p1636096147185300), this helps in automated testing where it's currently not possible to properly transfer data between the host app and the application under test. The previous `instanceof window.DataTransfer` fails as Cypress is not able to properly get hold of the window object Slate is referring to (despite using [cy.window](https://docs.cypress.io/api/commands/window)). To mitigate that the check is now checking for the constructor name.


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

