### PR TITLE
Adding update on library import to avoid error message

### DIFF
--- a/site/components.tsx
+++ b/site/components.tsx
@@ -1,6 +1,6 @@
 import React, { Ref, PropsWithChildren } from 'react'
 import ReactDOM from 'react-dom'
-import { css, cx } from @emotion/css';
+import { css, cx } from '@emotion/css';
 
 interface BaseProps {
   className: string

--- a/site/components.tsx
+++ b/site/components.tsx
@@ -1,6 +1,6 @@
 import React, { Ref, PropsWithChildren } from 'react'
 import ReactDOM from 'react-dom'
-import { css, cx } from "@emotion/css";
+import { css, cx } from @emotion/css';
 
 interface BaseProps {
   className: string

--- a/site/components.tsx
+++ b/site/components.tsx
@@ -1,6 +1,6 @@
 import React, { Ref, PropsWithChildren } from 'react'
 import ReactDOM from 'react-dom'
-import { cx, css } from 'emotion'
+import { css, cx } from "@emotion/css";
 
 interface BaseProps {
   className: string


### PR DESCRIPTION
The error message ' The package "emotion" has been replaced by "@emotion/styled" ' appears with the old one. With this, it compiles successfully and shows no errors (I'm on next js12).

Great lib, thanks!

**Description**
error message pops when copying the code from [components used in rich text](https://github.com/ianstormtaylor/slate/blob/main/site/components.tsx) example page.

**Issue**
Fixes: update the import on emotion library

**Context**
I'm on nextjs 12, I don't know if it matters.

Thanks for your work, I hope I'll really help later

