### PR TITLE
Revert insertText breaking change that deletes fragment (fixes #5153)

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -648,13 +648,6 @@ export const Editable = (props: EditableProps) => {
           case 'insertFromYank':
           case 'insertReplacementText':
           case 'insertText': {
-            const { selection } = editor
-            if (selection) {
-              if (Range.isExpanded(selection)) {
-                Editor.deleteFragment(editor)
-              }
-            }
-
             if (type === 'insertFromComposition') {
               // COMPAT: in Safari, `compositionend` is dispatched after the
               // `beforeinput` for "insertFromComposition". But if we wait for it


### PR DESCRIPTION
**Description**
This reverts https://github.com/ianstormtaylor/slate/pull/4868.

The issue reported at https://github.com/ianstormtaylor/slate/issues/4862 is a valid complaint, but the change is not an appropriate fix. It is a serious breaking change, reported in https://github.com/ianstormtaylor/slate/issues/5153.

If we wish to fix Chromium's triple-click bug, we should do so by unhanging the selection when it is created; not by changing insertText behavior.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5153

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

