### PR TITLE
fix double insert in anchor element decorations

### DIFF
--- a/.changeset/sixty-students-leave.md
+++ b/.changeset/sixty-students-leave.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix double insert in anchor element decorations


### PR DESCRIPTION
**Description**
Adjusts the fix in https://github.com/ianstormtaylor/slate/commit/9957c214357dbbd5492ec4761fd6e1c7b14310f5 to truly catch all edge-cases.

Right now it doesn't work for decorations since the `Editor.isEnd()` check will return false for decorations that split text node.

The `createTreeWalker` approach was the fastest way I could find to get the last dom text node inside the anchor element. Maybe there is a smarter way to do it using e.g. `document.evaluate`.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

