### PR TITLE
Fix CJK IME(like Chinese, Japanese) double input

### DIFF
--- a/.changeset/large-melons-warn.md
+++ b/.changeset/large-melons-warn.md
@@ -2,4 +2,4 @@
 'slate-react': minor
 ---
 
-Fix CJK IME(like Chinese, Japanese) double input
+Fix CJK IME (e.g. Chinese or Japanese) double input

--- a/.changeset/large-melons-warn.md
+++ b/.changeset/large-melons-warn.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fix CJK IME(like Chinese, Japanese) double input

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -25,6 +25,7 @@ import {
   IS_QQBROWSER,
   IS_SAFARI,
   IS_UC_MOBILE,
+  IS_WECHATBROWSER,
   CAN_USE_DOM,
 } from '../utils/environment'
 import { ReactEditor } from '..'
@@ -483,18 +484,13 @@ export const Editable = (props: EditableProps) => {
           case 'insertReplacementText':
           case 'insertText': {
             if (type === 'insertFromComposition') {
-              if (IS_SAFARI) {
-                // COMPAT: in Safari, `compositionend` is dispatched after the
-                // `beforeinput` for "insertFromComposition". But if we wait for it
-                // then we will abort because we're still composing and the selection
-                // won't be updated properly.
-                // https://www.w3.org/TR/input-events-2/
-                state.isComposing && setIsComposing(false)
-                state.isComposing = false
-              } else if (state.isComposing && !IS_UC_MOBILE) {
-                // browsers except UC mobile do nothing to avoid duplicated insertion
-                return
-              }
+              // COMPAT: in Safari, `compositionend` is dispatched after the
+              // `beforeinput` for "insertFromComposition". But if we wait for it
+              // then we will abort because we're still composing and the selection
+              // won't be updated properly.
+              // https://www.w3.org/TR/input-events-2/
+              state.isComposing && setIsComposing(false)
+              state.isComposing = false
             }
 
             // use a weak comparison instead of 'instanceof' to allow
@@ -778,6 +774,7 @@ export const Editable = (props: EditableProps) => {
                   !IS_FIREFOX_LEGACY &&
                   !IS_IOS &&
                   !IS_QQBROWSER &&
+                  !IS_WECHATBROWSER &&
                   !IS_UC_MOBILE &&
                   event.data
                 ) {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -24,6 +24,7 @@ import {
   IS_FIREFOX_LEGACY,
   IS_QQBROWSER,
   IS_SAFARI,
+  IS_UC_MOBILE,
   CAN_USE_DOM,
 } from '../utils/environment'
 import { ReactEditor } from '..'
@@ -490,8 +491,8 @@ export const Editable = (props: EditableProps) => {
                 // https://www.w3.org/TR/input-events-2/
                 state.isComposing && setIsComposing(false)
                 state.isComposing = false
-              } else if (state.isComposing) {
-                // other browser we should do nothing to avoid
+              } else if (state.isComposing && !IS_UC_MOBILE) {
+                // browsers except UC mobile do nothing to avoid duplicated insertion
                 return
               }
             }
@@ -777,6 +778,7 @@ export const Editable = (props: EditableProps) => {
                   !IS_FIREFOX_LEGACY &&
                   !IS_IOS &&
                   !IS_QQBROWSER &&
+                  !IS_UC_MOBILE &&
                   event.data
                 ) {
                   Editor.insertText(editor, event.data)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -482,13 +482,18 @@ export const Editable = (props: EditableProps) => {
           case 'insertReplacementText':
           case 'insertText': {
             if (type === 'insertFromComposition') {
-              // COMPAT: in Safari, `compositionend` is dispatched after the
-              // `beforeinput` for "insertFromComposition". But if we wait for it
-              // then we will abort because we're still composing and the selection
-              // won't be updated properly.
-              // https://www.w3.org/TR/input-events-2/
-              state.isComposing && setIsComposing(false)
-              state.isComposing = false
+              if (IS_SAFARI) {
+                // COMPAT: in Safari, `compositionend` is dispatched after the
+                // `beforeinput` for "insertFromComposition". But if we wait for it
+                // then we will abort because we're still composing and the selection
+                // won't be updated properly.
+                // https://www.w3.org/TR/input-events-2/
+                state.isComposing && setIsComposing(false)
+                state.isComposing = false
+              } else if (state.isComposing) {
+                // other browser we should do nothing to avoid
+                return
+              }
             }
 
             // use a weak comparison instead of 'instanceof' to allow

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -47,6 +47,10 @@ export const IS_QQBROWSER =
 export const IS_UC_MOBILE =
   typeof navigator !== 'undefined' && /.*UCBrowser/.test(navigator.userAgent)
 
+// Wechat browser
+export const IS_WECHATBROWSER =
+  typeof navigator !== 'undefined' && /.*Wechat/.test(navigator.userAgent)
+
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js
 export const CAN_USE_DOM = !!(

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -43,6 +43,10 @@ export const IS_FIREFOX_LEGACY =
 export const IS_QQBROWSER =
   typeof navigator !== 'undefined' && /.*QQBrowser/.test(navigator.userAgent)
 
+// UC mobile browser
+export const IS_UC_MOBILE =
+  typeof navigator !== 'undefined' && /.*UCBrowser/.test(navigator.userAgent)
+
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js
 export const CAN_USE_DOM = !!(


### PR DESCRIPTION
**Description**
* Resolve double input when using CJK IME
* adapt UC mobile which will input nothing after selected from the candidates

**Issue**
Fixes: #3914

**Example**
**Before**
![20211130201538654](https://user-images.githubusercontent.com/6411412/144057415-63bbd638-7218-4b36-a21d-8a4e3e65236f.gif)

**After**
![20211130201413465](https://user-images.githubusercontent.com/6411412/144057475-dd286a64-ada6-4756-9a25-36111953aaac.gif)

**Context**
CJK IME, like the Mac OS/iOS native ones, will trigger events(compositionstart, compositionend, insertFromComposition), which will invoke "insertText" multiple times if the conditions are not considered.
This PR will skip some insert actions to avoid strange behaviors, like double input, no content after selection

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

