### PR TITLE
Warn when normalization removes node

### DIFF
--- a/.changeset/wild-penguins-shout.md
+++ b/.changeset/wild-penguins-shout.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Warn when normalization removes node

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -227,6 +227,14 @@ export const createEditor = (): Editor => {
         // other inline nodes, or parent blocks that only contain inlines and
         // text.
         if (isInlineOrText !== shouldHaveInlines) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Removing ${
+              isInlineOrText ? 'inline' : 'block'
+            } node at path ${path.concat(n)} because parent expects ${
+              shouldHaveInlines ? 'inline' : 'block'
+            } children`
+          )
           Transforms.removeNodes(editor, { at: path.concat(n), voids: true })
           n--
         } else if (Element.isElement(child)) {


### PR DESCRIPTION
**Description**
Slate requires the invariant that children are all blocks or all inlines. It enforces this in default normalization by removing children. When such a node is removed, it's almost certainly due to a programming error: the developer needs to fix their application to ensure it maintains this invariant. But currently Slate does not tell the developer this.

I made such a programming error, and spent a long time debugging nodes that mysteriously went missing. I would have fixed it within 30 seconds if Slate had warned me when it detected this error.

**Context**
Note I have used `console.warn` despite the eslint rule. As far as I can see, Slate has no other facility for runtime warnings.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)