### PR TITLE
fix(example): no action when cancel a file prompt

### DIFF
--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -141,7 +141,7 @@ const InsertImageButton = () => {
           alert('URL is not an image')
           return
         }
-        insertImage(editor, url)
+        url && insertImage(editor, url)
       }}
     >
       <Icon>image</Icon>


### PR DESCRIPTION
**Description**
In the images example, it would still insert an image node after I cancel the file prompt which is unneccesary.

**Issue**
Fixes: (link to issue)
none

**Example**
none

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

