### PR TITLE
fix ssr prop mismatch

### DIFF
--- a/.changeset/strong-jeans-train.md
+++ b/.changeset/strong-jeans-train.md
@@ -1,0 +1,12 @@
+---
+'slate-react': minor
+---
+
+Support SSR for autoCorrect, spellCheck and autoCapitalize.
+Fixes prop mismatch between server and client.
+Removes the need to add
+<Editable
+  spellCheck={false}
+  autoCorrect="false"
+  autoCapitalize="false"
+/>

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -24,6 +24,7 @@ import {
   IS_FIREFOX_LEGACY,
   IS_QQBROWSER,
   IS_SAFARI,
+  CAN_USE_DOM,
 } from '../utils/environment'
 import { ReactEditor } from '..'
 import { ReadOnlyContext } from '../hooks/use-read-only'
@@ -579,12 +580,23 @@ export const Editable = (props: EditableProps) => {
           {...attributes}
           // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
           // have to use hacks to make these replacement-based features work.
-          spellCheck={!HAS_BEFORE_INPUT_SUPPORT ? false : attributes.spellCheck}
+          // For SSR situations HAS_BEFORE_INPUT_SUPPORT is false and results in prop
+          // mismatch warning app moves to browser. Pass-through consumer props when
+          // not CAN_USE_DOM (SSR) and default to falsy value
+          spellCheck={
+            HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
+              ? attributes.spellCheck
+              : false
+          }
           autoCorrect={
-            !HAS_BEFORE_INPUT_SUPPORT ? 'false' : attributes.autoCorrect
+            HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
+              ? attributes.autoCorrect
+              : 'false'
           }
           autoCapitalize={
-            !HAS_BEFORE_INPUT_SUPPORT ? 'false' : attributes.autoCapitalize
+            HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
+              ? attributes.autoCapitalize
+              : 'false'
           }
           data-slate-editor
           data-slate-node="value"


### PR DESCRIPTION
**Description**
Fixes 2 issue for Next.js (or any SSR method).

1) Under SSR the Editable component requires three props to be added to avoid a warning in the console.  This is because defaults are added to the component to deal with `HAS_BEFORE_INPUT_SUPPORT.` They are added because the check fails server side and the warning arrises because the check works client side, resulting in the prop mismatch.  The result is to force SSR users to add the following to avoid the warning.
```
<Editable
  spellCheck={false}
  autoCorrect="false"
  autoCapitalize="false"
>
```
![Screen Shot 2021-11-21 at 9 04 40 PM](https://user-images.githubusercontent.com/18608739/142791204-950f5ab1-b757-4bce-8b31-21ee57628f34.png)


2) SSR users are not able to use `spellCheck, autoCorrect or autoCapitalize.` If the developer would like to opt-in to these features they can set them to true and the library will verify compatibility.  However it is not possible to SSR render the application because `HAS_BEFORE_INPUT_SUPPORT` is false on the server which overrides the develop props. If a developer/consumer would like to attempt to use this feature, `HAS_BEFORE_INPUT_SUPPORT` results in false on the server and true on the browser which throws a warning for prop mismatch.
```
<Editable
  spellCheck={true}
  autoCorrect="true"
  autoCapitalize="true"
>
```
![Screen Shot 2021-11-21 at 9 04 16 PM](https://user-images.githubusercontent.com/18608739/142791984-65447262-5730-4a58-b9ed-859ad42b5de0.png)


**Issue**
Fixes: 
[Issue 4318](https://github.com/ianstormtaylor/slate/issues/4318)
[Issue 4657](https://github.com/ianstormtaylor/slate/issues/4657)

**Example**
![Screen Shot 2021-11-21 at 9 02 29 PM](https://user-images.githubusercontent.com/18608739/142792775-f255baa3-ca61-409c-a81a-fb7ef226c71b.png)
![Screen Shot 2021-11-21 at 9 03 35 PM](https://user-images.githubusercontent.com/18608739/142792807-18c94e23-eda2-422a-ba29-425d6b85eaa6.png)
![Screen Shot 2021-11-21 at 9 35 21 PM](https://user-images.githubusercontent.com/18608739/142792857-d60953c1-0ec4-4bcf-b2f2-661c9a56dd2e.png)
![Screen Shot 2021-11-21 at 9 04 16 PM](https://user-images.githubusercontent.com/18608739/142792868-b7b245a1-6329-42d8-8f1f-5d6e06deddf7.png)
![Screen Shot 2021-11-21 at 9 04 40 PM](https://user-images.githubusercontent.com/18608739/142792872-726439fe-7487-4426-8961-01a1a0ae77b4.png)



**Context**
Only made change to how props are added to the component, did not change value check `HAS_BEFORE_INPUT_SUPPORT` which is used in other places and could potentially change how other parts of the render happen.

Made this change to support developer ergonomics for SSR.  No longer need to added the spellCheck, auotCorrect and autoCapitalize props to the component.  Also made change to support users as [ 94.03% of users](https://caniuse.com/?search=beforeinput) will miss out on the opportunity to use spellCheck, autoCorrect, autoCapitalize with a text editing library when used under SSR situations.  Only drawback/tradeoff for this change is 6% of users will see a prop mismatch warning under SSR conditions (similar to issue 1) as the server will add the positive props and the client will not pass the `HAS_BEFORE_INPUT_SUPPORT` check.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

