### PR TITLE
Make it possible to delete block elements with backspace on Chrome and Safari

### DIFF
--- a/.changeset/good-cats-warn.md
+++ b/.changeset/good-cats-warn.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Make it possible to delete block elements with backspace in Chrome and Safari

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1555,7 +1555,8 @@ export const Editable = (props: EditableProps) => {
                         if (
                           Element.isElement(currentNode) &&
                           Editor.isVoid(editor, currentNode) &&
-                          Editor.isInline(editor, currentNode)
+                          (Editor.isInline(editor, currentNode) ||
+                            Editor.isBlock(editor, currentNode))
                         ) {
                           event.preventDefault()
                           Editor.deleteBackward(editor, { unit: 'block' })


### PR DESCRIPTION
**Description**
Make it possible to delete block elements with backspace on Chrome and Safari

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5122

**Example**
Before Chrome: 
![Kapture 2022-09-13 at 13 10 46](https://user-images.githubusercontent.com/15036127/189918269-fdb6341a-d5e3-462a-a9fa-9b26fc4ef5c2.gif)

After Chrome: 
![Kapture 2022-09-13 at 13 13 33](https://user-images.githubusercontent.com/15036127/189918292-650ea29b-750b-44dd-a4e8-4905d546794f.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

