### PR TITLE
Call user-defined keyDown handler while composing

### DIFF
--- a/.changeset/big-keys-grab.md
+++ b/.changeset/big-keys-grab.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Call keyDown handler while composing

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1064,9 +1064,9 @@ export const Editable = (props: EditableProps) => {
             (event: React.KeyboardEvent<HTMLDivElement>) => {
               if (
                 !readOnly &&
-                !state.isComposing &&
                 hasEditableTarget(editor, event.target) &&
-                !isEventHandled(event, attributes.onKeyDown)
+                !isEventHandled(event, attributes.onKeyDown) &&
+                !state.isComposing
               ) {
                 const { nativeEvent } = event
                 const { selection } = editor


### PR DESCRIPTION
**Description**
Updates the `Editable` component to call the `keyDown` handler while composing.

**Context**
Ever since https://github.com/ianstormtaylor/slate/pull/4450 the `keyDown` event handler on the `Editable` isn't called while composing. While it makes sense to not call the `Editable`s own handler logic while the user is composing, we should still call user-defined keyDown handlers which can ignore `keyDown` events based on e.g. `event.nativeEvent.isComposing`. There are a lot of use-cases where you might want to act on keyDown events while composing (e.g. when stopping propagation)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

