### PR TITLE
Firefox: fix wrong text highlighting with double-click

### DIFF
--- a/.changeset/thirty-starfishes-knock.md
+++ b/.changeset/thirty-starfishes-knock.md
@@ -1,0 +1,5 @@
+---
+'slate-react': major
+---
+
+Firefox: fix wrong text highlighting with double-click


### PR DESCRIPTION
**Description**
Firefox had an another response of `Document.getSelection()` method. After double-clicking on a word with some mark, you can't unmark this word.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/3336 https://github.com/ianstormtaylor/slate/pull/3374

**Example**
<details>
  <summary>Old behavior</summary>
![Untitled](https://user-images.githubusercontent.com/21054523/159647954-fdcdcbcf-1e00-4df1-9d71-d7c516e7c397.gif)
</details>

<details>
  <summary>New behavior</summary>
![Untitled](https://user-images.githubusercontent.com/21054523/159650729-fe733364-7e0d-40c4-9093-41c4853391f1.gif)
</details>

**Context**
I also changed `toSlatePoint` interface. I don't see any use and reason of this method with old generics. I tried to make a cypress test, but I can't do it. Cypress doesn't support highlighting text by double-clicking. Maybe this is not true. But I see that cypress moves the text cursor to the end of the word that was double-clicked. And I can say that the test (`cypress/integration/examples/select.ts`) is not correct. Because cursor pointer is seated at the end of a paragraph after triple-click

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

