### PR TITLE
Fix reporting of marks on a markableVoid

### DIFF
--- a/.changeset/sixty-ghosts-invent.md
+++ b/.changeset/sixty-ghosts-invent.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Report marks applied to a markableVoid if selection is collapsed

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -816,16 +816,21 @@ export const Editor: EditorInterface = {
 
     if (anchor.offset === 0) {
       const prev = Editor.previous(editor, { at: path, match: Text.isText })
-      const block = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+      const markedVoid = Editor.above(editor, {
+        match: n => Editor.isVoid(editor, n) && editor.markableVoid(n),
       })
+      if (!markedVoid) {
+        const block = Editor.above(editor, {
+          match: n => Editor.isBlock(editor, n),
+        })
 
-      if (prev && block) {
-        const [prevNode, prevPath] = prev
-        const [, blockPath] = block
+        if (prev && block) {
+          const [prevNode, prevPath] = prev
+          const [, blockPath] = block
 
-        if (Path.isAncestor(blockPath, prevPath)) {
-          node = prevNode as Text
+          if (Path.isAncestor(blockPath, prevPath)) {
+            node = prevNode as Text
+          }
         }
       }
     }

--- a/packages/slate/test/interfaces/Editor/marks/markable-void-collapsed.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/markable-void-collapsed.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>word</text>
+      <inline void markable>
+        <text bold />
+        <cursor />
+      </inline>
+      <text />
+    </block>
+  </editor>
+)
+export const test = editor => {
+  editor.markableVoid = node => node.markable
+  return Editor.marks(editor)
+}
+export const output = { bold: true }

--- a/packages/slate/test/interfaces/Editor/marks/markable-voids-mixed.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/markable-voids-mixed.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>word</text>
+      <inline void markable>
+        <anchor />
+        <text bold />
+      </inline>
+      <text bold>
+        <anchor />
+        bold
+      </text>
+      <inline void markable>
+        <text bold italic />
+      </inline>
+      <text bold italic>
+        bold italic
+        <focus />
+      </text>
+      <text />
+    </block>
+  </editor>
+)
+export const test = editor => {
+  editor.markableVoid = node => node.markable
+  return Editor.marks(editor)
+}
+export const output = { bold: true }

--- a/packages/slate/test/interfaces/Editor/marks/mixed-text.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/mixed-text.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      plain
+      <text bold>
+        <anchor />
+        bold
+      </text>
+      <text bold italic>
+        bold italic
+        <focus />
+      </text>
+    </block>
+    <block>block two</block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.marks(editor)
+}
+export const output = { bold: true }

--- a/packages/slate/test/interfaces/Editor/marks/text-collapsed.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/text-collapsed.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      plain
+      <text bold>
+        text that is
+        <cursor />
+        bold
+      </text>
+      <text bold italic>
+        bold italic
+      </text>
+    </block>
+    <block>block two</block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.marks(editor)
+}
+export const output = { bold: true }


### PR DESCRIPTION
**Description**
Now that `markableVoid()` allows marks to be applied to inline voids, our users discovered a problem where the marks applied to a currently-selected markable void are not reported properly by `Editor.marks()`

I have added a few unit tests for the previously un-tested `Editor.marks()`, including one for markable void that failed before the fix (markable-void-collapsed).

The `if (anchor.offset === 0)` test in `Editor.marks()` that checks if the `prevPath` is in the same block was effectively returning the marks of any Text that preceded the selected markable void.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

