### PR TITLE
Allow Operation type to be extended

### DIFF
--- a/.changeset/tough-rockets-walk.md
+++ b/.changeset/tough-rockets-walk.md
@@ -1,0 +1,22 @@
+---
+'slate': patch
+---
+
+Allow `Operation` type to be extended
+
+For example:
+
+```
+import type { BaseOperation } from 'slate'
+
+type CustomOperation =
+ | BaseOperation
+ | YourCustomOperation
+ | AnotherCustomOperation
+
+declare module 'slate' {
+  interface CustomTypes {
+    Operation: CustomOperation;
+  }
+}
+```

--- a/packages/slate/src/interfaces/custom-types.ts
+++ b/packages/slate/src/interfaces/custom-types.ts
@@ -9,6 +9,7 @@ type ExtendableTypes =
   | 'Selection'
   | 'Range'
   | 'Point'
+  | 'Operation'
   | 'InsertNodeOperation'
   | 'InsertTextOperation'
   | 'MergeNodeOperation'

--- a/packages/slate/src/interfaces/operation.ts
+++ b/packages/slate/src/interfaces/operation.ts
@@ -135,7 +135,8 @@ export type TextOperation = InsertTextOperation | RemoveTextOperation
  * collaboration, and other features.
  */
 
-export type Operation = NodeOperation | SelectionOperation | TextOperation
+export type BaseOperation = NodeOperation | SelectionOperation | TextOperation
+export type Operation = ExtendedType<'Operation', BaseOperation>
 
 export interface OperationInterface {
   isNodeOperation: (value: any) => value is NodeOperation

--- a/packages/slate/test/interfaces/CustomTypes/custom-types.ts
+++ b/packages/slate/test/interfaces/CustomTypes/custom-types.ts
@@ -4,6 +4,7 @@ import {
   BasePoint,
   BaseRange,
   Descendant,
+  Operation
 } from 'slate'
 
 export type HeadingElement = {
@@ -25,6 +26,14 @@ export type CustomText = {
   text: string
 }
 
+export type CustomOperation = {
+  type: 'custom_op',
+  value: string
+}
+
+
+export type ExtendedOperation = Operation | CustomOperation
+
 export type CustomElement = HeadingElement | ListItemElement
 
 declare module 'slate' {
@@ -36,5 +45,6 @@ declare module 'slate' {
     Point: BasePoint
     Range: BaseRange
     Selection: BaseSelection
+    Operation: ExtendedOperation
   }
 }

--- a/packages/slate/test/interfaces/CustomTypes/custom-types.ts
+++ b/packages/slate/test/interfaces/CustomTypes/custom-types.ts
@@ -4,7 +4,7 @@ import {
   BasePoint,
   BaseRange,
   Descendant,
-  Operation
+  Operation,
 } from 'slate'
 
 export type HeadingElement = {
@@ -27,10 +27,9 @@ export type CustomText = {
 }
 
 export type CustomOperation = {
-  type: 'custom_op',
+  type: 'custom_op'
   value: string
 }
-
 
 export type ExtendedOperation = Operation | CustomOperation
 

--- a/packages/slate/test/interfaces/CustomTypes/customOperation-false.tsx
+++ b/packages/slate/test/interfaces/CustomTypes/customOperation-false.tsx
@@ -5,10 +5,9 @@ export const input: Operation = {
   type: 'insert_text',
   path: [0, 0],
   offset: 0,
-  text: 'text'
+  text: 'text',
 }
 
 export const test = isCustomOperation
 
 export const output = false
-

--- a/packages/slate/test/interfaces/CustomTypes/customOperation-false.tsx
+++ b/packages/slate/test/interfaces/CustomTypes/customOperation-false.tsx
@@ -1,0 +1,14 @@
+import { Operation } from 'slate'
+import { isCustomOperation } from './type-guards'
+
+export const input: Operation = {
+  type: 'insert_text',
+  path: [0, 0],
+  offset: 0,
+  text: 'text'
+}
+
+export const test = isCustomOperation
+
+export const output = false
+

--- a/packages/slate/test/interfaces/CustomTypes/customOperation-true.tsx
+++ b/packages/slate/test/interfaces/CustomTypes/customOperation-true.tsx
@@ -3,11 +3,9 @@ import { isCustomOperation } from './type-guards'
 
 export const input: Operation = {
   type: 'custom_op',
-  value: 'some value'
+  value: 'some value',
 }
 
 export const test = isCustomOperation
 
 export const output = true
-
-

--- a/packages/slate/test/interfaces/CustomTypes/customOperation-true.tsx
+++ b/packages/slate/test/interfaces/CustomTypes/customOperation-true.tsx
@@ -1,0 +1,13 @@
+import { Operation } from 'slate'
+import { isCustomOperation } from './type-guards'
+
+export const input: Operation = {
+  type: 'custom_op',
+  value: 'some value'
+}
+
+export const test = isCustomOperation
+
+export const output = true
+
+

--- a/packages/slate/test/interfaces/CustomTypes/type-guards.ts
+++ b/packages/slate/test/interfaces/CustomTypes/type-guards.ts
@@ -7,9 +7,9 @@ export const isBoldText = (text: Text): text is CustomText =>
 export const isCustomText = (text: Text): text is CustomText =>
   !!(text as CustomText).placeholder
 
-export const isCustomOperation = (op: Operation): Operation is CustomOperation =>
-  (op as CustomOperation).type === 'custom_op'
-
+export const isCustomOperation = (
+  op: Operation
+): Operation is CustomOperation => (op as CustomOperation).type === 'custom_op'
 
 export const isHeadingElement = (element: Element): element is HeadingElement =>
   element.type === 'heading'

--- a/packages/slate/test/interfaces/CustomTypes/type-guards.ts
+++ b/packages/slate/test/interfaces/CustomTypes/type-guards.ts
@@ -1,11 +1,15 @@
-import { Element, Text } from 'slate'
-import { CustomText, HeadingElement } from './custom-types'
+import { Element, Text, Operation } from 'slate'
+import { CustomText, CustomOperation, HeadingElement } from './custom-types'
 
 export const isBoldText = (text: Text): text is CustomText =>
   !!(text as CustomText).bold
 
 export const isCustomText = (text: Text): text is CustomText =>
   !!(text as CustomText).placeholder
+
+export const isCustomOperation = (op: Operation): Operation is CustomOperation =>
+  (op as CustomOperation).type === 'custom_op'
+
 
 export const isHeadingElement = (element: Element): element is HeadingElement =>
   element.type === 'heading'


### PR DESCRIPTION
**Description**
This makes it possible to add your own custom operations to the `Operation` union type. Can be useful if you want to extend slate with extra operations (something I needed hence the PR :smile:).

**Issue**
Fixes: none

**Example**

`Operation` can now be extended as follows:
```
import type { BaseOperation } from 'slate'

type CustomOperation =
 | BaseOperation
 | YourCustomOperation
 | AnotherCustomOperation

declare module 'slate' {
  interface CustomTypes {
    Operation: CustomOperation;
  }
}
```

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

