### PR TITLE
fix macos accent menu when using arrow keys

### DIFF
--- a/.changeset/ten-chefs-cheat.md
+++ b/.changeset/ten-chefs-cheat.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix macos accent menu when using arrow keys

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -340,12 +340,12 @@ export const Editable = (props: EditableProps) => {
         const { inputType: type } = event
         const data = (event as any).dataTransfer || event.data || undefined
 
-        // These two types occur while a user is composing text and can't be
-        // cancelled. Let them through and wait for the composition to end.
-        if (
-          type === 'insertCompositionText' ||
-          type === 'deleteCompositionText'
-        ) {
+        const isCompositionChange =
+          type === 'insertCompositionText' || type === 'deleteCompositionText'
+
+        // COMPAT: use composition change events as a hint to where we should insert
+        // composition text if we aren't composing to work around https://github.com/ianstormtaylor/slate/issues/5038
+        if (isCompositionChange && ReactEditor.isComposing(editor)) {
           return
         }
 
@@ -410,7 +410,9 @@ export const Editable = (props: EditableProps) => {
               native = false
 
               const selectionRef =
-                editor.selection && Editor.rangeRef(editor, editor.selection)
+                !isCompositionChange &&
+                editor.selection &&
+                Editor.rangeRef(editor, editor.selection)
 
               Transforms.select(editor, range)
 
@@ -419,6 +421,12 @@ export const Editable = (props: EditableProps) => {
               }
             }
           }
+        }
+
+        // Composition change types occur while a user is composing text and can't be
+        // cancelled. Let them through and wait for the composition to end.
+        if (isCompositionChange) {
+          return
         }
 
         if (!native) {


### PR DESCRIPTION
**Description**
Fixes inserting accented characters using the macOS accent menu when using arrow keys

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5038

**Example**

Before:
![before](https://user-images.githubusercontent.com/13185548/178268750-620e5f95-aed5-49a8-801c-0d69602ce6e6.gif)

After:
![after](https://user-images.githubusercontent.com/13185548/178268765-6ee90da8-fb17-4939-bcd7-29e9b00b45d1.gif)

**Context**

<img width="580" alt="Screenshot 2022-07-11 at 14 05 09" src="https://user-images.githubusercontent.com/13185548/178260249-02baa210-2fa7-4ee6-8e90-6b85b055c5d1.png">

When holding down 'a' to type a with an accent the first 'ArrowLeft' key down is triggered with `isComposing=false` and before any event indicating that it is composing. Immediately afterward the 'normal' composition start/update events are fired and all following events have `isComposing` properly set, and because the composition start is fired before the selection change selecting the character / after the beforeinput we keep the selection obtained by manually handling the arrow keys which doesn't match the dom state and insert there because chrome doesn't fire the `insertFromComposition`.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

