### PR TITLE
fix: docs page - installing slate

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -40,7 +40,7 @@ The next step is to create a new `Editor` object. We want the editor to be stabl
 ```jsx
 const App = () => {
   // Create a Slate editor object that won't change across renders.
-  const editor = useState(() => withReact(createEditor()))
+  const [editor] = useState(() => withReact(createEditor()))
   return null
 }
 ```


### PR DESCRIPTION
**Description**
Documentation page(Installing slate) fix: 
proper use of `useState` for an editor initialization.

A clear and concise description of what this pull request solves. (Please do not just link to a long issue thread. Instead include a clear description here or your pull request will likely not be reviewed as quickly.)

**Issue**
Incorrect\Before:
```
const editor = useState(() => withReact(createEditor())) 
```
Correct\After:
```
const [editor] = useState(() => withReact(createEditor())) 
```

**Example**
-

**Context**
-

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

