### PR TITLE
fix: flush selection change on before input

### DIFF
--- a/.changeset/chilled-bears-lick.md
+++ b/.changeset/chilled-bears-lick.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Flush scheduleOnDOMSelectionChange on beforeinput

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -10,6 +10,7 @@ import {
   Path,
 } from 'slate'
 import getDirection from 'direction'
+import debounce from 'lodash/debounce'
 import throttle from 'lodash/throttle'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
@@ -253,6 +254,61 @@ export const Editable = (props: EditableProps) => {
     }
   }, [autoFocus])
 
+  // Listen on the native `selectionchange` event to be able to update any time
+  // the selection changes. This is required because React's `onSelect` is leaky
+  // and non-standard so it doesn't fire until after a selection has been
+  // released. This causes issues in situations where another change happens
+  // while a selection is being dragged.
+  const onDOMSelectionChange = useCallback(
+    throttle(() => {
+      if (
+        !state.isComposing &&
+        !state.isUpdatingSelection &&
+        !state.isDraggingInternally
+      ) {
+        const root = ReactEditor.findDocumentOrShadowRoot(editor)
+        const { activeElement } = root
+        const el = ReactEditor.toDOMNode(editor, editor)
+        const domSelection = root.getSelection()
+
+        if (activeElement === el) {
+          state.latestElement = activeElement
+          IS_FOCUSED.set(editor, true)
+        } else {
+          IS_FOCUSED.delete(editor)
+        }
+
+        if (!domSelection) {
+          return Transforms.deselect(editor)
+        }
+
+        const { anchorNode, focusNode } = domSelection
+
+        const anchorNodeSelectable =
+          hasEditableTarget(editor, anchorNode) ||
+          isTargetInsideVoid(editor, anchorNode)
+
+        const focusNodeSelectable =
+          hasEditableTarget(editor, focusNode) ||
+          isTargetInsideVoid(editor, focusNode)
+
+        if (anchorNodeSelectable && focusNodeSelectable) {
+          const range = ReactEditor.toSlateRange(editor, domSelection, {
+            exactMatch: false,
+            suppressThrow: false,
+          })
+          Transforms.select(editor, range)
+        }
+      }
+    }, 100),
+    [readOnly]
+  )
+
+  const scheduleOnDOMSelectionChange = useMemo(
+    () => debounce(onDOMSelectionChange, 0, { leading: false }),
+    [onDOMSelectionChange]
+  )
+
   // Listen on the native `beforeinput` event to get real "Level 2" events. This
   // is required because React's `beforeinput` is fake and never really attaches
   // to the real event sadly. (2019/11/01)
@@ -264,6 +320,11 @@ export const Editable = (props: EditableProps) => {
         hasEditableTarget(editor, event.target) &&
         !isDOMEventHandled(event, propsOnDOMBeforeInput)
       ) {
+        // Some IMEs/Chrome extensions like e.g. Grammarly set the selection immediately before
+        // triggering a `beforeinput` expecting the change to be applied to the immediately before
+        // set selection.
+        scheduleOnDOMSelectionChange.flush()
+
         const { selection } = editor
         const { inputType: type } = event
         const data = (event as any).dataTransfer || event.data || undefined
@@ -471,61 +532,6 @@ export const Editable = (props: EditableProps) => {
       }
     }
   }, [onDOMBeforeInput])
-
-  // Listen on the native `selectionchange` event to be able to update any time
-  // the selection changes. This is required because React's `onSelect` is leaky
-  // and non-standard so it doesn't fire until after a selection has been
-  // released. This causes issues in situations where another change happens
-  // while a selection is being dragged.
-  const onDOMSelectionChange = useCallback(
-    throttle(() => {
-      if (
-        !state.isComposing &&
-        !state.isUpdatingSelection &&
-        !state.isDraggingInternally
-      ) {
-        const root = ReactEditor.findDocumentOrShadowRoot(editor)
-        const { activeElement } = root
-        const el = ReactEditor.toDOMNode(editor, editor)
-        const domSelection = root.getSelection()
-
-        if (activeElement === el) {
-          state.latestElement = activeElement
-          IS_FOCUSED.set(editor, true)
-        } else {
-          IS_FOCUSED.delete(editor)
-        }
-
-        if (!domSelection) {
-          return Transforms.deselect(editor)
-        }
-
-        const { anchorNode, focusNode } = domSelection
-
-        const anchorNodeSelectable =
-          hasEditableTarget(editor, anchorNode) ||
-          isTargetInsideVoid(editor, anchorNode)
-
-        const focusNodeSelectable =
-          hasEditableTarget(editor, focusNode) ||
-          isTargetInsideVoid(editor, focusNode)
-
-        if (anchorNodeSelectable && focusNodeSelectable) {
-          const range = ReactEditor.toSlateRange(editor, domSelection, {
-            exactMatch: false,
-            suppressThrow: false,
-          })
-          Transforms.select(editor, range)
-        }
-      }
-    }, 100),
-    [readOnly]
-  )
-
-  const scheduleOnDOMSelectionChange = useCallback(
-    () => setTimeout(onDOMSelectionChange),
-    [onDOMSelectionChange]
-  )
 
   // Attach a native DOM event handler for `selectionchange`, because React's
   // built-in `onSelect` handler doesn't fire for all selection changes. It's a

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -305,7 +305,7 @@ export const Editable = (props: EditableProps) => {
   )
 
   const scheduleOnDOMSelectionChange = useMemo(
-    () => debounce(onDOMSelectionChange, 0, { leading: false }),
+    () => debounce(onDOMSelectionChange, 0),
     [onDOMSelectionChange]
   )
 


### PR DESCRIPTION
**Description**
Fixes a regression introduced by https://github.com/ianstormtaylor/slate/pull/4132.

Some IMEs/Chrome extensions like e.g. Grammarly set the selection immediately before triggering a `beforeinput` expecting the change to be applied to the immediately before set selection. Defering this selection update causes the change to be applied to an outdated selection.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4579

**Example**

Before:
![Screen Recording 2021-11-19 at 13 13 16](https://user-images.githubusercontent.com/13185548/142621372-844dbf11-b805-4ba2-adca-dea4cdfbd6f0.gif)

After:
![Screen Recording 2021-11-19 at 13 12 07](https://user-images.githubusercontent.com/13185548/142621512-8f25c72a-24ac-46eb-9aa2-f800dfee814b.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

