### PR TITLE
fix: [AndroidEditor] Solve input association problems and add click events.

### DIFF
--- a/.changeset/quick-feet-melt.md
+++ b/.changeset/quick-feet-melt.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+[AndroidEditor] Solve input association problems and add click events.

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -1,5 +1,10 @@
 import { ReactEditor } from '../../plugin/react-editor'
 import { Editor, Range, Transforms, Text } from 'slate'
+import {
+  IS_COMPOSING,
+  IS_ON_COMPOSITION_END,
+  EDITOR_ON_COMPOSITION_TEXT,
+} from '../../utils/weak-maps'
 
 import { DOMNode } from '../../utils/dom'
 
@@ -104,6 +109,17 @@ export class AndroidInputManager {
     debug('insertText')
 
     const { selection, marks } = this.editor
+
+    // If it is in composing or after `onCompositionend`, set `EDITOR_ON_COMPOSITION_TEXT` and return.
+    // Text will be inserted on compositionend event.
+    if (
+      IS_COMPOSING.get(this.editor) ||
+      IS_ON_COMPOSITION_END.get(this.editor)
+    ) {
+      EDITOR_ON_COMPOSITION_TEXT.set(this.editor, insertedText)
+      IS_ON_COMPOSITION_END.set(this.editor, false)
+      return
+    }
 
     // Insert the batched text diffs
     insertedText.forEach(insertion => {

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -1,5 +1,6 @@
 import { Ancestor, Editor, Node } from 'slate'
 import { Key } from './key'
+import { TextInsertion } from '../components/android/diff-text'
 
 /**
  * Two weak maps that allow us rebuild a path given a node. They are populated
@@ -32,6 +33,17 @@ export const IS_READ_ONLY: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_FOCUSED: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_DRAGGING: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_CLICKING: WeakMap<Editor, boolean> = new WeakMap()
+export const IS_COMPOSING: WeakMap<Editor, boolean> = new WeakMap()
+export const IS_ON_COMPOSITION_END: WeakMap<Editor, boolean> = new WeakMap()
+
+/**
+ * Weak maps for saving text on composition stage.
+ */
+
+export const EDITOR_ON_COMPOSITION_TEXT: WeakMap<
+  Editor,
+  TextInsertion[]
+> = new WeakMap()
 
 /**
  * Weak map for associating the context `onChange` context with the plugin.


### PR DESCRIPTION

**Description**
I asked some questions about Android devices earlier in #4705 . I tried to switch to `DefaultEditable` but that didn't resolve my questions. After i read source code about `AndroidEditable`.  I may sum up a few questions and try to resolve them.

Q:

1. As we can see in these issues #4715 #4714 or the first video, using the typing with association function will trigger an unexpected insertText operation .
2. We can't click block element on Android which also mentioned in #4719 .

A:

1. `MutationObserver` is used in `AndroidEditable` to monitor DOM changes. Whenever we input a character, `MutationObserver` will be triggered and `insertText` into the editor. However, in the keyboard association state, performing a delete operation or inputting characters may trigger character association, and then unexpected characters are added between triggering the onDOMBeforeInput event and triggering the MutationObserver event. I haven't figured out the reason yet, but I try to solve it in another way. The association function will trigger the `composition` event, so I attempt to record the characters that originally wanted to insertText in the MutationObserver event in the `isComposing` , and then `insertText` in the `onCompositionend` event.
2. Synchronize the click event from `Editable`. By the way, i also synchronize some other code from `Editable` like #4669 .

**Example**
before

https://user-images.githubusercontent.com/22654945/146237301-d3277a50-cf8d-4e5c-adb2-71efa254b8cc.mp4

after


https://user-images.githubusercontent.com/22654945/146237493-d6e66b7a-cede-4e65-af7a-ba9ee4b8e423.mp4


Image can be clicked.

https://user-images.githubusercontent.com/22654945/146238103-a3670a5d-840f-41ad-8538-50bada9696b4.mp4


**Context**
There are still some minor problems. When the above method is triggered, the mark setting cannot take effect immediately, but it takes effect after `onCompositionend`.

https://user-images.githubusercontent.com/22654945/146238981-d4f00790-d02a-45d5-8524-ef4bd72ed908.mp4



**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

