### PR TITLE
toSlatePoint should not consider a selection within a void node if the void node isn't in the editor itself.

### DIFF
--- a/.changeset/fuzzy-teachers-develop.md
+++ b/.changeset/fuzzy-teachers-develop.md
@@ -1,0 +1,7 @@
+---
+'slate-react': patch
+---
+
+toSlatePoint should not consider a selection within a void node if the void node isn't in the editor itself.
+
+Prior to this fix, a nested Slate editor inside a void node in a parent editor would not allow you to start typing text in a blank editor state correctly. After the first character insertion, the selection would jump back to the start of the nested editor.

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -484,7 +484,16 @@ export const ReactEditor = {
     let offset = 0
 
     if (parentNode) {
-      const voidNode = parentNode.closest('[data-slate-void="true"]')
+      const editorEl = ReactEditor.toDOMNode(editor, editor)
+      const potentialVoidNode = parentNode.closest('[data-slate-void="true"]')
+      // Need to ensure that the closest void node is actually a void node
+      // within this editor, and not a void node within some parent editor. This can happen
+      // if this editor is within a void node of another editor ("nested editors", like in
+      // the "Editable Voids" example on the docs site).
+      const voidNode =
+        potentialVoidNode && editorEl.contains(potentialVoidNode)
+          ? potentialVoidNode
+          : null
       let leafNode = parentNode.closest('[data-slate-leaf]')
       let domNode: DOMElement | null = null
 


### PR DESCRIPTION
If you have a nested editor setup. For example, one editor has a void node that contains another editor. In this case, a resolution of a selection by the nested editor previously would consider that the selection is for a void node since an ancestor void node does exist. However, the selection is only a void node in the context of this editor if the ancestor void node is contained in the editor.

In the "Editable Voids" example on the docs site, you can see this bug when you clear the text of the nested editor, and type one character. The selection will jump back to the beginning.

**Issue**
Fixes: [(link to issue)](https://github.com/ianstormtaylor/slate/issues/4293)

**Example**

There is a GIF in the original ticket, the new behavior is what would be expected, after inserting one character, the selection is collapsed at the end of the character that was just inserted.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

