### PR TITLE
Update examples in docs, editable voids example

### DIFF
--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -35,21 +35,21 @@ declare module 'slate' {
 
 ## Annotations in the Editor
 
-Annotate `initialValue` w/ `<Descendant[]>` and the editor's initial value w/ your custom Element type.
+Annotate the editor's initial value w/ `Descendant[]`.
 
 ```tsx
 import React, { useMemo, useState } from 'react'
 import { createEditor, Descendant } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 
-const App = () => {
-  const initialValue: Descendant[] = [
-    {
-      type: 'paragraph',
-      children: [{ text: 'A line of text in a paragraph.' }],
-    },
-  ]
+const initialValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [{ text: 'A line of text in a paragraph.' }],
+  },
+]
 
+const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
 
   return (

--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -35,7 +35,7 @@ declare module 'slate' {
 
 ## Annotations in the Editor
 
-Annotate `useState` w/ `<Descendant[]>` and the editor's initial value w/ your custom Element type.
+Annotate `initialValue` w/ `<Descendant[]>` and the editor's initial value w/ your custom Element type.
 
 ```tsx
 import React, { useMemo, useState } from 'react'
@@ -49,10 +49,11 @@ const App = () => {
       children: [{ text: 'A line of text in a paragraph.' }],
     },
   ]
+
   const editor = useMemo(() => withReact(createEditor()), [])
-  const [value, setValue] = useState<Descendant[]>(initialValue)
+
   return (
-    <Slate editor={editor} value={value} onChange={setValue}>
+    <Slate editor={editor} value={initialValue}>
       <Editable />
     </Slate>
   )

--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -95,7 +95,6 @@ const initialValue = []
 
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
-  const [value, setValue] = useState([])
   return (
     // Add the editable component inside the context.
     <Slate editor={editor} value={initialValue}>
@@ -122,7 +121,6 @@ const initialValue = [
 
 const App = () => {
   const [editor] = useState(() => withReact(createEditor())
-  const [value, setValue] = useState()
 
   return (
     <Slate editor={editor} value={initialValue}>

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -73,7 +73,7 @@ const App = () => {
   }, [])
 
   return (
-    <Slate editor={editor} value={value}>
+    <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
         onKeyDown={event => {

--- a/site/examples/editable-voids.tsx
+++ b/site/examples/editable-voids.tsx
@@ -9,14 +9,13 @@ import { Button, Icon, Toolbar } from '../components'
 import { EditableVoidElement } from './custom-types'
 
 const EditableVoidsExample = () => {
-  const [value, setValue] = useState<Descendant[]>(initialValue)
   const editor = useMemo(
     () => withEditableVoids(withHistory(withReact(createEditor()))),
     []
   )
 
   return (
-    <Slate editor={editor} value={value} onChange={setValue}>
+    <Slate editor={editor} value={initialValue}>
       <Toolbar>
         <InsertEditableVoidButton />
       </Toolbar>


### PR DESCRIPTION
**Description**
Just noticed a few things I missed in the docs in https://github.com/ianstormtaylor/slate/pull/4922, sorry about that.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

