### PR TITLE
Fix triple click handling in nested blocks

### DIFF
--- a/.changeset/neat-pets-grow.md
+++ b/.changeset/neat-pets-grow.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix tripple click handling in nested blocks

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -780,9 +780,17 @@ export const Editable = (props: EditableProps) => {
                 }
 
                 if (event.detail === TRIPLE_CLICK && path.length >= 1) {
-                  const start = Editor.start(editor, [path[0]])
-                  const end = Editor.end(editor, [path[0]])
-                  const range = Editor.range(editor, start, end)
+                  let blockPath = path
+                  if (!Editor.isBlock(editor, node)) {
+                    const block = Editor.above(editor, {
+                      match: n => Editor.isBlock(editor, n),
+                      at: path,
+                    })
+
+                    blockPath = block?.[1] ?? path.slice(0, 1)
+                  }
+
+                  const range = Editor.range(editor, blockPath)
                   Transforms.select(editor, range)
                   return
                 }


### PR DESCRIPTION
**Description**
Fixes a regression introduced by the manual triple-click handling introduced in https://github.com/ianstormtaylor/slate/pull/4914

**Example**
Before:
![Screen Recording 2022-04-25 at 11 13 45](https://user-images.githubusercontent.com/13185548/165119520-02a04fd1-ac33-4016-a030-a7b91304bcd8.gif)

After:
![Screen Recording 2022-04-25 at 11 14 39](https://user-images.githubusercontent.com/13185548/165119335-167e940d-9814-4e11-bef4-a3a9a6549e9c.gif)

**Context**
https://github.com/ianstormtaylor/slate/pull/4914 changed the triple click handling to always select the entire root node, which doesn't match the native browser behavior on nested blocks.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

