### PR TITLE
DOCS: improved deserialization example

### DIFF
--- a/docs/concepts/10-serializing.md
+++ b/docs/concepts/10-serializing.md
@@ -168,16 +168,18 @@ const deserialize = (el, markAttributes = {}) => {
   } else if (el.nodeType !== Node.ELEMENT_NODE) {
     return null
   }
-  
-  const nodeAttributes = { ...markAttributes };
-  
+
+  const nodeAttributes = { ...markAttributes }
+
   // define attibutes for text nodes
   switch (el.nodeName) {
     case 'strong':
-      nodeAttributes.bold = true;
+      nodeAttributes.bold = true
   }
-  
-  const children = Array.from(el.childNodes).map(node => deserialize(el, nodeAttributes)).flat()
+
+  const children = Array.from(el.childNodes)
+    .map(node => deserialize(el, nodeAttributes))
+    .flat()
 
   if (children.length === 0) {
     children.push(jsx('text', nodeAttributes, ''))

--- a/docs/concepts/10-serializing.md
+++ b/docs/concepts/10-serializing.md
@@ -177,7 +177,7 @@ const deserialize = (el, markAttributes = {}) => {
       nodeAttributes.bold = true;
   }
   
-  const children = Array.from(el.childNodes).map(node => deserialize(el, nodeAttributes))
+  const children = Array.from(el.childNodes).map(node => deserialize(el, nodeAttributes)).flat()
 
   if (children.length === 0) {
     children.push(jsx('text', nodeAttributes, ''))

--- a/docs/concepts/10-serializing.md
+++ b/docs/concepts/10-serializing.md
@@ -162,17 +162,25 @@ For example, here's a `deserialize` function for HTML:
 ```javascript
 import { jsx } from 'slate-hyperscript'
 
-const deserialize = el => {
-  if (el.nodeType === 3) {
-    return el.textContent
-  } else if (el.nodeType !== 1) {
+const deserialize = (el, markAttributes = {}) => {
+  if (el.nodeType === Node.TEXT_NODE) {
+    return jsx('text', markAttributes, el.textContent)
+  } else if (el.nodeType !== Node.ELEMENT_NODE) {
     return null
   }
-
-  let children = Array.from(el.childNodes).map(deserialize)
+  
+  const nodeAttributes = { ...markAttributes };
+  
+  // define attibutes for text nodes
+  switch (el.nodeName) {
+    case 'strong':
+      nodeAttributes.bold = true;
+  }
+  
+  const children = Array.from(el.childNodes).map(node => deserialize(el, nodeAttributes))
 
   if (children.length === 0) {
-    children = [{ text: '' }]
+    children.push(jsx('text', nodeAttributes, ''))
   }
 
   switch (el.nodeName) {
@@ -191,7 +199,7 @@ const deserialize = el => {
         children
       )
     default:
-      return el.textContent
+      return children
   }
 }
 ```


### PR DESCRIPTION
**Description**
The initial motivation for this was that the example did not provide details on how to deserialize marks.

Additionally I feel it's okay to return successfully serialized child nodes from unrecognized elements (default fallback of element switch), rather than just its text-content.
This also required the child map to be flattened.

While I was at it, I also replaced the numbers in the `nodeType` checks with their respective Constants (`Node.TEXT_NODE` and `Node.ELEMENT_NODE`), which makes the code easier to grasp for a reader.

**Context**
It took me quite a while how to figure out how to properly deserialize marks. An example is included for serialization (strong) but not for deserialization.

**Disclaimer**
While I have tested this in my actual code, the original is written in typescript.
So I may have made an error when converting it.
If you feel this is not an improvement, feel free to close.