### PR TITLE
bugfix: On Preact, sometimes DOM & Slate selection are mismatching

### DIFF
--- a/.changeset/shiny-eagles-swim.md
+++ b/.changeset/shiny-eagles-swim.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix "cannot resolve DOM point" error when switching between multiple errors

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -214,7 +214,10 @@ export const Editable = (props: EditableProps) => {
     // Otherwise the DOM selection is out of sync, so update it.
     state.isUpdatingSelection = true
 
-    const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
+    const newDomRange =
+      selection &&
+      hasDomSelectionInEditor &&
+      ReactEditor.toDOMRange(editor, selection)
 
     if (newDomRange) {
       if (Range.isBackward(selection!)) {


### PR DESCRIPTION
**Description**
Sadly, I cannot create stand-alone reproduction environment, only happens in real world for me.

When switching between multiple editors quickly, there is around 5% chance of following error (location differs):
```
Uncaught (in promise) Error: Cannot resolve a DOM point from Slate point: {"path":[1,0],"offset":6}
```

which is caused by this line:
https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/src/components/editable.tsx#L217

No idea why this only happens on real-world, but I was not able to reproduce this behavior on some demo stage.
However, the environment is the following:
- Slate 0.72.3, Slate-React 0.72.1
- Plate 7.x
- Preact 10.5.4
- 2 or more editors are present on a same page

Due to fact it is not happening every time, looks like this is race-condition problem and incompatibility between slate and (possibly) preact. However, this logic fully fixes everything.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

