### PR TITLE
Example: Add Alignment to richtext example

### DIFF
--- a/site/examples/custom-types.d.ts
+++ b/site/examples/custom-types.d.ts
@@ -10,10 +10,15 @@ import {
 import { ReactEditor } from 'slate-react'
 import { HistoryEditor } from 'slate-history'
 
-export type BlockQuoteElement = { type: 'block-quote'; children: Descendant[] }
+export type BlockQuoteElement = {
+  type: 'block-quote'
+  align?: string
+  children: Descendant[]
+}
 
 export type BulletedListElement = {
   type: 'bulleted-list'
+  align?: string
   children: Descendant[]
 }
 
@@ -28,9 +33,17 @@ export type EditableVoidElement = {
   children: EmptyText[]
 }
 
-export type HeadingElement = { type: 'heading'; children: Descendant[] }
+export type HeadingElement = {
+  type: 'heading'
+  align?: string
+  children: Descendant[]
+}
 
-export type HeadingTwoElement = { type: 'heading-two'; children: Descendant[] }
+export type HeadingTwoElement = {
+  type: 'heading-two'
+  align?: string
+  children: Descendant[]
+}
 
 export type ImageElement = {
   type: 'image'
@@ -50,7 +63,11 @@ export type MentionElement = {
   children: CustomText[]
 }
 
-export type ParagraphElement = { type: 'paragraph'; children: Descendant[] }
+export type ParagraphElement = {
+  type: 'paragraph'
+  align?: string
+  children: Descendant[]
+}
 
 export type TableElement = { type: 'table'; children: TableRow[] }
 


### PR DESCRIPTION
**Description**
Add the basic alignment to the rich-text example. I looked around for it and was unable to find it anywhere and thought it might be helpful to someone else like me. 

If not needed, I can close.

**Example**
<img width="607" alt="Screenshot 2022-03-04 at 23 37 22" src="https://user-images.githubusercontent.com/24846513/156845100-02a898b6-de2b-430a-8c44-961e17c75c0b.png">


**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

