### PR TITLE
Doc serializing fix

### DIFF
--- a/docs/concepts/10-serializing.md
+++ b/docs/concepts/10-serializing.md
@@ -171,14 +171,14 @@ const deserialize = (el, markAttributes = {}) => {
 
   const nodeAttributes = { ...markAttributes }
 
-  // define attibutes for text nodes
+  // define attributes for text nodes
   switch (el.nodeName) {
     case 'strong':
       nodeAttributes.bold = true
   }
 
   const children = Array.from(el.childNodes)
-    .map(node => deserialize(el, nodeAttributes))
+    .map(node => deserialize(node, nodeAttributes))
     .flat()
 
   if (children.length === 0) {


### PR DESCRIPTION
**Description**
Right now the example of the recursive function in the docs for serializing is never ending because of a typo.

