### PR TITLE
Export `createText` from `slate-hyperscript`

### DIFF
--- a/.changeset/chilly-boats-deny.md
+++ b/.changeset/chilly-boats-deny.md
@@ -1,0 +1,5 @@
+---
+'slate-hyperscript': patch
+---
+
+Export `createText` creator from `slate-hyperscript` package

--- a/packages/slate-hyperscript/src/index.ts
+++ b/packages/slate-hyperscript/src/index.ts
@@ -3,7 +3,10 @@ import {
   HyperscriptCreators,
   HyperscriptShorthands,
 } from './hyperscript'
-import { createEditor } from './creators'
+import { 
+  createEditor, 
+  createText,
+} from './creators'
 
 /**
  * The default hyperscript factory that ships with Slate, without custom tags.
@@ -15,6 +18,7 @@ export {
   jsx,
   createHyperscript,
   createEditor,
+  createText,
   HyperscriptCreators,
   HyperscriptShorthands,
 }

--- a/packages/slate-hyperscript/src/index.ts
+++ b/packages/slate-hyperscript/src/index.ts
@@ -3,10 +3,7 @@ import {
   HyperscriptCreators,
   HyperscriptShorthands,
 } from './hyperscript'
-import { 
-  createEditor, 
-  createText,
-} from './creators'
+import { createEditor, createText } from './creators'
 
 /**
  * The default hyperscript factory that ships with Slate, without custom tags.


### PR DESCRIPTION
**Description**

It is not possible to write slate-hyperscript tests in Typescript+React projects. As `<text>` element conflicts with React-defined SVG `<text>` element definition.
  
One possible solution could be to configure JSX with `createHyperscript()` by using the `createText` creator with a different name.  However, this is not possible, as `createText` is private and is never exported.

This PR solves it.

**Issue**
Fixes: #4931

**Example**

```tsx
import { createHyperscript, createText } from 'slate-hyperscript';

const jsx = createHyperscript({
  creators: {
    leaf: createText,
  },
});
```

```tsx
<editor>
  <paragraph>
    <leaf bold>Welcome</leaf> 
  </paragraph>
</editor>
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

