### PR TITLE
Added missing brackets to resolve inconsistency

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -40,7 +40,7 @@ The next step is to create a new `Editor` object. We want the editor to be stabl
 ```jsx
 const App = () => {
   // Create a Slate editor object that won't change across renders.
-  const editor = useState(() => withReact(createEditor()))
+  const [editor] = useState(() => withReact(createEditor()))
   return null
 }
 ```


### PR DESCRIPTION
**Description**
Not having the brackets around the editor is inconsistent with the rest of the walkthrough and created some problems when I tried to use it.

**Example**
In this code block, there's no bracket: 
![image](https://user-images.githubusercontent.com/99157490/186039586-6e6edaec-1b89-4d96-b127-97c47238a1ed.png)
Those are the next three blocks in the walkthrough:
![image](https://user-images.githubusercontent.com/99157490/186039621-e7202198-15f0-41c7-9fe3-0bbb0d2be3fc.png)
![image](https://user-images.githubusercontent.com/99157490/186039634-56d32218-66f8-4202-ba9d-27ec73c6ab61.png)
![image](https://user-images.githubusercontent.com/99157490/186039647-eb6cb6d2-a2bb-474e-b6ef-4d6840a6bcfa.png)

