### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   ci:
     name: ${{ matrix.command }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -6,8 +6,16 @@ on:
     types:
       - created
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  pull-requests: read # to get info about PR (cirrus-actions/rebase)
+
 jobs:
   rebase:
+    permissions:
+      contents: write # to push code to rebase (cirrus-actions/rebase)
+      pull-requests: read # to get info about PR (cirrus-actions/rebase)
+
     name: rebase
     runs-on: ubuntu-latest
     if: |
@@ -25,6 +33,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release_next:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
+
     name: release:next
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - main
 
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
+
     name: ${{ matrix.channel }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.