### PR TITLE
Fix - `withReact` type signature

### DIFF
--- a/.changeset/smooth-queens-tie.md
+++ b/.changeset/smooth-queens-tie.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix `withReact()` function type definition

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -1,5 +1,14 @@
 import ReactDOM from 'react-dom'
-import { Editor, Node, Operation, Path, Point, Range, Transforms } from 'slate'
+import {
+  BaseEditor,
+  Editor,
+  Node,
+  Operation,
+  Path,
+  Point,
+  Range,
+  Transforms,
+} from 'slate'
 import {
   TextDiff,
   transformPendingPoint,
@@ -35,7 +44,7 @@ import { ReactEditor } from './react-editor'
  * See https://docs.slatejs.org/concepts/11-typescript to learn how.
  */
 
-export const withReact = <T extends Editor>(editor: T) => {
+export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
   const e = editor as T & ReactEditor
   const { apply, onChange, deleteBackward, addMark, removeMark } = e
 

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -64,7 +64,7 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
       EDITOR_TO_PENDING_INSERTION_MARKS.set(e, null)
     }
 
-    EDITOR_TO_USER_MARKS.delete(editor)
+    EDITOR_TO_USER_MARKS.delete(e)
 
     addMark(key, value)
   }
@@ -79,7 +79,7 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
       EDITOR_TO_PENDING_INSERTION_MARKS.set(e, null)
     }
 
-    EDITOR_TO_USER_MARKS.delete(editor)
+    EDITOR_TO_USER_MARKS.delete(e)
 
     removeMark(key)
   }
@@ -89,24 +89,24 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
       return deleteBackward(unit)
     }
 
-    if (editor.selection && Range.isCollapsed(editor.selection)) {
-      const parentBlockEntry = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
-        at: editor.selection,
+    if (e.selection && Range.isCollapsed(e.selection)) {
+      const parentBlockEntry = Editor.above(e, {
+        match: n => Editor.isBlock(e, n),
+        at: e.selection,
       })
 
       if (parentBlockEntry) {
         const [, parentBlockPath] = parentBlockEntry
         const parentElementRange = Editor.range(
-          editor,
+          e,
           parentBlockPath,
-          editor.selection.anchor
+          e.selection.anchor
         )
 
         const currentLineRange = findCurrentLineRange(e, parentElementRange)
 
         if (!Range.isCollapsed(currentLineRange)) {
-          Transforms.delete(editor, { at: currentLineRange })
+          Transforms.delete(e, { at: currentLineRange })
         }
       }
     }
@@ -117,30 +117,30 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
   e.apply = (op: Operation) => {
     const matches: [Path, Key][] = []
 
-    const pendingDiffs = EDITOR_TO_PENDING_DIFFS.get(editor)
+    const pendingDiffs = EDITOR_TO_PENDING_DIFFS.get(e)
     if (pendingDiffs?.length) {
       const transformed = pendingDiffs
         .map(textDiff => transformTextDiff(textDiff, op))
         .filter(Boolean) as TextDiff[]
 
-      EDITOR_TO_PENDING_DIFFS.set(editor, transformed)
+      EDITOR_TO_PENDING_DIFFS.set(e, transformed)
     }
 
-    const pendingSelection = EDITOR_TO_PENDING_SELECTION.get(editor)
+    const pendingSelection = EDITOR_TO_PENDING_SELECTION.get(e)
     if (pendingSelection) {
       EDITOR_TO_PENDING_SELECTION.set(
-        editor,
-        transformPendingRange(editor, pendingSelection, op)
+        e,
+        transformPendingRange(e, pendingSelection, op)
       )
     }
 
-    const pendingAction = EDITOR_TO_PENDING_ACTION.get(editor)
+    const pendingAction = EDITOR_TO_PENDING_ACTION.get(e)
     if (pendingAction?.at) {
       const at = Point.isPoint(pendingAction?.at)
-        ? transformPendingPoint(editor, pendingAction.at, op)
-        : transformPendingRange(editor, pendingAction.at, op)
+        ? transformPendingPoint(e, pendingAction.at, op)
+        : transformPendingRange(e, pendingAction.at, op)
 
-      EDITOR_TO_PENDING_ACTION.set(editor, at ? { ...pendingAction, at } : null)
+      EDITOR_TO_PENDING_ACTION.set(e, at ? { ...pendingAction, at } : null)
     }
 
     switch (op.type) {
@@ -154,8 +154,8 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
 
       case 'set_selection': {
         // Selection was manually set, don't restore the user selection after the change.
-        EDITOR_TO_USER_SELECTION.get(editor)?.unref()
-        EDITOR_TO_USER_SELECTION.delete(editor)
+        EDITOR_TO_USER_SELECTION.get(e)?.unref()
+        EDITOR_TO_USER_SELECTION.delete(e)
         break
       }
 


### PR DESCRIPTION
**Description**
`withReact()` plugin type signature is inaccurate. 

In reality, it accepts any `editor` instance implementing `BaseEditor` and extends it with additional `ReactEditor` API.

But the type definitions require to pass an instance that is already a `ReactEditor`. 

The typical workaround is either to [cast the instance with `as ReactEditor`](https://github.com/ianstormtaylor/slate/issues/4144#issuecomment-1046097560) or [define the `Editor` custom type in the project](https://github.com/ianstormtaylor/slate/issues/4144#issuecomment-1075045383). However, both are band-aid solutions to the real problem: invalid type spec of the `withReact()` function.

**Issue**
Fixes: #4144

**Example**

Before the fix:

![Screenshot from 2022-08-19 17-38-17](https://user-images.githubusercontent.com/370680/185643387-5246404d-008f-4d1e-902c-9270eabb030a.png)

After the fix:

![Screenshot from 2022-08-19 17-38-45](https://user-images.githubusercontent.com/370680/185643363-a2b57de0-7371-48f1-b34c-08aca075802a.png)

**Context**

n/a

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

