### PR TITLE
Fixed a bug in the example code in docs

### DIFF
--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -72,7 +72,7 @@ const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
   // Update the initial content to be pulled from Local Storage if it exists.
   const initialValue = useMemo(
-    JSON.parse(localStorage.getItem('content')) || [
+    () => JSON.parse(localStorage.getItem('content')) || [
       {
         type: 'paragraph',
         children: [{ text: 'A line of text in a paragraph.' }],


### PR DESCRIPTION
**Description**
Fixed a bug in the example code which was causing a compiler warning: 
`React Hook useMemo received a function whose dependencies are unknown. Pass an inline function instead  react-hooks/exhaustive-deps`