### PR TITLE
Fix text not rendered on server-side rendering

### DIFF
--- a/.changeset/orange-zoos-exercise.md
+++ b/.changeset/orange-zoos-exercise.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix text not rendered on server-side rendering

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useLayoutEffect } from 'react'
+import React, { useRef } from 'react'
 import { Editor, Text, Path, Element, Node } from 'slate'
 
 import { ReactEditor, useSlateStatic } from '..'
+import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 
 /**
  * Leaf content strings.
@@ -69,7 +70,7 @@ const TextString = (props: { text: string; isTrailing?: boolean }) => {
   // eg makes native spellcheck opt out from checking the text node.
 
   // useLayoutEffect: updating our span before browser paint
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // null coalescing text to make sure we're not outputing "null" as a string in the extreme case it is nullish at runtime
     const textWithTrailing = `${text ?? ''}${isTrailing ? '\n' : ''}`
 


### PR DESCRIPTION
**Description**
The fix makes sure that the text content of the TextString component is rendered on the first render.

**Issue**
Fixes: server-side rendering issue introduced by #4733

**Example**
Before #4733: **slate-react@^0.72.1**
Text content is rendered as expected.
![image](https://user-images.githubusercontent.com/13460383/150302197-c69b4c4e-2310-4d1b-8762-a8690884ad21.png)

After #4733: **slate-react@^0.72.2**
Text content is not rendered.
![image](https://user-images.githubusercontent.com/13460383/150302857-fdc549d8-fe48-4864-84e6-f9a829f34f84.png)

**Context**
#4733 uses `useLayoutEffect` to fix the spellcheck issue. However, `useLayoutEffect` won't fire until the JavaScript is downloaded, which means the text content of the TextString component can't get rendered on ssr.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

