### PR TITLE
Docs: Clarifies when to use Editor.insertNode vs. Transforms.insertNodes

### DIFF
--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -268,19 +268,19 @@ Insert a block break at the current selection.
 
 #### `Editor.insertFragment(editor: Editor, fragment: Node[]) => void`
 
-Insert a fragment at the current selection.
+Inserts a fragment _at the current selection_.
 
-If the selection is currently expanded, it will be deleted first.
+If the selection is currently expanded, it will be deleted first. To atomically insert nodes (including at the very beginning or end), use [Transforms.insertNodes](../transforms.md#transformsinsertnodeseditor-editor-nodes-node--node-options).
 
 #### `Editor.insertNode(editor: Editor, node: Node) => void`
 
-Insert a node at the current selection.
+Inserts a node _at the current selection_.
 
-If the selection is currently expanded, it will be deleted first.
+If the selection is currently expanded, it will be deleted first. To atomically insert a node (including at the very beginning or end), use [Transforms.insertNodes](../transforms.md#transformsinsertnodeseditor-editor-nodes-node--node-options).
 
 #### `Editor.insertText(editor: Editor, text: string) => void`
 
-Insert text at the current selection.
+Inserts text _at the current selection_.
 
 If the selection is currently expanded, it will be deleted first.
 

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -44,9 +44,19 @@ Options: `{at?: Location, hanging?: boolean, voids?: boolean}`
 
 #### `Transforms.insertNodes(editor: Editor, nodes: Node | Node[], options?)`
 
-Insert `nodes` at the specified location in the document. If no location is specified, insert at the current selection. If there is no selection, insert at the end of the document.
+Atomically inserts `nodes` at the specified location in the document. If no location is specified, inserts at the current selection. If there is no selection, inserts at the end of the document.
 
 Options supported: `NodeOptions & {hanging?: boolean, select?: boolean}`.
+
+For example, to insert at the very end, without replacing the current selection and regardless of block nesting, use
+
+```javascript
+Transforms.insertNodes(
+  editor,
+  { type: targetType, children: [{ text: '' }] },
+  { at: [editor.children.length] }
+)
+```
 
 #### `Transforms.removeNodes(editor: Editor, options?)`
 


### PR DESCRIPTION
**Description**
Clarifies when to use Editor.insertNode vs. Transforms.insertNodes
