### PR TITLE
fix: update the useIsomorphicLayoutEffect dependencies in android-edi…

### DIFF
--- a/.changeset/angry-files-kick.md
+++ b/.changeset/angry-files-kick.md
@@ -1,7 +1,0 @@
----
-'slate-react': minor
----
-
-- Introduces a `useSlateSelection` hook that triggers whenever the selection changes.
-- This also changes the implementation of SlateContext to use an incrementing value instead of an array replace to trigger updates
-- Introduces a `useSlateWithV` hook that includes the version counter which can be used to prevent re-renders

--- a/.changeset/old-actors-decide.md
+++ b/.changeset/old-actors-decide.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+update the useIsomorphicLayoutEffect dependencies in android-editable

--- a/packages/slate-react/src/components/android/android-editable.tsx
+++ b/packages/slate-react/src/components/android/android-editable.tsx
@@ -301,7 +301,7 @@ export const AndroidEditable = (props: EditableProps): JSX.Element => {
 
     // @ts-ignore The `beforeinput` event isn't recognized.
     return () => node?.removeEventListener('beforeinput', onDOMBeforeInput)
-  }, [contentKey, propsOnDOMBeforeInput])
+  }, [contentKey, onDOMBeforeInput])
 
   // Attach a native DOM event handler for `selectionchange`, because React's
   // built-in `onSelect` handler doesn't fire for all selection changes. It's a


### PR DESCRIPTION

**Description**
In android-editoable component, the useIsomorphicLayoutEffect's dependencies is incorrect. 

if the initial value of readOnly is true, the function of onDOMBeforeInput  will always invalid， even if the value of the variable later changes to false



**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

