### PR TITLE
Fix typos in error messages + Improve searchability

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -29,14 +29,14 @@ export const Slate = (props: {
   const [context, setContext] = React.useState<SlateContextValue>(() => {
     if (!Node.isNodeList(value)) {
       throw new Error(
-        `[Slate] value is invalid! Expected a list of elements` +
-          `but got: ${Scrubber.stringify(value)}`
+        `[Slate] value is invalid! Expected a list of elements but got: ${Scrubber.stringify(
+          value
+        )}`
       )
     }
     if (!Editor.isEditor(editor)) {
       throw new Error(
-        `[Slate] editor is invalid! you passed:` +
-          `${Scrubber.stringify(editor)}`
+        `[Slate] editor is invalid! You passed: ${Scrubber.stringify(editor)}`
       )
     }
     editor.children = value


### PR DESCRIPTION
**Description**
This PR fixes two typos in error messages:
- Adds missing space in `elementsbut`
- Capitalises `you` in `you passed`

It also removes the line breaks in the string interpolation for these error messages to make it easier to find them in search, e.g. currently searching the codebase for `Expected a list of elements but got:` yields no results.

**Issue**
N/A

**Example**
`Uncaught Error: [Slate] value is invalid! Expected a list of elementsbut got: [{}]` -> `Uncaught Error: [Slate] value is invalid! Expected a list of elements but got: [{}]`

`Uncaught Error: [Slate] editor is invalid! you passed: {}` -> `Uncaught Error: [Slate] editor is invalid! You passed: {}` 

**Context**
 N/A

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.) - N/A
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.) - N/A

