### PR TITLE
Fix positions iteration when starting in an inline void node

### DIFF
--- a/.changeset/little-plums-behave.md
+++ b/.changeset/little-plums-behave.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix positions iteration when starting inside an inline void node

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1341,6 +1341,9 @@ export const Editor: EditorInterface = {
         // then we will iterate over their content.
         if (!voids && editor.isVoid(node)) {
           yield Editor.start(editor, path)
+          // It's possible the start of the range we're iterating over is in a void, in which case
+          // we want to make sure we don't incorrectly yield the start of a subsequent text node for unit !== 'offset'
+          isNewBlock = false
           continue
         }
 

--- a/packages/slate/test/interfaces/Editor/positions/range/start-in-void.tsx
+++ b/packages/slate/test/interfaces/Editor/positions/range/start-in-void.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block>
+      one
+      <inline void>
+        <text />
+      </inline>
+      two
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.positions(editor, {
+      at: {
+        anchor: { path: [0, 1, 0], offset: 0 },
+        focus: { path: [0, 2], offset: 2 },
+      },
+      unit: 'character',
+    })
+  )
+}
+export const output = [
+  { path: [0, 1, 0], offset: 0 },
+  { path: [0, 2], offset: 1 },
+  { path: [0, 2], offset: 2 },
+]


### PR DESCRIPTION
**Description**

The 'positions' iterator code has special logic to always return the 'start' of the first node in a block, when using a content based 'unit' such as 'character'. There's a flag to track whether we've returned that start point or not, in order to skip yielding the start point on subsequent nodes in the block. We also have an early continue on the loop for void nodes, to make sure we only ever yield the the first point of a void.

The bug was that if you start iteration inside a void, that early continue code executes, but does not reset the "I've returned the start point" flag, even though we have

**Example**
If you have 
```
<block>                  // path [0]
  <text text="hello"/>   // path [0, 0]
  <inline-void>          // path [0, 1]
    <text/>              // path [0, 1, 0]
  </inline-void> 
  <text text="world"/>   // path [0, 2]
</block>
```

and start iterating from `{path: [0, 1, 0], offset: 0}` with `unit: 'character'`, before this fix the second point returned will be `{path: [0, 2], offset: 0}` instead of `{path: [0, 2], offset: 1}`

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

