### PR TITLE
Ensure the min-height for placeholders is set on the correct editor

### DIFF
--- a/.changeset/funny-sheep-double.md
+++ b/.changeset/funny-sheep-double.md
@@ -1,5 +1,5 @@
 ---
-"slate-react": patch
+'slate-react': patch
 ---
 
 Ensure the min-height for placeholders is set on the correct editor

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -7,6 +7,7 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
+import { ReactEditor } from '..'
 
 /**
  * Individual leaves in a text node with unique formatting.
@@ -34,9 +35,7 @@ const Leaf = (props: {
 
   useEffect(() => {
     const placeholderEl = placeholderRef?.current
-    const editorEl = document.querySelector<HTMLDivElement>(
-      '[data-slate-editor="true"]'
-    )
+    const editorEl = ReactEditor.toDOMNode(editor, editor)
 
     if (!placeholderEl || !editorEl) {
       return


### PR DESCRIPTION
**Description**
Selector the correct DOM element on which to set the min-height in the case that the Editable has a custom renderElement set.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5147

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

