### PR TITLE
Fix toolbar and mentions examples on android

### DIFF
--- a/.changeset/silent-carrots-pretend.md
+++ b/.changeset/silent-carrots-pretend.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Memo Editable component by default to make it easier to work with on android

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -127,7 +127,7 @@ export type EditableProps = {
  * Editable.
  */
 
-export const Editable = (props: EditableProps) => {
+const EditableComponent = (props: EditableProps) => {
   const {
     autoFocus,
     decorate = defaultDecorate,
@@ -142,6 +142,7 @@ export const Editable = (props: EditableProps) => {
     as: Component = 'div',
     ...attributes
   } = props
+
   const editor = useSlate()
   // Rerender editor when composition status changed
   const [isComposing, setIsComposing] = useState(false)
@@ -1733,3 +1734,5 @@ export const isDOMEventHandled = <E extends Event>(
 
   return event.defaultPrevented
 }
+
+export const Editable = React.memo(EditableComponent)

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -44,7 +44,6 @@ export type CreateAndroidInputManagerOptions = {
 
 export type AndroidInputManager = {
   flush: () => void
-  scheduleFlush: () => void
 
   hasPendingDiffs: () => boolean
   hasPendingAction: () => boolean
@@ -599,15 +598,13 @@ export function createAndroidInputManager({
   }
 
   const handleInput = () => {
-    if (hasPendingAction() || !hasPendingDiffs()) {
+    const forceFlush = editor.shouldFlushPendingChanges(
+      ReactEditor.pendingChanges(editor)
+    )
+
+    if (forceFlush || hasPendingAction() || !hasPendingDiffs()) {
       debug('flush input')
       flush()
-    }
-  }
-
-  const scheduleFlush = () => {
-    if (!hasPendingAction()) {
-      actionTimeoutId = setTimeout(flush)
     }
   }
 
@@ -627,7 +624,6 @@ export function createAndroidInputManager({
 
   return {
     flush,
-    scheduleFlush,
 
     hasPendingDiffs,
     hasPendingAction,

--- a/packages/slate-react/src/hooks/android-input-manager/use-android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/use-android-input-manager.ts
@@ -1,7 +1,7 @@
 import { RefObject, useState } from 'react'
 import { useSlateStatic } from '../use-slate-static'
 import { IS_ANDROID } from '../../utils/environment'
-import { EDITOR_TO_SCHEDULE_FLUSH } from '../../utils/weak-maps'
+import { EDITOR_TO_FLUSH_CHANGES } from '../../utils/weak-maps'
 import {
   createAndroidInputManager,
   CreateAndroidInputManagerOptions,
@@ -46,7 +46,7 @@ export function useAndroidInputManager({
     MUTATION_OBSERVER_CONFIG
   )
 
-  EDITOR_TO_SCHEDULE_FLUSH.set(editor, inputManager.scheduleFlush)
+  EDITOR_TO_FLUSH_CHANGES.set(editor, inputManager.flush)
   if (isMounted) {
     inputManager.flush()
   }

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -21,7 +21,7 @@ import {
   EDITOR_TO_WINDOW,
   EDITOR_TO_KEY_TO_ELEMENT,
   IS_COMPOSING,
-  EDITOR_TO_SCHEDULE_FLUSH,
+  EDITOR_TO_FLUSH_CHANGES,
   EDITOR_TO_PENDING_DIFFS,
 } from '../utils/weak-maps'
 import {
@@ -37,6 +37,7 @@ import {
   hasShadowRoot,
 } from '../utils/dom'
 import { IS_CHROME, IS_FIREFOX, IS_ANDROID } from '../utils/environment'
+import { TextDiff } from '../utils/diff-text'
 
 /**
  * A React and DOM-specific version of the `Editor` interface.
@@ -51,6 +52,8 @@ export interface ReactEditor extends BaseEditor {
     originEvent?: 'drag' | 'copy' | 'cut'
   ) => void
   hasRange: (editor: ReactEditor, range: Range) => boolean
+
+  shouldFlushPendingChanges: (changes: TextDiff[]) => boolean
 }
 
 // eslint-disable-next-line no-redeclare
@@ -773,16 +776,17 @@ export const ReactEditor = {
   },
 
   /**
-   * Experimental and android specific: Flush all pending diffs and cancel composition at the next possible time.
+   * Experimental and android specific for now:
+   * Flush all pending changes and cancel composition at the next possible time.
    */
-  androidScheduleFlush(editor: Editor) {
-    EDITOR_TO_SCHEDULE_FLUSH.get(editor)?.()
+  applyPendingChanges(editor: Editor) {
+    EDITOR_TO_FLUSH_CHANGES.get(editor)?.()
   },
 
   /**
-   * Experimental and android specific: Get pending diffs
+   * Experimental and android specific: Get pending changes
    */
-  androidPendingDiffs(editor: Editor) {
-    return EDITOR_TO_PENDING_DIFFS.get(editor)
+  pendingChanges(editor: Editor) {
+    return EDITOR_TO_PENDING_DIFFS.get(editor) ?? []
   },
 }

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -22,7 +22,7 @@ import {
   EDITOR_TO_USER_MARKS,
   EDITOR_TO_USER_SELECTION,
   NODE_TO_KEY,
-  EDITOR_TO_SCHEDULE_FLUSH,
+  EDITOR_TO_FLUSH_CHANGES,
   EDITOR_TO_PENDING_INSERTION_MARKS,
 } from '../utils/weak-maps'
 import { ReactEditor } from './react-editor'
@@ -43,8 +43,10 @@ export const withReact = <T extends Editor>(editor: T) => {
   // avoid collisions between editors in the DOM that share the same value.
   EDITOR_TO_KEY_TO_ELEMENT.set(e, new WeakMap())
 
+  e.shouldFlushPendingChanges = () => false
+
   e.addMark = (key, value) => {
-    EDITOR_TO_SCHEDULE_FLUSH.get(e)?.()
+    EDITOR_TO_FLUSH_CHANGES.get(e)?.()
 
     if (
       !EDITOR_TO_PENDING_INSERTION_MARKS.get(e) &&

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -55,7 +55,7 @@ export const EDITOR_TO_ON_CHANGE = new WeakMap<Editor, () => void>()
  * Weak maps for saving pending state on composition stage.
  */
 
-export const EDITOR_TO_SCHEDULE_FLUSH: WeakMap<
+export const EDITOR_TO_FLUSH_CHANGES: WeakMap<
   Editor,
   () => void
 > = new WeakMap()

--- a/site/examples/hovering-toolbar.tsx
+++ b/site/examples/hovering-toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect } from 'react'
+import React, { useMemo, useRef, useEffect, useCallback } from 'react'
 import { Slate, Editable, withReact, useSlate, useFocused } from 'slate-react'
 import {
   Editor,
@@ -16,23 +16,29 @@ import { Button, Icon, Menu, Portal } from '../components'
 const HoveringMenuExample = () => {
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
 
+  const handleDOMBeforeInput = useCallback((event: InputEvent) => {
+    switch (event.inputType) {
+      case 'formatBold':
+        event.preventDefault()
+        return toggleFormat(editor, 'bold')
+      case 'formatItalic':
+        event.preventDefault()
+        return toggleFormat(editor, 'italic')
+      case 'formatUnderline':
+        event.preventDefault()
+        return toggleFormat(editor, 'underlined')
+    }
+  }, [])
+
+  const renderLeaf = useCallback(props => <Leaf {...props} />, [])
+
   return (
     <Slate editor={editor} value={initialValue}>
       <HoveringToolbar />
       <Editable
-        renderLeaf={props => <Leaf {...props} />}
+        renderLeaf={renderLeaf}
+        onDOMBeforeInput={handleDOMBeforeInput}
         placeholder="Enter some text..."
-        onDOMBeforeInput={(event: InputEvent) => {
-          event.preventDefault()
-          switch (event.inputType) {
-            case 'formatBold':
-              return toggleFormat(editor, 'bold')
-            case 'formatItalic':
-              return toggleFormat(editor, 'italic')
-            case 'formatUnderline':
-              return toggleFormat(editor, 'underlined')
-          }
-        }}
       />
     </Slate>
   )


### PR DESCRIPTION
**Description**
Updates the mention and hovering toolbar example so that they properly work on android.

This PR also contains a potentially breaking change: It memos the Editable component to make it easier to work with on android since renders cause a flush which will mess with the IME input.

I'm aware that there is still an issue when using swiftkey in the mention example. Swiftkey will duplicate the text inside the mention when pressing space directly after a mention component. This is (one of many) bugs with swiftkey itself and I haven't yet found a way to prevent it (also happens in a non-slate contenteditable, and every other editor out there that is based upon it)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

