### PR TITLE
Fix selection out of sync in readonly mode

### DIFF
--- a/.changeset/calm-readers-brake.md
+++ b/.changeset/calm-readers-brake.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix editor selection out of sync in readonly mode

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -231,6 +231,11 @@ export const Editable = (props: EditableProps) => {
             }
           }
         }
+
+        // Deselect the editor if the dom selection is not selectable in readonly mode
+        if (readOnly && (!anchorNodeSelectable || !focusNodeSelectable)) {
+          Transforms.deselect(editor)
+        }
       }
     }, 100),
     [readOnly]


### PR DESCRIPTION
**Description**
The editor selection is not updated in correspondence with the dom selection in readonly mode. When clicking outside of the editor, the editor is not deselected as expected and the selection remains unchanged.

**Example**
Now:

https://user-images.githubusercontent.com/13460383/189302488-cd5453c2-ce78-47ae-a06b-2556e0c23c59.mov

After fix:

https://user-images.githubusercontent.com/13460383/189302512-1829a9e7-bd72-4a4a-8692-6ffe81786edf.mov


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

