### PR TITLE
Fix toSlatePoint in void nodes with nested editors if children are rendered as the last child

### DIFF
--- a/.changeset/five-snails-travel.md
+++ b/.changeset/five-snails-travel.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix toSlatePoint in void nodes with nested editors if children are rendered as the last child

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -552,8 +552,16 @@ export const ReactEditor = {
         }
       } else if (voidNode) {
         // For void nodes, the element with the offset key will be a cousin, not an
-        // ancestor, so find it by going down from the nearest void parent.
-        leafNode = voidNode.querySelector('[data-slate-leaf]')!
+        // ancestor, so find it by going down from the nearest void parent and taking the
+        // first one that isn't inside a nested editor.
+        const leafNodes = voidNode.querySelectorAll('[data-slate-leaf]')
+        for (let index = 0; index < leafNodes.length; index++) {
+          const current = leafNodes[index]
+          if (ReactEditor.hasDOMNode(editor, current)) {
+            leafNode = current
+            break
+          }
+        }
 
         // COMPAT: In read-only editors the leaf is not rendered.
         if (!leafNode) {


### PR DESCRIPTION
**Description**
Fixes `toSlatePoint` in void nodes with nested editors if children are rendered as the last (or not first) child. Currently `toSlatePoint` will return an incorrect path since `voidNode.querySelector('[data-slate-leaf]')` will match the first child inside the nested editor and not the void children.

Why would you ever want not to have the slate children as the first child? To get around [this chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1297461), if the last element inside your document is a void node (reproducible inside the slate playground as well):

https://user-images.githubusercontent.com/13185548/180413815-7e260167-85df-4f67-9a5f-4e129b970d0b.mov

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

