### PR TITLE
Restore user selection after beforeinput with target range

### DIFF
--- a/.changeset/late-monkeys-hug.md
+++ b/.changeset/late-monkeys-hug.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Restore user selection after applying beforeinput with target range

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Transforms,
   Path,
+  RangeRef,
 } from 'slate'
 import getDirection from 'direction'
 import debounce from 'lodash/debounce'
@@ -51,6 +52,7 @@ import {
   IS_FOCUSED,
   PLACEHOLDER_SYMBOL,
   EDITOR_TO_WINDOW,
+  EDITOR_TO_USER_SELECTION,
 } from '../utils/weak-maps'
 
 type DeferredOperation = () => void
@@ -399,7 +401,14 @@ export const Editable = (props: EditableProps) => {
             })
 
             if (!selection || !Range.equals(selection, range)) {
+              const selectionRef =
+                editor.selection && Editor.rangeRef(editor, editor.selection)
+
               Transforms.select(editor, range)
+
+              if (selectionRef) {
+                EDITOR_TO_USER_SELECTION.set(editor, selectionRef)
+              }
             }
           }
         }
@@ -522,6 +531,17 @@ export const Editable = (props: EditableProps) => {
 
             break
           }
+        }
+
+        // Restore the actual user section if nothing manually set it.
+        const toRestore = EDITOR_TO_USER_SELECTION.get(editor)?.unref()
+        EDITOR_TO_USER_SELECTION.delete(editor)
+
+        if (
+          toRestore &&
+          (!editor.selection || !Range.equals(editor.selection, toRestore))
+        ) {
+          Transforms.select(editor, toRestore)
         }
       }
     },
@@ -1383,23 +1403,6 @@ const defaultScrollSelectionIntoView = (
     })
     delete leafEl.getBoundingClientRect
   }
-}
-
-/**
- * Check if two DOM range objects are equal.
- */
-
-export const isRangeEqual = (a: DOMRange, b: DOMRange) => {
-  return (
-    (a.startContainer === b.startContainer &&
-      a.startOffset === b.startOffset &&
-      a.endContainer === b.endContainer &&
-      a.endOffset === b.endOffset) ||
-    (a.startContainer === b.endContainer &&
-      a.startOffset === b.endOffset &&
-      a.endContainer === b.startContainer &&
-      a.endOffset === b.startOffset)
-  )
 }
 
 /**

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -7,6 +7,7 @@ import {
   EDITOR_TO_KEY_TO_ELEMENT,
   EDITOR_TO_ON_CHANGE,
   NODE_TO_KEY,
+  EDITOR_TO_USER_SELECTION,
 } from '../utils/weak-maps'
 import {
   isDOMText,
@@ -71,6 +72,13 @@ export const withReact = <T extends Editor>(editor: T) => {
       case 'set_node':
       case 'split_node': {
         matches.push(...getMatches(e, op.path))
+        break
+      }
+
+      case 'set_selection': {
+        // Selection was manually set, don't restore the user selection after the change.
+        EDITOR_TO_USER_SELECTION.get(editor)?.unref()
+        EDITOR_TO_USER_SELECTION.delete(editor)
         break
       }
 

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -1,4 +1,4 @@
-import { Ancestor, Editor, Node } from 'slate'
+import { Ancestor, Editor, Node, RangeRef } from 'slate'
 import { Key } from './key'
 import { TextInsertion } from '../components/android/diff-text'
 
@@ -35,6 +35,8 @@ export const IS_DRAGGING: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_CLICKING: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_COMPOSING: WeakMap<Editor, boolean> = new WeakMap()
 export const IS_ON_COMPOSITION_END: WeakMap<Editor, boolean> = new WeakMap()
+
+export const EDITOR_TO_USER_SELECTION: WeakMap<Editor, RangeRef> = new WeakMap()
 
 /**
  * Weak maps for saving text on composition stage.


### PR DESCRIPTION
**Description**
Fixes macOS auto replacement and possibly issues with other IMES by restoring the intended user selection after beforeInput events with a target range.

**Example**
Before:
![before](https://user-images.githubusercontent.com/13185548/160590225-11610be2-e79c-404c-b924-f0019fc380fc.gif)

After:
![after](https://user-images.githubusercontent.com/13185548/160590242-fa08a68c-0061-425a-911c-68b0595b7932.gif)

**Context**
We currently select the before-input target range thus overwriting the actual intended user selection. The target range of the before-input event isn't meant to be used as the user selection. This pr stores the origin user selection before we select the target range and restores it once we have applied the change if no `set_selection` operation was applied on between.

There are definitely other ways to achieve to solve this, but I went with this approach as it was the simplest to do and shouldn't break any existing plugins. I don't really have a strong opinion about this.

Here is how the current behavior breaks the macOS auto replacement:

Typing "omw " results in the following events:

- Insert text "o" with target range from offset 0 to 0
- Selection change event to offset 1 to 1
- Insert text "m" with target range from offset 1 to 1
- Selection change event to offset 2 to 2
- Insert text "w" with target range from offset 2 to 2
- Selection change event to offset 3 to 3
- Insert text " " with target range from offset 3 to 3
- Selection change event to offset 4 to 4
- Insert text "On my way!" with target range from 0 to 3 (The actual replacement)

In the last step we currently select the target range and don't restore the actual user selection, so it ends up being directly after the "On my way!" before the space, while it should be after the space.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

