### PR TITLE
Fix text content not rendered on ssr

### DIFF
--- a/.changeset/rude-humans-marry.md
+++ b/.changeset/rude-humans-marry.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix text not rendered on ssr


### PR DESCRIPTION
**Description**
The fix makes sure that the text content of the TextString component is rendered on the first render.

**Issue**
Fixes: server-side rendering issue introduced by #4733.
Correct fix of #4796.

**Example**
Please see example in #4796.

**Context**
#4733 spellcheck fix changed the render behavior of the TextString component. TextString won't render the actual text content on the first-time render, which means server-side rendering is broken. This fix ensures that the text content will get rendered immediately on the first-time render.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

