### PR TITLE
Fix failing unhangRange test case with inlines

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1656,7 +1656,7 @@ export const Editor: EditorInterface = {
       match: n => Editor.isBlock(editor, n),
     })
     const blockPath = endBlock ? endBlock[1] : []
-    const first = Editor.start(editor, [])
+    const first = Editor.start(editor, start)
     const before = { anchor: first, focus: end }
     let skip = true
 

--- a/packages/slate/test/interfaces/Editor/unhangRange/inline-range-normal.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/inline-range-normal.tsx
@@ -4,9 +4,14 @@ import { jsx } from '../../..'
 
 export const input = (
   <editor>
-    <block><text>Block before</text></block>
     <block>
-      <text><anchor />Some text before </text>
+      <text>Block before</text>
+    </block>
+    <block>
+      <text>
+        <anchor />
+        Some text before{' '}
+      </text>
       <inline void>
         <focus />
       </inline>
@@ -20,7 +25,6 @@ export const input = (
 
 export const test = editor => {
   const range = Editor.unhangRange(editor, editor.selection)
-  console.log(range)
   return range
 }
 
@@ -28,4 +32,3 @@ export const output = {
   anchor: { path: [1, 0], offset: 0 },
   focus: { path: [1, 1, 0], offset: 0 },
 }
-

--- a/packages/slate/test/interfaces/Editor/unhangRange/inline-range-normal.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/inline-range-normal.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block><text>Block before</text></block>
+    <block>
+      <text><anchor />Some text before </text>
+      <inline void>
+        <focus />
+      </inline>
+      <text />
+    </block>
+    <block>
+      <text>Another block</text>
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  const range = Editor.unhangRange(editor, editor.selection)
+  console.log(range)
+  return range
+}
+
+export const output = {
+  anchor: { path: [1, 0], offset: 0 },
+  focus: { path: [1, 1, 0], offset: 0 },
+}
+


### PR DESCRIPTION
**Description**

Adding this here for now to get some help on trying to fix this particular bug and can then modify it into an actual fix later on.

Take a look at the test that I added. It fails right now.

It returns:
```
{
  anchor: { path: [ 1, 0 ], offset: 0 },
  focus: { path: [ 0, 0 ], offset: 12 }
}
```

which is clearly not what we want. Adding this here for now so we can explore why this happens.

@e1himself you've looked at this code recently (thanks for adding the tests! They're a big help.). Do you have some idea what might be going wrong here?

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

