### PR TITLE
Optimize TextString rendering to support browser/OS text features, eg fix native spellcheck

### DIFF
--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -71,7 +71,7 @@ const TextString = (props: { text: string; isTrailing?: boolean }) => {
   // useLayoutEffect: updating our span before browser paint
   useLayoutEffect(() => {
     // null coalescing text to make sure we're not outputing "null" as a string in the extreme case it is nullish at runtime
-    const textWithTrailing = (text ?? '') + (isTrailing ? '\n' : '')
+    const textWithTrailing = `${text ?? ''}${isTrailing ? '\n' : ''}`
 
     if (ref.current && ref.current.textContent !== textWithTrailing) {
       ref.current.textContent = textWithTrailing

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -70,12 +70,8 @@ const TextString = (props: { text: string; isTrailing?: boolean }) => {
 
   // useLayoutEffect: updating our span before browser paint
   useLayoutEffect(() => {
-    let textWithTrailing: string | null = text + (isTrailing ? '\n' : '')
-
-    // making sure we're not outputing "null" in the extreme case the text is nullish at runtime
-    if (text == null) {
-      textWithTrailing = isTrailing ? '\n' : null
-    }
+    // null coalescing text to make sure we're not outputing "null" as a string in the extreme case it is nullish at runtime
+    const textWithTrailing = (text ?? '') + (isTrailing ? '\n' : '')
 
     if (ref.current && ref.current.textContent !== textWithTrailing) {
       ref.current.textContent = textWithTrailing

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useLayoutEffect } from 'react'
 import { Editor, Text, Path, Element, Node } from 'slate'
 
 import { ReactEditor, useSlateStatic } from '..'
@@ -55,24 +55,36 @@ const String = (props: {
 /**
  * Leaf strings with text in them.
  */
-const TextString = (props: { text: string; isTrailing?: boolean }) => {
+ const TextString = (props: { text: string; isTrailing?: boolean }) => {
   const { text, isTrailing = false } = props
 
   const ref = useRef<HTMLSpanElement>(null)
-  const forceUpdateCount = useRef(0)
 
-  if (ref.current && ref.current.textContent !== text) {
-    forceUpdateCount.current += 1
-  }
+  // This is the actual text rendering boundary where we interface with the DOM
+  // The text is not rendered as part of the virtual DOM, as since we handle basic character insertions natively,
+  // updating the DOM is not a one way dataflow anymore. What we need here is not reconciliation and diffing
+  // with previous version of the virtual DOM, but rather diffing with the actual DOM element, and replace the DOM <span> content
+  // exactly if and only if its current content does not match our current virtual DOM.
+  // Otherwise the DOM TextNode would always be replaced by React as the user types, which interferes with native text features,
+  // eg makes native spellcheck opt out from checking the text node.
 
-  // This component may have skipped rendering due to native operations being
-  // applied. If an undo is performed React will see the old and new shadow DOM
-  // match and not apply an update. Forces each render to actually reconcile.
+  // useLayoutEffect: updating our span before browser paint
+  useLayoutEffect(() => {
+    // making sure we're not outputing "null" in the extreme case the text is nullish at runtime
+    const textWithTrailing = text != null
+      ? text + (isTrailing ? '\n' : "")
+      : (isTrailing ? '\n' : null);
+
+    if (ref.current && ref.current.textContent !== textWithTrailing) {
+      ref.current.textContent = textWithTrailing;
+    }
+  // intentionally not specifying dependencies, so that this effect runs on every render
+  // as this effectively replaces "specifying the text in the virtual DOM under the <span> below" on each render
+  });
+
+  // the span is intentionally same on every render in virtual DOM, actual rendering happens in the layout effect above
   return (
-    <span data-slate-string ref={ref} key={forceUpdateCount.current}>
-      {text}
-      {isTrailing ? '\n' : null}
-    </span>
+    <span data-slate-string ref={ref} />
   )
 }
 

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -55,7 +55,7 @@ const String = (props: {
 /**
  * Leaf strings with text in them.
  */
- const TextString = (props: { text: string; isTrailing?: boolean }) => {
+const TextString = (props: { text: string; isTrailing?: boolean }) => {
   const { text, isTrailing = false } = props
 
   const ref = useRef<HTMLSpanElement>(null)
@@ -70,22 +70,23 @@ const String = (props: {
 
   // useLayoutEffect: updating our span before browser paint
   useLayoutEffect(() => {
+    let textWithTrailing: string | null = text + (isTrailing ? '\n' : '')
+
     // making sure we're not outputing "null" in the extreme case the text is nullish at runtime
-    const textWithTrailing = text != null
-      ? text + (isTrailing ? '\n' : "")
-      : (isTrailing ? '\n' : null);
+    if (text == null) {
+      textWithTrailing = isTrailing ? '\n' : null
+    }
 
     if (ref.current && ref.current.textContent !== textWithTrailing) {
-      ref.current.textContent = textWithTrailing;
+      ref.current.textContent = textWithTrailing
     }
-  // intentionally not specifying dependencies, so that this effect runs on every render
-  // as this effectively replaces "specifying the text in the virtual DOM under the <span> below" on each render
-  });
+
+    // intentionally not specifying dependencies, so that this effect runs on every render
+    // as this effectively replaces "specifying the text in the virtual DOM under the <span> below" on each render
+  })
 
   // the span is intentionally same on every render in virtual DOM, actual rendering happens in the layout effect above
-  return (
-    <span data-slate-string ref={ref} />
-  )
+  return <span data-slate-string ref={ref} />
 }
 
 /**


### PR DESCRIPTION
**Description**
This fix is the last or at least the next piece on the journey to [Use native character insertion to fix browser/OS text features](https://github.com/ianstormtaylor/slate/pull/3888/files) With all the good progress so far, native spellcheck as you type is still broken on practically all browsers (no spellcheck underlining on Safari & FF and blinking underlines on Chrome).

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4320
Related: https://github.com/ianstormtaylor/slate/pull/3888, https://github.com/ianstormtaylor/slate/issues/2051

**Example**
Safari, before (spellcheck prevented)
![video of Safari, before (spellcheck prevented)](https://user-images.githubusercontent.com/2234706/146193879-401b738e-f46d-4980-9505-c6900fab9879.gif)

Chrome, before (spellcheck blinks)
![Chrome-with-react-text](https://user-images.githubusercontent.com/2234706/146194317-76fb000b-4a9f-4935-994f-cc2dc4febe61.gif)

**Context**
The reason for this is that the continuously changing text will rerender the virtual DOM on each keystroke, which in turn updates the DOM TextNode, which will opt out browsers from checking spelling in that - now programatically updated, not user typed - text node.

Essentially now that data flow is two-way (simple characters are inserted natively, and propagated to slate, while complex characters and events are caught and happen in slate and propagated to native DOM), we need to tweak the leaf text node rendering to reflect this and instead of using the one way dataflow of virtual DOM, implement the leaf TextNode rendering as an Effect that does proper diffing between the actual DOM and the virtual DOM, and not based on diffing between older and newer version of the virtual DOM. We would like to replace the text content in a slate span exactly if and only if its current content does not match our current virtual DOM (and for natively inserted characters, it will already match and need no interference from code)

Safari, after
![video of Safari, after](https://user-images.githubusercontent.com/2234706/146194817-3392b5a6-646a-4338-a1ce-c3e90459693d.gif)

Chrome, after
![video of Chrome, after](https://user-images.githubusercontent.com/2234706/146194838-be7dfa07-71d2-44bd-ae21-b851eaa45da0.gif)

While this change may seem like quite fundamental and risky, I think it's actually quite locally confined: the `TextString` component behaves almost identical as before.

- it is rendered by React exactly on the same occasions when the previous version rendered (its props did not change)
- the result of the render will exactly be the same for the new and old version (both the traditional update via the virtual DOM, and the effect will achieve the same thing, namely that the span will contain the textContent)

A note on `null` handling: it may be unnecessary, but I added an extra measure to handle the extreme case if the incoming text is null/undefined, and also thereby preserving the previous render behavior in the `TextString` component (which also did not fail anddid not output any text node children for the span, should this happen).

Note 2: even with this fix spellcheck will still opt-out (or blink on Chrome) for all characters and events that are not natively handled (eg punctuation, backspace, shift+characters etc). Will have to see, this may be acceptable tradeoff, or if not, likely further steps need to be taken to handle as much natively as possible.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] functionality did not change, likely needs a `patch` changeset in `slate-react` package?

