### PR TITLE
Release workflow: Replace master with main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       # https://github.com/changesets/action
       - name: Create release pull request or Publish to npm
         if: matrix.channel == 'latest'
-        uses: changesets/action@master
+        uses: changesets/action@main
         with:
           # defined in package.json#scripts
           version: yarn changesetversion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       # https://github.com/changesets/action
       - name: Create release pull request or Publish to npm
         if: matrix.channel == 'latest'
-        uses: changesets/action@main
+        uses: changesets/action@v1
         with:
           # defined in package.json#scripts
           version: yarn changesetversion


### PR DESCRIPTION
npm tags sometimes failing to get applied with releases, warning mentioned this error. It looks like switching from master to main was missed in one place.