### PR TITLE
Fix editor root triple click crash

### DIFF
--- a/.changeset/fair-bobcats-accept.md
+++ b/.changeset/fair-bobcats-accept.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix crash when tripple clicking editor root

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -760,7 +760,19 @@ export const Editable = (props: EditableProps) => {
               ) {
                 const node = ReactEditor.toSlateNode(editor, event.target)
                 const path = ReactEditor.findPath(editor, node)
-                if (event.detail === TRIPLE_CLICK) {
+
+                // At this time, the Slate document may be arbitrarily different,
+                // because onClick handlers can change the document before we get here.
+                // Therefore we must check that this path actually exists,
+                // and that it still refers to the same node.
+                if (
+                  !Editor.hasPath(editor, path) ||
+                  Node.get(editor, path) !== node
+                ) {
+                  return
+                }
+
+                if (event.detail === TRIPLE_CLICK && path.length >= 1) {
                   const start = Editor.start(editor, [path[0]])
                   const end = Editor.end(editor, [path[0]])
                   const range = Editor.range(editor, start, end)
@@ -772,27 +784,18 @@ export const Editable = (props: EditableProps) => {
                   return
                 }
 
-                // At this time, the Slate document may be arbitrarily different,
-                // because onClick handlers can change the document before we get here.
-                // Therefore we must check that this path actually exists,
-                // and that it still refers to the same node.
-                if (Editor.hasPath(editor, path)) {
-                  const lookupNode = Node.get(editor, path)
-                  if (lookupNode === node) {
-                    const start = Editor.start(editor, path)
-                    const end = Editor.end(editor, path)
-                    const startVoid = Editor.void(editor, { at: start })
-                    const endVoid = Editor.void(editor, { at: end })
+                const start = Editor.start(editor, path)
+                const end = Editor.end(editor, path)
+                const startVoid = Editor.void(editor, { at: start })
+                const endVoid = Editor.void(editor, { at: end })
 
-                    if (
-                      startVoid &&
-                      endVoid &&
-                      Path.equals(startVoid[1], endVoid[1])
-                    ) {
-                      const range = Editor.range(editor, start)
-                      Transforms.select(editor, range)
-                    }
-                  }
+                if (
+                  startVoid &&
+                  endVoid &&
+                  Path.equals(startVoid[1], endVoid[1])
+                ) {
+                  const range = Editor.range(editor, start)
+                  Transforms.select(editor, range)
                 }
               }
             },


### PR DESCRIPTION
**Description**
Fixes a regression introduced by https://github.com/ianstormtaylor/slate/pull/4933. Basically, when triple-clicking the editor root, the path has a length of 0 so it was calling `Editor.start`,`Editor.end` with a path of `[undefined]`.

This pr also moved some in-place checks for the later handling before the manual triple-click handling to ensure we are acting on a valid state.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4941

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

