### PR TITLE
Replace useMemo with useState in the docs

### DIFF
--- a/docs/concepts/09-rendering.md
+++ b/docs/concepts/09-rendering.md
@@ -42,7 +42,7 @@ const MyEditor = () => {
 You don't have to use simple HTML elements, you can use your own custom React components too:
 
 ```javascript
-const renderElement = useCallback((props) => {
+const renderElement = useCallback(props => {
   switch (props.element.type) {
     case 'quote':
       return <QuoteElement {...props} />

--- a/docs/concepts/09-rendering.md
+++ b/docs/concepts/09-rendering.md
@@ -13,7 +13,7 @@ import { createEditor } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 
 const MyEditor = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
   const renderElement = useCallback(({ attributes, children, element }) => {
     switch (element.type) {
       case 'quote':
@@ -42,7 +42,7 @@ const MyEditor = () => {
 You don't have to use simple HTML elements, you can use your own custom React components too:
 
 ```javascript
-const renderElement = useCallback(props => {
+const renderElement = useCallback((props) => {
   switch (props.element.type) {
     case 'quote':
       return <QuoteElement {...props} />
@@ -115,7 +115,7 @@ A common use case for this is rendering a toolbar with formatting buttons that a
 
 ```jsx
 const MyEditor = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
   return (
     <Slate editor={editor}>
       <Toolbar />

--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -38,7 +38,7 @@ declare module 'slate' {
 Annotate the editor's initial value w/ `Descendant[]`.
 
 ```tsx
-import React, { useMemo, useState } from 'react'
+import React, { useState, useState } from 'react'
 import { createEditor, Descendant } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 
@@ -50,7 +50,7 @@ const initialValue: Descendant[] = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>

--- a/docs/libraries/slate-history.md
+++ b/docs/libraries/slate-history.md
@@ -17,5 +17,5 @@ The `withHistory` plugin keeps track of the operation history of a Slate editor 
 When used with `withReact`, `withHistory` should be applied inside. For example:
 
 ```javascript
-const editor = useMemo(() => withReact(withHistory(createEditor())), [])
+const [editor] = useState(() => withReact(withHistory(createEditor())))
 ```

--- a/docs/libraries/slate-react.md
+++ b/docs/libraries/slate-react.md
@@ -195,7 +195,7 @@ Adds React and DOM specific behaviors to the editor.
 When used with `withHistory`, `withReact` should be applied outside. For example:
 
 ```javascript
-const editor = useMemo(() => withReact(withHistory(createEditor())), [])
+const [editor] = useState(() => withReact(withHistory(createEditor())))
 ```
 
 ## Utils

--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -18,7 +18,7 @@ Once you've installed Slate, you'll need to import it.
 
 ```jsx
 // Import React dependencies.
-import React, { useMemo } from 'react'
+import React, { useState } from 'react'
 // Import the Slate editor factory.
 import { createEditor } from 'slate'
 
@@ -40,7 +40,7 @@ The next step is to create a new `Editor` object. We want the editor to be stabl
 ```jsx
 const App = () => {
   // Create a Slate editor object that won't change across renders.
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const editor = useState(() => withReact(createEditor()))
   return null
 }
 ```
@@ -74,7 +74,7 @@ The provider component keeps track of your Slate editor, its plugins, its value,
 const initialValue = []
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
   // Render the Slate context.
   return <Slate editor={editor} value={initialValue} />
 }
@@ -94,7 +94,7 @@ Okay, so the next step is to render the `<Editable>` component itself:
 const initialValue = []
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
   return (
     // Add the editable component inside the context.
     <Slate editor={editor} value={initialValue}>
@@ -120,7 +120,7 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>

--- a/docs/walkthroughs/02-adding-event-handlers.md
+++ b/docs/walkthroughs/02-adding-event-handlers.md
@@ -17,7 +17,7 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>
@@ -38,13 +38,13 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
         // Define a new handler which prints the key that was pressed.
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           console.log(event.key)
         }}
       />
@@ -68,12 +68,12 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (event.key === '&') {
             // Prevent the ampersand character from being inserted.
             event.preventDefault()

--- a/docs/walkthroughs/02-adding-event-handlers.md
+++ b/docs/walkthroughs/02-adding-event-handlers.md
@@ -44,7 +44,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         // Define a new handler which prints the key that was pressed.
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           console.log(event.key)
         }}
       />
@@ -73,7 +73,7 @@ const App = () => {
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (event.key === '&') {
             // Prevent the ampersand character from being inserted.
             event.preventDefault()

--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -15,12 +15,12 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (event.key === '&') {
             event.preventDefault()
             editor.insertText('and')
@@ -40,7 +40,7 @@ Element renderers are just simple React components, like so:
 
 ```jsx
 // Define a React component renderer for our code blocks.
-const CodeElement = props => {
+const CodeElement = (props) => {
   return (
     <pre {...props.attributes}>
       <code>{props.children}</code>
@@ -58,7 +58,7 @@ And see that `props.children` reference? Slate will automatically render all of 
 And here's a component for the "default" elements:
 
 ```jsx
-const DefaultElement = props => {
+const DefaultElement = (props) => {
   return <p {...props.attributes}>{props.children}</p>
 }
 ```
@@ -74,11 +74,11 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   // Define a rendering function based on the element passed to `props`. We use
   // `useCallback` here to memoize the function for subsequent renders.
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -92,7 +92,7 @@ const App = () => {
       <Editable
         // Pass in the `renderElement` function.
         renderElement={renderElement}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (event.key === '&') {
             event.preventDefault()
             editor.insertText('and')
@@ -103,7 +103,7 @@ const App = () => {
   )
 }
 
-const CodeElement = props => {
+const CodeElement = (props) => {
   return (
     <pre {...props.attributes}>
       <code>{props.children}</code>
@@ -111,7 +111,7 @@ const CodeElement = props => {
   )
 }
 
-const DefaultElement = props => {
+const DefaultElement = (props) => {
   return <p {...props.attributes}>{props.children}</p>
 }
 ```
@@ -130,9 +130,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -145,7 +145,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (event.key === '`' && event.ctrlKey) {
             // Prevent the "`" from being inserted by default.
             event.preventDefault()
@@ -153,7 +153,7 @@ const App = () => {
             Transforms.setNodes(
               editor,
               { type: 'code' },
-              { match: n => Editor.isBlock(editor, n) }
+              { match: (n) => Editor.isBlock(editor, n) }
             )
           }
         }}
@@ -162,7 +162,7 @@ const App = () => {
   )
 }
 
-const CodeElement = props => {
+const CodeElement = (props) => {
   return (
     <pre {...props.attributes}>
       <code>{props.children}</code>
@@ -170,7 +170,7 @@ const CodeElement = props => {
   )
 }
 
-const DefaultElement = props => {
+const DefaultElement = (props) => {
   return <p {...props.attributes}>{props.children}</p>
 }
 ```
@@ -188,9 +188,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -203,18 +203,18 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (event.key === '`' && event.ctrlKey) {
             event.preventDefault()
             // Determine whether any of the currently selected blocks are code blocks.
             const [match] = Editor.nodes(editor, {
-              match: n => n.type === 'code',
+              match: (n) => n.type === 'code',
             })
             // Toggle the block type depending on whether there's already a match.
             Transforms.setNodes(
               editor,
               { type: match ? 'paragraph' : 'code' },
-              { match: n => Editor.isBlock(editor, n) }
+              { match: (n) => Editor.isBlock(editor, n) }
             )
           }
         }}

--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -20,7 +20,7 @@ const App = () => {
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (event.key === '&') {
             event.preventDefault()
             editor.insertText('and')
@@ -40,7 +40,7 @@ Element renderers are just simple React components, like so:
 
 ```jsx
 // Define a React component renderer for our code blocks.
-const CodeElement = (props) => {
+const CodeElement = props => {
   return (
     <pre {...props.attributes}>
       <code>{props.children}</code>
@@ -58,7 +58,7 @@ And see that `props.children` reference? Slate will automatically render all of 
 And here's a component for the "default" elements:
 
 ```jsx
-const DefaultElement = (props) => {
+const DefaultElement = props => {
   return <p {...props.attributes}>{props.children}</p>
 }
 ```
@@ -78,7 +78,7 @@ const App = () => {
 
   // Define a rendering function based on the element passed to `props`. We use
   // `useCallback` here to memoize the function for subsequent renders.
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -92,7 +92,7 @@ const App = () => {
       <Editable
         // Pass in the `renderElement` function.
         renderElement={renderElement}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (event.key === '&') {
             event.preventDefault()
             editor.insertText('and')
@@ -103,7 +103,7 @@ const App = () => {
   )
 }
 
-const CodeElement = (props) => {
+const CodeElement = props => {
   return (
     <pre {...props.attributes}>
       <code>{props.children}</code>
@@ -111,7 +111,7 @@ const CodeElement = (props) => {
   )
 }
 
-const DefaultElement = (props) => {
+const DefaultElement = props => {
   return <p {...props.attributes}>{props.children}</p>
 }
 ```
@@ -132,7 +132,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -145,7 +145,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (event.key === '`' && event.ctrlKey) {
             // Prevent the "`" from being inserted by default.
             event.preventDefault()
@@ -153,7 +153,7 @@ const App = () => {
             Transforms.setNodes(
               editor,
               { type: 'code' },
-              { match: (n) => Editor.isBlock(editor, n) }
+              { match: n => Editor.isBlock(editor, n) }
             )
           }
         }}
@@ -162,7 +162,7 @@ const App = () => {
   )
 }
 
-const CodeElement = (props) => {
+const CodeElement = props => {
   return (
     <pre {...props.attributes}>
       <code>{props.children}</code>
@@ -170,7 +170,7 @@ const CodeElement = (props) => {
   )
 }
 
-const DefaultElement = (props) => {
+const DefaultElement = props => {
   return <p {...props.attributes}>{props.children}</p>
 }
 ```
@@ -190,7 +190,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -203,18 +203,18 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (event.key === '`' && event.ctrlKey) {
             event.preventDefault()
             // Determine whether any of the currently selected blocks are code blocks.
             const [match] = Editor.nodes(editor, {
-              match: (n) => n.type === 'code',
+              match: n => n.type === 'code',
             })
             // Toggle the block type depending on whether there's already a match.
             Transforms.setNodes(
               editor,
               { type: match ? 'paragraph' : 'code' },
-              { match: (n) => Editor.isBlock(editor, n) }
+              { match: n => Editor.isBlock(editor, n) }
             )
           }
         }}

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -7,7 +7,7 @@ In this guide, we'll show you how to add custom formatting options, like **bold*
 So we start with our app from earlier:
 
 ```jsx
-const renderElement = (props) => {
+const renderElement = props => {
   switch (props.element.type) {
     case 'code':
       return <CodeElement {...props} />
@@ -30,16 +30,16 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (event.key === '`' && event.ctrlKey) {
             event.preventDefault()
             const [match] = Editor.nodes(editor, {
-              match: (n) => n.type === 'code',
+              match: n => n.type === 'code',
             })
             Transforms.setNodes(
               editor,
               { type: match ? 'paragraph' : 'code' },
-              { match: (n) => Editor.isBlock(editor, n) }
+              { match: n => Editor.isBlock(editor, n) }
             )
           }
         }}
@@ -62,7 +62,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -75,7 +75,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (!event.ctrlKey) {
             return
           }
@@ -85,12 +85,12 @@ const App = () => {
             case '`': {
               event.preventDefault()
               const [match] = Editor.nodes(editor, {
-                match: (n) => n.type === 'code',
+                match: n => n.type === 'code',
               })
               Transforms.setNodes(
                 editor,
                 { type: match ? 'paragraph' : 'code' },
-                { match: (n) => Editor.isBlock(editor, n) }
+                { match: n => Editor.isBlock(editor, n) }
               )
               break
             }
@@ -103,7 +103,7 @@ const App = () => {
                 { bold: true },
                 // Apply it to text nodes, and split the text node up if the
                 // selection is overlapping only part of it.
-                { match: (n) => Text.isText(n), split: true }
+                { match: n => Text.isText(n), split: true }
               )
               break
             }
@@ -121,7 +121,7 @@ For every format you add, Slate will break up the text content into "leaves", an
 
 ```jsx
 // Define a React component to render leaves with bold text.
-const Leaf = (props) => {
+const Leaf = props => {
   return (
     <span
       {...props.attributes}
@@ -148,7 +148,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -158,7 +158,7 @@ const App = () => {
   }, [])
 
   // Define a leaf rendering function that is memoized with `useCallback`.
-  const renderLeaf = useCallback((props) => {
+  const renderLeaf = useCallback(props => {
     return <Leaf {...props} />
   }, [])
 
@@ -168,7 +168,7 @@ const App = () => {
         renderElement={renderElement}
         // Pass in the `renderLeaf` function.
         renderLeaf={renderLeaf}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (!event.ctrlKey) {
             return
           }
@@ -177,12 +177,12 @@ const App = () => {
             case '`': {
               event.preventDefault()
               const [match] = Editor.nodes(editor, {
-                match: (n) => n.type === 'code',
+                match: n => n.type === 'code',
               })
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: (n) => Editor.isBlock(editor, n) }
+                { match: n => Editor.isBlock(editor, n) }
               )
               break
             }
@@ -192,7 +192,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { bold: true },
-                { match: (n) => Text.isText(n), split: true }
+                { match: n => Text.isText(n), split: true }
               )
               break
             }
@@ -203,7 +203,7 @@ const App = () => {
   )
 }
 
-const Leaf = (props) => {
+const Leaf = props => {
   return (
     <span
       {...props.attributes}

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -7,7 +7,7 @@ In this guide, we'll show you how to add custom formatting options, like **bold*
 So we start with our app from earlier:
 
 ```jsx
-const renderElement = props => {
+const renderElement = (props) => {
   switch (props.element.type) {
     case 'code':
       return <CodeElement {...props} />
@@ -24,22 +24,22 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (event.key === '`' && event.ctrlKey) {
             event.preventDefault()
             const [match] = Editor.nodes(editor, {
-              match: n => n.type === 'code',
+              match: (n) => n.type === 'code',
             })
             Transforms.setNodes(
               editor,
               { type: match ? 'paragraph' : 'code' },
-              { match: n => Editor.isBlock(editor, n) }
+              { match: (n) => Editor.isBlock(editor, n) }
             )
           }
         }}
@@ -60,9 +60,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -75,7 +75,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <Editable
         renderElement={renderElement}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (!event.ctrlKey) {
             return
           }
@@ -85,12 +85,12 @@ const App = () => {
             case '`': {
               event.preventDefault()
               const [match] = Editor.nodes(editor, {
-                match: n => n.type === 'code',
+                match: (n) => n.type === 'code',
               })
               Transforms.setNodes(
                 editor,
                 { type: match ? 'paragraph' : 'code' },
-                { match: n => Editor.isBlock(editor, n) }
+                { match: (n) => Editor.isBlock(editor, n) }
               )
               break
             }
@@ -103,7 +103,7 @@ const App = () => {
                 { bold: true },
                 // Apply it to text nodes, and split the text node up if the
                 // selection is overlapping only part of it.
-                { match: n => Text.isText(n), split: true }
+                { match: (n) => Text.isText(n), split: true }
               )
               break
             }
@@ -121,7 +121,7 @@ For every format you add, Slate will break up the text content into "leaves", an
 
 ```jsx
 // Define a React component to render leaves with bold text.
-const Leaf = props => {
+const Leaf = (props) => {
   return (
     <span
       {...props.attributes}
@@ -146,9 +146,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -158,7 +158,7 @@ const App = () => {
   }, [])
 
   // Define a leaf rendering function that is memoized with `useCallback`.
-  const renderLeaf = useCallback(props => {
+  const renderLeaf = useCallback((props) => {
     return <Leaf {...props} />
   }, [])
 
@@ -168,7 +168,7 @@ const App = () => {
         renderElement={renderElement}
         // Pass in the `renderLeaf` function.
         renderLeaf={renderLeaf}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (!event.ctrlKey) {
             return
           }
@@ -177,12 +177,12 @@ const App = () => {
             case '`': {
               event.preventDefault()
               const [match] = Editor.nodes(editor, {
-                match: n => n.type === 'code',
+                match: (n) => n.type === 'code',
               })
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: n => Editor.isBlock(editor, n) }
+                { match: (n) => Editor.isBlock(editor, n) }
               )
               break
             }
