### PR TITLE
Fix logic error in isDeepEqual

### DIFF
--- a/.changeset/slow-mangos-know.md
+++ b/.changeset/slow-mangos-know.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix logic error in isDeepEqual() which could affect Array properties

--- a/packages/slate/src/utils/deep-equal.ts
+++ b/packages/slate/src/utils/deep-equal.ts
@@ -24,7 +24,6 @@ export const isDeepEqual = (
       for (let i = 0; i < a.length; i++) {
         if (a[i] !== b[i]) return false
       }
-      return true
     } else if (a !== b) {
       return false
     }

--- a/packages/slate/test/utils/deep-equal/deep-equal-array-prop.ts
+++ b/packages/slate/test/utils/deep-equal/deep-equal-array-prop.ts
@@ -1,0 +1,21 @@
+import { isDeepEqual } from '../../../src/utils/deep-equal'
+
+export const input = {
+  objectA: {
+    text: 'same text',
+    tags: ['monkey', 'chimp', 'orangutan'],
+    underline: { origin: 'inherited', value: false }, // "value" differs below
+  },
+  objectB: {
+    text: 'same text',
+    tags: ['monkey', 'chimp', 'orangutan'],
+    italic: { origin: 'inherited', value: true },
+    underline: { origin: 'inherited', value: true },
+  },
+}
+
+export const test = ({ objectA, objectB }) => {
+  return isDeepEqual(objectA, objectB)
+}
+
+export const output = false


### PR DESCRIPTION
**Description**

If an object being tested had an array property that matched, the test was cut short and true returned. If subsequent properties did not match, the result would be wrong.

**Example**
If a developer used a Mark or something where the value was an array, the `isDeepEqual()` utility function would incorrectly return `true` as soon as it found that the array property matched the other object's property.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

