### PR TITLE
Add `aria-multiline` attribute to textbox editor

### DIFF
--- a/.changeset/neat-pigs-hunt.md
+++ b/.changeset/neat-pigs-hunt.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Add `aria-multiline` attribute to textbox editor

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -804,6 +804,7 @@ export const Editable = (props: EditableProps) => {
         <RestoreDOM node={ref} receivedUserInput={receivedUserInput}>
           <Component
             role={readOnly ? undefined : 'textbox'}
+            aria-multiline={readOnly ? undefined : true}
             {...attributes}
             // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
             // have to use hacks to make these replacement-based features work.


### PR DESCRIPTION
**Description**

The portable text editor is a rich text field. It is marked up as a text field with `role="textbox"`, but does not have `aria-multiline="true"`. As it does allow for multiple lines, this attribute should be added to set the right expectations. 

Related reads:
- [WAI-ARIA 1.1 - textbox (role)](https://www.w3.org/TR/wai-aria/#textbox)
- [WCAG SC 1.3.1: Info and Relationships](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1#info-and-relationships)

Kind thanks to @hidde for the suggestion. :)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

