### PR TITLE
Rollback 4779 and always call Transforms.setSelection

### DIFF
--- a/.changeset/dry-worms-happen.md
+++ b/.changeset/dry-worms-happen.md
@@ -1,0 +1,8 @@
+---
+'slate-react': patch
+---
+
+Android editable updates
+
+- Remove logic to delay handling of text insertion
+- Call Transforms.setSelection before Editor.insertText to adjust position

--- a/.changeset/dry-worms-happen.md
+++ b/.changeset/dry-worms-happen.md
@@ -1,8 +1,0 @@
----
-'slate-react': patch
----
-
-Android editable updates
-
-- Remove logic to delay handling of text insertion
-- Call Transforms.setSelection before Editor.insertText to adjust position

--- a/.changeset/mean-ears-shop.md
+++ b/.changeset/mean-ears-shop.md
@@ -1,0 +1,6 @@
+---
+'slate-react': patch
+---
+
+- Restore logic to delay text insertion on android 
+- Always call Trasform.setSelection before ca

--- a/.changeset/mean-ears-shop.md
+++ b/.changeset/mean-ears-shop.md
@@ -2,5 +2,5 @@
 'slate-react': patch
 ---
 
-- Restore logic to delay text insertion on android 
+- Restore logic to delay text insertion on android
 - Always call Trasform.setSelection before ca

--- a/.changeset/mean-ears-shop.md
+++ b/.changeset/mean-ears-shop.md
@@ -3,4 +3,4 @@
 ---
 
 - Restore logic to delay text insertion on android
-- Always call Trasform.setSelection before ca
+- Always call Trasform.setSelection before calling Editor.insertText

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -24,7 +24,11 @@ import {
   IS_READ_ONLY,
   NODE_TO_ELEMENT,
   PLACEHOLDER_SYMBOL,
+  IS_COMPOSING,
+  IS_ON_COMPOSITION_END,
+  EDITOR_ON_COMPOSITION_TEXT,
 } from '../../utils/weak-maps'
+import { normalizeTextInsertionRange } from './diff-text'
 
 import { EditableProps, hasTarget } from '../editable'
 import useChildren from '../../hooks/use-children'
@@ -523,6 +527,42 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
                 setTimeout(() => {
                   state.isComposing && setIsComposing(false)
                   state.isComposing = false
+
+                  IS_COMPOSING.set(editor, false)
+                  IS_ON_COMPOSITION_END.set(editor, true)
+
+                  const insertedText =
+                    EDITOR_ON_COMPOSITION_TEXT.get(editor) || []
+
+                  // `insertedText` is set in `MutationObserver` constructor.
+                  // If open phone keyboard association function, `CompositionEvent` will be triggered.
+                  if (!insertedText.length) {
+                    return
+                  }
+
+                  EDITOR_ON_COMPOSITION_TEXT.set(editor, [])
+
+                  const { selection, marks } = editor
+
+                  insertedText.forEach(insertion => {
+                    const text = insertion.text.insertText
+                    const at = normalizeTextInsertionRange(
+                      editor,
+                      selection,
+                      insertion
+                    )
+                    if (marks) {
+                      const node = { text, ...marks }
+                      Transforms.insertNodes(editor, node, {
+                        match: Text.isText,
+                        at,
+                        select: true,
+                      })
+                      editor.marks = null
+                    } else {
+                      Editor.insertText(editor, text)
+                    }
+                  })
                 }, RESOLVE_DELAY)
               }
             },
@@ -536,6 +576,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
               ) {
                 !state.isComposing && setIsComposing(true)
                 state.isComposing = true
+                IS_COMPOSING.set(editor, true)
               }
             },
             [attributes.onCompositionUpdate]
@@ -548,6 +589,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
               ) {
                 !state.isComposing && setIsComposing(true)
                 state.isComposing = true
+                IS_COMPOSING.set(editor, true)
               }
             },
             [attributes.onCompositionStart]

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -560,6 +560,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
                       })
                       editor.marks = null
                     } else {
+                      Transforms.setSelection(editor, at)
                       Editor.insertText(editor, text)
                     }
                   })

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -1,9 +1,16 @@
-import { Editor, Range, Text, Transforms } from 'slate'
 import { ReactEditor } from '../../plugin/react-editor'
-import { DOMNode } from '../../utils/dom'
+import { Editor, Range, Transforms, Text } from 'slate'
 import {
-  combineInsertedText,
+  IS_COMPOSING,
+  IS_ON_COMPOSITION_END,
+  EDITOR_ON_COMPOSITION_TEXT,
+} from '../../utils/weak-maps'
+
+import { DOMNode } from '../../utils/dom'
+
+import {
   normalizeTextInsertionRange,
+  combineInsertedText,
   TextInsertion,
 } from './diff-text'
 import {
@@ -103,6 +110,17 @@ export class AndroidInputManager {
 
     const { selection, marks } = this.editor
 
+    // If it is in composing or after `onCompositionend`, set `EDITOR_ON_COMPOSITION_TEXT` and return.
+    // Text will be inserted on compositionend event.
+    if (
+      IS_COMPOSING.get(this.editor) ||
+      IS_ON_COMPOSITION_END.get(this.editor)
+    ) {
+      EDITOR_ON_COMPOSITION_TEXT.set(this.editor, insertedText)
+      IS_ON_COMPOSITION_END.set(this.editor, false)
+      return
+    }
+
     // Insert the batched text diffs
     insertedText.forEach(insertion => {
       const text = insertion.text.insertText
@@ -116,7 +134,6 @@ export class AndroidInputManager {
         })
         this.editor.marks = null
       } else {
-        Transforms.setSelection(this.editor, at)
         Editor.insertText(this.editor, text)
       }
     })

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -134,6 +134,7 @@ export class AndroidInputManager {
         })
         this.editor.marks = null
       } else {
+        Transforms.setSelection(this.editor, at)
         Editor.insertText(this.editor, text)
       }
     })

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -1,5 +1,6 @@
 import { Ancestor, Editor, Node } from 'slate'
 import { Key } from './key'
+import { TextInsertion } from '../components/android/diff-text'
 
 /**
  * Two weak maps that allow us rebuild a path given a node. They are populated
@@ -32,6 +33,17 @@ export const IS_READ_ONLY: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_FOCUSED: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_DRAGGING: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_CLICKING: WeakMap<Editor, boolean> = new WeakMap()
+export const IS_COMPOSING: WeakMap<Editor, boolean> = new WeakMap()
+export const IS_ON_COMPOSITION_END: WeakMap<Editor, boolean> = new WeakMap()
+
+/**
+ * Weak maps for saving text on composition stage.
+ */
+
+export const EDITOR_ON_COMPOSITION_TEXT: WeakMap<
+  Editor,
+  TextInsertion[]
+> = new WeakMap()
 
 /**
  * Weak map for associating the context `onChange` context with the plugin.


### PR DESCRIPTION
**Description**
* Rollback changes made in #4779 
* Always call `Transforms.setSelection` before calling `Editor.insertText`.


**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

