### PR TITLE
Run <Slate />'s focus event listeners after <Editable />'s focus handlers in React >= 17

### DIFF
--- a/.changeset/five-emus-roll.md
+++ b/.changeset/five-emus-roll.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix useFocused hook in react >= 17

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -9,7 +9,7 @@ import {
   SlateSelectorContext,
 } from '../hooks/use-slate-selector'
 import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
-import { IS_REACT_ABOVE_VERSION_17 } from '../utils/environment'
+import { IS_REACT_VERSION_17_OR_ABOVE } from '../utils/environment'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 
 /**
@@ -71,7 +71,7 @@ export const Slate = (props: {
 
   useIsomorphicLayoutEffect(() => {
     const fn = () => setIsFocused(ReactEditor.isFocused(editor))
-    if (IS_REACT_ABOVE_VERSION_17) {
+    if (IS_REACT_VERSION_17_OR_ABOVE) {
       document.addEventListener('focusin', fn)
       document.addEventListener('focusout', fn)
       return () => {

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -72,6 +72,9 @@ export const Slate = (props: {
   useIsomorphicLayoutEffect(() => {
     const fn = () => setIsFocused(ReactEditor.isFocused(editor))
     if (IS_REACT_VERSION_17_OR_ABOVE) {
+      // In React >= 17 onFocus and onBlur listen to the focusin and focusout events during the bubbling phase.
+      // Therefore in order for <Editable />'s handlers to run first, which is necessary for ReactEditor.isFocused(editor)
+      // to return the correct value, we have to listen to the focusin and focusout events without useCapture here.
       document.addEventListener('focusin', fn)
       document.addEventListener('focusout', fn)
       return () => {

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -9,6 +9,7 @@ import {
   SlateSelectorContext,
 } from '../hooks/use-slate-selector'
 import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
+import { IS_REACT_ABOVE_VERSION_17 } from '../utils/environment'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 
 /**
@@ -70,16 +71,20 @@ export const Slate = (props: {
 
   useIsomorphicLayoutEffect(() => {
     const fn = () => setIsFocused(ReactEditor.isFocused(editor))
-    document.addEventListener('focus', fn, true)
-    return () => document.removeEventListener('focus', fn, true)
-  }, [])
-
-  useIsomorphicLayoutEffect(() => {
-    const fn = () => setIsFocused(ReactEditor.isFocused(editor))
-    document.addEventListener('blur', fn, true)
-    return () => {
-      document.removeEventListener('focus', fn, true)
-      document.removeEventListener('blur', fn, true)
+    if (IS_REACT_ABOVE_VERSION_17) {
+      document.addEventListener('focusin', fn)
+      document.addEventListener('focusout', fn)
+      return () => {
+        document.removeEventListener('focusin', fn)
+        document.removeEventListener('focusout', fn)
+      }
+    } else {
+      document.addEventListener('focus', fn, true)
+      document.addEventListener('blur', fn, true)
+      return () => {
+        document.removeEventListener('focus', fn, true)
+        document.removeEventListener('blur', fn, true)
+      }
     }
   }, [])
 

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -1,3 +1,8 @@
+import React from 'react'
+
+export const IS_REACT_ABOVE_VERSION_17 =
+  parseInt(React.version.split('.')[0], 10) >= 17
+
 export const IS_IOS =
   typeof navigator !== 'undefined' &&
   typeof window !== 'undefined' &&

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const IS_REACT_ABOVE_VERSION_17 =
+export const IS_REACT_VERSION_17_OR_ABOVE =
   parseInt(React.version.split('.')[0], 10) >= 17
 
 export const IS_IOS =


### PR DESCRIPTION
**Description**
Run `<Slate />`'s focus event listeners after `<Editable />`'s focus handlers in React >= 17

**Issue**
Fixes: #4754

**Example**
See #4754 / #4755 - happy to provide more evidence if necessary

**Context**
In #4754, @jhurwitz noted that "the `useFocused` hook displays old values". I noticed this issue in my project as well, and the fix in #4755 solved the problem for me. However as noted by @bryanph, this change caused a regression when selecting between two different editors. Thus #4755 was reverted in #4874.

By chance, I noticed that running @jhurwitz's [code sandbox](https://codesandbox.io/s/stupefied-moore-qsmjh?file=/src/Editor.js) in slate's examples does not cause the "inverted" focus behaviour, and after some digging I realized that the difference is that the code sandbox uses React 17 whereas slate's examples use React 16. To validate this, I [cloned the sandbox](https://codesandbox.io/s/objective-grass-hcejne?file=/src/Editor.js) and downgraded to React 16.

After some debugging, I noticed that the order of execution of `<Editable />`'s onFocus handler and `<Slate />`'s focus event listener were reversed in React 17. This led me to look at the React changelog, and it became clear that all this comes down to a change in how `onFocus` and `onBlur` are implemented in React 17 (see https://github.com/facebook/react/pull/19186). As I understand it, `onFocus` and `onBlur` now listen to the `focusin` and `focusout` events during the bubbling phase.

Based on the above, I reasoned that listening to the `focusin` and `focusout` events without `useCapture` in `<Slate />` should fix the order of execution. I'm happy to report that this is indeed the case!

For backwards compatibility, I added a React version check, and only use the  `focusin` and `focusout` events if React >= 17. However, I've since tested using the `focusin` and `focusout` events no matter the React version and it doesn't seem to cause any issues (the focus behaviour in React 16 and 17 look identical and all tests still passing). Let me know whether it would be preferable to remove the version check.

Lastly, it would be good to get some input from @bryanph to verify that this doesn't cause the same issues as #4755 for them.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