@@ -192,7 +192,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { bold: true },
-                { match: n => Text.isText(n), split: true }
+                { match: (n) => Text.isText(n), split: true }
               )
               break
             }
@@ -203,7 +203,7 @@ const App = () => {
   )
 }
 
-const Leaf = props => {
+const Leaf = (props) => {
   return (
     <span
       {...props.attributes}

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -19,9 +19,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -30,7 +30,7 @@ const App = () => {
     }
   }, [])
 
-  const renderLeaf = useCallback(props => {
+  const renderLeaf = useCallback((props) => {
     return <Leaf {...props} />
   }, [])
 
@@ -39,7 +39,7 @@ const App = () => {
       <Editable
         renderElement={renderElement}
         renderLeaf={renderLeaf}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (!event.ctrlKey) {
             return
           }
@@ -48,12 +48,12 @@ const App = () => {
             case '`': {
               event.preventDefault()
               const [match] = Editor.nodes(editor, {
-                match: n => n.type === 'code',
+                match: (n) => n.type === 'code',
               })
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: n => Editor.isBlock(editor, n) }
+                { match: (n) => Editor.isBlock(editor, n) }
               )
               break
             }
@@ -63,7 +63,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { bold: true },
-                { match: n => Text.isText(n), split: true }
+                { match: (n) => Text.isText(n), split: true }
               )
               break
             }
@@ -84,7 +84,7 @@ We can instead implement these domain-specific concepts by creating custom helpe
 const CustomEditor = {
   isBoldMarkActive(editor) {
     const [match] = Editor.nodes(editor, {
-      match: n => n.bold === true,
+      match: (n) => n.bold === true,
       universal: true,
     })
 
@@ -93,7 +93,7 @@ const CustomEditor = {
 
   isCodeBlockActive(editor) {
     const [match] = Editor.nodes(editor, {
-      match: n => n.type === 'code',
+      match: (n) => n.type === 'code',
     })
 
     return !!match
@@ -104,7 +104,7 @@ const CustomEditor = {
     Transforms.setNodes(
       editor,
       { bold: isActive ? null : true },
-      { match: n => Text.isText(n), split: true }
+      { match: (n) => Text.isText(n), split: true }
     )
   },
 
@@ -113,7 +113,7 @@ const CustomEditor = {
     Transforms.setNodes(
       editor,
       { type: isActive ? null : 'code' },
-      { match: n => Editor.isBlock(editor, n) }
+      { match: (n) => Editor.isBlock(editor, n) }
     )
   },
 }
@@ -126,9 +126,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -137,7 +137,7 @@ const App = () => {
     }
   }, [])
 
-  const renderLeaf = useCallback(props => {
+  const renderLeaf = useCallback((props) => {
     return <Leaf {...props} />
   }, [])
 
@@ -146,7 +146,7 @@ const App = () => {
       <Editable
         renderElement={renderElement}
         renderLeaf={renderLeaf}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (!event.ctrlKey) {
             return
           }
@@ -183,9 +183,9 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback(props => {
+  const renderElement = useCallback((props) => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -194,7 +194,7 @@ const App = () => {
     }
   }, [])
 
-  const renderLeaf = useCallback(props => {
+  const renderLeaf = useCallback((props) => {
     return <Leaf {...props} />
   }, [])
 
@@ -203,7 +203,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <div>
         <button
-          onMouseDown={event => {
+          onMouseDown={(event) => {
             event.preventDefault()
             CustomEditor.toggleBoldMark(editor)
           }}
@@ -211,7 +211,7 @@ const App = () => {
           Bold
         </button>
         <button
-          onMouseDown={event => {
+          onMouseDown={(event) => {
             event.preventDefault()
             CustomEditor.toggleCodeBlock(editor)
           }}
@@ -223,7 +223,7 @@ const App = () => {
         editor={editor}
         renderElement={renderElement}
         renderLeaf={renderLeaf}
-        onKeyDown={event => {
+        onKeyDown={(event) => {
           if (!event.ctrlKey) {
             return
           }

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -21,7 +21,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -30,7 +30,7 @@ const App = () => {
     }
   }, [])
 
-  const renderLeaf = useCallback((props) => {
+  const renderLeaf = useCallback(props => {
     return <Leaf {...props} />
   }, [])
 
@@ -39,7 +39,7 @@ const App = () => {
       <Editable
         renderElement={renderElement}
         renderLeaf={renderLeaf}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (!event.ctrlKey) {
             return
           }
@@ -48,12 +48,12 @@ const App = () => {
             case '`': {
               event.preventDefault()
               const [match] = Editor.nodes(editor, {
-                match: (n) => n.type === 'code',
+                match: n => n.type === 'code',
               })
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: (n) => Editor.isBlock(editor, n) }
+                { match: n => Editor.isBlock(editor, n) }
               )
               break
             }
@@ -63,7 +63,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { bold: true },
-                { match: (n) => Text.isText(n), split: true }
+                { match: n => Text.isText(n), split: true }
               )
               break
             }
@@ -84,7 +84,7 @@ We can instead implement these domain-specific concepts by creating custom helpe
 const CustomEditor = {
   isBoldMarkActive(editor) {
     const [match] = Editor.nodes(editor, {
-      match: (n) => n.bold === true,
+      match: n => n.bold === true,
       universal: true,
     })
 
@@ -93,7 +93,7 @@ const CustomEditor = {
 
   isCodeBlockActive(editor) {
     const [match] = Editor.nodes(editor, {
-      match: (n) => n.type === 'code',
+      match: n => n.type === 'code',
     })
 
     return !!match
@@ -104,7 +104,7 @@ const CustomEditor = {
     Transforms.setNodes(
       editor,
       { bold: isActive ? null : true },
-      { match: (n) => Text.isText(n), split: true }
+      { match: n => Text.isText(n), split: true }
     )
   },
 
@@ -113,7 +113,7 @@ const CustomEditor = {
     Transforms.setNodes(
       editor,
       { type: isActive ? null : 'code' },
-      { match: (n) => Editor.isBlock(editor, n) }
+      { match: n => Editor.isBlock(editor, n) }
     )
   },
 }
@@ -128,7 +128,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -137,7 +137,7 @@ const App = () => {
     }
   }, [])
 
-  const renderLeaf = useCallback((props) => {
+  const renderLeaf = useCallback(props => {
     return <Leaf {...props} />
   }, [])
 
@@ -146,7 +146,7 @@ const App = () => {
       <Editable
         renderElement={renderElement}
         renderLeaf={renderLeaf}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (!event.ctrlKey) {
             return
           }
@@ -185,7 +185,7 @@ const initialValue = [
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
-  const renderElement = useCallback((props) => {
+  const renderElement = useCallback(props => {
     switch (props.element.type) {
       case 'code':
         return <CodeElement {...props} />
@@ -194,7 +194,7 @@ const App = () => {
     }
   }, [])
 
-  const renderLeaf = useCallback((props) => {
+  const renderLeaf = useCallback(props => {
     return <Leaf {...props} />
   }, [])
 
@@ -203,7 +203,7 @@ const App = () => {
     <Slate editor={editor} value={initialValue}>
       <div>
         <button
-          onMouseDown={(event) => {
+          onMouseDown={event => {
             event.preventDefault()
             CustomEditor.toggleBoldMark(editor)
           }}
@@ -211,7 +211,7 @@ const App = () => {
           Bold
         </button>
         <button
-          onMouseDown={(event) => {
+          onMouseDown={event => {
             event.preventDefault()
             CustomEditor.toggleCodeBlock(editor)
           }}
@@ -223,7 +223,7 @@ const App = () => {
         editor={editor}
         renderElement={renderElement}
         renderLeaf={renderLeaf}
-        onKeyDown={(event) => {
+        onKeyDown={event => {
           if (!event.ctrlKey) {
             return
           }

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -15,7 +15,7 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate editor={editor} value={initialValue}>
@@ -40,15 +40,15 @@ const initialValue = [
 ]
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
 
   return (
     <Slate
       editor={editor}
       value={initialValue}
-      onChange={value => {
+      onChange={(value) => {
         const isAstChange = editor.operations.some(
-          op => 'set_selection' !== op.type
+          (op) => 'set_selection' !== op.type
         )
         if (isAstChange) {
           // Save the value to Local Storage.
@@ -69,7 +69,7 @@ But... if you refresh the page, everything is still reset. That's because we nee
 
 ```jsx
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
   // Update the initial content to be pulled from Local Storage if it exists.
   const initialValue = useMemo(
     () =>
@@ -86,9 +86,9 @@ const App = () => {
     <Slate
       editor={editor}
       value={initialValue}
-      onChange={value => {
+      onChange={(value) => {
         const isAstChange = editor.operations.some(
-          op => 'set_selection' !== op.type
+          (op) => 'set_selection' !== op.type
         )
         if (isAstChange) {
           // Save the value to Local Storage.
@@ -114,20 +114,20 @@ But what if you want something other than JSON? Well, you'd need to serialize yo
 import { Node } from 'slate'
 
 // Define a serializing function that takes a value and returns a string.
-const serialize = value => {
+const serialize = (value) => {
   return (
     value
       // Return the string content of each paragraph in the value's children.
-      .map(n => Node.string(n))
+      .map((n) => Node.string(n))
       // Join them all with line breaks denoting paragraphs.
       .join('\n')
   )
 }
 
 // Define a deserializing function that takes a string and returns a value.
-const deserialize = string => {
+const deserialize = (string) => {
   // Return a value array of children derived by splitting the string.
-  return string.split('\n').map(line => {
+  return string.split('\n').map((line) => {
     return {
       children: [{ text: line }],
     }
@@ -135,7 +135,7 @@ const deserialize = string => {
 }
 
 const App = () => {
-  const editor = useMemo(() => withReact(createEditor()), [])
+  const [editor] = useState(() => withReact(createEditor()))
   // Use our deserializing function to read the data from Local Storage.
   const initialValue = useMemo(
     deserialize(localStorage.getItem('content')) || '',
@@ -146,9 +146,9 @@ const App = () => {
     <Slate
       editor={editor}
       value={initialValue}
-      onChange={value => {
+      onChange={(value) => {
         const isAstChange = editor.operations.some(
-          op => 'set_selection' !== op.type
+          (op) => 'set_selection' !== op.type
         )
         if (isAstChange) {
           // Serialize the value and save the string value to Local Storage.

--- a/docs/walkthroughs/06-saving-to-a-database.md
+++ b/docs/walkthroughs/06-saving-to-a-database.md
@@ -46,9 +46,9 @@ const App = () => {
     <Slate
       editor={editor}
       value={initialValue}
-      onChange={(value) => {
+      onChange={value => {
         const isAstChange = editor.operations.some(
-          (op) => 'set_selection' !== op.type
+          op => 'set_selection' !== op.type
         )
         if (isAstChange) {
           // Save the value to Local Storage.
@@ -86,9 +86,9 @@ const App = () => {
     <Slate
       editor={editor}
       value={initialValue}
-      onChange={(value) => {
+      onChange={value => {
         const isAstChange = editor.operations.some(
-          (op) => 'set_selection' !== op.type
+          op => 'set_selection' !== op.type
         )
         if (isAstChange) {
           // Save the value to Local Storage.
@@ -114,20 +114,20 @@ But what if you want something other than JSON? Well, you'd need to serialize yo
 import { Node } from 'slate'
 
 // Define a serializing function that takes a value and returns a string.
-const serialize = (value) => {
+const serialize = value => {
   return (
     value
       // Return the string content of each paragraph in the value's children.
-      .map((n) => Node.string(n))
+      .map(n => Node.string(n))
       // Join them all with line breaks denoting paragraphs.
       .join('\n')
   )
 }
 
 // Define a deserializing function that takes a string and returns a value.
-const deserialize = (string) => {
+const deserialize = string => {
   // Return a value array of children derived by splitting the string.
-  return string.split('\n').map((line) => {
+  return string.split('\n').map(line => {
     return {
       children: [{ text: line }],
     }
@@ -146,9 +146,9 @@ const App = () => {
     <Slate
       editor={editor}
       value={initialValue}
-      onChange={(value) => {
+      onChange={value => {
         const isAstChange = editor.operations.some(
-          (op) => 'set_selection' !== op.type
+          op => 'set_selection' !== op.type
         )
         if (isAstChange) {
           // Serialize the value and save the string value to Local Storage.


### PR DESCRIPTION
The documentation was previously using a mix of `useState` and `useMemo` for storing the editor. 90% of the times it was using `useMemo`.

As pointed by @cameronbraid in https://github.com/ianstormtaylor/slate/pull/5020#issuecomment-1149450318, React may forget about a previously memoized value and recalculate the useMemo.

So this PR suggests replacing all occurrences of `useMemo` to store the `editor` with `useState`.
