### PR TITLE
Add soft break as a separate overridable editor method

### DIFF
--- a/.changeset/fair-forks-hope.md
+++ b/.changeset/fair-forks-hope.md
@@ -1,0 +1,8 @@
+---
+'slate': minor
+'slate-react': minor
+---
+
+A different behavior for inserting a soft break with shift+enter is quite common in rich text editors. Right now you have to do this in onKeyDown which is not so nice. This adds a separate insertSoftBreak method on the editor instance that gets called when a soft break is inserted. This maintains the current default behavior for backwards compatibility (it just splits the block). But at least you can easily overwrite it now.
+
+If you rely on overwriting editor.insertBreak for extra behavior for soft breaks this might be a breaking change for you and you should overwrite editor.insertSoftBreak instead.

--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -460,6 +460,10 @@ Insert a fragment at the current selection. If the selection is currently expand
 
 Insert a block break at the current selection. If the selection is currently expanded, delete it first.
 
+#### `insertSoftBreak() => void`
+
+Insert a soft break at the current selection. If the selection is currently expanded, delete it first.
+
 #### `insertNode(node: Node) => void`
 
 Insert a node at the current selection. If the selection is currently expanded, delete it first.

--- a/docs/concepts/07-editor.md
+++ b/docs/concepts/07-editor.md
@@ -21,6 +21,7 @@ interface Editor {
   deleteForward: (unit: 'character' | 'word' | 'line' | 'block') => void
   deleteFragment: () => void
   insertBreak: () => void
+  insertSoftBreak: () => void
   insertFragment: (fragment: Node[]) => void
   insertNode: (node: Node) => void
   insertText: (text: string) => void

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -472,6 +472,9 @@ export const Editable = (props: EditableProps) => {
           }
 
           case 'insertLineBreak':
+            Editor.insertSoftBreak(editor)
+            break
+
           case 'insertParagraph': {
             Editor.insertBreak(editor)
             break
@@ -1173,6 +1176,12 @@ export const Editable = (props: EditableProps) => {
                     Hotkeys.isTransposeCharacter(nativeEvent)
                   ) {
                     event.preventDefault()
+                    return
+                  }
+
+                  if (Hotkeys.isSoftBreak(nativeEvent)) {
+                    event.preventDefault()
+                    Editor.insertSoftBreak(editor)
                     return
                   }
 

--- a/packages/slate-react/src/utils/hotkeys.ts
+++ b/packages/slate-react/src/utils/hotkeys.ts
@@ -17,7 +17,8 @@ const HOTKEYS = {
   extendBackward: 'shift+left',
   extendForward: 'shift+right',
   italic: 'mod+i',
-  splitBlock: 'shift?+enter',
+  insertSoftBreak: 'shift+enter',
+  splitBlock: 'enter',
   undo: 'mod+z',
 }
 
@@ -89,6 +90,7 @@ export default {
   isMoveWordBackward: create('moveWordBackward'),
   isMoveWordForward: create('moveWordForward'),
   isRedo: create('redo'),
+  isSoftBreak: create('insertSoftBreak'),
   isSplitBlock: create('splitBlock'),
   isTransposeCharacter: create('transposeCharacter'),
   isUndo: create('undo'),

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -158,6 +158,10 @@ export const createEditor = (): Editor => {
       Transforms.splitNodes(editor, { always: true })
     },
 
+    insertSoftBreak: () => {
+      Transforms.splitNodes(editor, { always: true })
+    },
+
     insertFragment: (fragment: Node[]) => {
       Transforms.insertFragment(editor, fragment)
     },

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -62,6 +62,7 @@ export interface BaseEditor {
   deleteFragment: (direction?: 'forward' | 'backward') => void
   getFragment: () => Descendant[]
   insertBreak: () => void
+  insertSoftBreak: () => void
   insertFragment: (fragment: Node[]) => void
   insertNode: (node: Node) => void
   insertText: (text: string) => void
@@ -126,6 +127,7 @@ export interface EditorInterface {
   hasPath: (editor: Editor, path: Path) => boolean
   hasTexts: (editor: Editor, element: Element) => boolean
   insertBreak: (editor: Editor) => void
+  insertSoftBreak: (editor: Editor) => void
   insertFragment: (editor: Editor, fragment: Node[]) => void
   insertNode: (editor: Editor, node: Node) => void
   insertText: (editor: Editor, text: string) => void
@@ -528,6 +530,16 @@ export const Editor: EditorInterface = {
   },
 
   /**
+   * Insert a soft break at the current selection.
+   *
+   * If the selection is currently expanded, it will be deleted first.
+   */
+
+  insertSoftBreak(editor: Editor): void {
+    editor.insertSoftBreak()
+  },
+
+  /**
    * Insert a fragment at the current selection.
    *
    * If the selection is currently expanded, it will be deleted first.
@@ -582,6 +594,7 @@ export const Editor: EditorInterface = {
       typeof value.deleteForward === 'function' &&
       typeof value.deleteFragment === 'function' &&
       typeof value.insertBreak === 'function' &&
+      typeof value.insertSoftBreak === 'function' &&
       typeof value.insertFragment === 'function' &&
       typeof value.insertNode === 'function' &&
       typeof value.insertText === 'function' &&

--- a/packages/slate/test/interfaces/Element/isElement/editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/editor.tsx
@@ -11,6 +11,7 @@ export const input = {
   deleteForward() {},
   deleteFragment() {},
   insertBreak() {},
+  insertSoftBreak() {},
   insertFragment() {},
   insertNode() {},
   insertText() {},

--- a/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
@@ -12,6 +12,7 @@ export const input = [
     deleteForward() {},
     deleteFragment() {},
     insertBreak() {},
+    insertSoftBreak() {},
     insertFragment() {},
     insertNode() {},
     insertText() {},


### PR DESCRIPTION
**Description**
A different behavior for inserting a soft break with `shift+enter` is quite common in rich text editors. Right now you have to do this in `onKeyDown` which is not so nice. This adds a separate `insertSoftBreak` method on the editor instance that gets called when a soft break is inserted. I made sure to maintain the current default behavior for backwards compatibility (it just splits the block). But at least you can easily overwrite it now.

If you rely on overwriting `editor.insertBreak` for extra behavior for soft breaks this might be a breaking change for you and you should overwrite `editor.insertSoftBreak` instead.

**Issue**
Fixes: (link to issue)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

