### PR TITLE
Fix children being undefined on HMR uploads.

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -101,7 +101,7 @@ export const Slate = (props: {
   return (
     <SlateSelectorContext.Provider value={selectorContext}>
       <SlateContext.Provider value={context}>
-        <EditorContext.Provider value={editor}>
+        <EditorContext.Provider value={context.editor}>
           <FocusedContext.Provider value={isFocused}>
             {children}
           </FocusedContext.Provider>


### PR DESCRIPTION
**Description**
Fixes HMR breaking the Editable component

**Issue**
[HMR breaking Editable](https://github.com/ianstormtaylor/slate/issues/5093)

**Example**

https://user-images.githubusercontent.com/23149166/185932982-7cc097d3-7af6-41e5-88ac-e6923847c087.mp4




**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`. (didn't even start, crashed immediately)
```
Error: Qualified path resolution failed - none of those files can be found on the disk.

Source path: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.js
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.json
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.node
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.jsx
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.es6
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.es
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.mjs
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.cjs
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.ts
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/dist/index.js.tsx
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.js
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.json
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.node
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.jsx
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.es6
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.es
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.mjs
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.cjs
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.ts
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/.tsx
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.js
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.json
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.node
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.jsx
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.es6
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.es
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.mjs
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.cjs
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.ts
Not found: /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/__virtual__/slate-hyperscript-virtual-07e8ae0801/1/packages/slate-hyperscript/index.tsx

Require stack:
- /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/packages/slate-history/test/index.js
- /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/mocha.js
- /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/cli/one-and-dones.js
- /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/cli/options.js
- /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/bin/mocha
    at Function.external_module_.Module._resolveFilename (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.pnp.cjs:29287:55)
    at Function.external_module_.Module._load (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.pnp.cjs:29086:48)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/packages/slate-history/test/index.js:3:1)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._compile (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/pirates-npm-4.0.1-377058e8fc-091e232aac.zip/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.newLoader [as .js] (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/pirates-npm-4.0.1-377058e8fc-091e232aac.zip/node_modules/pirates/lib/index.js:104:7)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.external_module_.Module._load (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.pnp.cjs:29136:14)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at /mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/mocha.js:334:36
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/mocha.js:331:14)
    at Mocha.run (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/mocha.js:809:10)
    at Object.exports.singleRun (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/cli/run-helpers.js:108:16)
    at exports.runMocha (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/cli/run-helpers.js:142:13)
    at Object.exports.handler (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/cli/run.js:292:3)
    at Object.runCommand (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/yargs-npm-13.3.2-1588f5dd4c-75c13e837e.zip/node_modules/yargs/lib/command.js:242:26)
    at Object.parseArgs [as _parseArgs] (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/yargs-npm-13.3.2-1588f5dd4c-75c13e837e.zip/node_modules/yargs/yargs.js:1096:28)
    at Object.parse (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/yargs-npm-13.3.2-1588f5dd4c-75c13e837e.zip/node_modules/yargs/yargs.js:575:25)
    at Object.exports.main (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/lib/cli/cli.js:68:6)
    at Object.<anonymous> (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.yarn/cache/mocha-npm-6.2.3-b87ac0ebf8-c069edeffb.zip/node_modules/mocha/bin/mocha:162:29)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.external_module_.Module._load (/mnt/SSD/projects/work/vitereacttsslatehmr/src/slate/.pnp.cjs:29136:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
```
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

