### PR TITLE
fix isDraggingInternally reset logic

### DIFF
--- a/.changeset/dirty-bobcats-marry.md
+++ b/.changeset/dirty-bobcats-marry.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Reset isDraggingInternally onDragEnd and onDrop even if the event is handled by the editable handler

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -973,8 +973,6 @@ export const Editable = (props: EditableProps) => {
                       at: draggedRange,
                     })
                   }
-
-                  state.isDraggingInternally = false
                 }
 
                 ReactEditor.insertData(editor, data)
@@ -985,22 +983,26 @@ export const Editable = (props: EditableProps) => {
                   ReactEditor.focus(editor)
                 }
               }
+
+              state.isDraggingInternally = false
             },
             [readOnly, attributes.onDrop]
           )}
           onDragEnd={useCallback(
             (event: React.DragEvent<HTMLDivElement>) => {
-              // When dropping on a different droppable element than the current editor,
-              // `onDrop` is not called. So we need to clean up in `onDragEnd` instead.
-              // Note: `onDragEnd` is only called when `onDrop` is not called
               if (
                 !readOnly &&
                 state.isDraggingInternally &&
-                hasTarget(editor, event.target) &&
-                !isEventHandled(event, attributes.onDragEnd)
+                attributes.onDragEnd &&
+                hasTarget(editor, event.target)
               ) {
-                state.isDraggingInternally = false
+                attributes.onDragEnd(event)
               }
+
+              // When dropping on a different droppable element than the current editor,
+              // `onDrop` is not called. So we need to clean up in `onDragEnd` instead.
+              // Note: `onDragEnd` is only called when `onDrop` is not called
+              state.isDraggingInternally = false
             },
             [readOnly, attributes.onDragEnd]
           )}


### PR DESCRIPTION
**Description**
Currently `isDraggingInternally` is only reset if the `onDrop`/`onDragEnd` events aren't handled by the respective "external" editable event handlers. This potentially causes `isDraggingInternally` to stay `true` even though the user isn't dragging anymore blocking `onDOMSelectionChange` thus preventing the user from selecting anything inside the editor.

**Context**
This pr simply ensues `isDraggingInternally` is always reset `onDrop`/`onDragEnd`

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

