### PR TITLE
Call `scrollSelectionIntoView()` on every cursor position change

### DIFF
--- a/.changeset/sixty-bears-march.md
+++ b/.changeset/sixty-bears-march.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Call `scrollSelectionIntoView` on every cursor position change

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -206,7 +206,9 @@ export const Editable = (props: EditableProps) => {
         try {
           const domRange = ReactEditor.toDOMRange(editor, selection)
           scrollSelectionIntoView(editor, domRange)
-        } catch {}
+        } catch {
+          // do nothing
+        }
 
         return
       }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -203,6 +203,11 @@ export const Editable = (props: EditableProps) => {
         suppressThrow: true,
       })
       if (slateRange && Range.equals(slateRange, selection)) {
+        try {
+          const domRange = ReactEditor.toDOMRange(editor, selection)
+          scrollSelectionIntoView(editor, domRange)
+        } catch { }
+
         return
       }
     }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -206,7 +206,7 @@ export const Editable = (props: EditableProps) => {
         try {
           const domRange = ReactEditor.toDOMRange(editor, selection)
           scrollSelectionIntoView(editor, domRange)
-        } catch { }
+        } catch {}
 
         return
       }


### PR DESCRIPTION
**Description**
Trigger `scrollSelectionIntoView` when cursor moves between text lines.

**Issue**
Fixes: #4995

**Example**

Both videos are recorded with this example codebase: https://codesandbox.io/s/slate-reproductions-forked-78jv4t?file=/index.js

With the patch applied, the passed custom `scrollSelectionIntoView` function is triggered on cursor position changes within the paragraph content, allowing to tweak auto-scrolling behavior during paragraph text keyboard navigation.

Before (custom `scrollSelectionIntoView` is not triggered, browser default behavior is in action):

https://user-images.githubusercontent.com/370680/168827772-648b0317-a5a9-4dae-8f82-edfcd9851da1.mp4

After (custom `scrollSelectionIntoView` is triggered, it takes into account the sticky header offset):

https://user-images.githubusercontent.com/370680/168835027-bcc09f4f-0323-47e9-a986-0dde3f565e06.mp4

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

