### PR TITLE
Add hanging option to unsetNodes

### DIFF
--- a/.changeset/light-moose-jam.md
+++ b/.changeset/light-moose-jam.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Add hanging option to unsetNodes so it matches setNodes

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -101,7 +101,7 @@ Options supported: `NodeOptions & {hanging?: boolean, split?: boolean}`. For `op
 
 Unset properties of nodes at the specified location. If no location is specified, use the selection.
 
-Options supported: `NodeOptions & {split?: boolean}`. For `options.mode`, `'all'` is also supported.
+Options supported: `NodeOptions & {hanging?: boolean, split?: boolean}`. For `options.mode`, `'all'` is also supported.
 
 #### `Transforms.liftNodes(editor: Editor, options?)`
 

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -100,6 +100,7 @@ export interface NodeTransforms {
       at?: Location
       match?: NodeMatch<T>
       mode?: MaximizeMode
+      hanging?: boolean
       split?: boolean
       voids?: boolean
     }
@@ -825,6 +826,7 @@ export const NodeTransforms: NodeTransforms = {
       at?: Location
       match?: NodeMatch<T>
       mode?: MaximizeMode
+      hanging?: boolean
       split?: boolean
       voids?: boolean
     } = {}


### PR DESCRIPTION
**Description**
Since `unsetNodes` really just calls `setNodes`, it seems like it should offer the same options.
Without this change, doing something like applying a mark to the contents of a selected block with `hanging` works one way, while trying to do the reverse (remove the mark) cannot include the "hang".

**Context**
We're running into some trouble with how `unhangRange` treats inline voids when they are at the end of a block (will open a separate issue for this), but an initial work-around was to change our code that adds marks to include `hanging: true` but we immediately discovered that removing a mark from the same range it was just applied to becomes impossible.
It just seems like `unsetNodes` and `setNodes` should be "symmetric".

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

