### PR TITLE
Fix pointRef leaks caused by not unref'ing

### DIFF
--- a/.changeset/khaki-panthers-burn.md
+++ b/.changeset/khaki-panthers-burn.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix pointRef leaks caused by not unref'ing

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -214,9 +214,9 @@ export const TextTransforms: TextTransforms = {
         })
       }
 
-      const point = reverse
-        ? startRef.unref() || endRef.unref()
-        : endRef.unref() || startRef.unref()
+      const startUnref = startRef.unref()
+      const endUnref = endRef.unref()
+      const point = reverse ? startUnref || endUnref : endUnref || startUnref
 
       if (options.at == null && point) {
         Transforms.select(editor, point)


### PR DESCRIPTION
May cause severe performance degradation if more and more point refs
need to be updated.

**Description**
PointRef instances are not cleaned up in some of the `Transform` functions and can cause performance degradation especially with large documents.

**Issue**
Fixes: no issue filed

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

