### PR TITLE
Fix deep-equals for array properties

### DIFF
--- a/.changeset/merge-nodes-issue
+++ b/.changeset/merge-nodes-issue
@@ -1,5 +1,0 @@
----
-"slate": patch
----
-
-Do not remove empty node in merge operation if it is first children in its parent.

--- a/.changeset/wicked-mayflies-approve.md
+++ b/.changeset/wicked-mayflies-approve.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Fix - deep-equals was always returning true when array props were equals.

--- a/packages/slate/src/utils/deep-equal.ts
+++ b/packages/slate/src/utils/deep-equal.ts
@@ -24,7 +24,6 @@ export const isDeepEqual = (
       for (let i = 0; i < a.length; i++) {
         if (a[i] !== b[i]) return false
       }
-      return true
     } else if (a !== b) {
       return false
     }

--- a/packages/slate/test/utils/deep-equal/deep-equals-with-array.js
+++ b/packages/slate/test/utils/deep-equal/deep-equals-with-array.js
@@ -1,0 +1,20 @@
+import { isDeepEqual } from '../../../src/utils/deep-equal'
+
+export const input = {
+  objectA: {
+    text: 'same text',
+    array: ['array-content'],
+    bold: true,
+  },
+  objectB: {
+    text: 'same text',
+    array: ['array-content'],
+    bold: true,
+  },
+}
+
+export const test = ({ objectA, objectB }) => {
+  return isDeepEqual(objectA, objectB)
+}
+
+export const output = true

--- a/packages/slate/test/utils/deep-equal/deep-not-equals-with-array.js
+++ b/packages/slate/test/utils/deep-equal/deep-not-equals-with-array.js
@@ -1,0 +1,20 @@
+import { isDeepEqual } from '../../../src/utils/deep-equal'
+
+export const input = {
+  objectA: {
+    text: 'same text',
+    array: ['array-content'],
+    bold: true,
+  },
+  objectB: {
+    text: 'same text',
+    array: ['array-content'],
+    bold: false,
+  },
+}
+
+export const test = ({ objectA, objectB }) => {
+  return isDeepEqual(objectA, objectB)
+}
+
+export const output = false


### PR DESCRIPTION
**Description**
deepEquals was always returning true if any array properties were equals.

**Issue**
Fixes: (link to issue)

**Example**
Code example :

```ts
const A = {
  array: [1],
  otherProp: true
};
const B = {
  array: [1],
  otherProp: false
};
deepEquals(A, B); // Should return false... but was returning true.
```

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
