### PR TITLE
Added types for options and common string literals

### DIFF
--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -14,6 +14,7 @@ import {
   Transforms,
 } from './'
 import { DIRTY_PATHS, DIRTY_PATH_KEYS, FLUSHING } from './utils/weak-maps'
+import { TextUnit } from './interfaces/types'
 
 /**
  * Create a new Slate `Editor` object.
@@ -121,7 +122,7 @@ export const createEditor = (): Editor => {
       }
     },
 
-    deleteBackward: (unit: 'character' | 'word' | 'line' | 'block') => {
+    deleteBackward: (unit: TextUnit) => {
       const { selection } = editor
 
       if (selection && Range.isCollapsed(selection)) {
@@ -129,7 +130,7 @@ export const createEditor = (): Editor => {
       }
     },
 
-    deleteForward: (unit: 'character' | 'word' | 'line' | 'block') => {
+    deleteForward: (unit: TextUnit) => {
       const { selection } = editor
 
       if (selection && Range.isCollapsed(selection)) {

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -10,42 +10,68 @@ import { Element, ElementEntry } from './element'
 export type BaseNode = Editor | Element | Text
 export type Node = Editor | Element | Text
 
+export interface NodeAncestorsOptions {
+  reverse?: boolean
+}
+
+export interface NodeChildrenOptions {
+  reverse?: boolean
+}
+
+export interface NodeDescendantsOptions {
+  from?: Path
+  to?: Path
+  reverse?: boolean
+  pass?: (node: NodeEntry) => boolean
+}
+
+export interface NodeElementsOptions {
+  from?: Path
+  to?: Path
+  reverse?: boolean
+  pass?: (node: NodeEntry) => boolean
+}
+
+export interface NodeLevelsOptions {
+  reverse?: boolean
+}
+
+export interface NodeNodesOptions {
+  from?: Path
+  to?: Path
+  reverse?: boolean
+  pass?: (entry: NodeEntry) => boolean
+}
+
+export interface NodeTextsOptions {
+  from?: Path
+  to?: Path
+  reverse?: boolean
+  pass?: (node: NodeEntry) => boolean
+}
+
 export interface NodeInterface {
   ancestor: (root: Node, path: Path) => Ancestor
   ancestors: (
     root: Node,
     path: Path,
-    options?: {
-      reverse?: boolean
-    }
+    options?: NodeAncestorsOptions
   ) => Generator<NodeEntry<Ancestor>, void, undefined>
   child: (root: Node, index: number) => Descendant
   children: (
     root: Node,
     path: Path,
-    options?: {
-      reverse?: boolean
-    }
+    options?: NodeChildrenOptions
   ) => Generator<NodeEntry<Descendant>, void, undefined>
   common: (root: Node, path: Path, another: Path) => NodeEntry
   descendant: (root: Node, path: Path) => Descendant
   descendants: (
     root: Node,
-    options?: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (node: NodeEntry) => boolean
-    }
+    options?: NodeDescendantsOptions
   ) => Generator<NodeEntry<Descendant>, void, undefined>
   elements: (
     root: Node,
-    options?: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (node: NodeEntry) => boolean
-    }
+    options?: NodeElementsOptions
   ) => Generator<ElementEntry, void, undefined>
   extractProps: (node: Node) => NodeProps
   first: (root: Node, path: Path) => NodeEntry
@@ -59,30 +85,18 @@ export interface NodeInterface {
   levels: (
     root: Node,
     path: Path,
-    options?: {
-      reverse?: boolean
-    }
+    options?: NodeLevelsOptions
   ) => Generator<NodeEntry, void, undefined>
   matches: (node: Node, props: Partial<Node>) => boolean
   nodes: (
     root: Node,
-    options?: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (entry: NodeEntry) => boolean
-    }
+    options?: NodeNodesOptions
   ) => Generator<NodeEntry, void, undefined>
   parent: (root: Node, path: Path) => Ancestor
   string: (node: Node) => string
   texts: (
     root: Node,
-    options?: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (node: NodeEntry) => boolean
-    }
+    options?: NodeTextsOptions
   ) => Generator<NodeEntry<Text>, void, undefined>
 }
 
@@ -115,9 +129,7 @@ export const Node: NodeInterface = {
   *ancestors(
     root: Node,
     path: Path,
-    options: {
-      reverse?: boolean
-    } = {}
+    options: NodeAncestorsOptions = {}
   ): Generator<NodeEntry<Ancestor>, void, undefined> {
     for (const p of Path.ancestors(path, options)) {
       const n = Node.ancestor(root, p)
@@ -157,9 +169,7 @@ export const Node: NodeInterface = {
   *children(
     root: Node,
     path: Path,
-    options: {
-      reverse?: boolean
-    } = {}
+    options: NodeChildrenOptions = {}
   ): Generator<NodeEntry<Descendant>, void, undefined> {
     const { reverse = false } = options
     const ancestor = Node.ancestor(root, path)
@@ -206,12 +216,7 @@ export const Node: NodeInterface = {
 
   *descendants(
     root: Node,
-    options: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (node: NodeEntry) => boolean
-    } = {}
+    options: NodeDescendantsOptions = {}
   ): Generator<NodeEntry<Descendant>, void, undefined> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (path.length !== 0) {
@@ -230,12 +235,7 @@ export const Node: NodeInterface = {
 
   *elements(
     root: Node,
-    options: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (node: NodeEntry) => boolean
-    } = {}
+    options: NodeElementsOptions = {}
   ): Generator<ElementEntry, void, undefined> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (Element.isElement(node)) {
@@ -445,9 +445,7 @@ export const Node: NodeInterface = {
   *levels(
     root: Node,
     path: Path,
-    options: {
-      reverse?: boolean
-    } = {}
+    options: NodeLevelsOptions = {}
   ): Generator<NodeEntry, void, undefined> {
     for (const p of Path.levels(path, options)) {
       const n = Node.get(root, p)
@@ -478,12 +476,7 @@ export const Node: NodeInterface = {
 
   *nodes(
     root: Node,
-    options: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (entry: NodeEntry) => boolean
-    } = {}
+    options: NodeNodesOptions = {}
   ): Generator<NodeEntry, void, undefined> {
     const { pass, reverse = false } = options
     const { from = [], to } = options
@@ -589,12 +582,7 @@ export const Node: NodeInterface = {
 
   *texts(
     root: Node,
-    options: {
-      from?: Path
-      to?: Path
-      reverse?: boolean
-      pass?: (node: NodeEntry) => boolean
-    } = {}
+    options: NodeTextsOptions = {}
   ): Generator<NodeEntry<Text>, void, undefined> {
     for (const [node, path] of Node.nodes(root, options)) {
       if (Text.isText(node)) {

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -1,5 +1,6 @@
 import { produce } from 'immer'
 import { Operation } from '..'
+import { TextDirection } from './types'
 
 /**
  * `Path` arrays are a list of indexes that describe a node's exact position in
@@ -9,8 +10,20 @@ import { Operation } from '..'
 
 export type Path = number[]
 
+export interface PathAncestorsOptions {
+  reverse?: boolean
+}
+
+export interface PathLevelsOptions {
+  reverse?: boolean
+}
+
+export interface PathTransformOptions {
+  affinity?: TextDirection | null
+}
+
 export interface PathInterface {
-  ancestors: (path: Path, options?: { reverse?: boolean }) => Path[]
+  ancestors: (path: Path, options?: PathAncestorsOptions) => Path[]
   common: (path: Path, another: Path) => Path
   compare: (path: Path, another: Path) => -1 | 0 | 1
   endsAfter: (path: Path, another: Path) => boolean
@@ -27,12 +40,7 @@ export interface PathInterface {
   isParent: (path: Path, another: Path) => boolean
   isPath: (value: any) => value is Path
   isSibling: (path: Path, another: Path) => boolean
-  levels: (
-    path: Path,
-    options?: {
-      reverse?: boolean
-    }
-  ) => Path[]
+  levels: (path: Path, options?: PathLevelsOptions) => Path[]
   next: (path: Path) => Path
   operationCanTransformPath: (operation: Operation) => boolean
   parent: (path: Path) => Path
@@ -41,7 +49,7 @@ export interface PathInterface {
   transform: (
     path: Path,
     operation: Operation,
-    options?: { affinity?: 'forward' | 'backward' | null }
+    options?: PathTransformOptions
   ) => Path | null
 }
 
@@ -53,7 +61,7 @@ export const Path: PathInterface = {
    * `reverse: true` option is passed, they are reversed.
    */
 
