### PR TITLE
Fix onDragStart callback dependency on 'readonly'

### DIFF
--- a/.changeset/hungry-dingos-do.md
+++ b/.changeset/hungry-dingos-do.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix: add 'readonly' dependency for onDragStart callback

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -936,7 +936,7 @@ export const Editable = (props: EditableProps) => {
                 ReactEditor.setFragmentData(editor, event.dataTransfer)
               }
             },
-            [attributes.onDragStart]
+            [readOnly, attributes.onDragStart]
           )}
           onDrop={useCallback(
             (event: React.DragEvent<HTMLDivElement>) => {


### PR DESCRIPTION
**Description**
PR #4617 fixed a bug by checking `readOnly` in the `onDragStart` callback, but missed setting the dependency on `useCallback`. Consequently, if you have an editable that switches from readonly to not-readonly, the drag event will not add the internal fragment and the drop will fallback to plain text (because the fragment is not there).

**Issue**
related to #4548

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

