### PR TITLE
fix not update state when unmounted

### DIFF
--- a/.changeset/hot-beers-poke.md
+++ b/.changeset/hot-beers-poke.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix a possible update of react state after Slate component is unmounted

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useEffect } from 'react'
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { Editor, Node, Element, Descendant } from 'slate'
 import { ReactEditor } from '../plugin/react-editor'
 import { FocusedContext } from '../hooks/use-focused'
@@ -19,6 +19,7 @@ export const Slate = (props: {
   onChange: (value: Descendant[]) => void
 }) => {
   const { editor, children, onChange, value, ...rest } = props
+  const unmountRef = useRef(false)
 
   const [context, setContext] = React.useState<[ReactEditor]>(() => {
     if (!Node.isNodeList(value)) {
@@ -47,6 +48,7 @@ export const Slate = (props: {
   useEffect(() => {
     return () => {
       EDITOR_TO_ON_CHANGE.set(editor, () => {})
+      unmountRef.current = true
     }
   }, [])
 
@@ -59,6 +61,9 @@ export const Slate = (props: {
   useIsomorphicLayoutEffect(() => {
     const fn = () => {
       setTimeout(() => {
+        if (unmountRef.current) {
+          return
+        }
         setIsFocused(ReactEditor.isFocused(editor))
       }, 0)
     }


### PR DESCRIPTION
**Description**
Changed so that the state of the slate component is not updated when unmounting.

**Issue**
Fixes: #4818 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

