### PR TITLE
Fix NODE_TO_KEY correction for split_node and merge_node

### DIFF
--- a/.changeset/funny-humans-whisper.md
+++ b/.changeset/funny-humans-whisper.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fixes a bug where nodes remounted on split_node and merge_node

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -87,7 +87,10 @@ export const withReact = <T extends Editor>(editor: T) => {
       }
 
       case 'move_node': {
-        const commonPath = Path.common(Path.parent(op.path), Path.parent(op.newPath))
+        const commonPath = Path.common(
+          Path.parent(op.path),
+          Path.parent(op.newPath)
+        )
         matches.push(...getMatches(e, commonPath))
         break
       }


### PR DESCRIPTION
**Description**
Fixes https://github.com/ianstormtaylor/slate/issues/4900

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4900

**Example**
The logic in `with-react` was not resetting the node keys for the right nodes for `split_node` and `merge_node` operations. This fixes that so that on `split_node` the node being split does not get remounted and on `merge_node` the node being merged into also does not get remounted.

**Context**
See https://github.com/ianstormtaylor/slate/issues/4900

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

