### PR TITLE
Use ReactEditor.toDOMNode to find editor DOMNode in leaf.tsx

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "3.19.0",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "3.19.0",
-  "version": "0.61.3",
+  "version": "0.82.2",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@babel/runtime": "^7.7.4",
     "lodash": "^4.17.21",
-    "slate": "^0.82.2",
-    "slate-hyperscript": "^0.82.2",
+    "slate": "^0.82.3",
+    "slate-hyperscript": "^0.82.3",
     "source-map-loader": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.81.3",
+  "version": "0.82.2",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@babel/runtime": "^7.7.4",
     "lodash": "^4.17.21",
-    "slate": "^0.82.0",
-    "slate-hyperscript": "^0.81.3",
+    "slate": "^0.82.2",
+    "slate-hyperscript": "^0.82.2",
     "source-map-loader": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-hyperscript",
   "description": "A hyperscript helper for creating Slate documents.",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.7.4",
-    "slate": "^0.82.2",
+    "slate": "^0.82.3",
     "source-map-loader": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-hyperscript",
   "description": "A hyperscript helper for creating Slate documents.",
-  "version": "0.81.3",
+  "version": "0.82.2",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.7.4",
-    "slate": "^0.82.0",
+    "slate": "^0.82.2",
     "source-map-loader": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.82.1",
+  "version": "0.82.2",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -33,8 +33,8 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-test-renderer": ">=16.8.0",
-    "slate": "^0.82.1",
-    "slate-hyperscript": "^0.81.3",
+    "slate": "^0.82.2",
+    "slate-hyperscript": "^0.82.2",
     "source-map-loader": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -33,8 +33,8 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-test-renderer": ">=16.8.0",
-    "slate": "^0.82.2",
-    "slate-hyperscript": "^0.82.2",
+    "slate": "^0.82.3",
+    "slate-hyperscript": "^0.82.3",
     "source-map-loader": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -7,6 +7,7 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
+import { ReactEditor } from '../plugin/react-editor'
 
 /**
  * Individual leaves in a text node with unique formatting.
@@ -34,9 +35,7 @@ const Leaf = (props: {
 
   useEffect(() => {
     const placeholderEl = placeholderRef?.current
-    const editorEl = document.querySelector<HTMLDivElement>(
-      '[data-slate-editor="true"]'
-    )
+    const editorEl = ReactEditor.toDOMNode(editor, editor)
 
     if (!placeholderEl || !editorEl) {
       return

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.82.1",
+  "version": "0.82.2",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@babel/runtime": "^7.7.4",
     "lodash": "^4.17.21",
-    "slate-hyperscript": "^0.81.3",
+    "slate-hyperscript": "^0.82.2",
     "source-map-loader": "^4.0.0"
   },
   "keywords": [

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@babel/runtime": "^7.7.4",
     "lodash": "^4.17.21",
-    "slate-hyperscript": "^0.82.2",
+    "slate-hyperscript": "^0.82.3",
     "source-map-loader": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
**Description**
Use ReactEditor.toDOMNode to find editor DOMNode in leaf.tsx instead of querySelector

Fixes: [(issue)](https://github.com/ianstormtaylor/slate/issues/5117)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

