### PR TITLE
Avoid transforming dirty paths if the op won't touch them

### DIFF
--- a/.changeset/two-coins-enjoy.md
+++ b/.changeset/two-coins-enjoy.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Optimize path transforms during normalization

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -57,13 +57,17 @@ export const createEditor = (): Editor => {
       }
 
       const oldDirtyPaths = DIRTY_PATHS.get(editor) || []
-      const newDirtyPaths = getDirtyPaths(op)
-
+      const canTransformPath = Path.operationCanTransformPath(op)
       for (const path of oldDirtyPaths) {
-        const newPath = Path.transform(path, op)
-        add(newPath)
+        if (canTransformPath) {
+          const newPath = Path.transform(path, op)
+          add(newPath)
+        } else {
+          add(path)
+        }
       }
 
+      const newDirtyPaths = getDirtyPaths(op)
       for (const path of newDirtyPaths) {
         add(path)
       }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -19,6 +19,7 @@ import {
 } from '..'
 import {
   DIRTY_PATHS,
+  DIRTY_PATH_KEYS,
   NORMALIZING,
   PATH_REFS,
   POINT_REFS,
@@ -979,13 +980,26 @@ export const Editor: EditorInterface = {
       return DIRTY_PATHS.get(editor) || []
     }
 
+    const getDirtyPathKeys = (editor: Editor) => {
+      return DIRTY_PATH_KEYS.get(editor) || new Set()
+    }
+
+    const popDirtyPath = (editor: Editor): Path => {
+      const path = getDirtyPaths(editor).pop()!
+      const key = path.join(',')
+      getDirtyPathKeys(editor).delete(key)
+      return path
+    }
+
     if (!Editor.isNormalizing(editor)) {
       return
     }
 
     if (force) {
       const allPaths = Array.from(Node.nodes(editor), ([, p]) => p)
+      const allPathKeys = new Set(allPaths.map(p => p.join(',')))
       DIRTY_PATHS.set(editor, allPaths)
+      DIRTY_PATH_KEYS.set(editor, allPathKeys)
     }
 
     if (getDirtyPaths(editor).length === 0) {
@@ -1026,7 +1040,7 @@ export const Editor: EditorInterface = {
           `)
         }
 
-        const dirtyPath = getDirtyPaths(editor).pop()!
+        const dirtyPath = popDirtyPath(editor)
 
         // If the node doesn't exist in the tree, it does not need to be normalized.
         if (Node.has(editor, dirtyPath)) {

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -34,6 +34,7 @@ export interface PathInterface {
     }
   ) => Path[]
   next: (path: Path) => Path
+  operationCanTransformPath: (operation: Operation) => boolean
   parent: (path: Path) => Path
   previous: (path: Path) => Path
   relative: (path: Path, ancestor: Path) => Path
@@ -289,6 +290,26 @@ export const Path: PathInterface = {
 
     const last = path[path.length - 1]
     return path.slice(0, -1).concat(last + 1)
+  },
+
+  /**
+   * Returns whether this operation can affect paths or not. Used as an
+   * optimization when updating dirty paths during normalization
+   *
+   * NOTE: This *must* be kept in sync with the implementation of 'transform'
+   * below
+   */
+  operationCanTransformPath(operation: Operation): boolean {
+    switch (operation.type) {
+      case 'insert_node':
+      case 'remove_node':
+      case 'merge_node':
+      case 'split_node':
+      case 'move_node':
+        return true
+      default:
+        return false
+    }
   },
 
   /**

--- a/packages/slate/src/utils/weak-maps.ts
+++ b/packages/slate/src/utils/weak-maps.ts
@@ -1,6 +1,7 @@
 import { Editor, Path, PathRef, PointRef, RangeRef } from '..'
 
 export const DIRTY_PATHS: WeakMap<Editor, Path[]> = new WeakMap()
+export const DIRTY_PATH_KEYS: WeakMap<Editor, Set<string>> = new WeakMap()
 export const FLUSHING: WeakMap<Editor, boolean> = new WeakMap()
 export const NORMALIZING: WeakMap<Editor, boolean> = new WeakMap()
 export const PATH_REFS: WeakMap<Editor, Set<PathRef>> = new WeakMap()


### PR DESCRIPTION
**Description**
While large bulk edits are not a common scenario, we noticed that the dirty path tracking during batches has an O(n^2) behavior in relation to the number of ops. This is because as every op gets applied, we loop over all previous dirty paths and transform them. This implements an optimization where we can bypass the no-op transform entirely if we know the op won't affect paths at all.

In a simple test where I had a slate with 1000 texts and I applied an 'insert_text' op appending a character to each text, I saw about a 50% time savings (went from ~2s down to ~1s)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

