### PR TITLE
Unhang a range even if the start point of the range is in the middle of a node

### DIFF
--- a/.changeset/stale-beds-kneel.md
+++ b/.changeset/stale-beds-kneel.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Unhang a range even if the start point of the range is in the middle of a node

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1614,7 +1614,7 @@ export const Editor: EditorInterface = {
     let [start, end] = Range.edges(range)
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if (start.offset !== 0 || end.offset !== 0 || Range.isCollapsed(range)) {
+    if ((start.offset !== 0 && end.offset !== 0) || Range.isCollapsed(range)) {
       return range
     }
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1614,7 +1614,7 @@ export const Editor: EditorInterface = {
     let [start, end] = Range.edges(range)
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if ((end.offset !== 0 || Range.isCollapsed(range)) {
+    if (end.offset !== 0 || Range.isCollapsed(range)) {
       return range
     }
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1614,7 +1614,7 @@ export const Editor: EditorInterface = {
     let [start, end] = Range.edges(range)
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if ((start.offset !== 0 && end.offset !== 0) || Range.isCollapsed(range)) {
+    if ((end.offset !== 0 || Range.isCollapsed(range)) {
       return range
     }
 

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-hanging.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-hanging.tsx
@@ -5,8 +5,9 @@ import { jsx } from '../../..'
 export const input = (
   <editor>
     <block>
+      wo
       <anchor />
-      word
+      rd
     </block>
     <block>
       <focus />
@@ -20,6 +21,6 @@ export const test = editor => {
 }
 
 export const output = {
-  anchor: { path: [0, 0], offset: 0 },
+  anchor: { path: [0, 0], offset: 2 },
   focus: { path: [0, 0], offset: 4 },
 }


### PR DESCRIPTION
**Description**
We noticed that a range will only unhang if the start and end both have an offset of zero. This seems incorrect, we would expect the end range to be corrected even if the start point is within a node.

**Example**
```
Text <anchor>line 1
<focus>Text line 2
```
We would expect this range to be considered hanging and it should be corrected using `unhangRange`. The fix is to avoid an early return caused by an incorrect `start.offset` check

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

