### PR TITLE
Fix chrome and edge three digit version check

### DIFF
--- a/.changeset/cuddly-foxes-sell.md
+++ b/.changeset/cuddly-foxes-sell.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fix chrome and edge three digit version check

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -21,7 +21,7 @@ export const IS_SAFARI =
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =
   typeof navigator !== 'undefined' &&
-  /Edge?\/(?:[0-6][0-9]|[0-7][0-8])/i.test(navigator.userAgent)
+  /Edge?\/(?:[0-6][0-9]|[0-7][0-8])(\.)/i.test(navigator.userAgent)
 
 export const IS_CHROME =
   typeof navigator !== 'undefined' && /Chrome/i.test(navigator.userAgent)
@@ -30,7 +30,7 @@ export const IS_CHROME =
 // and older, Chrome 76+ can use `beforeInput` though.
 export const IS_CHROME_LEGACY =
   typeof navigator !== 'undefined' &&
-  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])/i.test(navigator.userAgent)
+  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])(\.)/i.test(navigator.userAgent)
 
 // Firefox did not support `beforeInput` until `v87`.
 export const IS_FIREFOX_LEGACY =


### PR DESCRIPTION
**Description**
The chrome will hit 100 in a couple of weeks. this pr fix regex for checking three-digit chrome and edge version.

**Issue**
Fixes: [4869](https://github.com/ianstormtaylor/slate/issues/4869)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

