### PR TITLE
Define "hanging range" and intended behavior of unhangRange

### DIFF
--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -302,7 +302,16 @@ If the selection is currently collapsed, the removal will be stored on `editor.m
 
 Convert a range into a non-hanging one.
 
-Options: `{voids?: boolean}`
+A "hanging" range is one created by the browser's "triple-click" selection behavior. When triple-clicking a block, the browser selects from the start of that block to the start of the _next_ block. The range thus "hangs over" into the next block. If `unhangRange` is given such a range, it moves the end backwards until it's in a non-empty text node that precedes the hanging block.
+
+Note that `unhangRange` is designed for the specific purpose of fixing triple-clicked blocks, and therefore currently has a number of caveats:
+
+- It does not modify the start of the range; only the end. For example, it does not "unhang" a selection that starts at the end of a previous block.
+- It only does anything if the start block is fully selected. For example, it does not handle ranges created by double-clicking the end of a paragraph (which browsers treat by selecting from the end of that paragraph to the start of the next).
+
+Options:
+
+- `voids?: boolean = false`: Allow placing the end of the selection in a void node.
 
 ### Check methods
 


### PR DESCRIPTION
**Description**

There is currently no definition of this in the docs, so it's very hard to understand what this function is supposed to do, and whether it's buggy. I've written this definition based on Ian Taylor's messages on Slack:

    Jason: Why does unhangRange only unhang the end of a range and not
    the start as well? Trying to tell if this is a bug or some logic I'm
    not following. If the start of the range is at the last index of a
    text shouldn't unhangRange advance that to the next node?

    ianstormtaylor: I don’t believe it’s a bug. It was designed to
    handle ranges that result from triple-clicks. Not that there might
    not be improvements, or that there might not be some other better
    way to solve for triple-clicks, or that there might be a better
    name for it

    Jason: When you say triple-click handling you mean the fact that
    the browser selection by default gets placed from start of line to
    start of next line? In that cause yes the end of the selection is
    where the problem is. If looked at as a more generic implementation
    it seems like unhanging the start in cases where you have
    {text: 'foo|'}, {text: 'bar|', bold: true} and it makes sense to
    normalize the selection to {text: 'foo'},
    {text: '|bar|', bold: true} which helps in some cases by avoiding
    splits that immediately get merged back, etc.

    ianstormtaylor: Yup, that’s exactly right. It was created for the
    triple-click case. I agree that something to handle the
    start-edged cases would be nice too. But folks in GitHub
    discussions have been kind of assuming that the code meant to be
    written for both, and that it’s a bug to fix, which isn’t true.
    I’m not sure if there are gotchas to expanding the scope to
    handle both edges

-- https://slate-js.slack.com/archives/CC58ZGGU9/p1632188507024300

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/discussions/4244 (Note: that discussion has a definition of "hanging" that is incorrect, at least according to the current implementation, and @ianstormtaylor's notes: "starts at the end of a node" should not be part of the definition of "hanging".)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)