### PR TITLE
Add origin event type to setFragmentData to be able to distinguish copy, cut and drag

### DIFF
--- a/.changeset/brave-emus-refuse.md
+++ b/.changeset/brave-emus-refuse.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Add origin event type to setFragmentData to be able to distinguish copy, cut and drag

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -148,7 +148,7 @@ Insert fragment data from a `DataTransfer` into the editor. Returns true if some
 
 Insert text data from a `DataTransfer` into the editor. Returns true if some content has been effectively inserted.
 
-### `setFragmentData(editor: ReactEditor, data: DataTransfer)`
+### `setFragmentData(editor: ReactEditor, data: DataTransfer, originEvent: 'drag' | 'copy' | 'cut')`
 
 Sets data from the currently selected fragment on a `DataTransfer`.
 

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -148,7 +148,7 @@ Insert fragment data from a `DataTransfer` into the editor. Returns true if some
 
 Insert text data from a `DataTransfer` into the editor. Returns true if some content has been effectively inserted.
 
-### `setFragmentData(editor: ReactEditor, data: DataTransfer, originEvent: 'drag' | 'copy' | 'cut')`
+### `setFragmentData(editor: ReactEditor, data: DataTransfer, originEvent?: 'drag' | 'copy' | 'cut')`
 
 Sets data from the currently selected fragment on a `DataTransfer`.
 

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -340,7 +340,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
                 !isEventHandled(event, attributes.onCopy)
               ) {
                 event.preventDefault()
-                ReactEditor.setFragmentData(editor, event.clipboardData)
+                ReactEditor.setFragmentData(editor, event.clipboardData, 'copy')
               }
             },
             [attributes.onCopy]
@@ -353,7 +353,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
                 !isEventHandled(event, attributes.onCut)
               ) {
                 event.preventDefault()
-                ReactEditor.setFragmentData(editor, event.clipboardData)
+                ReactEditor.setFragmentData(editor, event.clipboardData, 'cut')
                 const { selection } = editor
 
                 if (selection) {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -867,7 +867,7 @@ export const Editable = (props: EditableProps) => {
                 !isEventHandled(event, attributes.onCopy)
               ) {
                 event.preventDefault()
-                ReactEditor.setFragmentData(editor, event.clipboardData)
+                ReactEditor.setFragmentData(editor, event.clipboardData, 'copy')
               }
             },
             [attributes.onCopy]
@@ -880,7 +880,7 @@ export const Editable = (props: EditableProps) => {
                 !isEventHandled(event, attributes.onCut)
               ) {
                 event.preventDefault()
-                ReactEditor.setFragmentData(editor, event.clipboardData)
+                ReactEditor.setFragmentData(editor, event.clipboardData, 'cut')
                 const { selection } = editor
 
                 if (selection) {
@@ -937,7 +937,7 @@ export const Editable = (props: EditableProps) => {
 
                 state.isDraggingInternally = true
 
-                ReactEditor.setFragmentData(editor, event.dataTransfer)
+                ReactEditor.setFragmentData(editor, event.dataTransfer, 'drag')
               }
             },
             [readOnly, attributes.onDragStart]

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -34,7 +34,10 @@ export interface ReactEditor extends BaseEditor {
   insertData: (data: DataTransfer) => void
   insertFragmentData: (data: DataTransfer) => boolean
   insertTextData: (data: DataTransfer) => boolean
-  setFragmentData: (data: DataTransfer, originEvent: 'drag' | 'copy' | 'cut') => void
+  setFragmentData: (
+    data: DataTransfer,
+    originEvent: 'drag' | 'copy' | 'cut'
+  ) => void
   hasRange: (editor: ReactEditor, range: Range) => boolean
 }
 
@@ -253,7 +256,11 @@ export const ReactEditor = {
    * Sets data from the currently selected fragment on a `DataTransfer`.
    */
 
-  setFragmentData(editor: ReactEditor, data: DataTransfer, originEvent: 'drag' | 'copy' | 'cut'): void {
+  setFragmentData(
+    editor: ReactEditor,
+    data: DataTransfer,
+    originEvent: 'drag' | 'copy' | 'cut'
+  ): void {
     editor.setFragmentData(data, originEvent)
   },
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -34,7 +34,7 @@ export interface ReactEditor extends BaseEditor {
   insertData: (data: DataTransfer) => void
   insertFragmentData: (data: DataTransfer) => boolean
   insertTextData: (data: DataTransfer) => boolean
-  setFragmentData: (data: DataTransfer) => void
+  setFragmentData: (data: DataTransfer, originEvent: 'drag' | 'copy' | 'cut') => void
   hasRange: (editor: ReactEditor, range: Range) => boolean
 }
 
@@ -253,8 +253,8 @@ export const ReactEditor = {
    * Sets data from the currently selected fragment on a `DataTransfer`.
    */
 
-  setFragmentData(editor: ReactEditor, data: DataTransfer): void {
-    editor.setFragmentData(data)
+  setFragmentData(editor: ReactEditor, data: DataTransfer, originEvent: 'drag' | 'copy' | 'cut'): void {
+    editor.setFragmentData(data, originEvent)
   },
 
   /**

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -36,7 +36,7 @@ export interface ReactEditor extends BaseEditor {
   insertTextData: (data: DataTransfer) => boolean
   setFragmentData: (
     data: DataTransfer,
-    originEvent: 'drag' | 'copy' | 'cut'
+    originEvent?: 'drag' | 'copy' | 'cut'
   ) => void
   hasRange: (editor: ReactEditor, range: Range) => boolean
 }
@@ -259,7 +259,7 @@ export const ReactEditor = {
   setFragmentData(
     editor: ReactEditor,
     data: DataTransfer,
-    originEvent: 'drag' | 'copy' | 'cut'
+    originEvent?: 'drag' | 'copy' | 'cut'
   ): void {
     editor.setFragmentData(data, originEvent)
   },


### PR DESCRIPTION
**Description**
Currently in order to know whether `setFragmentData` was called as a result of a copy, cut or drag; you have to overwrite all of the `onCut`, `onCopy`, `onDrag` methods and call your own function with the original event. This change adds a single property to `setFragmentData` called `originEvent` that can be set to `copy`, `cut`, `drag`. This allows you to set some extra data (or emit data) on the `DataTransfer` object based on whether `setFragmentData` was called as part of a drag, copy or cut event without having to modify a lot of code. We could potentially do the same thing for `insertData` as the same thing applies there but for `paste` and `drop`.

**Issue**
Fixes: (link to issue)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

