### PR TITLE
Android merge `Editor.insertText` logic.

### DIFF
--- a/.changeset/witty-moose-join.md
+++ b/.changeset/witty-moose-join.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Android merge `Editor.insertText` logic.

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -542,7 +542,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
 
                   EDITOR_ON_COMPOSITION_TEXT.set(editor, [])
 
-                  const { selection, marks } = editor
+                  const { selection } = editor
 
                   insertedText.forEach(insertion => {
                     const text = insertion.text.insertText
@@ -551,18 +551,8 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
                       selection,
                       insertion
                     )
-                    if (marks) {
-                      const node = { text, ...marks }
-                      Transforms.insertNodes(editor, node, {
-                        match: Text.isText,
-                        at,
-                        select: true,
-                      })
-                      editor.marks = null
-                    } else {
-                      Transforms.setSelection(editor, at)
-                      Editor.insertText(editor, text)
-                    }
+                    Transforms.setSelection(editor, at)
+                    Editor.insertText(editor, text)
                   })
                 }, RESOLVE_DELAY)
               }

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -108,7 +108,7 @@ export class AndroidInputManager {
   private insertText = (insertedText: TextInsertion[]) => {
     debug('insertText')
 
-    const { selection, marks } = this.editor
+    const { selection } = this.editor
 
     // If it is in composing or after `onCompositionend`, set `EDITOR_ON_COMPOSITION_TEXT` and return.
     // Text will be inserted on compositionend event.
@@ -125,18 +125,8 @@ export class AndroidInputManager {
     insertedText.forEach(insertion => {
       const text = insertion.text.insertText
       const at = normalizeTextInsertionRange(this.editor, selection, insertion)
-      if (marks) {
-        const node = { text, ...marks }
-        Transforms.insertNodes(this.editor, node, {
-          match: Text.isText,
-          at,
-          select: true,
-        })
-        this.editor.marks = null
-      } else {
-        Transforms.setSelection(this.editor, at)
-        Editor.insertText(this.editor, text)
-      }
+      Transforms.setSelection(this.editor, at)
+      Editor.insertText(this.editor, text)
     })
   }
 


### PR DESCRIPTION
**Description**
Based on discussion from #4709 #4753  #4779 . We have discussed the issue of externally overridden `Editor.insertText` not being called, and I think there is still room for adjustment. 

`Editor.insertText` already contains the logic to set marks, https://github.com/ianstormtaylor/slate/blob/67aa1f10106e15486031b4103285c7fae4373056/packages/slate/src/create-editor.ts#L169-L182 so we can merge the logic here. This PR also avoids the situation that the externally override `Editor.insertText` will not be called when `marks` are set.


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

