### PR TITLE
feat: add custom compare node props

### DIFF
--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1721,3 +1721,5 @@ export const Editor: EditorInterface = {
 export type NodeMatch<T extends Node> =
   | ((node: Node, path: Path) => node is T)
   | ((node: Node, path: Path) => boolean)
+
+export type PropsCompare = (prop: Partial<Node>, node: Partial<Node>) => boolean

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -11,7 +11,7 @@ import {
   NodeEntry,
   Ancestor,
 } from '..'
-import { NodeMatch } from '../interfaces/editor'
+import { NodeMatch, PropsCompare } from '../interfaces/editor'
 
 export interface NodeTransforms {
   insertNodes: <T extends Node>(
@@ -75,6 +75,7 @@ export interface NodeTransforms {
       hanging?: boolean
       split?: boolean
       voids?: boolean
+      compare?: PropsCompare
     }
   ) => void
   splitNodes: <T extends Node>(
@@ -568,10 +569,11 @@ export const NodeTransforms: NodeTransforms = {
       hanging?: boolean
       split?: boolean
       voids?: boolean
+      compare?: PropsCompare
     } = {}
   ): void {
     Editor.withoutNormalizing(editor, () => {
-      let { match, at = editor.selection } = options
+      let { match, at = editor.selection, compare } = options
       const {
         hanging = false,
         mode = 'lowest',
@@ -628,6 +630,10 @@ export const NodeTransforms: NodeTransforms = {
         }
       }
 
+      if (!compare) {
+        compare = (prop, nodeProp) => prop !== nodeProp
+      }
+
       for (const [node, path] of Editor.nodes(editor, {
         at,
         match,
@@ -649,7 +655,7 @@ export const NodeTransforms: NodeTransforms = {
             continue
           }
 
-          if (props[k] !== node[k]) {
+          if (compare(props[k], node[k])) {
             hasChanges = true
             // Omit new properties from the old properties list
             if (node.hasOwnProperty(k)) properties[k] = node[k]

--- a/packages/slate/test/transforms/normalization/set_node.tsx
+++ b/packages/slate/test/transforms/normalization/set_node.tsx
@@ -1,0 +1,43 @@
+/** @jsx jsx */
+import { Editor, Element, Transforms } from 'slate'
+import { jsx } from '../..'
+import _ from 'lodash'
+
+export const input = (
+  <editor>
+    <block type="body" attr={{ a: true }}>
+      one
+    </block>
+  </editor>
+)
+
+const editor = (input as unknown) as Editor
+const defaultNormalize = editor.normalizeNode
+editor.normalizeNode = entry => {
+  const [node, path] = entry
+  if (
+    Element.isElement(node) &&
+    (node as any).type === 'body' &&
+    Editor.string(editor, path, { voids: true }) === 'one'
+  ) {
+    Transforms.setNodes(
+      editor,
+      { attr: { a: false } },
+      { at: path, compare: (p, n) => !_.isEqual(p, n) }
+    )
+  }
+
+  defaultNormalize(entry)
+}
+
+export const run = editor => {
+  Editor.normalize(editor, { force: true })
+}
+
+export const output = (
+  <editor>
+    <block type="body" attr={{ a: false }}>
+      one
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
add custom compare node props

**Example**
node = { type: 'p', attributes: { hidden: true } }

**Context**
If you don't do it, you may create an infinite loop when setting properties

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

