### PR TITLE
Add normalizeSelection api to editor

### DIFF
--- a/.changeset/long-buttons-refuse.md
+++ b/.changeset/long-buttons-refuse.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Added `normalizeSelection` API to split selection before applying node update

--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -13,6 +13,7 @@ interface Editor {
   isInline: (element: Element) => boolean
   isVoid: (element: Element) => boolean
   normalizeNode: (entry: NodeEntry) => void
+  normalizeSelection: (fn: (selection: Selection) => void) => void
   onChange: () => void
 
   // Overrideable core actions.
@@ -412,6 +413,10 @@ Check if a value is a void `Element` object.
 ### Normalize method
 
 #### `normalizeNode(entry: NodeEntry) => void`
+
+[Normalize](../../concepts/11-normalizing.md) a Node according to the schema.
+
+#### `normalizeSelection: (fn: (selection: Selection) => void) => void`
 
 [Normalize](../../concepts/11-normalizing.md) a Node according to the schema.
 

--- a/docs/concepts/07-editor.md
+++ b/docs/concepts/07-editor.md
@@ -13,6 +13,7 @@ interface Editor {
   isInline: (element: Element) => boolean
   isVoid: (element: Element) => boolean
   normalizeNode: (entry: NodeEntry) => void
+  normalizeSelection: (fn: (selection: Selection) => void) => void
   onChange: () => void
   // Overrideable core actions.
   addMark: (key: string, value: any) => void

--- a/docs/concepts/11-normalizing.md
+++ b/docs/concepts/11-normalizing.md
@@ -66,7 +66,7 @@ But what if the child has nested blocks?
 | cell4 | cell5 | cell6 |
 | cell7 | cell8 | cell9 |
 
-`Selection` is usually continuous, however in `Grid` data structure(such as a table) `Selection` is expected to be expressed by cell matrix. Take the matrix above as an example, when `anchor` is located at `cell1` and `focus` is located at `cell5`, `cell1` `cell2` `cell3` `cell4` and `cell5` will all be selected. In practice we expect only `cell1` `cell2` `cell4` `cell5` to be selected in matrix form(exclude `cell3`), and the execution of node changes will only applied to these 4 cells.
+`Selection` is usually continuous, however in `Grid` data structure(such as a table) `Selection` is expected to be expressed by cell matrix. Take the matrix above as an example, when `anchor` is located at `cell1` and `focus` is located at `cell5`, `cell1` `cell2` `cell3` `cell4` and `cell5` will all be selected. In practice we expect only `cell1` `cell2` `cell4` `cell5` to be selected in matrix form(exclude `cell3`), and the execution of node changes should only applied to these 4 cells.
 
 The following code shows how `Selection` can be normalized according to cell matrix when `normalizeSelection` function gets called on `table` element.
 

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -277,6 +277,11 @@ export const createEditor = (): Editor => {
       }
     },
 
+    normalizeSelection: fn => {
+      const { selection } = editor
+      fn(selection)
+    },
+
     removeMark: (key: string) => {
       const { selection } = editor
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -62,7 +62,7 @@ export interface BaseEditor {
   isInline: (element: Element) => boolean
   isVoid: (element: Element) => boolean
   normalizeNode: (entry: NodeEntry) => void
-  normalizeSelection: (fn: (range: Range) => void) => void
+  normalizeSelection: (fn: (selection: Selection) => void) => void
   onChange: () => void
 
   // Overrideable core actions.
@@ -626,6 +626,7 @@ export const Editor: EditorInterface = {
       typeof value.isInline === 'function' &&
       typeof value.isVoid === 'function' &&
       typeof value.normalizeNode === 'function' &&
+      typeof value.normalizeSelection === 'function' &&
       typeof value.onChange === 'function' &&
       typeof value.removeMark === 'function' &&
       typeof value.getDirtyPaths === 'function' &&
@@ -781,7 +782,7 @@ export const Editor: EditorInterface = {
     let result: Omit<Text, 'text'> = {}
     editor.normalizeSelection(selection => {
       const { marks } = editor
-
+      if (!selection) return
       if (marks) {
         result = Object.assign(result, marks)
         return

--- a/packages/slate/test/interfaces/Element/isElement/editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElement/editor.tsx
@@ -18,6 +18,7 @@ export const input = {
   isInline() {},
   isVoid() {},
   normalizeNode() {},
+  normalizeSelection() {},
   onChange() {},
   removeMark() {},
   getDirtyPaths() {},

--- a/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
+++ b/packages/slate/test/interfaces/Element/isElementList/full-editor.tsx
@@ -19,6 +19,7 @@ export const input = [
     isInline() {},
     isVoid() {},
     normalizeNode() {},
+    normalizeSelection() {},
     onChange() {},
     removeMark() {},
     getDirtyPaths() {},

--- a/packages/slate/test/transforms/normalization/add_mark.tsx
+++ b/packages/slate/test/transforms/normalization/add_mark.tsx
@@ -1,0 +1,180 @@
+/** @jsx jsx */
+import { Editor, Element, Transforms, Range, Text } from 'slate'
+import { jsx } from '../..'
+import _ from 'lodash'
+
+export interface TableGeneratorCellsOptions {
+  at?: Location
+  startRow?: number
+  startCol?: number
+  endRow?: number
+  endCol?: number
+  reverse?: boolean
+}
+
+export type CellPoint = [number, number]
+export interface TableSelection {
+  start: CellPoint
+  end: CellPoint
+}
+
+const TableEditor = {
+  *cells(
+    editor: Editor,
+    opitons: TableGeneratorCellsOptions = {}
+  ): Generator<[Element, number, number]> {
+    const { at = editor.selection } = opitons
+    const [tableEntry] = Editor.nodes(editor, {
+      at,
+      match: n => Element.isElement(n) && n.type === 'table',
+    })
+    if (!tableEntry) return
+    const [table] = tableEntry
+    const { children } = table
+    const {
+      startRow = 0,
+      startCol = 0,
+      endRow = children.length - 1,
+      reverse = false,
+    } = opitons
+    let r = reverse ? Math.max(endRow, children.length - 1) : startRow
+    while (reverse ? r >= 0 : r <= endRow) {
+      const row = children[r]
+      if (!row) break
+      const { children: cells } = row
+      const { endCol = cells.length - 1 } = opitons
+      let c = reverse ? Math.max(endCol, cells.length - 1) : startCol
+      while (reverse ? c >= 0 : c <= endCol) {
+        const cell = cells[c]
+        yield [cell, r, c]
+        c = reverse ? c - 1 : c + 1
+      }
+      r = reverse ? r - 1 : r + 1
+    }
+  },
+
+  getSelection: (editor: Editor, at?: Location): TableSelection | undefined => {
+    const [tableEntry] = Editor.nodes(editor, {
+      at,
+      match: n => Element.isElement(n) && n.type === 'table',
+    })
+    if (!tableEntry) return
+    const [, path] = tableEntry
+    const { selection } = editor
+    if (!selection) return
+    const [start, end] = Range.edges(selection)
+    try {
+      const range = Editor.range(editor, path)
+      if (
+        !Range.includes(range, selection.anchor) ||
+        !Range.includes(range, selection.focus)
+      )
+        return
+    } catch (error) {
+      return
+    }
+    const [startEntry] = Editor.nodes<Element>(editor, {
+      at: start,
+      match: n => Element.isElement(n) && n.type === 'table-cell',
+    })
+    if (!startEntry) return
+    const [endEntry] = Range.isExpanded(selection)
+      ? Editor.nodes<Element>(editor, {
+          at: end,
+          match: n => Element.isElement(n) && n.type === 'table-cell',
+        })
+      : [startEntry]
+    if (!endEntry) return
+    const [, startPath] = startEntry
+    const [, endPath] = endEntry
+    return {
+      start: startPath.slice(startPath.length - 2) as CellPoint,
+      end: endPath.slice(endPath.length - 2) as CellPoint,
+    }
+  },
+}
+
+const selection = {
+  anchor: {
+    path: [0, 0, 1, 0],
+    offset: 0,
+  },
+  focus: {
+    path: [0, 1, 1, 0],
+    offset: 0,
+  },
+}
+
+export const input = (
+  <editor selection={selection}>
+    <block type="table">
+      <block type="table-row">
+        <block type="table-cell">one</block>
+        <block type="table-cell">two</block>
+        <block type="table-cell">three</block>
+      </block>
+      <block type="table-row">
+        <block type="table-cell">four</block>
+        <block type="table-cell">five</block>
+        <block type="table-cell">six</block>
+      </block>
+    </block>
+  </editor>
+)
+
+const editor = (input as unknown) as Editor
+const defaultNormalize = editor.normalizeSelection
+editor.normalizeSelection = fn => {
+  const [tableEntry] = Editor.nodes(editor, {
+    match: n => Element.isElement(n) && n.type === 'table',
+  })
+  if (tableEntry) {
+    const [, path] = tableEntry
+    const { selection } = editor
+    const sel = TableEditor.getSelection(editor, path)
+    if (!sel) return defaultNormalize(fn)
+    const { start, end } = sel
+    const cells = TableEditor.cells(editor, {
+      at: path,
+      startRow: start[0],
+      startCol: start[1],
+      endRow: end[0],
+      endCol: end[1],
+    })
+
+    for (const [cell, row, col] of cells) {
+      if (!cell) break
+      const anchor = Editor.start(editor, path.concat([row, col]))
+      const focus = Editor.end(editor, path.concat([row, col]))
+      const range = { anchor, focus }
+      fn(range)
+    }
+    Transforms.select(editor, selection)
+  } else {
+    defaultNormalize(fn)
+  }
+}
+export const run = editor => {
+  Editor.addMark(editor, 'bold', true)
+}
+
+export const output = (
+  <editor selection={selection}>
+    <block type="table">
+      <block type="table-row">
+        <block type="table-cell">one</block>
+        <block type="table-cell">
+          <text bold>two</text>
+        </block>
+        <block type="table-cell">three</block>
+      </block>
+      <block type="table-row">
+        <block type="table-cell">four</block>
+        <block type="table-cell">
+          <text bold>five</text>
+        </block>
+        <block type="table-cell">six</block>
+      </block>
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
In the case of selecting some cells on the table, I want any node's change operation to be applied separately using the selection in each cell

table selection effect on example
![image](https://user-images.githubusercontent.com/55792257/185611280-679c18c5-c054-4494-8ca1-33ee1b408d69.png)

I'm trying to implement rich text without using the contenteditable property(https://github.com/editablejs/editable).
This is the result after selecting the table

![image](https://user-images.githubusercontent.com/55792257/185611586-8171747e-7d74-4a45-903e-e12a55d73852.png)

In fact, this does not change the selection, cell3 is still selected, but I want to reorganize the selection by adding the normalizeSelection api

**Example**
![20220819194658](https://user-images.githubusercontent.com/55792257/185611912-318c2aeb-1769-4d78-af9a-255a79dfb386.gif)

**Context**
Traversing the cells that need to be changed in the table plugin
```
const { normalizeSelection } = editor
editor.normalizeSelection = (fn) => {
  if (isTable) {
   const { selection } = editor
   for(const cell of cells) {
     fn(...cell selection)
   }
  // restore selection
  Transforms.select(editor,  selection)
  } else {
    normalizeSelection(fn)
  }
}
```
Call the normalizeSelection method within withoutNormalizing and modify the editor's selection property
```
withoutNormalizing(editor: Editor, fn: () => void): void {
    const value = Editor.isNormalizing(editor)
    Editor.setNormalizing(editor, false)
    try {
      editor.normalizeSelection(selection => {
        if (editor.selection !== selection) editor.selection = selection
        fn()
      })
    } finally {
      Editor.setNormalizing(editor, value)
    }
    Editor.normalize(editor)
  }
```

If you agree with this approach, I will improve the follow-up work and documentation

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

