### PR TITLE
Reverted 03861af (#4804) and added a test for the exception it caused

### DIFF
--- a/.changeset/purple-walls-kiss.md
+++ b/.changeset/purple-walls-kiss.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Reverted #4804 as it triggered an exception when inserting text with multi-block selection

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -487,8 +487,7 @@ export const TextTransforms: TextTransforms = {
           if (!voids && Editor.void(editor, { at: end })) {
             return
           }
-          const start = Range.start(at)
-          const pointRef = Editor.pointRef(editor, start)
+          const pointRef = Editor.pointRef(editor, end)
           Transforms.delete(editor, { at, voids })
           at = pointRef.unref()!
           Transforms.setSelection(editor, { anchor: at, focus: at })

--- a/packages/slate/test/transforms/insertText/selection/block-across.tsx
+++ b/packages/slate/test/transforms/insertText/selection/block-across.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertText(editor, 'a')
+}
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      first paragraph
+    </block>
+    <block>
+      second
+      <focus /> paragraph
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      a<cursor /> paragraph
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
Fixes a problem where selecting multiple lines of text and typing triggered an exception

**Issue**
Reverts: #4804

**Example**
Video posted as a comment to 4804, reporting the error
https://github.com/ianstormtaylor/slate/pull/4804#issuecomment-1038557582

**Context**
4804 was a significant change to how typing interacts with selection. While I sympathise with the intent this fix was not the right way to do it. I've added a test to make sure any future attempts to adjust the behaviour won't regress this issue again.

We already had a test that would fail with this bug, incidentally, but it has been set to skip since the 0.5 release because hanging ranges don't quite work how they should:
https://github.com/ianstormtaylor/slate/blob/93fe25151722343488e9002a0ebd8ed3ba66ee95/packages/slate/test/transforms/insertText/selection/block-hanging-across.tsx#L29


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

