### PR TITLE
Docs: first walkthrough missing TS 'Descendant' dependency

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -51,7 +51,7 @@ Of course we haven't rendered anything, so you won't see any changes.
 
 ```typescript
 // TypeScript users only add this code
-import { BaseEditor } from 'slate'
+import { BaseEditor, Descendant } from 'slate'
 import { ReactEditor } from 'slate-react'
 
 type CustomElement = { type: 'paragraph'; children: CustomText[] }


### PR DESCRIPTION
**Issue**
Fixes: the walkthrough code doesn't work for typescript without adding Descendant as a dependency
