### PR TITLE
fix: isBlockActive should use Array.from()

### DIFF
--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -96,11 +96,11 @@ const isBlockActive = (editor, format) => {
   const { selection } = editor
   if (!selection) return false
 
-  const [match] = Editor.nodes(editor, {
+  const [match] = Array.from(Editor.nodes(editor, {
     at: Editor.unhangRange(editor, selection),
     match: n =>
       !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === format,
-  })
+  }))
 
   return !!match
 }

--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -96,11 +96,13 @@ const isBlockActive = (editor, format) => {
   const { selection } = editor
   if (!selection) return false
 
-  const [match] = Array.from(Editor.nodes(editor, {
-    at: Editor.unhangRange(editor, selection),
-    match: n =>
-      !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === format,
-  }))
+  const [match] = Array.from(
+    Editor.nodes(editor, {
+      at: Editor.unhangRange(editor, selection),
+      match: n =>
+        !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === format,
+    })
+  )
 
   return !!match
 }


### PR DESCRIPTION
**Description**
The [richtext.tsx](https://github.com/ianstormtaylor/slate/blob/main/site/examples/richtext.tsx#L99) example `isBlockActive`  was not working for me in my environment because `Editor.nodes` returns a Generator, not an Array. So `isBlockActive` always returned false. Wrapping it in `Array.from` fixes the example. 

**Issue**
Fixes: #4663

**Example**
| Before | After |
| -- | -- | 
| ![before](https://user-images.githubusercontent.com/647549/142044364-cd390842-8d99-4a4e-a59d-1e345bfadd1f.gif) | ![after](https://user-images.githubusercontent.com/647549/142044401-534cbe9d-2cad-4a71-b7a2-9f222da1a439.gif) | 
| `isBlockActive` always returns `false` | `isBlockActive` properly toggles |

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

