### PR TITLE
Fix: better decorations handling and memoizing

### DIFF
--- a/.changeset/blue-dots-count.md
+++ b/.changeset/blue-dots-count.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Restore use of decorate context, wrap element and text with component to memoize.

--- a/.changeset/light-schools-switch.md
+++ b/.changeset/light-schools-switch.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Improve performance of Range.intersection by returning original range when possible.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -600,9 +600,7 @@ export const Editable = (props: EditableProps) => {
     }
   }, [scheduleOnDOMSelectionChange])
 
-  const decorations = [...Node.nodes(editor)].flatMap(([n, p]) =>
-    decorate([n, p])
-  )
+  const decorations = decorate([editor, []])
 
   if (
     placeholder &&

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -48,11 +48,15 @@ const useChildren = (props: {
     const range = Editor.range(editor, p)
     const sel = selection && Range.intersection(range, selection)
 
-    const ds = decorations.reduce<Range[]>((acc, dec) => {
-      const intersection = Range.intersection(dec, range)
-      if (intersection) acc.push(intersection)
-      return acc
-    }, [])
+    const ds: Range[] = []
+
+    for (const dec of decorations) {
+      const d = Range.intersection(dec, range)
+
+      if (d) {
+        ds.push(d)
+      }
+    }
 
     if (Element.isElement(n)) {
       children.push(
@@ -60,6 +64,7 @@ const useChildren = (props: {
           <ElementComponent
             decorations={ds}
             element={n}
+            path={p}
             key={key.id}
             renderElement={renderElement}
             renderPlaceholder={renderPlaceholder}
@@ -78,6 +83,7 @@ const useChildren = (props: {
           renderPlaceholder={renderPlaceholder}
           renderLeaf={renderLeaf}
           text={n}
+          path={p}
         />
       )
     }

--- a/packages/slate/src/interfaces/range.ts
+++ b/packages/slate/src/interfaces/range.ts
@@ -116,15 +116,17 @@ export const Range: RangeInterface = {
    */
 
   intersection(range: Range, another: Range): Range | null {
-    const { anchor, focus, ...rest } = range
     const [s1, e1] = Range.edges(range)
     const [s2, e2] = Range.edges(another)
     const start = Point.isBefore(s1, s2) ? s2 : s1
-    const end = Point.isBefore(e1, e2) ? e1 : e2
+    const end = Point.isAfter(e1, e2) ? e2 : e1
 
     if (Point.isBefore(end, start)) {
       return null
+    } else if (start === s1 && end === e1) {
+      return range
     } else {
+      const { anchor, focus, ...rest } = range
       return { anchor: start, focus: end, ...rest }
     }
   },


### PR DESCRIPTION
**Description**
Decorations have undergone several changes recently, most notably from https://github.com/ianstormtaylor/slate/pull/4876 (which broke a few things fixed in https://github.com/ianstormtaylor/slate/pull/4910).

Prior to [4876](https://github.com/ianstormtaylor/slate/pull/4876), slate-react used a context to communicate the `decorate` function down the tree, with the purpose of notifying all elements of a change to the decorate function without passing it directly down the tree. However, this didn't work correctly ever since removing the extra component between parent and children, because when `useContext` is called from within another hook (`useChildren` in this case), it will always cause a rerender in the nearest parent component, regardless of the results of that outer hook. There is no way to avoid a changed context causing a rerender in the nearest parent of the `useContext` hook in React--so ever since the children wrapping component was removed, the entire tree would rerender on every `decorate` change even if the resulting decoration ranges themselves are compared and found equal.

In [4876](https://github.com/ianstormtaylor/slate/pull/4876), that was changed so that decorations are computed for the _entire tree_ up front, but there are problems with that PR in retrospect (not just the fix referenced above):

 - it's not clear if stale decorations (reason for that PR) were a real issue, because the test added by the PR was incorrect. [Here](https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/test/index.spec.tsx#L82) the decorate function is updated in-place by using `mockImplementation`, but this doesn't change its reference--so the context isn't invalided and of course the nested elements wouldn't update their decorations in that case. Slate's [search highlighting](https://github.com/ianstormtaylor/slate/blob/main/site/examples/search-highlighting.tsx) example shows that anything which wants to trigger redoraction of the entire tree is expected to invalidate `decorate`, not change it in-place.
 - the android component [was not updated to match](https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/src/components/android/android-editable.tsx#L326) the new approach of generating decorations at the top, so this caused a significant regression on android.
 - the old `useDecorate` context and provider was never cleaned up even though it no longer served any purpose after those changes 🤔 

More imporantly, performance is a major problem with the approach of that PR. Since decorations are generated at the top, every single element down the entire tree now calls `Range.intersection` on every decoration passed to it from above. This can explode in complexity in many cases, particularly if you have any intervening elements. 

For instance, see this example (variation on the code highlighting example), where there is a `code-container` wrapping many `code-line` elements (for the purposes of rendering line numbers). 

- [on slate-react@0.73](https://codesandbox.io/s/slate-react-0-73-decorations-with-depth-87rkr1?file=/src/App.js) it performs perfectly okay despite over 4,000 children of the code container and many more decorations.
- [on current slate-react](https://codesandbox.io/s/slate-react-0-79-decorations-with-depth-i5unon) (**warning, may freeze your browser for a bit**) the performance is basically broken and the editor is not usable. The reason for this is that decorations now have an exponential complexity when there are intervening elements, because (A) all the decorations are generated at the top, then (B) they are all (many thousands) passed down into the code container from above, then (C) that container calls `Range.intersection` on every combination of decoration and child. 

The fix in this PR is restore the context-based generation of decorations down the react tree (so that we don't have to run intersection checks all the way from the top every time), but then add a component that wraps this context and therefore and avoid rerenders if the decorations are in fact unchanged. The performance is tremendously improved this way.

There is also small change included to `Range.intersect` so that it doesn't unnecessarily spread every single range passed in. When the range is a child of the outer range being checked, we can return it directly and avoid a great deal of lost performance due to copying these objects all the way down the tree.   

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

