### PR TITLE
update docs on Node.ancestors/levels and Path.ancestors

### DIFF
--- a/docs/api/locations/path.md
+++ b/docs/api/locations/path.md
@@ -19,7 +19,7 @@ type Path = number[]
 
 Get a list of ancestor paths for a given path.
 
-The paths are sorted from deepest to shallowest ancestor. However, if the `reverse: true` option is passed, they are reversed.
+The paths are sorted from shallowest to deepest ancestor. However, if the `reverse: true` option is passed, they are reversed.
 
 #### `Path.common(path: Path, another: Path) => Path`
 

--- a/docs/api/nodes/node.md
+++ b/docs/api/nodes/node.md
@@ -15,7 +15,7 @@ Get the node at a specific `path`, asserting that it is an ancestor node. If the
 
 #### `Node.ancestors(root: Node, path: Path, options?) => Generator<NodeEntry<Ancestor>>`
 
-Return a generator of all the ancestor nodes above a specific path. By default, the order is bottom-up, from lowest to highest ancestor in the tree, but you can pass the `reverse: true` option to go top-down.
+Return a generator of all the ancestor nodes above a specific path. By default, the order is top-down, from highest to lowest ancestor in the tree, but you can pass the `reverse: true` option to go bottom-up.
 
 Options: `{reverse?: boolean}`
 
@@ -71,7 +71,7 @@ Get the node at a specific `path`, ensuring it's a leaf text node. If the node i
 
 #### `Node.levels(root: Node, path: Path, options?) => Generator<NodeEntry>`
 
-Return a generator of the nodes in a branch of the tree, from a specific `path`. By default, the order is top-down, from the lowest to the highest node in the tree, but you can pass the `reverse: true` option to go bottom-up.
+Return a generator of the nodes in a branch of the tree, from a specific `path`. By default, the order is top-down, from the highest to the lowest node in the tree, but you can pass the `reverse: true` option to go bottom-up.
 
 Options: `{reverse?: boolean}`
 

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -122,8 +122,8 @@ export const Node: NodeInterface = {
   /**
    * Return a generator of all the ancestor nodes above a specific path.
    *
-   * By default the order is bottom-up, from lowest to highest ancestor in
-   * the tree, but you can pass the `reverse: true` option to go top-down.
+   * By default the order is top-down, from highest to lowest ancestor in
+   * the tree, but you can pass the `reverse: true` option to go bottom-up.
    */
 
   *ancestors(
@@ -438,7 +438,7 @@ export const Node: NodeInterface = {
   /**
    * Return a generator of the in a branch of the tree, from a specific path.
    *
-   * By default the order is top-down, from lowest to highest node in the tree,
+   * By default the order is top-down, from highest to lowest node in the tree,
    * but you can pass the `reverse: true` option to go bottom-up.
    */
 

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -57,7 +57,7 @@ export const Path: PathInterface = {
   /**
    * Get a list of ancestor paths for a given path.
    *
-   * The paths are sorted from deepest to shallowest ancestor. However, if the
+   * The paths are sorted from shallowest to deepest ancestor. However, if the
    * `reverse: true` option is passed, they are reversed.
    */
 


### PR DESCRIPTION
**Description**
This PR updates the documentation of `Node.ancestors`, `Node.levels` and `Path.ancestors` to be correct. They all depend on `Path.levels` which sorts from shallowest to deepest, but the docs stated they sorted from deepest to shallowest. This PR has no functional changes.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4398

**Example**
There is no example given for this PR, since it contains no functional changes. For reasoning for updating docs, see `Context` section. 

**Context**
[Node.ancestors depends on `Path.ancestors`](https://github.com/ianstormtaylor/slate/blob/main/packages/slate/src/interfaces/node.ts#L134), which [depends on `Path.levels`](https://github.com/ianstormtaylor/slate/blob/d2fc25c3c31453597f59cd2ac6ba087a1beb1fe3/packages/slate/src/interfaces/path.ts#L66) , [`Node.levels` depends on `Path.levels` as well](https://github.com/ianstormtaylor/slate/blob/main/packages/slate/src/interfaces/node.ts#L450) ,  and [`Path.levels` inserts elements into the returned list from shallowest to deepest](https://github.com/ianstormtaylor/slate/blob/d2fc25c3c31453597f59cd2ac6ba087a1beb1fe3/packages/slate/src/interfaces/path.ts#L273) by looping over increasingly higher `end` parameters given to [`Array.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#parameters). Because of this dependency they all sort from shallowest to deepest. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

