### PR TITLE
Add ReactEditor.isComposing(editor)

### DIFF
--- a/.changeset/odd-cats-tie.md
+++ b/.changeset/odd-cats-tie.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Add `ReactEditor.isComposing(editor)` to get the current `isComposing` state

--- a/.changeset/odd-cats-tie.md
+++ b/.changeset/odd-cats-tie.md
@@ -1,5 +1,5 @@
 ---
-'slate-react': patch
+'slate-react': minor
 ---
 
 Add `ReactEditor.isComposing(editor)` to get the current `isComposing` state

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -104,6 +104,10 @@ Get the current editor object from the React context. A version of useSlate that
 
 A React and DOM-specific version of the `Editor` interface. All about translating between the DOM and Slate.
 
+### `isComposing(editor: ReactEditor)`
+
+Check if the user is currently composing inside the editor.
+
 ### `findKey(editor: ReactEditor, node: Node)`
 
 Find a key for a Slate node.

--- a/packages/slate-react/src/components/android/android-input-manager.ts
+++ b/packages/slate-react/src/components/android/android-input-manager.ts
@@ -1,7 +1,6 @@
 import { ReactEditor } from '../../plugin/react-editor'
 import { Editor, Range, Transforms, Text } from 'slate'
 import {
-  IS_COMPOSING,
   IS_ON_COMPOSITION_END,
   EDITOR_ON_COMPOSITION_TEXT,
 } from '../../utils/weak-maps'
@@ -113,7 +112,7 @@ export class AndroidInputManager {
     // If it is in composing or after `onCompositionend`, set `EDITOR_ON_COMPOSITION_TEXT` and return.
     // Text will be inserted on compositionend event.
     if (
-      IS_COMPOSING.get(this.editor) ||
+      ReactEditor.isComposing(this.editor) ||
       IS_ON_COMPOSITION_END.get(this.editor)
     ) {
       EDITOR_ON_COMPOSITION_TEXT.set(this.editor, insertedText)

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -11,6 +11,7 @@ import {
   NODE_TO_PARENT,
   EDITOR_TO_WINDOW,
   EDITOR_TO_KEY_TO_ELEMENT,
+  IS_COMPOSING,
 } from '../utils/weak-maps'
 import {
   DOMElement,
@@ -42,6 +43,14 @@ export interface ReactEditor extends BaseEditor {
 }
 
 export const ReactEditor = {
+  /**
+   * Check if the user is currently composing inside the editor.
+   */
+
+  isComposing(editor: ReactEditor): boolean {
+    return !!IS_COMPOSING.get(editor)
+  },
+
   /**
    * Return the host window of the current editor.
    */


### PR DESCRIPTION
**Description**

Moves the Editable `isComposing` state into the `isComposing` WeakMap used by the AndroidEditable and exposes the current state via `ReactEditor.isComposing(editor)`.

It's quite common to handle some events differently inside a user-defined handler based on the `isComposing` state (e.g. you don't want to trigger markdown shortcuts etc. while the user is composing as that often leads to undesirable behavior).

Currently, you have to keep track of the `isComposing` state on your own using your own, which I don't think is desirable.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

