### PR TITLE
Change how slate-history handles selection undo

### DIFF
--- a/.changeset/cuddly-kiwis-work.md
+++ b/.changeset/cuddly-kiwis-work.md
@@ -1,0 +1,5 @@
+---
+'slate-history': minor
+---
+
+Changes how selections are stored in the history resulting in more consistent results

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -9,7 +9,6 @@ export const HISTORY = new WeakMap<Editor, History>()
 export const SAVING = new WeakMap<Editor, boolean | undefined>()
 export const MERGING = new WeakMap<Editor, boolean | undefined>()
 
-
 /**
  * `HistoryEditor` contains helpers for history-enabled editors.
  */

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -9,6 +9,7 @@ export const HISTORY = new WeakMap<Editor, History>()
 export const SAVING = new WeakMap<Editor, boolean | undefined>()
 export const MERGING = new WeakMap<Editor, boolean | undefined>()
 
+
 /**
  * `HistoryEditor` contains helpers for history-enabled editors.
  */

--- a/packages/slate-history/src/history.ts
+++ b/packages/slate-history/src/history.ts
@@ -1,14 +1,19 @@
 import { isPlainObject } from 'is-plain-object'
-import { Operation } from 'slate'
+import { Operation, Range } from 'slate'
 
 /**
  * `History` objects hold all of the operations that are applied to a value, so
  * they can be undone or redone as necessary.
  */
 
+interface Batch {
+    operations: Operation[];
+    selectionBefore: Range | null
+}
+
 export interface History {
-  redos: Operation[][]
-  undos: Operation[][]
+  redos: Batch[]
+  undos: Batch[]
 }
 
 export const History = {

--- a/packages/slate-history/src/history.ts
+++ b/packages/slate-history/src/history.ts
@@ -1,15 +1,15 @@
 import { isPlainObject } from 'is-plain-object'
 import { Operation, Range } from 'slate'
 
-/**
- * `History` objects hold all of the operations that are applied to a value, so
- * they can be undone or redone as necessary.
- */
-
 interface Batch {
   operations: Operation[]
   selectionBefore: Range | null
 }
+
+/**
+ * `History` objects hold all of the operations that are applied to a value, so
+ * they can be undone or redone as necessary.
+ */
 
 export interface History {
   redos: Batch[]

--- a/packages/slate-history/src/history.ts
+++ b/packages/slate-history/src/history.ts
@@ -7,8 +7,8 @@ import { Operation, Range } from 'slate'
  */
 
 interface Batch {
-    operations: Operation[];
-    selectionBefore: Range | null
+  operations: Operation[]
+  selectionBefore: Range | null
 }
 
 export interface History {

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -153,10 +153,3 @@ const shouldSave = (op: Operation, prev: Operation | undefined): boolean => {
   return true
 }
 
-/**
- * Check whether an operation should clear the redos stack.
- */
-
-const shouldClear = (op: Operation): boolean => {
-  return true
-}

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -152,4 +152,3 @@ const shouldSave = (op: Operation, prev: Operation | undefined): boolean => {
 
   return true
 }
-

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -24,6 +24,10 @@ export const withHistory = <T extends Editor>(editor: T) => {
     if (redos.length > 0) {
       const batch = redos[redos.length - 1]
 
+      if (batch.selectionBefore) {
+        Transforms.setSelection(e, batch.selectionBefore)
+      }
+
       HistoryEditor.withoutSaving(e, () => {
         Editor.withoutNormalizing(e, () => {
           for (const op of batch.operations) {

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -52,7 +52,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
             e.apply(op)
           }
           if (batch.selectionBefore) {
-              Transforms.setSelection(e, batch.selectionBefore)
+            Transforms.setSelection(e, batch.selectionBefore)
           }
         })
       })
@@ -66,7 +66,8 @@ export const withHistory = <T extends Editor>(editor: T) => {
     const { operations, history } = e
     const { undos } = history
     const lastBatch = undos[undos.length - 1]
-    const lastOp = lastBatch && lastBatch.operations[lastBatch.operations.length - 1]
+    const lastOp =
+      lastBatch && lastBatch.operations[lastBatch.operations.length - 1]
     const overwrite = shouldOverwrite(op, lastOp)
     let save = HistoryEditor.isSaving(e)
     let merge = HistoryEditor.isMerging(e)
@@ -94,8 +95,8 @@ export const withHistory = <T extends Editor>(editor: T) => {
         lastBatch.operations.push(op)
       } else {
         const batch = {
-            operations: [op],
-            selectionBefore: e.selection
+          operations: [op],
+          selectionBefore: e.selection,
         }
         undos.push(batch)
       }

--- a/packages/slate-history/test/undo/cursor/keep_after_focus_and_remove_text_undo.js
+++ b/packages/slate-history/test/undo/cursor/keep_after_focus_and_remove_text_undo.js
@@ -44,6 +44,6 @@ export const output = {
   ],
   selection: {
     anchor: { path: [0, 0], offset: 5 },
-    focus: { path: [0, 0], offset: 5 },
+    focus: { path: [0, 0], offset: 0 },
   },
 }


### PR DESCRIPTION
**Description**
This is a proposal, curious what you all think.

As @TheSpyder mentioned in https://github.com/ianstormtaylor/slate/issues/3756#issuecomment-737022068, often times normalization logic can trigger `set_selection` operations that modify the selection state in the middle of an operation stack. Also, the `set_selection` operation often only contains the `anchor` OR the `focus` property because partial updates are allowed. As the current handling of the `set_selection` operation in `slate-history` overrides the previous op, this information is often lost as you apply more operations and undo them.

Instead of using operations to reset selection, this change stores a separate `selectionBefore` property as part of the undo batch that contains the selection as it was before the operations were applied. This works around some of the complexities with undoing that were well described by @TheSpyder in https://github.com/ianstormtaylor/slate/issues/3756 by explicitly storing the selection state as part of the undo. This change also means that `set_selection` operations are no longer stored in the history operations stack. Instead a full selection is included with every undo batch.

With the limited testing that I have done, the results seem to be what I would expect from an undo. Could add the same behavior for redo as well perhaps as in some cases I've noticed it doesn't reset the selection quite well (you can notice in the video when I redo the mark change that it doesn't reselect the remarked selection after changing the selection). Besides mark changes, I couldn't find another redo case that doesn't set the selection properly as besides the mark operations the selection is normally collapsed when redoing. EDIT: fixed this case in https://github.com/ianstormtaylor/slate/pull/4717/commits/a7385110db58e85f94057a42f9bbef743cfc472e

**Issue**
Fixes:  #4694, https://github.com/ianstormtaylor/slate/issues/4559, https://github.com/ianstormtaylor/slate/issues/3756, https://github.com/ianstormtaylor/slate/issues/3534, probably more

**Example**
The cases that were mentioned in https://github.com/ianstormtaylor/slate/issues/3756 work well from my testing

https://user-images.githubusercontent.com/3816712/144755757-e73d1d29-8189-4f3d-80e0-52fcb3ddf749.mp4



**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

