### PR TITLE
Add tests for Editor.unhangRange()

### DIFF
--- a/.changeset/soft-trees-taste.md
+++ b/.changeset/soft-trees-taste.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Add tests for Editor.unhangRange() behavior

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-hanging-over-void-with-voids-option.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-hanging-over-void-with-voids-option.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is a first paragraph
+    </block>
+    <block>This is the second paragraph</block>
+    <block void />
+    <block>
+      <focus />
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 28 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-hanging-over-void.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-hanging-over-void.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is a first paragraph
+    </block>
+    <block>This is the second paragraph</block>
+    <block void />
+    <block>
+      <focus />
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 28 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-hanging.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-hanging.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      word
+    </block>
+    <block>
+      <focus />
+      another
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 4 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/collapsed.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/collapsed.tsx
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>one<cursor/></block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection)
+}
+export const output = {
+  anchor: { path: [0, 0], offset: 3 },
+  focus: { path: [0, 0], offset: 3 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/collapsed.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/collapsed.tsx
@@ -4,7 +4,10 @@ import { jsx } from '../../..'
 
 export const input = (
   <editor>
-    <block>one<cursor/></block>
+    <block>
+      one
+      <cursor />
+    </block>
   </editor>
 )
 export const test = editor => {

--- a/packages/slate/test/interfaces/Editor/unhangRange/text-hanging.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/text-hanging.tsx
@@ -9,9 +9,7 @@ export const input = (
         before
         <anchor />
       </text>
-      <text>
-        selected
-      </text>
+      <text>selected</text>
       <text>
         <focus />
         after

--- a/packages/slate/test/interfaces/Editor/unhangRange/text-hanging.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/text-hanging.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>
+        before
+        <anchor />
+      </text>
+      <text>
+        selected
+      </text>
+      <text>
+        <focus />
+        after
+      </text>
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 6 },
+  focus: { path: [0, 2], offset: 0 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/void-hanging-with-voids-option.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/void-hanging-with-voids-option.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is a first paragraph
+    </block>
+    <block>This is the second paragraph</block>
+    <block void>
+      <focus />
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 0], offset: 28 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/void-hanging.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/void-hanging.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is a first paragraph
+    </block>
+    <block>This is the second paragraph</block>
+    <block void>
+      <focus />
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection)
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 0], offset: 25 },
+}


### PR DESCRIPTION
**Description**

Add tests for `Editor.unhangRange()`

**Issue**

Related to #3683 

**Example**

n/a

**Context**

`Editor.unhangRange()` has zero tests. So it's really difficult to understand how it should work.
Also any changes to its behavior will not have obvious effect visible in tests expectations.

This PR documents the existing behavior of `Editor.unhangRange()` without modifying it.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

