### PR TITLE
fix point transform for insert_text to account for affinity

### DIFF
--- a/.changeset/fast-doors-peel.md
+++ b/.changeset/fast-doors-peel.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+fix point transform for insert_text operations to account for affinity

--- a/packages/slate/src/interfaces/point.ts
+++ b/packages/slate/src/interfaces/point.ts
@@ -110,7 +110,11 @@ export const Point: PointInterface = {
         }
 
         case 'insert_text': {
-          if (Path.equals(op.path, path) && op.offset <= offset) {
+          if (
+            Path.equals(op.path, path) &&
+            (op.offset < offset ||
+              (op.offset === offset && affinity === 'forward'))
+          ) {
             p.offset += op.text.length
           }
 

--- a/packages/slate/test/interfaces/Point/transform/backward-insert-text-after-point.tsx
+++ b/packages/slate/test/interfaces/Point/transform/backward-insert-text-after-point.tsx
@@ -1,0 +1,24 @@
+import { Point } from 'slate'
+
+export const input = {
+  path: [0, 0],
+  offset: 0,
+}
+
+export const test = value => {
+  return Point.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 1,
+      properties: {},
+    },
+    { affinity: 'backward' }
+  )
+}
+export const output = {
+  path: [0, 0],
+  offset: 0,
+}

--- a/packages/slate/test/interfaces/Point/transform/backward-insert-text-at-point.tsx
+++ b/packages/slate/test/interfaces/Point/transform/backward-insert-text-at-point.tsx
@@ -1,0 +1,24 @@
+import { Point } from 'slate'
+
+export const input = {
+  path: [0, 0],
+  offset: 1,
+}
+
+export const test = value => {
+  return Point.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 1,
+      properties: {},
+    },
+    { affinity: 'backward' }
+  )
+}
+export const output = {
+  path: [0, 0],
+  offset: 1,
+}

--- a/packages/slate/test/interfaces/Point/transform/backward-insert-text-before-point.tsx
+++ b/packages/slate/test/interfaces/Point/transform/backward-insert-text-before-point.tsx
@@ -1,0 +1,24 @@
+import { Point } from 'slate'
+
+export const input = {
+  path: [0, 0],
+  offset: 1,
+}
+
+export const test = value => {
+  return Point.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 0,
+      properties: {},
+    },
+    { affinity: 'backward' }
+  )
+}
+export const output = {
+  path: [0, 0],
+  offset: 2,
+}

--- a/packages/slate/test/interfaces/Point/transform/forward-insert-text-after-point.tsx
+++ b/packages/slate/test/interfaces/Point/transform/forward-insert-text-after-point.tsx
@@ -1,0 +1,24 @@
+import { Point } from 'slate'
+
+export const input = {
+  path: [0, 0],
+  offset: 0,
+}
+
+export const test = value => {
+  return Point.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 1,
+      properties: {},
+    },
+    { affinity: 'forward' }
+  )
+}
+export const output = {
+  path: [0, 0],
+  offset: 0,
+}

--- a/packages/slate/test/interfaces/Point/transform/forward-insert-text-at-point.tsx
+++ b/packages/slate/test/interfaces/Point/transform/forward-insert-text-at-point.tsx
@@ -1,0 +1,24 @@
+import { Point } from 'slate'
+
+export const input = {
+  path: [0, 0],
+  offset: 1,
+}
+
+export const test = value => {
+  return Point.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 1,
+      properties: {},
+    },
+    { affinity: 'forward' }
+  )
+}
+export const output = {
+  path: [0, 0],
+  offset: 2,
+}

--- a/packages/slate/test/interfaces/Point/transform/forward-insert-text-before-point.tsx
+++ b/packages/slate/test/interfaces/Point/transform/forward-insert-text-before-point.tsx
@@ -1,0 +1,24 @@
+import { Point } from 'slate'
+
+export const input = {
+  path: [0, 0],
+  offset: 1,
+}
+
+export const test = value => {
+  return Point.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 0,
+      properties: {},
+    },
+    { affinity: 'forward' }
+  )
+}
+export const output = {
+  path: [0, 0],
+  offset: 2,
+}

--- a/packages/slate/test/interfaces/Range/transform/outward-collapsed.tsx
+++ b/packages/slate/test/interfaces/Range/transform/outward-collapsed.tsx
@@ -1,0 +1,39 @@
+import { Range } from 'slate'
+
+/**
+ * If a collapsed Range is transformed with affinity outward by an insert_text operation, it should expand.
+ */
+
+export const input = {
+  anchor: {
+    path: [0, 0],
+    offset: 1,
+  },
+  focus: {
+    path: [0, 0],
+    offset: 1,
+  },
+}
+export const test = value => {
+  return Range.transform(
+    value,
+    {
+      type: 'insert_text',
+      path: [0, 0],
+      text: 'a',
+      offset: 1,
+      properties: {},
+    },
+    { affinity: 'outward' }
+  )
+}
+export const output = {
+  anchor: {
+    path: [0, 0],
+    offset: 1,
+  },
+  focus: {
+    path: [0, 0],
+    offset: 2,
+  },
+}


### PR DESCRIPTION
**Description**
When one creates a RangeRef with affinity `outward` and the ref becomes collapsed, it can't be expanded again with an `insert_text` operation (although it should IMO). 

**Example**
Lets take an example string (and not care about paths for simplicity sake)
```
This is a test
```
The RangeRef is the following
```ts
{ 
  affinity: 'outward',
  current: { 
    anchor: { offset: 4 }, 
    focus: { offset: 4 } 
  },
}
```

Now if the user types something at offset 4 (right after the first word) the RangeRef right now changes to the following
```ts
{ 
  affinity: 'outward',
  current: { 
    anchor: { offset: 5 }, 
    focus: { offset: 5 } 
  },
}
```
Although I naively expected it to be this.
```ts
{ 
  affinity: 'outward',
  current: { 
    anchor: { offset: 4 }, 
    focus: { offset: 5 } 
  },
}
```

**Context**

If you take a collapsed RangeRef with affinity `outward` and apply an `insert_text` operation at the offset of where the Range is the following happens: 
Because the collapsed ranges count as forward pointing ranges, the `Range.transform()` will determine the anchors' affinity as `backward`. Therefor it will run the `Point.transform()` on the anchor with that affinity. But, because the `Point.transform()` doesn't account for the affinity, the offset of the anchor gets incremented regardless. The same happens with the focus thus the Range will stay collapsed.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

