### PR TITLE
Use callback-style ref in `Element` component

### DIFF
--- a/.changeset/poor-jokes-chew.md
+++ b/.changeset/poor-jokes-chew.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Change `Element` component to use callback-style ref to reliably track DOM node of rendered custom elements


### PR DESCRIPTION
**Description**
When a parent Element re-render child Elements using React context, Slate can no longer track the DOM node to Slate node mapping.

**Issue**
Fixes #5104

**Example**
The same repro in #5104 with locally patched `slate-react` package:

https://user-images.githubusercontent.com/1330321/187604574-36b4e2ea-2616-42fe-a51e-73de17498563.mp4

**Context**
This PR changes `Element` to use callback-style ref, so every change in the ref target (including unmounting) will be observed.

`Editor` and `Leaf` doesn't need this treatment, because they attach `ref` to nodes that can only change when the component itself re-renders.

However, if we also change `Editor` and `Leaf`, then `ELEMENT_TO_NODE` and `NODE_TO_ELEMENT` maps can use normal `Map`s, instead of `WeakMap`s, which is 5x faster in reading, according to some random [benchmark](https://gist.github.com/jung-kim/d146b25ea754e73bf60a?permalink_comment_id=3811484#gistcomment-3811484).

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

