### PR TITLE
Add merge to set node

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -97,7 +97,7 @@ export const createEditor = (): Editor => {
       }
     },
 
-    addMark: (key: string, value: any, merge) => {
+    addMark: (key: string, value: any) => {
       const { selection } = editor
 
       if (selection) {
@@ -105,7 +105,7 @@ export const createEditor = (): Editor => {
           Transforms.setNodes(
             editor,
             { [key]: value },
-            { match: Text.isText, split: true, merge }
+            { match: Text.isText, split: true }
           )
         } else {
           const marks = {

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -97,7 +97,7 @@ export const createEditor = (): Editor => {
       }
     },
 
-    addMark: (key: string, value: any, merge: Function | null = null) => {
+    addMark: (key: string, value: any, merge) => {
       const { selection } = editor
 
       if (selection) {

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -97,7 +97,7 @@ export const createEditor = (): Editor => {
       }
     },
 
-    addMark: (key: string, value: any) => {
+    addMark: (key: string, value: any, merge: Function | null = null) => {
       const { selection } = editor
 
       if (selection) {
@@ -105,7 +105,7 @@ export const createEditor = (): Editor => {
           Transforms.setNodes(
             editor,
             { [key]: value },
-            { match: Text.isText, split: true }
+            { match: Text.isText, split: true, merge }
           )
         } else {
           const marks = {

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -55,7 +55,7 @@ export interface BaseEditor {
   onChange: () => void
 
   // Overrideable core actions.
-  addMark: (key: string, value: any, merge?: PropsMerge) => void
+  addMark: (key: string, value: any) => void
   apply: (operation: Operation) => void
   deleteBackward: (unit: 'character' | 'word' | 'line' | 'block') => void
   deleteForward: (unit: 'character' | 'word' | 'line' | 'block') => void
@@ -81,7 +81,7 @@ export interface EditorInterface {
       voids?: boolean
     }
   ) => NodeEntry<T> | undefined
-  addMark: (editor: Editor, key: string, value: any, merge?: PropsMerge) => void
+  addMark: (editor: Editor, key: string, value: any) => void
   after: (
     editor: Editor,
     at: Location,
@@ -336,8 +336,8 @@ export const Editor: EditorInterface = {
    * `editor.marks` property instead, and applied when text is inserted next.
    */
 
-  addMark(editor: Editor, key: string, value: any, merge?: PropsMerge): void {
-    editor.addMark(key, value, merge)
+  addMark(editor: Editor, key: string, value: any): void {
+    editor.addMark(key, value)
   },
 
   /**

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -55,7 +55,7 @@ export interface BaseEditor {
   onChange: () => void
 
   // Overrideable core actions.
-  addMark: (key: string, value: any) => void
+  addMark: (key: string, value: any, merge: Function | null) => void
   apply: (operation: Operation) => void
   deleteBackward: (unit: 'character' | 'word' | 'line' | 'block') => void
   deleteForward: (unit: 'character' | 'word' | 'line' | 'block') => void
@@ -81,7 +81,7 @@ export interface EditorInterface {
       voids?: boolean
     }
   ) => NodeEntry<T> | undefined
-  addMark: (editor: Editor, key: string, value: any) => void
+  addMark: (editor: Editor, key: string, value: any, merge?: Function) => void
   after: (
     editor: Editor,
     at: Location,
@@ -336,8 +336,8 @@ export const Editor: EditorInterface = {
    * `editor.marks` property instead, and applied when text is inserted next.
    */
 
-  addMark(editor: Editor, key: string, value: any): void {
-    editor.addMark(key, value)
+  addMark(editor: Editor, key: string, value: any, merge: Function | null = null): void {
+    editor.addMark(key, value, merge)
   },
 
   /**

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -336,7 +336,12 @@ export const Editor: EditorInterface = {
    * `editor.marks` property instead, and applied when text is inserted next.
    */
 
-  addMark(editor: Editor, key: string, value: any, merge: Function | null = null): void {
+  addMark(
+    editor: Editor,
+    key: string,
+    value: any,
+    merge: Function | null = null
+  ): void {
     editor.addMark(key, value, merge)
   },
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -55,7 +55,7 @@ export interface BaseEditor {
   onChange: () => void
 
   // Overrideable core actions.
-  addMark: (key: string, value: any, merge: Function | null) => void
+  addMark: (key: string, value: any, merge?: PropsMerge) => void
   apply: (operation: Operation) => void
   deleteBackward: (unit: 'character' | 'word' | 'line' | 'block') => void
   deleteForward: (unit: 'character' | 'word' | 'line' | 'block') => void
@@ -81,7 +81,7 @@ export interface EditorInterface {
       voids?: boolean
     }
   ) => NodeEntry<T> | undefined
-  addMark: (editor: Editor, key: string, value: any, merge?: Function) => void
+  addMark: (editor: Editor, key: string, value: any, merge?: PropsMerge) => void
   after: (
     editor: Editor,
     at: Location,
@@ -336,12 +336,7 @@ export const Editor: EditorInterface = {
    * `editor.marks` property instead, and applied when text is inserted next.
    */
 
-  addMark(
-    editor: Editor,
-    key: string,
-    value: any,
-    merge: Function | null = null
-  ): void {
+  addMark(editor: Editor, key: string, value: any, merge?: PropsMerge): void {
     editor.addMark(key, value, merge)
   },
 
@@ -1741,3 +1736,4 @@ export type NodeMatch<T extends Node> =
   | ((node: Node, path: Path) => boolean)
 
 export type PropsCompare = (prop: Partial<Node>, node: Partial<Node>) => boolean
+export type PropsMerge = (prop: Partial<Node>, node: Partial<Node>) => object

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -11,7 +11,7 @@ import {
   NodeEntry,
   Ancestor,
 } from '..'
-import { NodeMatch, PropsCompare } from '../interfaces/editor'
+import { NodeMatch, PropsCompare, PropsMerge } from '../interfaces/editor'
 
 export interface NodeTransforms {
   insertNodes: <T extends Node>(
@@ -76,7 +76,7 @@ export interface NodeTransforms {
       split?: boolean
       voids?: boolean
       compare?: PropsCompare
-      merge?: Function | null
+      merge?: PropsMerge
     }
   ) => void
   splitNodes: <T extends Node>(
@@ -571,7 +571,7 @@ export const NodeTransforms: NodeTransforms = {
       split?: boolean
       voids?: boolean
       compare?: PropsCompare
-      merge?: Function | null
+      merge?: PropsMerge
     } = {}
   ): void {
     Editor.withoutNormalizing(editor, () => {

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -76,6 +76,7 @@ export interface NodeTransforms {
       split?: boolean
       voids?: boolean
       compare?: PropsCompare
+      merge?: Function | null
     }
   ) => void
   splitNodes: <T extends Node>(
@@ -570,10 +571,11 @@ export const NodeTransforms: NodeTransforms = {
       split?: boolean
       voids?: boolean
       compare?: PropsCompare
+      merge?: Function | null
     } = {}
   ): void {
     Editor.withoutNormalizing(editor, () => {
-      let { match, at = editor.selection, compare } = options
+      let { match, at = editor.selection, compare, merge } = options
       const {
         hanging = false,
         mode = 'lowest',
@@ -660,7 +662,11 @@ export const NodeTransforms: NodeTransforms = {
             // Omit new properties from the old properties list
             if (node.hasOwnProperty(k)) properties[k] = node[k]
             // Omit properties that have been removed from the new properties list
-            if (props[k] != null) newProperties[k] = props[k]
+            if (merge) {
+              if (props[k] != null) newProperties[k] = merge(node[k], props[k])
+            } else {
+              if (props[k] != null) newProperties[k] = props[k]
+            }
           }
         }
 

--- a/packages/slate/test/transforms/setNodes/merge/text.tsx
+++ b/packages/slate/test/transforms/setNodes/merge/text.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { Transforms, Text } from 'slate'
+import { jsx } from '../../..'
+import _ from 'lodash'
+
+export const run = editor => {
+  Transforms.setNodes(
+    editor, { a: { b: 2, c: 3 } },
+    { at: [0, 0], match: Text.isText, merge: (n, p) => _.defaultsDeep(p, n) }
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      <text a={{ b: 1 }}>
+        word
+      </text>
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      <text a={{ b: 2, c: 3 }}>
+        word
+      </text>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/setNodes/merge/text.tsx
+++ b/packages/slate/test/transforms/setNodes/merge/text.tsx
@@ -5,25 +5,22 @@ import _ from 'lodash'
 
 export const run = editor => {
   Transforms.setNodes(
-    editor, { a: { b: 2, c: 3 } },
+    editor,
+    { a: { b: 2, c: 3 } },
     { at: [0, 0], match: Text.isText, merge: (n, p) => _.defaultsDeep(p, n) }
   )
 }
 export const input = (
   <editor>
     <block>
-      <text a={{ b: 1 }}>
-        word
-      </text>
+      <text a={{ b: 1 }}>word</text>
     </block>
   </editor>
 )
 export const output = (
   <editor>
     <block>
-      <text a={{ b: 2, c: 3 }}>
-        word
-      </text>
+      <text a={{ b: 2, c: 3 }}>word</text>
     </block>
   </editor>
 )


### PR DESCRIPTION
**Description**
I have a problem adding marks and need to merge

**Example**
```
before
  <editor>
    <block>
      <text a={{ b: 1 }}>
        word
      </text>
    </block>
  </editor>

 after
 <editor>
    <block>
      <text a={{ b: 2, c: 3 }}>
        word
      </text>
    </block>
  </editor>
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

