### PR TITLE
fixed4811: input Chinese at the end of link element, focus lose 

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -837,20 +837,22 @@ export const Editable = (props: EditableProps) => {
                     Editor.deleteFragment(editor)
                     return
                   }
-                  const inline = Editor.above(editor, {
-                    match: n => Editor.isInline(editor, n),
-                    mode: 'highest',
-                  })
-                  if (inline) {
-                    const [, inlinePath] = inline
-                    if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
-                      const point = Editor.after(editor, inlinePath)!
-                      Transforms.setSelection(editor, {
-                        anchor: point,
-                        focus: point,
-                      })
-                    }
-                  }
+
+                  // const inline = Editor.above(editor, {
+                  //   match: n => Editor.isInline(editor, n),
+                  //   mode: 'highest',
+                  // })
+                  // if (inline) {
+                  //   const [, inlinePath] = inline
+                  //   if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
+                  //     const point = Editor.after(editor, inlinePath)!
+                  //     Transforms.setSelection(editor, {
+                  //       anchor: point,
+                  //       focus: point,
+                  //     })
+                  //   }
+                  // }
+
                   // insert new node in advance to ensure composition text will insert
                   // along with final input text
                   // add Unicode BOM prefix to avoid normalize removing this node


### PR DESCRIPTION
**Description**
input Chinese at the end of link element, focus lose (maybe others IME also has this bug)

**Issue**
Fixes:  [#4811 ](url)

**Example**
before:
https://user-images.githubusercontent.com/16861647/151319338-747db06d-6fd7-4f67-8e00-a61241456bfe.mp4
after:
https://user-images.githubusercontent.com/16861647/159625215-4ff51bba-ed5b-43a7-8ec1-1a1158a1004f.mov

**Context**
i wonder known why we should change selection when input end of inline element on compositionStart event, as i comment this lines, everything  is okay.

**Checks**
- [✅] The new code matches the existing patterns and styles.
- [✅ ] The tests pass with `yarn test`.
- [✅ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [✅ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

