### PR TITLE
Docs: fix incorrect name.

### DIFF
--- a/docs/concepts/11-normalizing.md
+++ b/docs/concepts/11-normalizing.md
@@ -76,7 +76,7 @@ You might at first think this is odd, because with the `return` there, the origi
 
 But, there's a slight "trick" to normalizing.
 
-When you do call `Editor.unwrapNodes`, you're actually changing the content of the node that is currently being normalized. So even though you're ending the current normalization pass, by making a change to the node you're kicking off a _new_ normalization pass. This results in a sort of _recursive_ normalizing.
+When you do call `Transforms.unwrapNodes`, you're actually changing the content of the node that is currently being normalized. So even though you're ending the current normalization pass, by making a change to the node you're kicking off a _new_ normalization pass. This results in a sort of _recursive_ normalizing.
 
 This multi-pass characteristic makes it _much_ easier to write normalizations, because you only ever have to worry about fixing a single issue at once, and not fixing _every_ possible issue that could be putting a node in an invalid state.
 


### PR DESCRIPTION
This is a documentation fix only.

A reference to the preceding code sample incorrectly mentions `Editor.unwrapNodes` instead of `Transforms.unwrapNodes`.