### PR TITLE
Chore/add "mentions with space" example

### DIFF
--- a/site/examples/mentions-with-space.tsx
+++ b/site/examples/mentions-with-space.tsx
@@ -88,9 +88,13 @@ const MentionExample = () => {
             })
           const textRange = end && Editor.range(editor, end, start)
           const text = textRange && Editor.string(editor, textRange)
-          const match = text?.match(/@([\w\s]+)$/) // change the regex according to your use case
+          const match = text?.match(/@(\w+\s?\w*)$/) // change the regex according to your use case
+          const after = Editor.after(editor, start)
+          const afterRange = Editor.range(editor, start, after)
+          const afterText = Editor.string(editor, afterRange)
+          const afterMatch = afterText.match(/^(\s|$)/)
 
-          if (match) {
+          if (match && afterMatch) {
             const [targetText, matchText] = match
             const entity = Editor.before(editor, start, {
               unit: 'offset',
@@ -100,7 +104,7 @@ const MentionExample = () => {
 
             if (targetRange) {
               setTarget(targetRange)
-              setSearch(matchText)
+              setSearch(matchText.trim())
               setIndex(0)
               return
             }

--- a/site/examples/mentions-with-space.tsx
+++ b/site/examples/mentions-with-space.tsx
@@ -88,7 +88,7 @@ const MentionExample = () => {
             })
           const textRange = end && Editor.range(editor, end, start)
           const text = textRange && Editor.string(editor, textRange)
-          const match = text?.match(/@([\w+\s]+)$/)
+          const match = text?.match(/@([\w\s]+)$/) // change the regex according to your use case
 
           if (match) {
             const [targetText, matchText] = match

--- a/site/examples/mentions-with-space.tsx
+++ b/site/examples/mentions-with-space.tsx
@@ -1,0 +1,649 @@
+import React, { useMemo, useCallback, useRef, useEffect, useState } from 'react'
+import { Editor, Transforms, Range, createEditor, Descendant } from 'slate'
+import { withHistory } from 'slate-history'
+import {
+  Slate,
+  Editable,
+  ReactEditor,
+  withReact,
+  useSelected,
+  useFocused,
+} from 'slate-react'
+
+import { Portal } from '../components'
+import { MentionElement } from './custom-types'
+
+const MentionExample = () => {
+  const ref = useRef<HTMLDivElement | null>()
+  const [value, setValue] = useState<Descendant[]>(initialValue)
+  const [target, setTarget] = useState<Range | undefined>()
+  const [index, setIndex] = useState(0)
+  const [search, setSearch] = useState('')
+  const renderElement = useCallback(props => <Element {...props} />, [])
+  const editor = useMemo(
+    () => withMentions(withReact(withHistory(createEditor()))),
+    []
+  )
+
+  const chars = CHARACTERS.filter(c =>
+    c.toLowerCase().startsWith(search.toLowerCase())
+  ).slice(0, 10)
+
+  const onKeyDown = useCallback(
+    event => {
+      if (target) {
+        switch (event.key) {
+          case 'ArrowDown':
+            event.preventDefault()
+            const prevIndex = index >= chars.length - 1 ? 0 : index + 1
+            setIndex(prevIndex)
+            break
+          case 'ArrowUp':
+            event.preventDefault()
+            const nextIndex = index <= 0 ? chars.length - 1 : index - 1
+            setIndex(nextIndex)
+            break
+          case 'Tab':
+          case 'Enter':
+            event.preventDefault()
+            Transforms.select(editor, target)
+            insertMention(editor, chars[index])
+            setTarget(null)
+            break
+          case 'Escape':
+            event.preventDefault()
+            setTarget(null)
+            break
+        }
+      }
+    },
+    [index, search, target]
+  )
+
+  useEffect(() => {
+    if (target && chars.length > 0) {
+      const el = ref.current
+      const domRange = ReactEditor.toDOMRange(editor, target)
+      const rect = domRange.getBoundingClientRect()
+      el.style.top = `${rect.top + window.pageYOffset + 24}px`
+      el.style.left = `${rect.left + window.pageXOffset}px`
+    }
+  }, [chars.length, editor, index, search, target])
+
+  return (
+    <Slate
+      editor={editor}
+      value={value}
+      onChange={value => {
+        setValue(value)
+        const { selection } = editor
+
+        if (selection && Range.isCollapsed(selection)) {
+          const [start] = Range.edges(selection)
+          const end =
+            start &&
+            Editor.before(editor, start, {
+              unit: 'offset',
+              distance: start.offset,
+            })
+          const textRange = end && Editor.range(editor, end, start)
+          const text = textRange && Editor.string(editor, textRange)
+          const match = text?.match(/@([\w+\s]+)$/)
+
+          if (match) {
+            const [targetText, matchText] = match
+            const entity = Editor.before(editor, start, {
+              unit: 'offset',
+              distance: targetText.length,
+            })
+            const targetRange = entity && Editor.range(editor, entity, start)
+
+            if (targetRange) {
+              setTarget(targetRange)
+              setSearch(matchText)
+              setIndex(0)
+              return
+            }
+          }
+        }
+
+        setSearch('')
+        setTarget(null)
+      }}
+    >
+      <Editable
+        renderElement={renderElement}
+        onKeyDown={onKeyDown}
+        placeholder="Enter some text..."
+      />
+      {target && chars.length > 0 && (
+        <Portal>
+          <div
+            ref={ref}
+            style={{
+              top: '-9999px',
+              left: '-9999px',
+              position: 'absolute',
+              zIndex: 1,
+              padding: '3px',
+              background: 'white',
+              borderRadius: '4px',
+              boxShadow: '0 1px 5px rgba(0,0,0,.2)',
+            }}
+            data-cy="mentions-portal"
+          >
+            {chars.map((char, i) => (
+              <div
+                key={char}
+                style={{
+                  padding: '1px 3px',
+                  borderRadius: '3px',
+                  background: i === index ? '#B4D5FF' : 'transparent',
+                }}
+              >
+                {char}
+              </div>
+            ))}
+          </div>
+        </Portal>
+      )}
+    </Slate>
+  )
+}
+
+const withMentions = editor => {
+  const { isInline, isVoid } = editor
+
+  editor.isInline = element => {
+    return element.type === 'mention' ? true : isInline(element)
+  }
+
+  editor.isVoid = element => {
+    return element.type === 'mention' ? true : isVoid(element)
+  }
+
+  return editor
+}
+
+const insertMention = (editor, character) => {
+  const mention: MentionElement = {
+    type: 'mention',
+    character,
+    children: [{ text: '' }],
+  }
+  Transforms.insertNodes(editor, mention)
+  Transforms.move(editor)
+}
+
+const Element = props => {
+  const { attributes, children, element } = props
+  switch (element.type) {
+    case 'mention':
+      return <Mention {...props} />
+    default:
+      return <p {...attributes}>{children}</p>
+  }
+}
+
+const Mention = ({ attributes, children, element }) => {
+  const selected = useSelected()
+  const focused = useFocused()
+  return (
+    <span
+      {...attributes}
+      contentEditable={false}
+      data-cy={`mention-${element.character.replace(' ', '-')}`}
+      style={{
+        padding: '3px 3px 2px',
+        margin: '0 1px',
+        verticalAlign: 'baseline',
+        display: 'inline-block',
+        borderRadius: '4px',
+        backgroundColor: '#eee',
+        fontSize: '0.9em',
+        boxShadow: selected && focused ? '0 0 0 2px #B4D5FF' : 'none',
+      }}
+    >
+      @{element.character}
+      {children}
+    </span>
+  )
+}
+
+const initialValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text:
+          'This example shows how you might implement a simple @-mentions feature that lets users autocomplete mentioning a user by their full name. Which, in this case, means Star Wars characters. The mentions are rendered as void inline elements inside the document.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      { text: 'Try mentioning characters, like ' },
+      {
+        type: 'mention',
+        character: 'Aayla Secura',
+        children: [{ text: '' }],
+      },
+      { text: ' or ' },
+      {
+        type: 'mention',
+        character: 'Mace Windu',
+        children: [{ text: '' }],
+      },
+      { text: '!' },
+    ],
+  },
+]
+
+const CHARACTERS = [
+  'Aayla Secura',
+  'Adi Gallia',
+  'Admiral Dodd Rancit',
+  'Admiral Firmus Piett',
+  'Admiral Gial Ackbar',
+  'Admiral Ozzel',
+  'Admiral Raddus',
+  'Admiral Terrinald Screed',
+  'Admiral Trench',
+  'Admiral U.O. Statura',
+  'Agen Kolar',
+  'Agent Kallus',
+  'Aiolin and Morit Astarte',
+  'Aks Moe',
+  'Almec',
+  'Alton Kastle',
+  'Amee',
+  'AP-5',
+  'Armitage Hux',
+  'Artoo',
+  'Arvel Crynyd',
+  'Asajj Ventress',
+  'Aurra Sing',
+  'AZI-3',
+  'Bala-Tik',
+  'Barada',
+  'Bargwill Tomder',
+  'Baron Papanoida',
+  'Barriss Offee',
+  'Baze Malbus',
+  'Bazine Netal',
+  'BB-8',
+  'BB-9E',
+  'Ben Quadinaros',
+  'Berch Teller',
+  'Beru Lars',
+  'Bib Fortuna',
+  'Biggs Darklighter',
+  'Black Krrsantan',
+  'Bo-Katan Kryze',
+  'Boba Fett',
+  'Bobbajo',
+  'Bodhi Rook',
+  'Borvo the Hutt',
+  'Boss Nass',
+  'Bossk',
+  'Breha Antilles-Organa',
+  'Bren Derlin',
+  'Brendol Hux',
+  'BT-1',
+  'C-3PO',
+  'C1-10P',
+  'Cad Bane',
+  'Caluan Ematt',
+  'Captain Gregor',
+  'Captain Phasma',
+  'Captain Quarsh Panaka',
+  'Captain Rex',
+  'Carlist Rieekan',
+  'Casca Panzoro',
+  'Cassian Andor',
+  'Cassio Tagge',
+  'Cham Syndulla',
+  'Che Amanwe Papanoida',
+  'Chewbacca',
+  'Chi Eekway Papanoida',
+  'Chief Chirpa',
+  'Chirrut Îmwe',
+  'Ciena Ree',
+  'Cin Drallig',
+  'Clegg Holdfast',
+  'Cliegg Lars',
+  'Coleman Kcaj',
+  'Coleman Trebor',
+  'Colonel Kaplan',
+  'Commander Bly',
+  'Commander Cody (CC-2224)',
+  'Commander Fil (CC-3714)',
+  'Commander Fox',
+  'Commander Gree',
+  'Commander Jet',
+  'Commander Wolffe',
+  'Conan Antonio Motti',
+  'Conder Kyl',
+  'Constable Zuvio',
+  'Cordé',
+  'Cpatain Typho',
+  'Crix Madine',
+  'Cut Lawquane',
+  'Dak Ralter',
+  'Dapp',
+  'Darth Bane',
+  'Darth Maul',
+  'Darth Tyranus',
+  'Daultay Dofine',
+  'Del Meeko',
+  'Delian Mors',
+  'Dengar',
+  'Depa Billaba',
+  'Derek Klivian',
+  'Dexter Jettster',
+  'Dineé Ellberger',
+  'DJ',
+  'Doctor Aphra',
+  'Doctor Evazan',
+  'Dogma',
+  'Dormé',
+  'Dr. Cylo',
+  'Droidbait',
+  'Droopy McCool',
+  'Dryden Vos',
+  'Dud Bolt',
+  'Ebe E. Endocott',
+  'Echuu Shen-Jon',
+  'Eeth Koth',
+  'Eighth Brother',
+  'Eirtaé',
+  'Eli Vanto',
+  'Ellé',
+  'Ello Asty',
+  'Embo',
+  'Eneb Ray',
+  'Enfys Nest',
+  'EV-9D9',
+  'Evaan Verlaine',
+  'Even Piell',
+  'Ezra Bridger',
+  'Faro Argyus',
+  'Feral',
+  'Fifth Brother',
+  'Finis Valorum',
+  'Finn',
+  'Fives',
+  'FN-1824',
+  'FN-2003',
+  'Fodesinbeed Annodue',
+  'Fulcrum',
+  'FX-7',
+  'GA-97',
+  'Galen Erso',
+  'Gallius Rax',
+  'Garazeb "Zeb" Orrelios',
+  'Gardulla the Hutt',
+  'Garrick Versio',
+  'Garven Dreis',
+  'Gavyn Sykes',
+  'Gideon Hask',
+  'Gizor Dellso',
+  'Gonk droid',
+  'Grand Inquisitor',
+  'Greeata Jendowanian',
+  'Greedo',
+  'Greer Sonnel',
+  'Grievous',
+  'Grummgar',
+  'Gungi',
+  'Hammerhead',
+  'Han Solo',
+  'Harter Kalonia',
+  'Has Obbit',
+  'Hera Syndulla',
+  'Hevy',
+  'Hondo Ohnaka',
+  'Huyang',
+  'Iden Versio',
+  'IG-88',
+  'Ima-Gun Di',
+  'Inquisitors',
+  'Inspector Thanoth',
+  'Jabba',
+  'Jacen Syndulla',
+  'Jan Dodonna',
+  'Jango Fett',
+  'Janus Greejatus',
+  'Jar Jar Binks',
+  'Jas Emari',
+  'Jaxxon',
+  'Jek Tono Porkins',
+  'Jeremoch Colton',
+  'Jira',
+  'Jobal Naberrie',
+  'Jocasta Nu',
+  'Joclad Danva',
+  'Joh Yowza',
+  'Jom Barell',
+  'Joph Seastriker',
+  'Jova Tarkin',
+  'Jubnuk',
+  'Jyn Erso',
+  'K-2SO',
+  'Kanan Jarrus',
+  'Karbin',
+  'Karina the Great',
+  'Kes Dameron',
+  'Ketsu Onyo',
+  'Ki-Adi-Mundi',
+  'King Katuunko',
+  'Kit Fisto',
+  'Kitster Banai',
+  'Klaatu',
+  'Klik-Klak',
+  'Korr Sella',
+  'Kylo Ren',
+  'L3-37',
+  'Lama Su',
+  'Lando Calrissian',
+  'Lanever Villecham',
+  'Leia Organa',
+  'Letta Turmond',
+  'Lieutenant Kaydel Ko Connix',
+  'Lieutenant Thire',
+  'Lobot',
+  'Logray',
+  'Lok Durd',
+  'Longo Two-Guns',
+  'Lor San Tekka',
+  'Lorth Needa',
+  'Lott Dod',
+  'Luke Skywalker',
+  'Lumat',
+  'Luminara Unduli',
+  'Lux Bonteri',
+  'Lyn Me',
+  'Lyra Erso',
+  'Mace Windu',
+  'Malakili',
+  'Mama the Hutt',
+  'Mars Guo',
+  'Mas Amedda',
+  'Mawhonic',
+  'Max Rebo',
+  'Maximilian Veers',
+  'Maz Kanata',
+  'ME-8D9',
+  'Meena Tills',
+  'Mercurial Swift',
+  'Mina Bonteri',
+  'Miraj Scintel',
+  'Mister Bones',
+  'Mod Terrik',
+  'Moden Canady',
+  'Mon Mothma',
+  'Moradmin Bast',
+  'Moralo Eval',
+  'Morley',
+  'Mother Talzin',
+  'Nahdar Vebb',
+  'Nahdonnis Praji',
+  'Nien Nunb',
+  'Niima the Hutt',
+  'Nines',
+  'Norra Wexley',
+  'Nute Gunray',
+  'Nuvo Vindi',
+  'Obi-Wan Kenobi',
+  'Odd Ball',
+  'Ody Mandrell',
+  'Omi',
+  'Onaconda Farr',
+  'Oola',
+  'OOM-9',
+  'Oppo Rancisis',
+  'Orn Free Taa',
+  'Oro Dassyne',
+  'Orrimarko',
+  'Osi Sobeck',
+  'Owen Lars',
+  'Pablo-Jill',
+  'Padmé Amidala',
+  'Pagetti Rook',
+  'Paige Tico',
+  'Paploo',
+  'Petty Officer Thanisson',
+  'Pharl McQuarrie',
+  'Plo Koon',
+  'Po Nudo',
+  'Poe Dameron',
+  'Poggle the Lesser',
+  'Pong Krell',
+  'Pooja Naberrie',
+  'PZ-4CO',
+  'Quarrie',
+  'Quay Tolsite',
+  'Queen Apailana',
+  'Queen Jamillia',
+  'Queen Neeyutnee',
+  'Qui-Gon Jinn',
+  'Quiggold',
+  'Quinlan Vos',
+  'R2-D2',
+  'R2-KT',
+  'R3-S6',
+  'R4-P17',
+  'R5-D4',
+  'RA-7',
+  'Rabé',
+  'Rako Hardeen',
+  'Ransolm Casterfo',
+  'Rappertunie',
+  'Ratts Tyerell',
+  'Raymus Antilles',
+  'Ree-Yees',
+  'Reeve Panzoro',
+  'Rey',
+  'Ric Olié',
+  'Riff Tamson',
+  'Riley',
+  'Rinnriyin Di',
+  'Rio Durant',
+  'Rogue Squadron',
+  'Romba',
+  'Roos Tarpals',
+  'Rose Tico',
+  'Rotta the Hutt',
+  'Rukh',
+  'Rune Haako',
+  'Rush Clovis',
+  'Ruwee Naberrie',
+  'Ryoo Naberrie',
+  'Sabé',
+  'Sabine Wren',
+  'Saché',
+  'Saelt-Marae',
+  'Saesee Tiin',
+  'Salacious B. Crumb',
+  'San Hill',
+  'Sana Starros',
+  'Sarco Plank',
+  'Sarkli',
+  'Satine Kryze',
+  'Savage Opress',
+  'Sebulba',
+  'Senator Organa',
+  'Sergeant Kreel',
+  'Seventh Sister',
+  'Shaak Ti',
+  'Shara Bey',
+  'Shmi Skywalker',
+  'Shu Mai',
+  'Sidon Ithano',
+  'Sifo-Dyas',
+  'Sim Aloo',
+  'Siniir Rath Velus',
+  'Sio Bibble',
+  'Sixth Brother',
+  'Slowen Lo',
+  'Sly Moore',
+  'Snaggletooth',
+  'Snap Wexley',
+  'Snoke',
+  'Sola Naberrie',
+  'Sora Bulq',
+  'Strono Tuggs',
+  'Sy Snootles',
+  'Tallissan Lintra',
+  'Tarfful',
+  'Tasu Leech',
+  'Taun We',
+  'TC-14',
+  'Tee Watt Kaa',
+  'Teebo',
+  'Teedo',
+  'Teemto Pagalies',
+  'Temiri Blagg',
+  'Tessek',
+  'Tey How',
+  'Thane Kyrell',
+  'The Bendu',
+  'The Smuggler',
+  'Thrawn',
+  'Tiaan Jerjerrod',
+  'Tion Medon',
+  'Tobias Beckett',
+  'Tulon Voidgazer',
+  'Tup',
+  'U9-C4',
+  'Unkar Plutt',
+  'Val Beckett',
+  'Vanden Willard',
+  'Vice Admiral Amilyn Holdo',
+  'Vober Dand',
+  'WAC-47',
+  'Wag Too',
+  'Wald',
+  'Walrus Man',
+  'Warok',
+  'Wat Tambor',
+  'Watto',
+  'Wedge Antilles',
+  'Wes Janson',
+  'Wicket W. Warrick',
+  'Wilhuff Tarkin',
+  'Wollivan',
+  'Wuher',
+  'Wullf Yularen',
+  'Xamuel Lennox',
+  'Yaddle',
+  'Yarael Poof',
+  'Yoda',
+  'Zam Wesell',
+  'Zev Senesca',
+  'Ziro the Hutt',
+  'Zuckuss',
+]
+
+export default MentionExample

--- a/site/pages/examples/[example].tsx
+++ b/site/pages/examples/[example].tsx
@@ -19,6 +19,7 @@ import Inlines from '../../examples/inlines'
 import MarkdownPreview from '../../examples/markdown-preview'
 import MarkdownShortcuts from '../../examples/markdown-shortcuts'
 import Mentions from '../../examples/mentions'
+import MentionsWithSpace from '../../examples/mentions-with-space'
 import PasteHtml from '../../examples/paste-html'
 import PlainText from '../../examples/plaintext'
 import ReadOnly from '../../examples/read-only'
@@ -45,6 +46,7 @@ const EXAMPLES = [
   ['Markdown Preview', MarkdownPreview, 'markdown-preview'],
   ['Markdown Shortcuts', MarkdownShortcuts, 'markdown-shortcuts'],
   ['Mentions', Mentions, 'mentions'],
+  ['Mentions with Space', MentionsWithSpace, 'mentions-with-space'],
   ['Paste HTML', PasteHtml, 'paste-html'],
   ['Plain Text', PlainText, 'plaintext'],
   ['Read-only', ReadOnly, 'read-only'],


### PR DESCRIPTION
**Description**
This PR adds an example of how to implement the mentions with space-separated names.

**Example**
The current mentions example doesn't allow full name search. In the image below, we're unable to search for "Mace Windu" because of the space.
![Screenshot 2021-12-25 at 20-07-28 Slate Examples](https://user-images.githubusercontent.com/10219539/147391962-d54f53ee-59c5-4b73-ac17-3b0f1287fd61.png)

This PR allows space separated names.
![Screenshot 2021-12-25 at 20-07-48 Slate Examples(1)](https://user-images.githubusercontent.com/10219539/147392063-90e652fd-a950-42fc-ab2f-959801dfb241.png)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)
This is one way to implement a Slack-like mentions feature that allows users to look up using full names and filter more specific names.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

