### PR TITLE
Cleanup and fix insertion placeholder mark compare

### DIFF
--- a/.changeset/pink-panthers-appear.md
+++ b/.changeset/pink-panthers-appear.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Cleanup and fix insertion placeholder mark compare

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -765,9 +765,12 @@ export const Editable = (props: EditableProps) => {
 
   if (editor.selection && Range.isCollapsed(editor.selection) && marks) {
     const { anchor } = editor.selection
-    const { text, ...rest } = Node.leaf(editor, anchor.path)
+    const leaf = Node.leaf(editor, anchor.path)
+    const { text, ...rest } = leaf
 
-    if (!Text.equals(rest as Text, marks as Text, { loose: true })) {
+    // While marks isn't a 'complete' text, we can still use loose Text.equals
+    // here which only compares marks anyway.
+    if (!Text.equals(leaf, marks as Text, { loose: true })) {
       state.hasMarkPlaceholder = true
 
       const unset = Object.fromEntries(
@@ -792,8 +795,11 @@ export const Editable = (props: EditableProps) => {
       const { selection } = editor
       if (selection) {
         const { anchor } = selection
-        const { text, ...rest } = Node.leaf(editor, anchor.path)
-        if (!Text.equals(rest as Text, marks as Text, { loose: true })) {
+        const text = Node.leaf(editor, anchor.path)
+
+        // While marks isn't a 'complete' text, we can still use loose Text.equals
+        // here which only compares marks anyway.
+        if (marks && !Text.equals(text, marks as Text, { loose: true })) {
           EDITOR_TO_PENDING_INSERTION_MARKS.set(editor, marks)
           return
         }


### PR DESCRIPTION
**Description**
Tiny cleanup and fix as discussed in https://github.com/ianstormtaylor/slate/discussions/5125

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