-  ancestors(path: Path, options: { reverse?: boolean } = {}): Path[] {
+  ancestors(path: Path, options: PathAncestorsOptions = {}): Path[] {
     const { reverse = false } = options
     let paths = Path.levels(path, options)
 
@@ -257,12 +265,7 @@ export const Path: PathInterface = {
    * true` option is passed, they are reversed.
    */
 
-  levels(
-    path: Path,
-    options: {
-      reverse?: boolean
-    } = {}
-  ): Path[] {
+  levels(path: Path, options: PathLevelsOptions = {}): Path[] {
     const { reverse = false } = options
     const list: Path[] = []
 
@@ -367,7 +370,7 @@ export const Path: PathInterface = {
   transform(
     path: Path | null,
     operation: Operation,
-    options: { affinity?: 'forward' | 'backward' | null } = {}
+    options: PathTransformOptions = {}
   ): Path | null {
     return produce(path, p => {
       const { affinity = 'forward' } = options

--- a/packages/slate/src/interfaces/point-ref.ts
+++ b/packages/slate/src/interfaces/point-ref.ts
@@ -1,4 +1,5 @@
 import { Operation, Point } from '..'
+import { TextDirection } from './types'
 
 /**
  * `PointRef` objects keep a specific point in a document synced over time as new
@@ -8,7 +9,7 @@ import { Operation, Point } from '..'
 
 export interface PointRef {
   current: Point | null
-  affinity: 'forward' | 'backward' | null
+  affinity: TextDirection | null
   unref(): Point | null
 }
 

--- a/packages/slate/src/interfaces/point.ts
+++ b/packages/slate/src/interfaces/point.ts
@@ -1,6 +1,7 @@
 import { isPlainObject } from 'is-plain-object'
 import { produce } from 'immer'
 import { ExtendedType, Operation, Path } from '..'
+import { TextDirection } from './types'
 
 /**
  * `Point` objects refer to a specific location in a text node in a Slate
@@ -16,6 +17,10 @@ export interface BasePoint {
 
 export type Point = ExtendedType<'Point', BasePoint>
 
+export interface PointTransformOptions {
+  affinity?: TextDirection | null
+}
+
 export interface PointInterface {
   compare: (point: Point, another: Point) => -1 | 0 | 1
   isAfter: (point: Point, another: Point) => boolean
@@ -25,7 +30,7 @@ export interface PointInterface {
   transform: (
     point: Point,
     op: Operation,
-    options?: { affinity?: 'forward' | 'backward' | null }
+    options?: PointTransformOptions
   ) => Point | null
 }
 
@@ -93,7 +98,7 @@ export const Point: PointInterface = {
   transform(
     point: Point | null,
     op: Operation,
-    options: { affinity?: 'forward' | 'backward' | null } = {}
+    options: PointTransformOptions = {}
   ): Point | null {
     return produce(point, p => {
       if (p === null) {

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -1,6 +1,7 @@
 import { produce } from 'immer'
 import { isPlainObject } from 'is-plain-object'
 import { ExtendedType, Operation, Path, Point, PointEntry } from '..'
+import { RangeDirection } from './types'
 
 /**
  * `Range` objects are a set of points that refer to a specific span of a Slate
@@ -15,13 +16,16 @@ export interface BaseRange {
 
 export type Range = ExtendedType<'Range', BaseRange>
 
+export interface RangeEdgesOptions {
+  reverse?: boolean
+}
+
+export interface RangeTransformOptions {
+  affinity?: RangeDirection | null
+}
+
 export interface RangeInterface {
-  edges: (
-    range: Range,
-    options?: {
-      reverse?: boolean
-    }
-  ) => [Point, Point]
+  edges: (range: Range, options?: RangeEdgesOptions) => [Point, Point]
   end: (range: Range) => Point
   equals: (range: Range, another: Range) => boolean
   includes: (range: Range, target: Path | Point | Range) => boolean
@@ -36,9 +40,7 @@ export interface RangeInterface {
   transform: (
     range: Range,
     op: Operation,
-    options?: {
-      affinity?: 'forward' | 'backward' | 'outward' | 'inward' | null
-    }
+    options?: RangeTransformOptions
   ) => Range | null
 }
 
@@ -48,12 +50,7 @@ export const Range: RangeInterface = {
    * in the document.
    */
 
-  edges(
-    range: Range,
-    options: {
-      reverse?: boolean
-    } = {}
-  ): [Point, Point] {
+  edges(range: Range, options: RangeEdgesOptions = {}): [Point, Point] {
     const { reverse = false } = options
     const { anchor, focus } = range
     return Range.isBackward(range) === reverse
@@ -209,9 +206,7 @@ export const Range: RangeInterface = {
   transform(
     range: Range | null,
     op: Operation,
-    options: {
-      affinity?: 'forward' | 'backward' | 'outward' | 'inward' | null
-    } = {}
+    options: RangeTransformOptions = {}
   ): Range | null {
     return produce(range, r => {
       if (r === null) {

--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -15,8 +15,12 @@ export interface BaseText {
 
 export type Text = ExtendedType<'Text', BaseText>
 
+export interface TextEqualsOptions {
+  loose?: boolean
+}
+
 export interface TextInterface {
-  equals: (text: Text, another: Text, options?: { loose?: boolean }) => boolean
+  equals: (text: Text, another: Text, options?: TextEqualsOptions) => boolean
   isText: (value: any) => value is Text
   isTextList: (value: any) => value is Text[]
   isTextProps: (props: any) => props is Partial<Text>
@@ -31,11 +35,7 @@ export const Text: TextInterface = {
    * When loose is set, the text is not compared. This is
    * used to check whether sibling text nodes can be merged.
    */
-  equals(
-    text: Text,
-    another: Text,
-    options: { loose?: boolean } = {}
-  ): boolean {
+  equals(text: Text, another: Text, options: TextEqualsOptions = {}): boolean {
     const { loose = false } = options
 
     function omitText(obj: Record<any, any>) {

--- a/packages/slate/src/interfaces/types.ts
+++ b/packages/slate/src/interfaces/types.ts
@@ -1,0 +1,19 @@
+export type LeafEdge = 'start' | 'end'
+
+export type MaximizeMode = RangeMode | 'all'
+
+export type MoveUnit = 'offset' | 'character' | 'word' | 'line'
+
+export type RangeDirection = TextDirection | 'outward' | 'inward'
+
+export type RangeMode = 'highest' | 'lowest'
+
+export type SelectionEdge = 'anchor' | 'focus' | 'start' | 'end'
+
+export type SelectionMode = 'all' | 'highest' | 'lowest'
+
+export type TextDirection = 'forward' | 'backward'
+
+export type TextUnit = 'character' | 'word' | 'line' | 'block'
+
+export type TextUnitAdjustment = TextUnit | 'offset'

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -13,6 +13,7 @@ import {
 } from '..'
 import { NodeMatch, PropsCompare, PropsMerge } from '../interfaces/editor'
 import { PointRef } from '../interfaces/point-ref'
+import { RangeMode, MaximizeMode } from '../interfaces/types'
 
 export interface NodeTransforms {
   insertNodes: <T extends Node>(
@@ -21,7 +22,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       hanging?: boolean
       select?: boolean
       voids?: boolean
@@ -32,7 +33,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       voids?: boolean
     }
   ) => void
@@ -41,7 +42,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       hanging?: boolean
       voids?: boolean
     }
@@ -51,7 +52,7 @@ export interface NodeTransforms {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       to: Path
       voids?: boolean
     }
@@ -61,7 +62,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       hanging?: boolean
       voids?: boolean
     }
@@ -72,7 +73,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       hanging?: boolean
       split?: boolean
       voids?: boolean
@@ -85,7 +86,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       always?: boolean
       height?: number
       voids?: boolean
@@ -97,7 +98,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       split?: boolean
       voids?: boolean
     }
@@ -107,7 +108,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       split?: boolean
       voids?: boolean
     }
@@ -118,7 +119,7 @@ export interface NodeTransforms {
     options?: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       split?: boolean
       voids?: boolean
     }
@@ -136,7 +137,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       hanging?: boolean
       select?: boolean
       voids?: boolean
@@ -255,7 +256,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       voids?: boolean
     } = {}
   ): void {
@@ -319,7 +320,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       hanging?: boolean
       voids?: boolean
     } = {}
@@ -459,7 +460,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       to: Path
       voids?: boolean
     }
@@ -520,7 +521,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       hanging?: boolean
       voids?: boolean
     } = {}
@@ -567,7 +568,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       hanging?: boolean
       split?: boolean
       voids?: boolean
@@ -692,7 +693,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'highest' | 'lowest'
+      mode?: RangeMode
       always?: boolean
       height?: number
       voids?: boolean
@@ -821,7 +822,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       split?: boolean
       voids?: boolean
     } = {}
@@ -849,7 +850,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       split?: boolean
       voids?: boolean
     } = {}
@@ -915,7 +916,7 @@ export const NodeTransforms: NodeTransforms = {
     options: {
       at?: Location
       match?: NodeMatch<T>
-      mode?: 'all' | 'highest' | 'lowest'
+      mode?: MaximizeMode
       split?: boolean
       voids?: boolean
     } = {}

--- a/packages/slate/src/transforms/selection.ts
+++ b/packages/slate/src/transforms/selection.ts
@@ -1,29 +1,30 @@
 import { Editor, Location, Point, Range, Transforms } from '..'
+import { SelectionEdge, MoveUnit } from '../interfaces/types'
+
+export interface SelectionCollapseOptions {
+  edge?: SelectionEdge
+}
+
+export interface SelectionMoveOptions {
+  distance?: number
+  unit?: MoveUnit
+  reverse?: boolean
+  edge?: SelectionEdge
+}
+
+export interface SelectionSetPointOptions {
+  edge?: SelectionEdge
+}
 
 export interface SelectionTransforms {
-  collapse: (
-    editor: Editor,
-    options?: {
-      edge?: 'anchor' | 'focus' | 'start' | 'end'
-    }
-  ) => void
+  collapse: (editor: Editor, options?: SelectionCollapseOptions) => void
   deselect: (editor: Editor) => void
-  move: (
-    editor: Editor,
-    options?: {
-      distance?: number
-      unit?: 'offset' | 'character' | 'word' | 'line'
-      reverse?: boolean
-      edge?: 'anchor' | 'focus' | 'start' | 'end'
-    }
-  ) => void
+  move: (editor: Editor, options?: SelectionMoveOptions) => void
   select: (editor: Editor, target: Location) => void
   setPoint: (
     editor: Editor,
     props: Partial<Point>,
-    options?: {
-      edge?: 'anchor' | 'focus' | 'start' | 'end'
-    }
+    options?: SelectionSetPointOptions
   ) => void
   setSelection: (editor: Editor, props: Partial<Range>) => void
 }
@@ -33,12 +34,7 @@ export const SelectionTransforms: SelectionTransforms = {
    * Collapse the selection.
    */
 
-  collapse(
-    editor: Editor,
-    options: {
-      edge?: 'anchor' | 'focus' | 'start' | 'end'
-    } = {}
-  ): void {
+  collapse(editor: Editor, options: SelectionCollapseOptions = {}): void {
     const { edge = 'anchor' } = options
     const { selection } = editor
 
@@ -77,15 +73,7 @@ export const SelectionTransforms: SelectionTransforms = {
    * Move the selection's point forward or backward.
    */
 
-  move(
-    editor: Editor,
-    options: {
-      distance?: number
-      unit?: 'offset' | 'character' | 'word' | 'line'
-      reverse?: boolean
-      edge?: 'anchor' | 'focus' | 'start' | 'end'
-    } = {}
-  ): void {
+  move(editor: Editor, options: SelectionMoveOptions = {}): void {
     const { selection } = editor
     const { distance = 1, unit = 'character', reverse = false } = options
     let { edge = null } = options
@@ -164,9 +152,7 @@ export const SelectionTransforms: SelectionTransforms = {
   setPoint(
     editor: Editor,
     props: Partial<Point>,
-    options: {
-      edge?: 'anchor' | 'focus' | 'start' | 'end'
-    } = {}
+    options: SelectionSetPointOptions = {}
   ): void {
     const { selection } = editor
     let { edge = 'both' } = options

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -10,35 +10,39 @@ import {
   Range,
   Transforms,
 } from '..'
+import { TextUnit } from '../interfaces/types'
+
+export interface TextDeleteOptions {
+  at?: Location
+  distance?: number
+  unit?: TextUnit
+  reverse?: boolean
+  hanging?: boolean
+  voids?: boolean
+}
+
+export interface TextInsertFragmentOptions {
+  at?: Location
+  hanging?: boolean
+  voids?: boolean
+}
+
+export interface TextInsertTextOptions {
+  at?: Location
+  voids?: boolean
+}
 
 export interface TextTransforms {
-  delete: (
-    editor: Editor,
-    options?: {
-      at?: Location
-      distance?: number
-      unit?: 'character' | 'word' | 'line' | 'block'
-      reverse?: boolean
-      hanging?: boolean
-      voids?: boolean
-    }
-  ) => void
+  delete: (editor: Editor, options?: TextDeleteOptions) => void
   insertFragment: (
     editor: Editor,
     fragment: Node[],
-    options?: {
-      at?: Location
-      hanging?: boolean
-      voids?: boolean
-    }
+    options?: TextInsertFragmentOptions
   ) => void
   insertText: (
     editor: Editor,
     text: string,
-    options?: {
-      at?: Location
-      voids?: boolean
-    }
+    options?: TextInsertTextOptions
   ) => void
 }
 
@@ -47,17 +51,7 @@ export const TextTransforms: TextTransforms = {
    * Delete content in the editor.
    */
 
-  delete(
-    editor: Editor,
-    options: {
-      at?: Location
-      distance?: number
-      unit?: 'character' | 'word' | 'line' | 'block'
-      reverse?: boolean
-      hanging?: boolean
-      voids?: boolean
-    } = {}
-  ): void {
+  delete(editor: Editor, options: TextDeleteOptions = {}): void {
     Editor.withoutNormalizing(editor, () => {
       const {
         reverse = false,
@@ -231,11 +225,7 @@ export const TextTransforms: TextTransforms = {
   insertFragment(
     editor: Editor,
     fragment: Node[],
-    options: {
-      at?: Location
-      hanging?: boolean
-      voids?: boolean
-    } = {}
+    options: TextInsertFragmentOptions = {}
   ): void {
     Editor.withoutNormalizing(editor, () => {
       const { hanging = false, voids = false } = options
@@ -462,10 +452,7 @@ export const TextTransforms: TextTransforms = {
   insertText(
     editor: Editor,
     text: string,
-    options: {
-      at?: Location
-      voids?: boolean
-    } = {}
+    options: TextInsertTextOptions = {}
   ): void {
     Editor.withoutNormalizing(editor, () => {
       const { voids = false } = options


### PR DESCRIPTION
**Description**
Adds options types such as `EditorPathOptions` for each of the inline object literal types used as function parameters.

Also adds union types of string literals such as `LeafEdge` for ones commonly reused.

I have low confidence in any names, as this is my first PR in this repository. 🙂 

**Issue**
Fixes #4966

**Example**

<img alt="Screenshot of an import for 'Options' autocompetion list with many options types from slate" src="https://user-images.githubusercontent.com/3335181/165212840-38b5639e-7b72-4edb-a9f2-202c9fc81a0e.png" width="500px" />

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] ~You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)~

