### PR TITLE
Fix deleteBackward behavior for Thai script

### DIFF
--- a/.changeset/twelve-elephants-burn.md
+++ b/.changeset/twelve-elephants-burn.md
@@ -1,0 +1,6 @@
+---
+'slate': patch
+---
+
+Fix deleteBackward behavior for Thai script where deleting N character(s) backward should delete
+N code point(s) instead of an entire grapheme cluster

--- a/packages/slate/test/transforms/delete/unit-character/thai-multiple-reverse.tsx
+++ b/packages/slate/test/transforms/delete/unit-character/thai-multiple-reverse.tsx
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.delete(editor, { unit: 'character', distance: 2, reverse: true })
+}
+export const input = (
+  <editor>
+    <block>
+      พี่
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      พ
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/delete/unit-character/thai-reverse.tsx
+++ b/packages/slate/test/transforms/delete/unit-character/thai-reverse.tsx
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.delete(editor, { unit: 'character', reverse: true })
+}
+export const input = (
+  <editor>
+    <block>
+      พี่
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      พี
+      <cursor />
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
When Thai characters are deleting from backward, each code point should be considered as 1 unit for deletion regardless of their grapheme cluster. For example, deleting พี่ from backward should delete the last code point, leaving พี instead of deleting all entirely. 

**This PR fixes deleteBackward behavior for Thai script where deleting N character(s) backward should delete N code point(s) instead of an entire grapheme cluster.**

This change should not affect other languages as the regular expression `/[\u0E00-\u0E7F]+/` checks for the range of Thai script before performing any operation.


**Issue**
Fixes: #4884 


**Example**
Before (unexpected behavior):

https://user-images.githubusercontent.com/30551284/171138953-e72f8c20-17d9-466b-afa1-64080a5a433e.mp4

After (expected):

https://user-images.githubusercontent.com/30551284/171138969-1c6e1a53-b3a6-48f1-8390-566139c0b26d.mp4


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

