### PR TITLE
render void spacer in readonly mode

### DIFF
--- a/.changeset/hip-pigs-film.md
+++ b/.changeset/hip-pigs-film.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Render void spacer in readonly mode

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -96,7 +96,7 @@ const Element = (props: {
     const Tag = isInline ? 'span' : 'div'
     const [[text]] = Node.texts(element)
 
-    children = readOnly ? null : (
+    children = (
       <Tag
         data-slate-spacer
         style={{


### PR DESCRIPTION
**Description**
Currently finding the dom range of a void node in read-only crashes the editor since slate doesn't render the void spacer in read-only.

This pr simply adjusts the Element component so that it is rendered even in read-only.

> ⚠️  I'm not sure why this wasn't the case before, so there might be something I'm missing here. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

