### PR TITLE
Fix Cannot find DOM for readonly void elements

### DIFF
--- a/.changeset/twenty-moles-breathe.md
+++ b/.changeset/twenty-moles-breathe.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fixes graceful handling of selecting void slements inside readonly editors

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../utils/weak-maps'
 import { normalizeTextInsertionRange } from './diff-text'
 
-import { EditableProps, hasTarget } from '../editable'
+import { EditableProps, hasTarget, isTargetInsideReadonlyVoid } from '../editable'
 import useChildren from '../../hooks/use-children'
 import {
   defaultDecorate,
@@ -239,12 +239,12 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
           const { anchorNode, focusNode } = domSelection
 
           const anchorNodeSelectable =
-            hasEditableTarget(editor, anchorNode) ||
-            isTargetInsideNonReadonlyVoid(editor, anchorNode)
+            hasEditableTarget(editor, anchorNode) &&
+            !isTargetInsideReadonlyVoid(editor, anchorNode)
 
           const focusNodeSelectable =
-            hasEditableTarget(editor, focusNode) ||
-            isTargetInsideNonReadonlyVoid(editor, focusNode)
+            hasEditableTarget(editor, focusNode) &&
+            !isTargetInsideReadonlyVoid(editor, focusNode)
 
           if (anchorNodeSelectable && focusNodeSelectable) {
             const range = ReactEditor.toSlateRange(editor, domSelection, {

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -30,14 +30,14 @@ import {
 } from '../../utils/weak-maps'
 import { normalizeTextInsertionRange } from './diff-text'
 
-import { EditableProps, hasTarget, isTargetInsideReadonlyVoid } from '../editable'
+import { EditableProps, hasTarget } from '../editable'
 import useChildren from '../../hooks/use-children'
 import {
   defaultDecorate,
   hasEditableTarget,
   isEventHandled,
   isDOMEventHandled,
-  isTargetInsideNonReadonlyVoid,
+  isTargetInsideReadonlyVoid,
 } from '../editable'
 
 import { useAndroidInputManager } from './use-android-input-manager'

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -287,12 +287,12 @@ export const Editable = (props: EditableProps) => {
         const { anchorNode, focusNode } = domSelection
 
         const anchorNodeSelectable =
-          hasEditableTarget(editor, anchorNode) ||
-          isTargetInsideNonReadonlyVoid(editor, anchorNode)
+          hasEditableTarget(editor, anchorNode) &&
+          !isTargetInsideReadonlyVoid(editor, anchorNode)
 
         const focusNodeSelectable =
-          hasEditableTarget(editor, focusNode) ||
-          isTargetInsideNonReadonlyVoid(editor, focusNode)
+          hasEditableTarget(editor, focusNode) &&
+          !isTargetInsideReadonlyVoid(editor, focusNode)
 
         if (anchorNodeSelectable && focusNodeSelectable) {
           const range = ReactEditor.toSlateRange(editor, domSelection, {
@@ -1419,19 +1419,17 @@ export const hasEditableTarget = (
 }
 
 /**
- * Check if the target is inside void and in an non-readonly editor.
+ * Check if the target is inside void and in an readonly editor.
  */
-
-export const isTargetInsideNonReadonlyVoid = (
+export const isTargetInsideReadonlyVoid = (
   editor: ReactEditor,
   target: EventTarget | null
 ): boolean => {
-  if (IS_READ_ONLY.get(editor)) return false
-
   const slateNode =
     hasTarget(editor, target) && ReactEditor.toSlateNode(editor, target)
-  return Editor.isVoid(editor, slateNode)
+  return IS_READ_ONLY.get(editor) && Editor.isVoid(editor, slateNode)
 }
+
 
 /**
  * Check if an event is overrided by a handler.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1427,7 +1427,7 @@ export const isTargetInsideReadonlyVoid = (
 ): boolean => {
   const slateNode =
     hasTarget(editor, target) && ReactEditor.toSlateNode(editor, target)
-  return IS_READ_ONLY.get(editor) && Editor.isVoid(editor, slateNode)
+  return IS_READ_ONLY.get(editor) === true && Editor.isVoid(editor, slateNode)
 }
 
 

--- a/site/examples/read-only.tsx
+++ b/site/examples/read-only.tsx
@@ -2,26 +2,78 @@ import React, { useState, useMemo } from 'react'
 import { createEditor, Descendant, Element } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 
+const renderElement = (props) => {
+  if (props.element.__typename === 'TemplateVariable') {
+    return (
+      <span
+        style={{
+          paddingInline: '4px',
+          border: '1px solid red'
+        }}
+      >
+        {props.element.variableType}
+      </span>
+    )
+  }
+  return props.children
+}
+
+export const withTemplateVariables = (editor) => {
+  const { isInline, isVoid } = editor
+
+  editor.isInline = (element) => {
+    if (element.__typename === 'TemplateVariable') {
+      return true
+    }
+    return isInline(element)
+  }
+
+  editor.isVoid = (element) => {
+    if (element.__typename === 'TemplateVariable') {
+      return true
+    }
+    return isVoid(element)
+  }
+
+  return editor
+}
+
 const ReadOnlyExample = () => {
-  const [value, setValue] = useState<Descendant[]>(initialValue)
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useMemo(
+    () => withTemplateVariables(withReact(createEditor())),
+    []
+  )
   return (
-    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
-      <Editable readOnly placeholder="Enter some plain text..." />
+    <Slate
+      editor={editor}
+      value={[
+        {
+          children: [
+            {
+              text: 'This is readonly text',
+              marks: []
+            },
+            {
+              __typename: 'TemplateVariable',
+              variableType: 'name',
+              children: [{ text: '' }]
+            }
+          ]
+        }
+      ]}
+      onChange={() => undefined}
+    >
+      <Editable
+        placeholder="Enter some plain text..."
+        style={{
+          padding: '10px',
+          border: '1px solid #999'
+        }}
+        renderElement={renderElement}
+        readOnly
+      />
     </Slate>
   )
 }
-
-const initialValue: Descendant[] = [
-  {
-    type: 'paragraph',
-    children: [
-      {
-        text:
-          'This example shows what happens when the Editor is set to readOnly, it is not editable',
-      },
-    ],
-  },
-]
 
 export default ReadOnlyExample

--- a/site/examples/read-only.tsx
+++ b/site/examples/read-only.tsx
@@ -2,78 +2,26 @@ import React, { useState, useMemo } from 'react'
 import { createEditor, Descendant, Element } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 
-const renderElement = (props) => {
-  if (props.element.__typename === 'TemplateVariable') {
-    return (
-      <span
-        style={{
-          paddingInline: '4px',
-          border: '1px solid red'
-        }}
-      >
-        {props.element.variableType}
-      </span>
-    )
-  }
-  return props.children
-}
-
-export const withTemplateVariables = (editor) => {
-  const { isInline, isVoid } = editor
-
-  editor.isInline = (element) => {
-    if (element.__typename === 'TemplateVariable') {
-      return true
-    }
-    return isInline(element)
-  }
-
-  editor.isVoid = (element) => {
-    if (element.__typename === 'TemplateVariable') {
-      return true
-    }
-    return isVoid(element)
-  }
-
-  return editor
-}
-
 const ReadOnlyExample = () => {
-  const editor = useMemo(
-    () => withTemplateVariables(withReact(createEditor())),
-    []
-  )
+  const [value, setValue] = useState<Descendant[]>(initialValue)
+  const editor = useMemo(() => withReact(createEditor()), [])
   return (
-    <Slate
-      editor={editor}
-      value={[
-        {
-          children: [
-            {
-              text: 'This is readonly text',
-              marks: []
-            },
-            {
-              __typename: 'TemplateVariable',
-              variableType: 'name',
-              children: [{ text: '' }]
-            }
-          ]
-        }
-      ]}
-      onChange={() => undefined}
-    >
-      <Editable
-        placeholder="Enter some plain text..."
-        style={{
-          padding: '10px',
-          border: '1px solid #999'
-        }}
-        renderElement={renderElement}
-        readOnly
-      />
+    <Slate editor={editor} value={value} onChange={value => setValue(value)}>
+      <Editable readOnly placeholder="Enter some plain text..." />
     </Slate>
   )
 }
+
+const initialValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text:
+          'This example shows what happens when the Editor is set to readOnly, it is not editable',
+      },
+    ],
+  },
+]
 
 export default ReadOnlyExample


### PR DESCRIPTION
**Description**
Modified the logic for the editor to gracefully handle selections inside void elements of readonly editors.
Changed the `isTargetInsideNonReadonlyVoid` to be `isTargetInsideReadonlyVoid` because double negatives are confusing :)

PENDING: Tests based on feedback from @dylans.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4886

**Example**
Before:


https://user-images.githubusercontent.com/48929123/158206992-bb0348d6-ae4f-4881-beb1-2acb16f5c84a.mov


After:

https://user-images.githubusercontent.com/48929123/158207019-d0d1bbbd-0ed3-43de-9909-900a7ecdc569.mov


**Context**
The logic previously was:
```
const anchorNodeSelectable =
          hasEditableTarget(editor, anchorNode) ||
          isTargetInsideNonReadonlyVoid(editor, anchorNode)
```
The node selection wouldn't go inside the second if-statement because the first clause would return true (`hasEditableTarget` checks if this node target is in the same editor, which is true). The second clause also needs to be checked as well to see if the target is inside a readonly-void element. If it is, then we should avoid selection.

I'm not sure if this is the right long term approach. Void elements should be selectable too, but the behavior should probably be up to the element-renderer. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

