### PR TITLE
Replace useState with useMemo in the "Installing Slate" walkthrough

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -51,11 +51,11 @@ Of course we haven't rendered anything, so you won't see any changes.
 
 ```typescript
 // TypeScript users only add this code
-import { BaseEditor, BaseElement, BaseText, Descendant } from 'slate'
+import { BaseEditor, Descendant } from 'slate'
 import { ReactEditor } from 'slate-react'
 
-type CustomElement = BaseElement & { type: 'paragraph'; children: CustomText[] }
-type CustomText = BaseText & { text: string }
+type CustomElement = { type: 'paragraph'; children: CustomText[] }
+type CustomText = { text: string }
 
 declare module 'slate' {
   interface CustomTypes {

--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -18,7 +18,7 @@ Once you've installed Slate, you'll need to import it.
 
 ```jsx
 // Import React dependencies.
-import React, { useState } from 'react'
+import React, { useMemo } from 'react'
 // Import the Slate editor factory.
 import { createEditor } from 'slate'
 
@@ -40,7 +40,7 @@ The next step is to create a new `Editor` object. We want the editor to be stabl
 ```jsx
 const App = () => {
   // Create a Slate editor object that won't change across renders.
-  const [editor] = useState(() => withReact(createEditor()))
+  const editor = useMemo(() => withReact(createEditor()), [])
   return null
 }
 ```
@@ -51,11 +51,11 @@ Of course we haven't rendered anything, so you won't see any changes.
 
 ```typescript
 // TypeScript users only add this code
-import { BaseEditor, Descendant } from 'slate'
+import { BaseEditor, BaseElement, BaseText, Descendant } from 'slate'
 import { ReactEditor } from 'slate-react'
 
-type CustomElement = { type: 'paragraph'; children: CustomText[] }
-type CustomText = { text: string }
+type CustomElement = BaseElement & { type: 'paragraph'; children: CustomText[] }
+type CustomText = BaseText & { text: string }
 
 declare module 'slate' {
   interface CustomTypes {
@@ -74,7 +74,7 @@ The provider component keeps track of your Slate editor, its plugins, its value,
 const initialValue = []
 
 const App = () => {
-  const [editor] = useState(() => withReact(createEditor()))
+  const editor = useMemo(() => withReact(createEditor()), [])
   // Render the Slate context.
   return <Slate editor={editor} value={initialValue} />
 }
@@ -94,7 +94,7 @@ Okay, so the next step is to render the `<Editable>` component itself:
 const initialValue = []
 
 const App = () => {
-  const [editor] = useState(() => withReact(createEditor()))
+  const editor = useMemo(() => withReact(createEditor()), [])
   return (
     // Add the editable component inside the context.
     <Slate editor={editor} value={initialValue}>
@@ -120,7 +120,7 @@ const initialValue = [
 ]
 
 const App = () => {
-  const [editor] = useState(() => withReact(createEditor()))
+  const editor = useMemo(() => withReact(createEditor()), [])
 
   return (
     <Slate editor={editor} value={initialValue}>


### PR DESCRIPTION
This PR replaces the `useState`s in the "Installing Slate" walkthrough with `useMemo`s to reflect what's recommended in the rest of the documentation. 