### PR TITLE
iframe example - use an onLoad callback instead of the ref

### DIFF
--- a/cypress/integration/examples/iframe.ts
+++ b/cypress/integration/examples/iframe.ts
@@ -12,6 +12,7 @@ const getIframeBody = () => {
       .its('body')
       // automatically retries until body is loaded
       .should('not.be.undefined')
+      .should('not.be.null')
       .then(cy.wrap)
   )
 }

--- a/site/examples/iframe.tsx
+++ b/site/examples/iframe.tsx
@@ -104,15 +104,17 @@ const MarkButton = ({ format, icon }) => {
   )
 }
 
-const IFrame = ({ children, ...props }) => {
-  const [contentRef, setContentRef] = useState(null)
-  const mountNode =
-    contentRef &&
-    contentRef.contentWindow &&
-    contentRef.contentWindow.document.body
+const IFrame = ({ children, onLoad = null, ...props }) => {
+  const [iframeBody, setIframeBody] = useState(null)
+
+  const handleLoad = e => {
+    onLoad && onLoad(e)
+    !e.defaultPrevented && setIframeBody(e.target.contentDocument.body)
+  }
+
   return (
-    <iframe {...props} ref={setContentRef}>
-      {mountNode && createPortal(React.Children.only(children), mountNode)}
+    <iframe srcDoc={`<!DOCTYPE html>`} {...props} onLoad={handleLoad}>
+      {iframeBody && createPortal(children, iframeBody)}
     </iframe>
   )
 }

--- a/site/examples/iframe.tsx
+++ b/site/examples/iframe.tsx
@@ -104,14 +104,11 @@ const MarkButton = ({ format, icon }) => {
   )
 }
 
-const IFrame = ({ children, onLoad = null, ...props }) => {
+const IFrame = ({ children, ...props }) => {
   const [iframeBody, setIframeBody] = useState(null)
-
   const handleLoad = e => {
-    onLoad && onLoad(e)
-    !e.defaultPrevented && setIframeBody(e.target.contentDocument.body)
+    setIframeBody(e.target.contentDocument.body)
   }
-
   return (
     <iframe srcDoc={`<!DOCTYPE html>`} {...props} onLoad={handleLoad}>
       {iframeBody && createPortal(children, iframeBody)}


### PR DESCRIPTION
**Description**
Makes the iframe example work on the Firefox and keeps it working on other browsers. It changes using the ref on the iframe to an `onLoad` event solution

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4285

**Example**
https://www.slatejs.org/examples/iframe on the Firefox

**Context**
Firefox resets the iframe content on the load event. I've tested on some older versions of the browser and it keeps happening too. Here is an issue on the react repo https://github.com/facebook/react/issues/22847

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

