### PR TITLE
Add caching to isElement

### DIFF
--- a/.changeset/silver-taxis-drive.md
+++ b/.changeset/silver-taxis-drive.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Add caching to isElement

--- a/packages/slate/src/interfaces/element.ts
+++ b/packages/slate/src/interfaces/element.ts
@@ -11,6 +11,8 @@ export interface BaseElement {
   children: Descendant[]
 }
 
+const IS_ELEMENT_CACHE = new WeakMap<object, boolean>()
+
 export type Element = ExtendedType<'Element', BaseElement>
 
 export interface ElementInterface {
@@ -30,11 +32,18 @@ export interface ElementInterface {
  * Shared the function with isElementType utility
  */
 const isElement = (value: any): value is Element => {
-  return (
-    isPlainObject(value) &&
-    Node.isNodeList(value.children) &&
-    !Editor.isEditor(value)
-  )
+  if (!isPlainObject(value)) {
+    return false
+  }
+
+  const cachedIsElement = IS_ELEMENT_CACHE.get(value)
+  if (cachedIsElement !== undefined) {
+    return cachedIsElement
+  }
+
+  const isElement = Node.isNodeList(value.children) && !Editor.isEditor(value)
+  IS_ELEMENT_CACHE.set(value, isElement)
+  return isElement
 }
 
 export const Element: ElementInterface = {


### PR DESCRIPTION
**Description**
Adds caching to the `isElement` method greatly improving performance on repeated `isElement` calls on deeply nested elements using the same approach we currently use for `Editor.isEditor`.

**Context**
`Element.isElement` can be quite slow (2ms+) on deeply nested elements due to it validating that all descendants of the element are valid. We call it repeatedly on the same elements inside the slate codebase and it's a commonly used utility in user-land. For our usage caching the result can shave off 20ms of the keystroke to paint time on longer notes.

This is definitely a trade-off since we make the assumption that elements are updated immutably, even if they are not part of the slate document, but I think that's a fair assumption to make since we currently make it for elements inside the document (and sort of for the editor objects as well).

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

