### PR TITLE
Unset isComposing on keydown with isCompsing false

### DIFF
--- a/.changeset/breezy-lizards-impress.md
+++ b/.changeset/breezy-lizards-impress.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Unset isComposing on keydown with isCompsing false

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1090,15 +1090,25 @@ export const Editable = (props: EditableProps) => {
           )}
           onKeyDown={useCallback(
             (event: React.KeyboardEvent<HTMLDivElement>) => {
-              if (
-                !readOnly &&
-                hasEditableTarget(editor, event.target) &&
-                !isEventHandled(event, attributes.onKeyDown) &&
-                !state.isComposing
-              ) {
+              if (!readOnly && hasEditableTarget(editor, event.target)) {
                 const { nativeEvent } = event
-                const { selection } = editor
 
+                // COMPAT: The composition end event isn't fired reliably in all browsers,
+                // so we sometimes might end up stuck in a composition state even though we
+                // aren't composing any more.
+                if (state.isComposing && nativeEvent.isComposing === false) {
+                  state.isComposing = false
+                  setIsComposing(false)
+                }
+
+                if (
+                  isEventHandled(event, attributes.onKeyDown) ||
+                  state.isComposing
+                ) {
+                  return
+                }
+
+                const { selection } = editor
                 const element =
                   editor.children[
                     selection !== null ? selection.focus.path[0] : 0


### PR DESCRIPTION
**Description**

 The composition end event isn't fired reliably in all browsers, so we sometimes might end up stuck in a composition state even though we / aren't composing anymore resulting in the selection not being updated:

https://user-images.githubusercontent.com/13185548/166024085-cda35d14-05d7-457a-952e-3637d9cb4fe7.mov

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

