### PR TITLE
Customize get dirty paths

### DIFF
--- a/.changeset/spotty-mirrors-matter.md
+++ b/.changeset/spotty-mirrors-matter.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Expose getDirtyPaths method on Editor object to allow for customization

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -71,7 +71,7 @@ export const createEditor = (): Editor => {
         dirtyPathKeys = oldDirtyPathKeys
       }
 
-      const newDirtyPaths = getDirtyPaths(op)
+      const newDirtyPaths = editor.getDirtyPaths(op)
       for (const path of newDirtyPaths) {
         add(path)
       }
@@ -296,83 +296,83 @@ export const createEditor = (): Editor => {
         }
       }
     },
+
+    /**
+     * Get the "dirty" paths generated from an operation.
+     */
+
+    getDirtyPaths: (op: Operation): Path[] => {
+      switch (op.type) {
+        case 'insert_text':
+        case 'remove_text':
+        case 'set_node': {
+          const { path } = op
+          return Path.levels(path)
+        }
+
+        case 'insert_node': {
+          const { node, path } = op
+          const levels = Path.levels(path)
+          const descendants = Text.isText(node)
+            ? []
+            : Array.from(Node.nodes(node), ([, p]) => path.concat(p))
+
+          return [...levels, ...descendants]
+        }
+
+        case 'merge_node': {
+          const { path } = op
+          const ancestors = Path.ancestors(path)
+          const previousPath = Path.previous(path)
+          return [...ancestors, previousPath]
+        }
+
+        case 'move_node': {
+          const { path, newPath } = op
+
+          if (Path.equals(path, newPath)) {
+            return []
+          }
+
+          const oldAncestors: Path[] = []
+          const newAncestors: Path[] = []
+
+          for (const ancestor of Path.ancestors(path)) {
+            const p = Path.transform(ancestor, op)
+            oldAncestors.push(p!)
+          }
+
+          for (const ancestor of Path.ancestors(newPath)) {
+            const p = Path.transform(ancestor, op)
+            newAncestors.push(p!)
+          }
+
+          const newParent = newAncestors[newAncestors.length - 1]
+          const newIndex = newPath[newPath.length - 1]
+          const resultPath = newParent.concat(newIndex)
+
+          return [...oldAncestors, ...newAncestors, resultPath]
+        }
+
+        case 'remove_node': {
+          const { path } = op
+          const ancestors = Path.ancestors(path)
+          return [...ancestors]
+        }
+
+        case 'split_node': {
+          const { path } = op
+          const levels = Path.levels(path)
+          const nextPath = Path.next(path)
+          return [...levels, nextPath]
+        }
+
+        default: {
+          return []
+        }
+      }
+    },
   }
 
   return editor
-}
-
-/**
- * Get the "dirty" paths generated from an operation.
- */
-
-const getDirtyPaths = (op: Operation): Path[] => {
-  switch (op.type) {
-    case 'insert_text':
-    case 'remove_text':
-    case 'set_node': {
-      const { path } = op
-      return Path.levels(path)
-    }
-
-    case 'insert_node': {
-      const { node, path } = op
-      const levels = Path.levels(path)
-      const descendants = Text.isText(node)
-        ? []
-        : Array.from(Node.nodes(node), ([, p]) => path.concat(p))
-
-      return [...levels, ...descendants]
-    }
-
-    case 'merge_node': {
-      const { path } = op
-      const ancestors = Path.ancestors(path)
-      const previousPath = Path.previous(path)
-      return [...ancestors, previousPath]
-    }
-
-    case 'move_node': {
-      const { path, newPath } = op
-
-      if (Path.equals(path, newPath)) {
-        return []
-      }
-
-      const oldAncestors: Path[] = []
-      const newAncestors: Path[] = []
-
-      for (const ancestor of Path.ancestors(path)) {
-        const p = Path.transform(ancestor, op)
-        oldAncestors.push(p!)
-      }
-
-      for (const ancestor of Path.ancestors(newPath)) {
-        const p = Path.transform(ancestor, op)
-        newAncestors.push(p!)
-      }
-
-      const newParent = newAncestors[newAncestors.length - 1]
-      const newIndex = newPath[newPath.length - 1]
-      const resultPath = newParent.concat(newIndex)
-
-      return [...oldAncestors, ...newAncestors, resultPath]
-    }
-
-    case 'remove_node': {
-      const { path } = op
-      const ancestors = Path.ancestors(path)
-      return [...ancestors]
-    }
-
-    case 'split_node': {
-      const { path } = op
-      const levels = Path.levels(path)
-      const nextPath = Path.next(path)
-      return [...levels, nextPath]
-    }
-
-    default: {
-      return []
-    }
-  }
 }

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -77,6 +77,7 @@ export interface BaseEditor {
   insertNode: (node: Node) => void
   insertText: (text: string) => void
   removeMark: (key: string) => void
+  getDirtyPaths: (op: Operation) => Path[]
 }
 
 export type Editor = ExtendedType<'Editor', BaseEditor>
@@ -626,6 +627,7 @@ export const Editor: EditorInterface = {
       typeof value.normalizeNode === 'function' &&
       typeof value.onChange === 'function' &&
       typeof value.removeMark === 'function' &&
+      typeof value.getDirtyPaths === 'function' &&
       (value.marks === null || isPlainObject(value.marks)) &&
       (value.selection === null || Range.isRange(value.selection)) &&
       Node.isNodeList(value.children) &&

--- a/packages/slate/test/interfaces/Element/isElement/editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/editor.tsx
@@ -20,6 +20,7 @@ export const input = {
   normalizeNode() {},
   onChange() {},
   removeMark() {},
+  getDirtyPaths() {},
 }
 export const test = value => {
   return Element.isElement(value)

--- a/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
@@ -21,6 +21,7 @@ export const input = [
     normalizeNode() {},
     onChange() {},
     removeMark() {},
+    getDirtyPaths() {},
   },
 ]
 export const test = value => {


### PR DESCRIPTION
**Description**
https://github.com/ianstormtaylor/slate/pull/4012 Previously added the ability to customize the `getDirtyPaths` as one would any other editor method. In my case, this will be useful for the case where deleting a node results in two lists being adjacent to one another, in which case the I'd like the lists to be merged. Currently, the default implementation of `getDirtyPaths` only sets the ancestors of the removed node as dirty, while I'd need to set the immediate siblings as dirty as well. Presumably there are other helpful use cases out there.

From what I can tell, https://github.com/ianstormtaylor/slate/pull/4012 was approved and merged, but somewhere along the way the changes were lost. Viewing the [merge commit](https://github.com/ianstormtaylor/slate/commit/1bfde7efde1c1c785c9d00aa552ad27c84869955) results in a "This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository." message. And the code changes are nowhere in any of the branches I can see in Github.

All credit should go to @tomdng as they were the original contributor and implementor. I'm just trying to get the changes re-merged hoping it'll stick this time :).

**Context**
See https://github.com/ianstormtaylor/slate/pull/4012 for a full description of the changes and logic behind them.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

