### PR TITLE
run focus event listener after existing onFocus handlers

### DIFF
--- a/.changeset/stale-poems-itch.md
+++ b/.changeset/stale-poems-itch.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix useFocused hook

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -57,13 +57,21 @@ export const Slate = (props: {
   })
 
   useIsomorphicLayoutEffect(() => {
-    const fn = () => setIsFocused(ReactEditor.isFocused(editor))
+    const fn = () => {
+      window.setTimeout(() => {
+        setIsFocused(ReactEditor.isFocused(editor))
+      }, 0)
+    }
     document.addEventListener('focus', fn, true)
     return () => document.removeEventListener('focus', fn, true)
   }, [])
 
   useIsomorphicLayoutEffect(() => {
-    const fn = () => setIsFocused(ReactEditor.isFocused(editor))
+    const fn = () => {
+      window.setTimeout(() => {
+        setIsFocused(ReactEditor.isFocused(editor))
+      }, 0)
+    }
     document.addEventListener('blur', fn, true)
     return () => document.removeEventListener('blur', fn, true)
   }, [])

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -58,7 +58,7 @@ export const Slate = (props: {
 
   useIsomorphicLayoutEffect(() => {
     const fn = () => {
-      window.setTimeout(() => {
+      setTimeout(() => {
         setIsFocused(ReactEditor.isFocused(editor))
       }, 0)
     }
@@ -68,7 +68,7 @@ export const Slate = (props: {
 
   useIsomorphicLayoutEffect(() => {
     const fn = () => {
-      window.setTimeout(() => {
+      setTimeout(() => {
         setIsFocused(ReactEditor.isFocused(editor))
       }, 0)
     }


### PR DESCRIPTION
**Description**
As described in the issue, the `useFocused` hook was returning incorrect/unexpected values. I debugged and realized it was displaying old values because of the order in which event listeners were running.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4754

**Example**
Here I repro the exact two behaviors I described in the linked issue, but with this fix in place. (View the GIFs in the issue to see what they looked like before this fix.)
![GIF 12-30-21 at 3 49 48 PM](https://user-images.githubusercontent.com/591990/147794987-df6d9abc-9606-4488-94f6-c10a16f67cac.gif)
![GIF 12-30-21 at 3 50 21 PM](https://user-images.githubusercontent.com/591990/147794989-b2f496cb-754c-4c2f-85a0-4f7a5318d85e.gif)

**Context**
Based on my testing, I think there was a race condition between the focus/blur event listeners in `components/slate.tsx` (added in #3987) and the onFocus/onBlur handlers in `components/editable.tsx`. The `IS_FOCUSED` map was eventually consistent/had the correct values after all handlers ran, but the event listeners in `slate.tsx` were running before the handlers in `editable.tsx` and therefore the `isFocused` hook was displaying the old values, from _before_ the focus/blur handlers ran.

Adding a `setTimeout` with a delay of 0 cause the event listeners in `slate.tsx` to run after the handlers in `editable.tsx`, thereby fixing the issue.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

