### PR TITLE
Attempt to clear GH actions cache with key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: 16
           cache: yarn
+          key: node16
 
       - name: Run ${{ matrix.command }}
         run: yarn && yarn build && yarn ${{ matrix.command }}


### PR DESCRIPTION
**Description**

Working to upgrade to Node 16. GH Actions are cached. Adding a key should clear the cache per various sources.

