### PR TITLE
fixed cursor when we triple click on text and type over it #4862

### DIFF
--- a/.changeset/healthy-wasps-sit.md
+++ b/.changeset/healthy-wasps-sit.md
@@ -1,0 +1,5 @@
+---
+'slate-react: patch
+---
+
+fixed cursor when triple clicking on text and type over it, fixes #4862

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1048,7 +1048,7 @@ export const Editable = (props: EditableProps) => {
 
                 const element =
                   editor.children[
-                  selection !== null ? selection.focus.path[0] : 0
+                    selection !== null ? selection.focus.path[0] : 0
                   ]
                 const isRTL = getDirection(Node.string(element)) === 'rtl'
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -484,11 +484,10 @@ export const Editable = (props: EditableProps) => {
           case 'insertReplacementText':
           case 'insertText': {
             const { selection } = editor
-                if (selection) {
-                    if (Range.isExpanded(selection)) {
-                        Editor.deleteFragment(editor)
-                    }
-                }
+            if (selection) {
+              if (Range.isExpanded(selection)) {
+                Editor.deleteFragment(editor)
+              }
             }
 
             if (type === 'insertFromComposition') {
@@ -1049,7 +1048,7 @@ export const Editable = (props: EditableProps) => {
 
                 const element =
                   editor.children[
-                    selection !== null ? selection.focus.path[0] : 0
+                  selection !== null ? selection.focus.path[0] : 0
                   ]
                 const isRTL = getDirection(Node.string(element)) === 'rtl'
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -483,6 +483,14 @@ export const Editable = (props: EditableProps) => {
           case 'insertFromYank':
           case 'insertReplacementText':
           case 'insertText': {
+            const { selection } = editor
+                if (selection) {
+                    if (Range.isExpanded(selection)) {
+                        Editor.deleteFragment(editor)
+                    }
+                }
+            }
+
             if (type === 'insertFromComposition') {
               // COMPAT: in Safari, `compositionend` is dispatched after the
               // `beforeinput` for "insertFromComposition". But if we wait for it


### PR DESCRIPTION
**Description**
fixed cursor when we triple click on text and type over it

**Issue**
Fixes: ([bug when we triple click on text and type over it #4862](https://github.com/ianstormtaylor/slate/issues/4862))

**Example**
Before:
![QQ20220307-123057-HD](https://user-images.githubusercontent.com/16861647/156968511-c7d7bf8c-47f4-4fab-973d-3b4d937586f4.gif)

current:
![QQ20220307-123140-HD](https://user-images.githubusercontent.com/16861647/156968470-f5d7c0f8-848d-4e98-a682-26e2ff837d09.gif)


**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ✅] The tests pass with `yarn test`.
- [ ✅] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ✅] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

