### PR TITLE
fix: error getting parentEntry in selection range

### DIFF
--- a/.changeset/tame-melons-clap.md
+++ b/.changeset/tame-melons-clap.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fixed above method that failed to get parentEntry when selection was range

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -357,8 +357,18 @@ export const Editor: EditorInterface = {
       match,
       reverse,
     })) {
-      if (!Text.isText(n) && !Path.equals(path, p)) {
-        return [n, p]
+      if (Text.isText(n)) return
+      if (Range.isRange(at)) {
+        if (
+          Path.isAncestor(p, at.anchor.path) &&
+          Path.isAncestor(p, at.focus.path)
+        ) {
+          return [n, p]
+        }
+      } else {
+        if (!Path.equals(path, p)) {
+          return [n, p]
+        }
       }
     }
   },

--- a/packages/slate/test/interfaces/Editor/above/range.tsx
+++ b/packages/slate/test/interfaces/Editor/above/range.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <block>
+        <block>one</block>
+      </block>
+      <block>two</block>
+    </block>
+  </editor>
+)
+const range = {
+  anchor: { offset: 0, path: [0, 0, 0, 0] },
+  focus: { offset: 0, path: [0, 1, 0] },
+}
+export const test = editor => {
+  return Editor.above(editor, {
+    at: range,
+    match: n => Editor.isBlock(editor, n),
+  })
+}
+export const output = [
+  <block>
+    <block>
+      <block>one</block>
+    </block>
+    <block>two</block>
+  </block>,
+  [0],
+]


### PR DESCRIPTION
**Description**
Wrong matching ancestor above a location in the document when selection range multiple nodes.

**Jsfiddle**
[demo](https://jsfiddle.net/Steven_zhong/wsoaL4zk/45/)

**Context**
The correctness of the method is guaranteed by different verification processing logic for points, paths or range.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

