### PR TITLE
Fixed  #3871 (can reproduction when i click 4 times)

### DIFF
--- a/.changeset/giant-mirrors-explain.md
+++ b/.changeset/giant-mirrors-explain.md
@@ -2,4 +2,4 @@
 'slate-react': patch
 ---
 
-fixed triple click bug #4930 
+fixed triple click bug #4930

--- a/.changeset/giant-mirrors-explain.md
+++ b/.changeset/giant-mirrors-explain.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fixed triple click bug #4930 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -303,7 +303,13 @@ export const Editable = (props: EditableProps) => {
             exactMatch: false,
             suppressThrow: false,
           })
-          Transforms.select(editor, range)
+
+          if (state.isTripleClick) {
+            state.isTripleClick = false
+            Editor.unhangRange(editor, range)
+          } else {
+            Transforms.select(editor, range)
+          }
         }
       }
     }, 100),

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -765,6 +765,7 @@ export const Editable = (props: EditableProps) => {
                   const end = Editor.end(editor, [path[0]])
                   const range = Editor.range(editor, start, end)
                   setTimeout(() => {
+                    if (!ref.current) return
                     Transforms.select(editor, range)
                     Editor.unhangRange(editor, range)
                   }, 100)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -144,6 +144,7 @@ export const Editable = (props: EditableProps) => {
       hasInsertPrefixInCompositon: false,
       isDraggingInternally: false,
       isUpdatingSelection: false,
+      isTripleClick: false,
       latestElement: null as DOMElement | null,
     }),
     []
@@ -760,12 +761,15 @@ export const Editable = (props: EditableProps) => {
               ) {
                 const node = ReactEditor.toSlateNode(editor, event.target)
                 const path = ReactEditor.findPath(editor, node)
+
+                state.isTripleClick = false
                 if (event.detail >= TRIPLE_CLICK && path.length) {
+                  state.isTripleClick = true
                   const start = Editor.start(editor, [path[0]])
                   const end = Editor.end(editor, [path[0]])
                   const range = Editor.range(editor, start, end)
                   setTimeout(() => {
-                    if (!ref.current) return
+                    if (!ref.current || !state.isTripleClick) return
                     Transforms.select(editor, range)
                     Editor.unhangRange(editor, range)
                   }, 100)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -760,11 +760,14 @@ export const Editable = (props: EditableProps) => {
               ) {
                 const node = ReactEditor.toSlateNode(editor, event.target)
                 const path = ReactEditor.findPath(editor, node)
-                if (event.detail === TRIPLE_CLICK) {
+                if (event.detail >= TRIPLE_CLICK && path.length) {
                   const start = Editor.start(editor, [path[0]])
                   const end = Editor.end(editor, [path[0]])
                   const range = Editor.range(editor, start, end)
-                  Transforms.select(editor, range)
+                  setTimeout(() => {
+                    Transforms.select(editor, range)
+                    Editor.unhangRange(editor, range)
+                  }, 100)
                   return
                 }
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -785,7 +785,6 @@ export const Editable = (props: EditableProps) => {
                   const start = Editor.start(editor, [path[0]])
                   const end = Editor.end(editor, [path[0]])
                   const range = Editor.range(editor, start, end)
-                  if (!ref.current) return
                   Transforms.select(editor, range)
                   return
                 }


### PR DESCRIPTION
**Description**
When i click 4 times, the selection is not expected, like #3871 


https://user-images.githubusercontent.com/16861647/163365630-22f55edf-625c-46ad-b575-c4001edc9288.mp4

fixed

https://user-images.githubusercontent.com/16861647/163365819-7f3e7115-cbcc-4bf2-bb40-ff84e5bb54c3.mp4



**Issue**
Fixes: #4930 #3871 

**Example**
https://user-images.githubusercontent.com/82301/162357857-514f3563-a256-45e2-ab11-21f6c019ab0c.mp4

**Context**
In the case of triple clicking on the Editable component itself, the node returned from toSlateNode is the editor node, and the path returned from findPath is of zero length. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

