### PR TITLE
fix: `Path.previous()` dose not working when path is `null`

### DIFF
--- a/.changeset/nervous-cars-divide.md
+++ b/.changeset/nervous-cars-divide.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+fix: `Path.previous()` dose not working when path is `null`

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -451,16 +451,18 @@ export const TextTransforms: TextTransforms = {
       if (!options.at) {
         let path
 
-        if (ends.length > 0) {
-          path = Path.previous(endRef.current!)
-        } else if (middles.length > 0) {
-          path = Path.previous(middleRef.current!)
-        } else {
-          path = Path.previous(startRef.current!)
+        if (ends.length > 0 && endRef.current) {
+          path = Path.previous(endRef.current)
+        } else if (middles.length > 0 && middleRef.current) {
+          path = Path.previous(middleRef.current)
+        } else if (startRef.current) {
+          path = Path.previous(startRef.current)
         }
 
-        const end = Editor.end(editor, path)
-        Transforms.select(editor, end)
+        if (path) {
+          const end = Editor.end(editor, path)
+          Transforms.select(editor, end)
+        }
       }
 
       startRef.unref()


### PR DESCRIPTION
**Description**

`Path.previous()` dose not working when path is `null` because null is passed as the argument to `previous()`

`Path.previous()` argument does not allow `null`: https://github.com/ianstormtaylor/slate/blob/0a90e6420ca622077f59208b86ffaba2137c9477/packages/slate/src/interfaces/path.ts#L47
But here `previous()` can pass null. Because it uses the [non-null assertion operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator): https://github.com/ianstormtaylor/slate/blob/0a90e6420ca622077f59208b86ffaba2137c9477/packages/slate/src/transforms/text.ts#L454-L460

So I fixed it to not allow null. Please check codesandbox.

**Example**

codesandbox: https://codesandbox.io/s/young-paper-s9fhvf?file=/src/App.tsx:526-582

1. focus
2. click button

**Screen Shot**
<img width="919" alt="Screen Shot 2022-06-22 at 18 14 05" src="https://user-images.githubusercontent.com/4067007/174995156-60c291f0-0624-4be1-95a4-5751053223ee.png">


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

