### PR TITLE
Prevent swiftkey from closing when typing next to the placeholder element

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1289,6 +1289,8 @@ export const Editable = (props: EditableProps) => {
             onKeyDown={useCallback(
               (event: React.KeyboardEvent<HTMLDivElement>) => {
                 if (!readOnly && hasEditableTarget(editor, event.target)) {
+                  androidInputManager?.handleKeyDown(event)
+
                   const { nativeEvent } = event
 
                   // COMPAT: The composition end event isn't fired reliably in all browsers,


### PR DESCRIPTION
**Description**
Fixes https://github.com/ianstormtaylor/slate/pull/4988#issuecomment-1201060222. Swiftkey is a pain 😅

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
