### PR TITLE
Don't native insert in elements with white-space="pre" containing tab chars

### DIFF
--- a/.changeset/hot-seahorses-smile.md
+++ b/.changeset/hot-seahorses-smile.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Don't native insert inside blocks with whitespace="pre" containing tab chars to work around https://bugs.chromium.org/p/chromium/issues/detail?id=1219139

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -380,15 +380,36 @@ export const Editable = (props: EditableProps) => {
           const [node, offset] = ReactEditor.toDOMPoint(editor, anchor)
           const anchorNode = node.parentElement?.closest('a')
 
-          if (anchorNode && ReactEditor.hasDOMNode(editor, anchorNode)) {
-            const { document } = ReactEditor.getWindow(editor)
+          const window = ReactEditor.getWindow(editor)
 
+          if (
+            native &&
+            anchorNode &&
+            ReactEditor.hasDOMNode(editor, anchorNode)
+          ) {
             // Find the last text node inside the anchor.
-            const lastText = document
+            const lastText = window.document
               .createTreeWalker(anchorNode, NodeFilter.SHOW_TEXT)
               .lastChild() as DOMText | null
 
             if (lastText === node && lastText.textContent?.length === offset) {
+              native = false
+            }
+          }
+
+          // Chrome has issues with the presence of tab characters inside elements with whiteSpace = 'pre'
+          // causing abnormal insert behavior: https://bugs.chromium.org/p/chromium/issues/detail?id=1219139
+          if (
+            native &&
+            node.parentElement &&
+            window.getComputedStyle(node.parentElement).whiteSpace === 'pre'
+          ) {
+            const block = Editor.above(editor, {
+              at: anchor.path,
+              match: n => Editor.isBlock(editor, n),
+            })
+
+            if (block && Node.string(block[0]).includes('\t')) {
               native = false
             }
           }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -388,7 +388,7 @@ export const Editable = (props: EditableProps) => {
             ReactEditor.hasDOMNode(editor, anchorNode)
           ) {
             // Find the last text node inside the anchor.
-            const lastText = window.document
+            const lastText = window?.document
               .createTreeWalker(anchorNode, NodeFilter.SHOW_TEXT)
               .lastChild() as DOMText | null
 
@@ -402,7 +402,7 @@ export const Editable = (props: EditableProps) => {
           if (
             native &&
             node.parentElement &&
-            window.getComputedStyle(node.parentElement).whiteSpace === 'pre'
+            window?.getComputedStyle(node.parentElement)?.whiteSpace === 'pre'
           ) {
             const block = Editor.above(editor, {
               at: anchor.path,


### PR DESCRIPTION
**Description**
Workaround for a obscure bug in chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1219139

**Example**
Behavior when adding whitespace="pre" styling to the code highlighting example and pasting tab chars:

Before:
![before](https://user-images.githubusercontent.com/13185548/178244655-2774f4ca-6a90-4bf3-ab73-16949170cfe9.gif)

After:
![after](https://user-images.githubusercontent.com/13185548/178244644-a013f772-bd18-4fe7-a104-9977ec99508d.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

