### PR TITLE
fix scrollIntoView when selection is collapsed inside mark placeholder

### DIFF
--- a/.changeset/dry-nails-brake.md
+++ b/.changeset/dry-nails-brake.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix scrollIntoView when selection is collapsed inside mark placeholder

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -35,6 +35,7 @@ import {
   isDOMSelection,
   normalizeDOMPoint,
   hasShadowRoot,
+  DOMText,
 } from '../utils/dom'
 import { IS_CHROME, IS_FIREFOX, IS_ANDROID } from '../utils/environment'
 
@@ -346,8 +347,15 @@ export const ReactEditor = {
         point.offset === end &&
         nextText?.hasAttribute('data-slate-mark-placeholder')
       ) {
+        const domText = nextText.childNodes[0]
+
         domPoint = [
-          nextText,
+          // COMPAT: If we don't explicity set the dom point to be on the actual
+          // dom text element, chrome will put the selection behind the actual dom
+          // text element, causing domRange.getBoundingClientRect() calls on a collapsed
+          // selection to return incorrect zero values (https://bugs.chromium.org/p/chromium/issues/detail?id=435438)
+          // which will cause issues when scrolling to it.
+          domText instanceof DOMText ? domText : nextText,
           nextText.textContent?.startsWith('\uFEFF') ? 1 : 0,
         ]
         break


### PR DESCRIPTION
**Description**
Updates `toDOMPoint` to explicitly put the dom point into the dom text element inside mark placeholders to get around https://bugs.chromium.org/p/chromium/issues/detail?id=435438. Seems like we didn't run into this issue beforehand because zero-widths typically have surrounding content (like <br/> on line break zero-widths), which forces chrome to put the selection into the actual dom text element resulting in `getBoundingClientRect` returning the correct values.

**Example**
Before:

https://user-images.githubusercontent.com/13185548/192734925-81103a0f-e345-4cb6-807c-e0a705a3a915.mov

After:

https://user-images.githubusercontent.com/13185548/192734942-9b702018-d0b1-40d0-8613-8f921da86676.mov

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

