### PR TITLE
Fix mixed inline/block insertFragment.

### DIFF
--- a/.changeset/pretty-plums-grow.md
+++ b/.changeset/pretty-plums-grow.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix for insertFragment text/inline + block mixed fragments.

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -372,15 +372,13 @@ export const TextTransforms: TextTransforms = {
 
       const middleRef = Editor.pathRef(
         editor,
-        isBlockEnd ? Path.next(blockPath) : blockPath
+        isBlockEnd && !ends.length ? Path.next(blockPath) : blockPath
       )
 
       const endRef = Editor.pathRef(
         editor,
         isInlineEnd ? Path.next(inlinePath) : inlinePath
       )
-
-      const blockPathRef = Editor.pathRef(editor, blockPath)
 
       Transforms.splitNodes(editor, {
         at,
@@ -389,6 +387,10 @@ export const TextTransforms: TextTransforms = {
             ? Editor.isBlock(editor, n)
             : Text.isText(n) || Editor.isInline(editor, n),
         mode: hasBlocks ? 'lowest' : 'highest',
+        always:
+          hasBlocks &&
+          (!isBlockStart || starts.length > 0) &&
+          (!isBlockEnd || ends.length > 0),
         voids,
       })
 
@@ -406,8 +408,8 @@ export const TextTransforms: TextTransforms = {
         voids,
       })
 
-      if (isBlockEmpty && middles.length) {
-        Transforms.delete(editor, { at: blockPathRef.unref()!, voids })
+      if (isBlockEmpty && !starts.length && middles.length && !ends.length) {
+        Transforms.delete(editor, { at: blockPath, voids })
       }
 
       Transforms.insertNodes(editor, middles, {

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-empty.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-empty.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <text>one</text>
+      <block>two</block>
+      <text>three</text>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>word</block>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>word</block>
+    <block>one</block>
+    <block>two</block>
+    <block>
+      three
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-empty2.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-empty2.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <block>two</block>
+      <text>three</text>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>word</block>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>word</block>
+    <block>two</block>
+    <block>
+      <text>
+        three
+        <cursor />
+      </text>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-empty3.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-empty3.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <text>one</text>
+      <block>two</block>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>word</block>
+    <block>
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>word</block>
+    <block>one</block>
+    <block>
+      two
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-end.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-end.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <text>one</text>
+      <block>two</block>
+      <text>three</text>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      word
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>wordone</block>
+    <block>two</block>
+    <block>
+      three
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-end2.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-end2.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <text>one</text>
+      <block>two</block>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      word
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>wordone</block>
+    <block>
+      two
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-middle.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-middle.tsx
@@ -1,0 +1,34 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <text>one</text>
+      <block>two</block>
+      <text>three</text>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      wo
+      <cursor />
+      rd
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>woone</block>
+    <block>two</block>
+    <block>
+      three
+      <cursor />
+      rd
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-start.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-start.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <text>one</text>
+      <block>two</block>
+      <text>three</text>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      <cursor />
+      word
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>one</block>
+    <block>two</block>
+    <block>
+      three
+      <cursor />
+      word
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/insertFragment/of-mixed/block-start2.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-mixed/block-start2.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = editor => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <block>one</block>
+      <text>two</text>
+    </fragment>
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      <cursor />
+      word
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>one</block>
+    <block>
+      two
+      <cursor />
+      word
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
When insert mixed fragments (inline1 + block + inline2) at an empty block end, the insert result is: inline1 + inline2 + block

**Issue**
Fixes: #3457

**Example**
insertFragment([{"text":"inline1\n"},{"type":"ul","children":[{"type":"li","children":[{"text":"block li1 \n"}]},{"type":"li","children":[{"text":"block li2 \n"}]},{"type":"li","children":[{"text":"block li3 \n"}]}]},{"text":"inline2\n"},{"text":"inline3\n"},{"text":"inline4"}])

should result:
> inline1
> - block li1 
> - block li2 
> - block li3 
> 
> inline2
> inline3
> inline4

but result:
> inline1
> inline2
> inline3
> inline4
> - block li1 
> - block li2 
> - block li3 

NOTICE: to get the correct input of the insertFragment, it depends on the deserializer used by the slate instance. so no directly online reproduce here, but if you call the insertFragment with the initial fragments input, the bug is just there.

**Context**
The reason of this bug is: middleRef is manually set to next blockPath when insert point is at blockEnd, but the endRef is not consider this case (it only calculate the next inline path and no split happens) so result the wrong ordered result.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

