### PR TITLE
Fix child element decorations

### DIFF
--- a/.changeset/poor-hats-design.md
+++ b/.changeset/poor-hats-design.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix decorations applied across nested elements

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -5,7 +5,6 @@ import ElementComponent from '../components/element'
 import TextComponent from '../components/text'
 import { ReactEditor } from '..'
 import { useSlateStatic } from './use-slate-static'
-import { useDecorate } from './use-decorate'
 import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
 import {
   RenderElementProps,
@@ -34,7 +33,6 @@ const useChildren = (props: {
     renderLeaf,
     selection,
   } = props
-  const decorate = useDecorate()
   const editor = useSlateStatic()
   const path = ReactEditor.findPath(editor, node)
   const children = []

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -50,7 +50,11 @@ const useChildren = (props: {
     const range = Editor.range(editor, p)
     const sel = selection && Range.intersection(range, selection)
 
-    const ds = decorations.filter(dec => Range.intersection(dec, range))
+    const ds = decorations.reduce<Range[]>((acc, dec) => {
+      const intersection = Range.intersection(dec, range)
+      if (intersection) acc.push(intersection)
+      return acc
+    }, [])
 
     if (Element.isElement(n)) {
       children.push(

--- a/packages/slate-react/test/index.spec.tsx
+++ b/packages/slate-react/test/index.spec.tsx
@@ -6,7 +6,9 @@ import {
   withReact,
   DefaultEditable,
   RenderElementProps,
+  RenderLeafProps,
   DefaultElement,
+  DefaultLeaf,
 } from '../src'
 
 describe('slate-react', () => {
@@ -95,6 +97,91 @@ describe('slate-react', () => {
         })
 
         expect(renderElement).toHaveBeenCalledTimes(3)
+      })
+
+      it('should pass the intersecting part of decorations to nested elements', () => {
+        const editor = withReact(createEditor())
+
+        const value = [
+          {
+            type: 'parent',
+            children: [
+              { type: 'block', children: [{ text: 'foo', highlight: false }] },
+              { type: 'block', children: [{ text: 'bar', highlight: false }] },
+              { type: 'block', children: [{ text: 'baz', highlight: false }] },
+            ],
+          },
+        ]
+
+        // initial render does not return
+        const decorate = jest.fn<Range[], [NodeEntry]>(() => [])
+        const renderLeaf = jest.fn<JSX.Element, [RenderLeafProps]>(DefaultLeaf)
+        const onChange = jest.fn<void, []>()
+
+        let el: ReactTestRenderer
+
+        act(() => {
+          el = create(
+            <Slate editor={editor} value={value} onChange={onChange}>
+              <DefaultEditable decorate={decorate} renderLeaf={renderLeaf} />
+            </Slate>,
+            { createNodeMock }
+          )
+        })
+
+        // 3 leaves (foo,bar,baz)
+        expect(renderLeaf).toHaveBeenCalledTimes(3)
+        renderLeaf.mockClear()
+
+        // return a decoration spanning foo_b[ar_ba]z
+        decorate.mockImplementation(([node]) => {
+          if (node !== value[0]) {
+            return []
+          }
+
+          return [
+            {
+              anchor: { path: [0, 1, 0], offset: 1 },
+              focus: { path: [0, 2, 0], offset: 2 },
+              highlight: true,
+            },
+          ]
+        })
+
+        act(() => {
+          el.update(
+            <Slate editor={editor} value={value} onChange={onChange}>
+              <DefaultEditable decorate={decorate} renderLeaf={renderLeaf} />
+            </Slate>
+          )
+        })
+
+        // 4 rerenders, for b,ar,ba,z
+        expect(renderLeaf).toHaveBeenCalledTimes(4)
+        expect(renderLeaf.mock.calls).toEqual(
+          expect.arrayContaining([
+            [
+              expect.objectContaining({
+                leaf: { highlight: false, text: 'b' },
+              }),
+            ],
+            [
+              expect.objectContaining({
+                leaf: { highlight: true, text: 'ar' },
+              }),
+            ],
+            [
+              expect.objectContaining({
+                leaf: { highlight: true, text: 'ba' },
+              }),
+            ],
+            [
+              expect.objectContaining({
+                leaf: { highlight: false, text: 'z' },
+              }),
+            ],
+          ])
+        )
       })
     })
   })


### PR DESCRIPTION
**Description**
Due to a regression, decorations that cross child elements were not properly passed to those elements for rendering; the offsets from the anchor and node were being applied to every child node, rather than the specific intersection. This PR ensures that the child elements always receive the intersecting range of the decoration. 

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4909

**Example**
Given this value, where some elments are nested under a parent element:

```javascript
[
  {
    type: "parent",
    children: [
      { type: "block", children: [{ text: "foo" }] },
      { type: "block", children: [{ text: "bar" }] },
      { type: "block", children: [{ text: "baz" }] }
    ]
  }
]
```

And this return from decorateNode on the parent element above:

```javascript
[
    {
        anchor: { path: [0, 1, 0], offset: 1 },  // from b(ar
        focus: { path: [0, 2, 0], offset: 2 },   // to ba)z
        bold: true
    }
]
```

The decorations passed down to the child elements will be only their intersecting range, so that the decoration is applied correctly across the children. 

From the linked issue, see this image of the regression (this PR seeks to restore prior behavior shown on 0.66 here):
![image](https://user-images.githubusercontent.com/5672408/159790402-a3ea34a2-7c3f-4fa9-83c1-50e44cb65008.png)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

