### PR TITLE
only preventDefault if the input is actually a format action

### DIFF
--- a/site/examples/hovering-toolbar.tsx
+++ b/site/examples/hovering-toolbar.tsx
@@ -23,13 +23,15 @@ const HoveringMenuExample = () => {
         renderLeaf={props => <Leaf {...props} />}
         placeholder="Enter some text..."
         onDOMBeforeInput={(event: InputEvent) => {
-          event.preventDefault()
           switch (event.inputType) {
             case 'formatBold':
+              event.preventDefault()
               return toggleFormat(editor, 'bold')
             case 'formatItalic':
+              event.preventDefault()
               return toggleFormat(editor, 'italic')
             case 'formatUnderline':
+              event.preventDefault()
               return toggleFormat(editor, 'underlined')
           }
         }}


### PR DESCRIPTION
**Description**
Currently, the [Hovering Toolbar example](https://www.slatejs.org/examples/hovering-toolbar) does not let edits pass through. This is because we are doing `event.preventDefault()` en every `onDOMBeforeInput`. This fixes the issue by running `event.preventDefault()` only when it applies.

**Example**

https://user-images.githubusercontent.com/40034115/188515801-657161c0-4bab-44c4-a06f-91be905177f6.mp4



**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

