### PR TITLE
Fixed legacy check for Firefox v100+

### DIFF
--- a/.changeset/shy-wasps-mix.md
+++ b/.changeset/shy-wasps-mix.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fix firefox three digit version check

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -26,7 +26,7 @@ export const IS_SAFARI =
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =
   typeof navigator !== 'undefined' &&
-  /Edge?\/(?:[0-6][0-9]|[0-7][0-8])(\.)/i.test(navigator.userAgent)
+  /Edge?\/(?:[0-6][0-9]|[0-7][0-8])(?:\.)/i.test(navigator.userAgent)
 
 export const IS_CHROME =
   typeof navigator !== 'undefined' && /Chrome/i.test(navigator.userAgent)
@@ -35,12 +35,12 @@ export const IS_CHROME =
 // and older, Chrome 76+ can use `beforeInput` though.
 export const IS_CHROME_LEGACY =
   typeof navigator !== 'undefined' &&
-  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])(\.)/i.test(navigator.userAgent)
+  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])(?:\.)/i.test(navigator.userAgent)
 
 // Firefox did not support `beforeInput` until `v87`.
 export const IS_FIREFOX_LEGACY =
   typeof navigator !== 'undefined' &&
-  /^(?!.*Seamonkey)(?=.*Firefox\/(?:[0-7][0-9]|[0-8][0-6])).*/i.test(
+  /^(?!.*Seamonkey)(?=.*Firefox\/(?:[0-7][0-9]|[0-8][0-6])(?:\.)).*/i.test(
     navigator.userAgent
   )
 


### PR DESCRIPTION
**Description**
Firefox v100 was [released to the beta channel today](https://www.mozilla.org/en-US/firefox/100.0beta/releasenotes/) and is being incorrect caught by the Firefox legacy check, breaking composition. This is the same as https://github.com/ianstormtaylor/slate/pull/4883 which fixed the checks for Chrome and Edge.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

