### PR TITLE
Fix links example in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,7 @@ To get a sense for how you might use Slate, check out a few of the examples:
 - [**Plain text**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/plaintext.tsx) — showing the most basic case: a glorified `<textarea>`.
 - [**Rich text**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/richtext.tsx) — showing the features you'd expect from a basic editor.
 - [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/markdown-preview.tsx) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Links**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/links.tsx) — showing how wrap text in inline nodes with associated data.
+- [**Inlines**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/inlines.tsx) — showing how wrap text in inline nodes with associated data.
 - [**Images**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/images.tsx) — showing how to use void (text-less) nodes to add images.
 - [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/hovering-toolbar.tsx) — showing how a hovering toolbar can be implemented.
 - [**Tables**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/tables.tsx) — showing how to nest blocks to render more advanced components.


### PR DESCRIPTION
**Description**
In https://github.com/ianstormtaylor/slate/pull/4615/files links example was moved to the inlines, but in the readme, we still have a link to the old example. 

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

