### PR TITLE
Prevent native insert at the end of anchors

### DIFF
--- a/.changeset/poor-mangos-burn.md
+++ b/.changeset/poor-mangos-burn.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Prevent native insert at the end of anchor elements

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -368,19 +368,20 @@ export const Editable = (props: EditableProps) => {
             native = false
           }
 
-          // Chrome also has issues correctly editing the end of nodes: https://bugs.chromium.org/p/chromium/issues/detail?id=1259100
-          // Therefore we don't allow native events to insert text at the end of nodes.
+          // Chrome also has issues correctly editing the end of anchor elements: https://bugs.chromium.org/p/chromium/issues/detail?id=1259100
+          // Therefore we don't allow native events to insert text at the end of anchor nodes.
           const { anchor } = selection
-          const inline = Editor.above(editor, {
-            at: anchor,
-            match: n => Editor.isInline(editor, n),
-            mode: 'highest',
-          })
-          if (inline) {
-            const [, inlinePath] = inline
+          if (Editor.isEnd(editor, anchor, anchor.path)) {
+            const [node] = ReactEditor.toDOMPoint(editor, selection.anchor)
+            const anchorNode = node.parentElement?.closest('a')
 
-            if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
-              native = false
+            if (anchorNode && ReactEditor.hasDOMNode(editor, anchorNode)) {
+              const node = ReactEditor.toSlateNode(editor, anchorNode)
+              const path = ReactEditor.findPath(editor, node)
+
+              if (Editor.isEnd(editor, anchor, path)) {
+                native = false
+              }
             }
           }
         }


### PR DESCRIPTION
**Description**
Updates the 'native insert' logic to don't treat inserts at the end of anchor elements as native. Currently, we only check if we insert at the end of inline elements to try and catch this case, but this is insufficient as we can:

- Render leaves as anchors 
- Render elements as anchors

This PR updates the check to be on a dom level to try and catch the 2 cases mentioned above.

Chrome is very aggressive in trying to insert outside anchors. It seems to determine the end of an anchor element on a text level so even higher level blocks rendered as anchor elements can cause issues.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4911

**Example**
See https://github.com/ianstormtaylor/slate/issues/4911 which includes a sandbox link as well.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

