### PR TITLE
update insertText logic when selection is not collapsed

### DIFF
--- a/.changeset/silly-flowers-worry.md
+++ b/.changeset/silly-flowers-worry.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+update insertText logic when selection is not collapsed

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -483,12 +483,11 @@ export const TextTransforms: TextTransforms = {
         if (Range.isCollapsed(at)) {
           at = at.anchor
         } else {
-          const start = Range.start(at)
-
-          if (!voids && Editor.void(editor, { at: start })) {
+          const end = Range.end(at)
+          if (!voids && Editor.void(editor, { at: end })) {
             return
           }
-
+          const start = Range.start(at)
           const pointRef = Editor.pointRef(editor, start)
           Transforms.delete(editor, { at, voids })
           at = pointRef.unref()!

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -483,13 +483,13 @@ export const TextTransforms: TextTransforms = {
         if (Range.isCollapsed(at)) {
           at = at.anchor
         } else {
-          const end = Range.end(at)
+          const start = Range.start(at)
 
-          if (!voids && Editor.void(editor, { at: end })) {
+          if (!voids && Editor.void(editor, { at: start })) {
             return
           }
 
-          const pointRef = Editor.pointRef(editor, end)
+          const pointRef = Editor.pointRef(editor, start)
           Transforms.delete(editor, { at, voids })
           at = pointRef.unref()!
           Transforms.setSelection(editor, { anchor: at, focus: at })


### PR DESCRIPTION
**Description**
When I select a paragraph with different styles of text, for example, bold and plain, and then insert the letter q. What I want is to insert a non-bold letter.

**Example**
this is old code, the q is bold
![chrome-capture](https://user-images.githubusercontent.com/23088895/151141152-a8d19518-8af3-407b-83ed-c4a415f1816e.gif)

this is new code, the q is normal
![chrome-capture1](https://user-images.githubusercontent.com/23088895/151141293-53ee388c-1626-4d74-bed0-eeb7928df110.gif)


**Context**

![chrome-capture 2](https://user-images.githubusercontent.com/23088895/151141976-b0a650ec-6805-419c-8c7c-dde7f6f88cb5.gif)

Normally, when we insert the character q between unbold and bold, it is unbold. the style use position of anchor. but when selection is not collapsed, selection be set by focus or end of range.

The processing logic is inconsistent for different actions. also, the cursor should be placed at the starting position. If the deleted area has elements that cannot be deleted, like table, the cursor position will be incorrect



**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset]

