### PR TITLE
fix: use ownerDocument to create element

### DIFF
--- a/.changeset/warm-dolphins-roll.md
+++ b/.changeset/warm-dolphins-roll.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+use ownerDocument to create element

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -168,7 +168,7 @@ export const withReact = <T extends Editor>(editor: T) => {
     // in the HTML, and can be used for intra-Slate pasting. If it's a text
     // node, wrap it in a `<span>` so we have something to set an attribute on.
     if (isDOMText(attach)) {
-      const span = document.createElement('span')
+      const span = attach.ownerDocument.createElement('span')
       // COMPAT: In Chrome and Safari, if we don't add the `white-space` style
       // then leading and trailing spaces will be ignored. (2017/09/21)
       span.style.whiteSpace = 'pre'
@@ -184,13 +184,13 @@ export const withReact = <T extends Editor>(editor: T) => {
     data.setData('application/x-slate-fragment', encoded)
 
     // Add the content to a <div> so that we can get its inner HTML.
-    const div = document.createElement('div')
+    const div = contents.ownerDocument.createElement('div')
     div.appendChild(contents)
     div.setAttribute('hidden', 'true')
-    document.body.appendChild(div)
+    contents.ownerDocument.body.appendChild(div)
     data.setData('text/html', div.innerHTML)
     data.setData('text/plain', getPlainText(div))
-    document.body.removeChild(div)
+    contents.ownerDocument.body.removeChild(div)
     return data
   }
 


### PR DESCRIPTION
**Description**
Fixed the issue that copying from editable inside iframe does not work
https://github.com/leoc4e/slate/blob/d06706c9e15bbbdd7cdd9a1bbb38c87d37c85ea1/packages/slate-react/src/utils/dom.ts#L66-L70


**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4660

**Example**
![capture](https://user-images.githubusercontent.com/20469933/141959327-de73bbee-9d8d-49c6-94a3-5acc728b0bac.gif)



**Context**
The issues is due to `getPlainText` is returning empty string in iframe.
https://github.com/leoc4e/slate/blob/272ad7ffddae8d1163e395a44dd59f66e2b0f1b0/packages/slate-react/src/plugin/with-react.ts#L191-L192

This is because `isDomNode` would check if the element is an instance of the `ownerDocument.defaultValue.Node`
(https://github.com/leoc4e/slate/blob/d06706c9e15bbbdd7cdd9a1bbb38c87d37c85ea1/packages/slate-react/src/utils/dom.ts#L66-L70)
While slate is using default document when creating the element.
This PR change to use the `ownerDocument` instead


**Checks**
- [x] The new code matches the existing patterns and styles.
-  [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

