### PR TITLE
transform.delete and transform.insertFragment performance optimize

### DIFF
--- a/.changeset/new-needles-itch.md
+++ b/.changeset/new-needles-itch.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+transform.delete and transform.insertFragment performance optimize

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -1,4 +1,3 @@
-import { produce } from 'immer'
 import { Operation } from '..'
 import { TextDirection } from './types'
 
@@ -373,125 +372,125 @@ export const Path: PathInterface = {
     operation: Operation,
     options: PathTransformOptions = {}
   ): Path | null {
-    return produce(path, p => {
-      const { affinity = 'forward' } = options
+    if (!path) return null
 
-      // PERF: Exit early if the operation is guaranteed not to have an effect.
-      if (!path || path?.length === 0) {
-        return
-      }
+    // PERF: use destructing instead of immer
+    const p = [...path]
+    const { affinity = 'forward' } = options
 
-      if (p === null) {
-        return null
-      }
+    // PERF: Exit early if the operation is guaranteed not to have an effect.
+    if (path.length === 0) {
+      return p
+    }
 
-      switch (operation.type) {
-        case 'insert_node': {
-          const { path: op } = operation
+    switch (operation.type) {
+      case 'insert_node': {
+        const { path: op } = operation
 
-          if (
-            Path.equals(op, p) ||
-            Path.endsBefore(op, p) ||
-            Path.isAncestor(op, p)
-          ) {
-            p[op.length - 1] += 1
-          }
-
-          break
+        if (
+          Path.equals(op, p) ||
+          Path.endsBefore(op, p) ||
+          Path.isAncestor(op, p)
+        ) {
+          p[op.length - 1] += 1
         }
 
-        case 'remove_node': {
-          const { path: op } = operation
+        break
+      }
 
-          if (Path.equals(op, p) || Path.isAncestor(op, p)) {
+      case 'remove_node': {
+        const { path: op } = operation
+
+        if (Path.equals(op, p) || Path.isAncestor(op, p)) {
+          return null
+        } else if (Path.endsBefore(op, p)) {
+          p[op.length - 1] -= 1
+        }
+
+        break
+      }
+
+      case 'merge_node': {
+        const { path: op, position } = operation
+
+        if (Path.equals(op, p) || Path.endsBefore(op, p)) {
+          p[op.length - 1] -= 1
+        } else if (Path.isAncestor(op, p)) {
+          p[op.length - 1] -= 1
+          p[op.length] += position
+        }
+
+        break
+      }
+
+      case 'split_node': {
+        const { path: op, position } = operation
+
+        if (Path.equals(op, p)) {
+          if (affinity === 'forward') {
+            p[p.length - 1] += 1
+          } else if (affinity === 'backward') {
+            // Nothing, because it still refers to the right path.
+          } else {
             return null
-          } else if (Path.endsBefore(op, p)) {
-            p[op.length - 1] -= 1
           }
-
-          break
+        } else if (Path.endsBefore(op, p)) {
+          p[op.length - 1] += 1
+        } else if (Path.isAncestor(op, p) && path[op.length] >= position) {
+          p[op.length - 1] += 1
+          p[op.length] -= position
         }
 
-        case 'merge_node': {
-          const { path: op, position } = operation
-
-          if (Path.equals(op, p) || Path.endsBefore(op, p)) {
-            p[op.length - 1] -= 1
-          } else if (Path.isAncestor(op, p)) {
-            p[op.length - 1] -= 1
-            p[op.length] += position
-          }
-
-          break
-        }
-
-        case 'split_node': {
-          const { path: op, position } = operation
-
-          if (Path.equals(op, p)) {
-            if (affinity === 'forward') {
-              p[p.length - 1] += 1
-            } else if (affinity === 'backward') {
-              // Nothing, because it still refers to the right path.
-            } else {
-              return null
-            }
-          } else if (Path.endsBefore(op, p)) {
-            p[op.length - 1] += 1
-          } else if (Path.isAncestor(op, p) && path[op.length] >= position) {
-            p[op.length - 1] += 1
-            p[op.length] -= position
-          }
-
-          break
-        }
-
-        case 'move_node': {
-          const { path: op, newPath: onp } = operation
-
-          // If the old and new path are the same, it's a no-op.
-          if (Path.equals(op, onp)) {
-            return
-          }
-
-          if (Path.isAncestor(op, p) || Path.equals(op, p)) {
-            const copy = onp.slice()
-
-            if (Path.endsBefore(op, onp) && op.length < onp.length) {
-              copy[op.length - 1] -= 1
-            }
-
-            return copy.concat(p.slice(op.length))
-          } else if (
-            Path.isSibling(op, onp) &&
-            (Path.isAncestor(onp, p) || Path.equals(onp, p))
-          ) {
-            if (Path.endsBefore(op, p)) {
-              p[op.length - 1] -= 1
-            } else {
-              p[op.length - 1] += 1
-            }
-          } else if (
-            Path.endsBefore(onp, p) ||
-            Path.equals(onp, p) ||
-            Path.isAncestor(onp, p)
-          ) {
-            if (Path.endsBefore(op, p)) {
-              p[op.length - 1] -= 1
-            }
-
-            p[onp.length - 1] += 1
-          } else if (Path.endsBefore(op, p)) {
-            if (Path.equals(onp, p)) {
-              p[onp.length - 1] += 1
-            }
-
-            p[op.length - 1] -= 1
-          }
-
-          break
-        }
+        break
       }
-    })
+
+      case 'move_node': {
+        const { path: op, newPath: onp } = operation
+
+        // If the old and new path are the same, it's a no-op.
+        if (Path.equals(op, onp)) {
+          return p
+        }
+
+        if (Path.isAncestor(op, p) || Path.equals(op, p)) {
+          const copy = onp.slice()
+
+          if (Path.endsBefore(op, onp) && op.length < onp.length) {
+            copy[op.length - 1] -= 1
+          }
+
+          return copy.concat(p.slice(op.length))
+        } else if (
+          Path.isSibling(op, onp) &&
+          (Path.isAncestor(onp, p) || Path.equals(onp, p))
+        ) {
+          if (Path.endsBefore(op, p)) {
+            p[op.length - 1] -= 1
+          } else {
+            p[op.length - 1] += 1
+          }
+        } else if (
+          Path.endsBefore(onp, p) ||
+          Path.equals(onp, p) ||
+          Path.isAncestor(onp, p)
+        ) {
+          if (Path.endsBefore(op, p)) {
+            p[op.length - 1] -= 1
+          }
+
+          p[onp.length - 1] += 1
+        } else if (Path.endsBefore(op, p)) {
+          if (Path.equals(onp, p)) {
+            p[onp.length - 1] += 1
+          }
+
+          p[op.length - 1] -= 1
+        }
+
+        break
+      }
+    }
+
+    return p
   },
 }

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -187,9 +187,13 @@ export const TextTransforms: TextTransforms = {
         }
       }
 
-      for (const pathRef of pathRefs) {
-        const path = pathRef.unref()!
-        Transforms.removeNodes(editor, { at: path, voids })
+      const middlePaths = pathRefs
+        .reverse()
+        .map(r => r.unref())
+        .filter((r): r is Path => !!r)
+
+      for (const p of middlePaths) {
+        Transforms.removeNodes(editor, { at: p, voids })
       }
 
       if (!endVoid) {

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -187,14 +187,11 @@ export const TextTransforms: TextTransforms = {
         }
       }
 
-      const middlePaths = pathRefs
+      pathRefs
         .reverse()
         .map(r => r.unref())
-        .filter((r): r is Path => !!r)
-
-      for (const p of middlePaths) {
-        Transforms.removeNodes(editor, { at: p, voids })
-      }
+        .filter((r): r is Path => r !== null)
+        .forEach(p => Transforms.removeNodes(editor, { at: p, voids }))
 
       if (!endVoid) {
         const point = endRef.current!


### PR DESCRIPTION
**Description**
delete and insert large fragment can be very time consuming，the time complexity is `O(n2)`

**Example**
```ts
import { createEditor, Editor, Descendant, Transforms } from "slate";
import type { Descendant } from "slate";

const createP = (i: string = '') => ({
  type: "p",
  children: [
    { text: `${i} This is editable ` },
    { text: 'rich', bold: true },
    { text: ' text, ' },
    { text: 'much', italic: true },
    { text: ' better than a ' },
    { text: '<textarea>', code: true },
    { text: '!' },
  ],
})

// one thousand paragraphs
const largeFragment: Descendant[] = new Array(2000).fill(1).map((_, i) => createP(i + ''));

export const testDelete = () => {
  const editor = createEditor();
  editor.children = largeFragment;

  const sel = Editor.range(editor, []);
  Transforms.select(editor, sel);

  console.time("delete");
  Transforms.delete(editor);
  console.timeEnd("delete");
};

```

environment
* `MacBook Pro (13-inch, 2019) 2.4 GHz 4 Intel Core i5`
* `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36`

result: `2000` pargagraphs
| seq       | time(millisecond) |
|---------|----------|
| 1       | 12210.78 |
| 2       | 12882.65 |
| 3       | 13567.65 |
| 4       | 13315.84 |
| average | 12994.23 |

but with `200` pargagraphs
| seq       | time(millisecond) |
|---------|----------|
| 1       | 191 |
| 2       | 179 |
| 3       | 177 |
| 4       | 180 |
| average | 181 |

**Context**
The reason is related to the number of **path refs** in the apply process. 

for `transform.delete`, The following code causes each **apply** to process the **path transform** of the first i-1 paragraphs.
```ts
for (const pathRef of pathRefs) {
    const path = pathRef.unref()!
    Transforms.removeNodes(editor, { at: path, voids })
}
```
we can remove nodes from last to first to avoid use path ref.
```ts
const middlePaths = pathRefs
  .reverse()
  .map(r => r.unref())
  .filter((r): r is Path => !!r)

for (const p of middlePaths) {
  Transforms.removeNodes(editor, { at: p, voids })
}
```

for `transform.insertFragment`, the `O(n2)` has something todo with the dirtyPath logic, each insertNode will add new dirtyPath to DIRTY_PATHS and subsquent `apply` will transform all previous dirtyPath。I hadn't figure out how to opitimize it。according to the logic, move large fragment may also has the same problem。

I just add a tiny optimization to `Path.transform`, array destruction is faster than `immer's produce`, and it also make remove 2000 paragraphs **3x faster**。

**after optimize**

delete 2000 paragraphs
| seq       | time(millisecond) |
|---------|----------|
| 1       | 896 |
| 2       | 843 |
| 3       | 853 |
| 4       | 850 |
| average | 860 |

delete 200 paragraphs
| seq       | time(millisecond) |
|---------|----------|
| 1       | 49 |
| 2       | 46 |
| 3       | 47 |
| 4       | 44 |
| average | 46 |

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

