### PR TITLE
fix: flush onDOMSelectionChange on onDOMBeforeInput

### DIFF
--- a/.changeset/wise-kings-serve.md
+++ b/.changeset/wise-kings-serve.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Flush onDOMSelectionChange on onDOMBeforeInput

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -330,6 +330,7 @@ export const Editable = (props: EditableProps) => {
         // triggering a `beforeinput` expecting the change to be applied to the immediately before
         // set selection.
         scheduleOnDOMSelectionChange.flush()
+        onDOMSelectionChange.flush()
 
         const { selection } = editor
         const { inputType: type } = event


### PR DESCRIPTION
**Description**
Fixes the same fundamental issue as #4669 did, only triggered in a slightly different way. If the editor isn't focused the first select causes the 2nd one that Grammarly causes to be delayed by the `onDOMSelectionChangeonDOMSelectionChange` throttle.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4801

**Example**
Before:
![before](https://user-images.githubusercontent.com/13185548/151199742-db63c34b-4b28-4d44-90de-2527b54a7e7e.gif)

After:
![after](https://user-images.githubusercontent.com/13185548/151199783-610955af-8389-40d4-90a5-479e18d95820.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

