### PR TITLE
Fix "Cannot resolve from DOM point" error on onDomSelectionChange for readonly void elements

### DIFF
--- a/.changeset/cyan-games-share.md
+++ b/.changeset/cyan-games-share.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix "Cannot resolve from DOM point" error on onDomSelectionChange for readonly void elements

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -31,7 +31,7 @@ import {
   hasEditableTarget,
   isEventHandled,
   isDOMEventHandled,
-  isTargetInsideVoid,
+  isTargetInsideNonReadonlyVoid,
 } from '../editable'
 
 import { useAndroidInputManager } from './use-android-input-manager'
@@ -249,11 +249,11 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
 
           const anchorNodeSelectable =
             hasEditableTarget(editor, anchorNode) ||
-            isTargetInsideVoid(editor, anchorNode)
+            isTargetInsideNonReadonlyVoid(editor, anchorNode)
 
           const focusNodeSelectable =
             hasEditableTarget(editor, focusNode) ||
-            isTargetInsideVoid(editor, focusNode)
+            isTargetInsideNonReadonlyVoid(editor, focusNode)
 
           if (anchorNodeSelectable && focusNodeSelectable) {
             const range = ReactEditor.toSlateRange(editor, domSelection, {

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -289,11 +289,11 @@ export const Editable = (props: EditableProps) => {
 
         const anchorNodeSelectable =
           hasEditableTarget(editor, anchorNode) ||
-          isTargetInsideVoid(editor, anchorNode)
+          isTargetInsideNonReadonlyVoid(editor, anchorNode)
 
         const focusNodeSelectable =
           hasEditableTarget(editor, focusNode) ||
-          isTargetInsideVoid(editor, focusNode)
+          isTargetInsideNonReadonlyVoid(editor, focusNode)
 
         if (anchorNodeSelectable && focusNodeSelectable) {
           const range = ReactEditor.toSlateRange(editor, domSelection, {
@@ -1408,13 +1408,15 @@ export const hasEditableTarget = (
 }
 
 /**
- * Check if the target is inside void and in the editor.
+ * Check if the target is inside void and in an non-readonly editor.
  */
 
-export const isTargetInsideVoid = (
+export const isTargetInsideNonReadonlyVoid = (
   editor: ReactEditor,
   target: EventTarget | null
 ): boolean => {
+  if (IS_READ_ONLY.get(editor)) return false
+
   const slateNode =
     hasTarget(editor, target) && ReactEditor.toSlateNode(editor, target)
   return Editor.isVoid(editor, slateNode)


### PR DESCRIPTION
**Description**
Fixes "Cannot resolve from DOM point" error on onDomSelectionChange for readonly void elements (see #4726). The code tries to update selection and falsely elects void elements in a readonly editor.

**Issue**
Fixes: #4726 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

