### PR TITLE
Don't treat events with non-selection target range as native

### DIFF
--- a/.changeset/twenty-papayas-vanish.md
+++ b/.changeset/twenty-papayas-vanish.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Don't treat events with non-selection target range as native

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -390,10 +390,6 @@ export const Editable = (props: EditableProps) => {
           }
         }
 
-        if (!native) {
-          event.preventDefault()
-        }
-
         // COMPAT: For the deleting forward/backward input types we don't want
         // to change the selection because it is the range that will be deleted,
         // and those commands determine that for themselves.
@@ -407,6 +403,8 @@ export const Editable = (props: EditableProps) => {
             })
 
             if (!selection || !Range.equals(selection, range)) {
+              native = false
+
               const selectionRef =
                 editor.selection && Editor.rangeRef(editor, editor.selection)
 
@@ -417,6 +415,10 @@ export const Editable = (props: EditableProps) => {
               }
             }
           }
+        }
+
+        if (!native) {
+          event.preventDefault()
         }
 
         // COMPAT: If the selection is expanded, even if the command seems like


### PR DESCRIPTION
**Description**
Don't treat events with a non-selection target range as native. This e.g. happens with a 'i' => 'I' substitution on macos.

Before:
![Screen Recording 2022-04-20 at 17 16 33](https://user-images.githubusercontent.com/13185548/164324445-9fcac4bd-805c-4d16-9406-c4ee481b235d.gif)

After:
![after](https://user-images.githubusercontent.com/13185548/164324201-9cb5df5c-c127-400f-be9f-2096aa02d24f.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

