### PR TITLE
Fix Copy/pasting void elements is not working

### DIFF
--- a/.changeset/seven-waves-rhyme.md
+++ b/.changeset/seven-waves-rhyme.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Make it possible to copy/paste void elements

--- a/cypress/integration/examples/editable-voids.ts
+++ b/cypress/integration/examples/editable-voids.ts
@@ -1,7 +1,8 @@
 describe('editable voids', () => {
+  const input = 'input[type="text"]'
   const elements = [
     { tag: 'h4', count: 3 },
-    { tag: 'input[type="text"]', count: 1 },
+    { tag: input, count: 1 },
     { tag: 'input[type="radio"]', count: 2 },
   ]
 
@@ -24,5 +25,10 @@ describe('editable voids', () => {
     elements.forEach(({ tag, count }) => {
       cy.get(tag).should('have.length', count * 2)
     })
+  })
+
+  it('make sure you can edit editable void', () => {
+    cy.get(input).type('Typing')
+    cy.get(input).should('have.value', 'Typing')
   })
 })

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -434,7 +434,7 @@ export const Editable = (props: EditableProps) => {
 
       if (
         !readOnly &&
-        hasSelectableTarget(editor, event.target) &&
+        hasEditableTarget(editor, event.target) &&
         !isDOMEventHandled(event, propsOnDOMBeforeInput)
       ) {
         // COMPAT: BeforeInput events aren't cancelable on android, so we have to handle them differently using the android input manager.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -206,12 +206,12 @@ export const Editable = (props: EditableProps) => {
         const { anchorNode, focusNode } = domSelection
 
         const anchorNodeSelectable =
-          hasEditableTarget(editor, anchorNode) ||
-          isTargetInsideNonReadonlyVoid(editor, anchorNode)
+          ReactEditor.hasEditableTarget(editor, anchorNode) ||
+          ReactEditor.isTargetInsideNonReadonlyVoid(editor, anchorNode)
 
         const focusNodeSelectable =
-          hasEditableTarget(editor, focusNode) ||
-          isTargetInsideNonReadonlyVoid(editor, focusNode)
+          ReactEditor.hasEditableTarget(editor, focusNode) ||
+          ReactEditor.isTargetInsideNonReadonlyVoid(editor, focusNode)
 
         if (anchorNodeSelectable && focusNodeSelectable) {
           const range = ReactEditor.toSlateRange(editor, domSelection, {
@@ -434,7 +434,7 @@ export const Editable = (props: EditableProps) => {
 
       if (
         !readOnly &&
-        hasEditableTarget(editor, event.target) &&
+        ReactEditor.hasEditableTarget(editor, event.target) &&
         !isDOMEventHandled(event, propsOnDOMBeforeInput)
       ) {
         // COMPAT: BeforeInput events aren't cancelable on android, so we have to handle them differently using the android input manager.
@@ -862,7 +862,7 @@ export const Editable = (props: EditableProps) => {
                   !HAS_BEFORE_INPUT_SUPPORT &&
                   !readOnly &&
                   !isEventHandled(event, attributes.onBeforeInput) &&
-                  hasSelectableTarget(editor, event.target)
+                  ReactEditor.hasSelectableTarget(editor, event.target)
                 ) {
                   event.preventDefault()
                   if (!ReactEditor.isComposing(editor)) {
@@ -893,7 +893,7 @@ export const Editable = (props: EditableProps) => {
                 if (
                   readOnly ||
                   state.isUpdatingSelection ||
-                  !hasEditableTarget(editor, event.target) ||
+                  !ReactEditor.hasSelectableTarget(editor, event.target) ||
                   isEventHandled(event, attributes.onBlur)
                 ) {
                   return
@@ -957,7 +957,7 @@ export const Editable = (props: EditableProps) => {
             onClick={useCallback(
               (event: React.MouseEvent<HTMLDivElement>) => {
                 if (
-                  hasTarget(editor, event.target) &&
+                  ReactEditor.hasTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onClick) &&
                   isDOMNode(event.target)
                 ) {
@@ -1014,7 +1014,7 @@ export const Editable = (props: EditableProps) => {
             )}
             onCompositionEnd={useCallback(
               (event: React.CompositionEvent<HTMLDivElement>) => {
-                if (hasSelectableTarget(editor, event.target)) {
+                if (ReactEditor.hasSelectableTarget(editor, event.target)) {
                   if (ReactEditor.isComposing(editor)) {
                     setIsComposing(false)
                     IS_COMPOSING.set(editor, false)
@@ -1068,7 +1068,7 @@ export const Editable = (props: EditableProps) => {
             onCompositionUpdate={useCallback(
               (event: React.CompositionEvent<HTMLDivElement>) => {
                 if (
-                  hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onCompositionUpdate)
                 ) {
                   if (!ReactEditor.isComposing(editor)) {
@@ -1081,7 +1081,7 @@ export const Editable = (props: EditableProps) => {
             )}
             onCompositionStart={useCallback(
               (event: React.CompositionEvent<HTMLDivElement>) => {
-                if (hasSelectableTarget(editor, event.target)) {
+                if (ReactEditor.hasSelectableTarget(editor, event.target)) {
                   androidInputManager?.handleCompositionStart(event)
 
                   if (
@@ -1121,7 +1121,7 @@ export const Editable = (props: EditableProps) => {
             onCopy={useCallback(
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
-                  hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onCopy)
                 ) {
                   event.preventDefault()
@@ -1138,7 +1138,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onCut)
                 ) {
                   event.preventDefault()
@@ -1166,7 +1166,7 @@ export const Editable = (props: EditableProps) => {
             onDragOver={useCallback(
               (event: React.DragEvent<HTMLDivElement>) => {
                 if (
-                  hasTarget(editor, event.target) &&
+                  ReactEditor.hasTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onDragOver)
                 ) {
                   // Only when the target is void, call `preventDefault` to signal
@@ -1185,7 +1185,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.DragEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  hasTarget(editor, event.target) &&
+                  ReactEditor.hasTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onDragStart)
                 ) {
                   const node = ReactEditor.toSlateNode(editor, event.target)
@@ -1216,7 +1216,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.DragEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  hasTarget(editor, event.target) &&
+                  ReactEditor.hasTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onDrop)
                 ) {
                   event.preventDefault()
@@ -1261,7 +1261,7 @@ export const Editable = (props: EditableProps) => {
                   !readOnly &&
                   state.isDraggingInternally &&
                   attributes.onDragEnd &&
-                  hasTarget(editor, event.target)
+                  ReactEditor.hasTarget(editor, event.target)
                 ) {
                   attributes.onDragEnd(event)
                 }
@@ -1278,7 +1278,7 @@ export const Editable = (props: EditableProps) => {
                 if (
                   !readOnly &&
                   !state.isUpdatingSelection &&
-                  hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onFocus)
                 ) {
                   const el = ReactEditor.toDOMNode(editor, editor)
@@ -1300,7 +1300,10 @@ export const Editable = (props: EditableProps) => {
             )}
             onKeyDown={useCallback(
               (event: React.KeyboardEvent<HTMLDivElement>) => {
-                if (!readOnly && hasSelectableTarget(editor, event.target)) {
+                if (
+                  !readOnly &&
+                  ReactEditor.hasEditableTarget(editor, event.target)
+                ) {
                   androidInputManager?.handleKeyDown(event)
 
                   const { nativeEvent } = event
@@ -1573,7 +1576,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onPaste)
                 ) {
                   // COMPAT: Certain browsers don't support the `beforeinput` event, so we
@@ -1666,60 +1669,6 @@ const defaultScrollSelectionIntoView = (
     // @ts-expect-error an unorthodox delete D:
     delete leafEl.getBoundingClientRect
   }
-}
-
-/**
- * Check if the target is in the editor.
- */
-
-export const hasTarget = (
-  editor: ReactEditor,
-  target: EventTarget | null
-): target is DOMNode => {
-  return isDOMNode(target) && ReactEditor.hasDOMNode(editor, target)
-}
-
-/**
- * Check if the target is editable and in the editor.
- */
-
-export const hasEditableTarget = (
-  editor: ReactEditor,
-  target: EventTarget | null
-): target is DOMNode => {
-  return (
-    isDOMNode(target) &&
-    ReactEditor.hasDOMNode(editor, target, { editable: true })
-  )
-}
-
-/**
- * Check if the target is inside void and in an non-readonly editor.
- */
-
-export const isTargetInsideNonReadonlyVoid = (
-  editor: ReactEditor,
-  target: EventTarget | null
-): boolean => {
-  if (IS_READ_ONLY.get(editor)) return false
-
-  const slateNode =
-    hasTarget(editor, target) && ReactEditor.toSlateNode(editor, target)
-  return Editor.isVoid(editor, slateNode)
-}
-
-/**
- * Check if the target can be selectable
- */
-
-export const hasSelectableTarget = (
-  editor: ReactEditor,
-  target: EventTarget | null
-): boolean => {
-  return (
-    hasEditableTarget(editor, target) ||
-    isTargetInsideNonReadonlyVoid(editor, target)
-  )
 }
 
 /**

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -434,7 +434,7 @@ export const Editable = (props: EditableProps) => {
 
       if (
         !readOnly &&
-        hasEditableTarget(editor, event.target) &&
+        hasSelectableTarget(editor, event.target) &&
         !isDOMEventHandled(event, propsOnDOMBeforeInput)
       ) {
         // COMPAT: BeforeInput events aren't cancelable on android, so we have to handle them differently using the android input manager.
@@ -862,7 +862,7 @@ export const Editable = (props: EditableProps) => {
                   !HAS_BEFORE_INPUT_SUPPORT &&
                   !readOnly &&
                   !isEventHandled(event, attributes.onBeforeInput) &&
-                  hasEditableTarget(editor, event.target)
+                  hasSelectableTarget(editor, event.target)
                 ) {
                   event.preventDefault()
                   if (!ReactEditor.isComposing(editor)) {
@@ -1014,7 +1014,7 @@ export const Editable = (props: EditableProps) => {
             )}
             onCompositionEnd={useCallback(
               (event: React.CompositionEvent<HTMLDivElement>) => {
-                if (hasEditableTarget(editor, event.target)) {
+                if (hasSelectableTarget(editor, event.target)) {
                   if (ReactEditor.isComposing(editor)) {
                     setIsComposing(false)
                     IS_COMPOSING.set(editor, false)
@@ -1068,7 +1068,7 @@ export const Editable = (props: EditableProps) => {
             onCompositionUpdate={useCallback(
               (event: React.CompositionEvent<HTMLDivElement>) => {
                 if (
-                  hasEditableTarget(editor, event.target) &&
+                  hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onCompositionUpdate)
                 ) {
                   if (!ReactEditor.isComposing(editor)) {
@@ -1081,7 +1081,7 @@ export const Editable = (props: EditableProps) => {
             )}
             onCompositionStart={useCallback(
               (event: React.CompositionEvent<HTMLDivElement>) => {
-                if (hasEditableTarget(editor, event.target)) {
+                if (hasSelectableTarget(editor, event.target)) {
                   androidInputManager?.handleCompositionStart(event)
 
                   if (
@@ -1121,7 +1121,7 @@ export const Editable = (props: EditableProps) => {
             onCopy={useCallback(
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
-                  hasEditableTarget(editor, event.target) &&
+                  hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onCopy)
                 ) {
                   event.preventDefault()
@@ -1138,7 +1138,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  hasEditableTarget(editor, event.target) &&
+                  hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onCut)
                 ) {
                   event.preventDefault()
@@ -1278,7 +1278,7 @@ export const Editable = (props: EditableProps) => {
                 if (
                   !readOnly &&
                   !state.isUpdatingSelection &&
-                  hasEditableTarget(editor, event.target) &&
+                  hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onFocus)
                 ) {
                   const el = ReactEditor.toDOMNode(editor, editor)
@@ -1300,7 +1300,7 @@ export const Editable = (props: EditableProps) => {
             )}
             onKeyDown={useCallback(
               (event: React.KeyboardEvent<HTMLDivElement>) => {
-                if (!readOnly && hasEditableTarget(editor, event.target)) {
+                if (!readOnly && hasSelectableTarget(editor, event.target)) {
                   androidInputManager?.handleKeyDown(event)
 
                   const { nativeEvent } = event
@@ -1573,7 +1573,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  hasEditableTarget(editor, event.target) &&
+                  hasSelectableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onPaste)
                 ) {
                   // COMPAT: Certain browsers don't support the `beforeinput` event, so we
@@ -1706,6 +1706,20 @@ export const isTargetInsideNonReadonlyVoid = (
   const slateNode =
     hasTarget(editor, target) && ReactEditor.toSlateNode(editor, target)
   return Editor.isVoid(editor, slateNode)
+}
+
+/**
+ * Check if the target can be selectable
+ */
+
+export const hasSelectableTarget = (
+  editor: ReactEditor,
+  target: EventTarget | null
+): boolean => {
+  return (
+    hasEditableTarget(editor, target) ||
+    isTargetInsideNonReadonlyVoid(editor, target)
+  )
 }
 
 /**

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -33,6 +33,7 @@ import {
   DOMStaticRange,
   isDOMElement,
   isDOMSelection,
+  isDOMNode,
   normalizeDOMPoint,
   hasShadowRoot,
 } from '../utils/dom'
@@ -51,6 +52,22 @@ export interface ReactEditor extends BaseEditor {
     originEvent?: 'drag' | 'copy' | 'cut'
   ) => void
   hasRange: (editor: ReactEditor, range: Range) => boolean
+  hasTarget: (
+    editor: ReactEditor,
+    target: EventTarget | null
+  ) => target is DOMNode
+  hasEditableTarget: (
+    editor: ReactEditor,
+    target: EventTarget | null
+  ) => target is DOMNode
+  hasSelectableTarget: (
+    editor: ReactEditor,
+    target: EventTarget | null
+  ) => boolean
+  isTargetInsideNonReadonlyVoid: (
+    editor: ReactEditor,
+    target: EventTarget | null
+  ) => boolean
 }
 
 // eslint-disable-next-line no-redeclare
@@ -770,6 +787,57 @@ export const ReactEditor = {
     return (
       Editor.hasPath(editor, anchor.path) && Editor.hasPath(editor, focus.path)
     )
+  },
+
+  /**
+   * Check if the target is in the editor.
+   */
+  hasTarget(
+    editor: ReactEditor,
+    target: EventTarget | null
+  ): target is DOMNode {
+    return isDOMNode(target) && ReactEditor.hasDOMNode(editor, target)
+  },
+
+  /**
+   * Check if the target is editable and in the editor.
+   */
+  hasEditableTarget(
+    editor: ReactEditor,
+    target: EventTarget | null
+  ): target is DOMNode {
+    return (
+      isDOMNode(target) &&
+      ReactEditor.hasDOMNode(editor, target, { editable: true })
+    )
+  },
+
+  /**
+   * Check if the target can be selectable
+   */
+  hasSelectableTarget(
+    editor: ReactEditor,
+    target: EventTarget | null
+  ): boolean {
+    return (
+      ReactEditor.hasEditableTarget(editor, target) ||
+      ReactEditor.isTargetInsideNonReadonlyVoid(editor, target)
+    )
+  },
+
+  /**
+   * Check if the target is inside void and in an non-readonly editor.
+   */
+  isTargetInsideNonReadonlyVoid(
+    editor: ReactEditor,
+    target: EventTarget | null
+  ): boolean {
+    if (IS_READ_ONLY.get(editor)) return false
+
+    const slateNode =
+      ReactEditor.hasTarget(editor, target) &&
+      ReactEditor.toSlateNode(editor, target)
+    return Editor.isVoid(editor, slateNode)
   },
 
   /**


### PR DESCRIPTION
**Description**
This PR makes it possible to copy/cut void elements. 

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4808 and https://github.com/ianstormtaylor/slate/issues/4806

**Example**
Before
![Kapture 2022-09-13 at 11 50 06](https://user-images.githubusercontent.com/15036127/189903295-0918068e-96bc-40d1-b18a-d82b7a200e36.gif)
After: 
![Kapture 2022-09-13 at 12 46 02](https://user-images.githubusercontent.com/15036127/189904637-8dbe6b89-a082-4fe3-b92d-81db1c0a9f11.gif)


**Context**
Created a new function hasSelectableTarget that checks if hasEditableTarget and isTargetInsideNonReadonlyVoid. 
Using this function instead of hasEditableTarget so we are not excluding nonReadonlyVoids fx onCopy and onCut and onPaste

I did not add Cypress tests for the new logic since Cypress does not support copy/paste and the only solution I found was to use some package like https://www.npmjs.com/package/clipboardy. If we want to include the package or if there is a better solution for it I'm happy to add the tests.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

