### PR TITLE
update insertText logic when selection is not collapsed

### DIFF
--- a/.changeset/wise-dots-cheat.md
+++ b/.changeset/wise-dots-cheat.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+update insertText logic when selection is not collapsed

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -487,9 +487,14 @@ export const TextTransforms: TextTransforms = {
           if (!voids && Editor.void(editor, { at: end })) {
             return
           }
-          const pointRef = Editor.pointRef(editor, end)
+          const start = Range.start(at)
+          const startRef = Editor.pointRef(editor, start)
+          const endRef = Editor.pointRef(editor, end)
           Transforms.delete(editor, { at, voids })
-          at = pointRef.unref()!
+          const startPoint = startRef.unref()
+          const endPoint = endRef.unref()
+
+          at = startPoint || endPoint!
           Transforms.setSelection(editor, { anchor: at, focus: at })
         }
       }

--- a/packages/slate/test/transforms/insertText/selection/block-across-inline-wold.tsx
+++ b/packages/slate/test/transforms/insertText/selection/block-across-inline-wold.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertText(editor, 'a')
+}
+export const input = (
+  <editor>
+    <block>
+      first paragraph
+      <inline>
+        tw
+        <anchor />o
+      </inline>
+    </block>
+    <block>
+      second
+      <focus />
+      paragraph
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      first paragraph
+      <inline>
+        twa
+        <cursor />
+      </inline>
+      paragraph
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
When select a paragraph with different styles of text, for example, bold and plain, and then insert the letter q. What I want is to insert a non-bold letter.

**PR**
Fixes: [#4804 ]

**Context**
I fix the error of PR #4804 , and add a test case to describe the scene as I see it. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

