### PR TITLE
Fix editor.insertText never gets called inside plugins on Android

### DIFF
--- a/.changeset/breezy-ears-happen.md
+++ b/.changeset/breezy-ears-happen.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix "editor.insertText never gets called inside plugins on android"

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -560,9 +560,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
                       })
                       editor.marks = null
                     } else {
-                      Transforms.insertText(editor, text, {
-                        at,
-                      })
+                      Editor.insertText(editor, text)
                     }
                   })
                 }, RESOLVE_DELAY)

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -134,9 +134,7 @@ export class AndroidInputManager {
         })
         this.editor.marks = null
       } else {
-        Transforms.insertText(this.editor, text, {
-          at,
-        })
+        Editor.insertText(this.editor, text)
       }
     })
   }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -793,7 +793,7 @@ export const Editable = (props: EditableProps) => {
                         distance: currentTextNode.text.length,
                         reverse: true,
                       })
-                      Transforms.insertText(editor, text)
+                      Editor.insertText(editor, text)
                     })
                   }
                 }


### PR DESCRIPTION
**Description**
Call `editor.insertText` instead of `Transforms.insertText` to allow overriding behavior in plugins.

**Issue**
Fixes: #4709
I was able to verify that this now works correctly on my Android device, but I am not sure how to add a test for this. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
