### PR TITLE
Fix overly-aggressive unhangRange

### DIFF
--- a/.changeset/purple-planes-study.md
+++ b/.changeset/purple-planes-study.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Stops Editor.unhangRange() from adjusting the range in some cases when it was not actually hanging

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1632,13 +1632,19 @@ export const Editor: EditorInterface = {
     let [start, end] = Range.edges(range)
 
     // PERF: exit early if we can guarantee that the range isn't hanging.
-    if (start.offset !== 0 || end.offset !== 0 || Range.isCollapsed(range)) {
+    if (
+      start.offset !== 0 ||
+      end.offset !== 0 ||
+      Range.isCollapsed(range) ||
+      Path.hasPrevious(end.path)
+    ) {
       return range
     }
 
     const endBlock = Editor.above(editor, {
       at: end,
       match: n => Editor.isBlock(editor, n),
+      voids,
     })
     const blockPath = endBlock ? endBlock[1] : []
     const first = Editor.start(editor, start)

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -180,7 +180,7 @@ export const NodeTransforms: NodeTransforms = {
 
       if (Range.isRange(at)) {
         if (!hanging) {
-          at = Editor.unhangRange(editor, at)
+          at = Editor.unhangRange(editor, at, { voids })
         }
 
         if (Range.isCollapsed(at)) {
@@ -345,7 +345,7 @@ export const NodeTransforms: NodeTransforms = {
       }
 
       if (!hanging && Range.isRange(at)) {
-        at = Editor.unhangRange(editor, at)
+        at = Editor.unhangRange(editor, at, { voids })
       }
 
       if (Range.isRange(at)) {
@@ -543,7 +543,7 @@ export const NodeTransforms: NodeTransforms = {
       }
 
       if (!hanging && Range.isRange(at)) {
-        at = Editor.unhangRange(editor, at)
+        at = Editor.unhangRange(editor, at, { voids })
       }
 
       const depths = Editor.nodes(editor, { at, match, mode, voids })
@@ -598,7 +598,7 @@ export const NodeTransforms: NodeTransforms = {
       }
 
       if (!hanging && Range.isRange(at)) {
-        at = Editor.unhangRange(editor, at)
+        at = Editor.unhangRange(editor, at, { voids })
       }
 
       if (split && Range.isRange(at)) {

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -265,7 +265,7 @@ export const TextTransforms: TextTransforms = {
         return
       } else if (Range.isRange(at)) {
         if (!hanging) {
-          at = Editor.unhangRange(editor, at)
+          at = Editor.unhangRange(editor, at, { voids })
         }
 
         if (Range.isCollapsed(at)) {

--- a/packages/slate/test/interfaces/Editor/unhangRange/block-hanging-over-non-empty-void-with-voids-option.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/block-hanging-over-non-empty-void-with-voids-option.tsx
@@ -8,11 +8,11 @@ export const input = (
       <anchor />
       This is a first paragraph
     </block>
-    <block>
-      This is the second paragraph
-      {/* unhang should move focus to here because, without `voids` set, it should skip over void block below */}
+    <block>This is the second paragraph</block>
+    <block void>
+      This is the third paragraph
+      {/* unhang should move focus to here */}
     </block>
-    <block void>This void paragraph gets skipped over</block>
     <block>
       <focus />
     </block>
@@ -20,10 +20,10 @@ export const input = (
 )
 
 export const test = editor => {
-  return Editor.unhangRange(editor, editor.selection)
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
 }
 
 export const output = {
   anchor: { path: [0, 0], offset: 0 },
-  focus: { path: [1, 0], offset: 28 },
+  focus: { path: [2, 0], offset: 27 },
 }

--- a/packages/slate/test/interfaces/Editor/unhangRange/inline-at-end.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/inline-at-end.tsx
@@ -7,23 +7,24 @@ export const input = (
     <block>
       <anchor />
       This is a first paragraph
+      <inline void>
+        <text />
+      </inline>
+      <text />
+      {/* unhang should move focus to here */}
     </block>
-    <block>
-      This is the second paragraph
-      {/* unhang should move focus to here because, without `voids` set, it should skip over void block below */}
-    </block>
-    <block void>This void paragraph gets skipped over</block>
     <block>
       <focus />
+      This is the second paragraph
     </block>
   </editor>
 )
 
 export const test = editor => {
-  return Editor.unhangRange(editor, editor.selection)
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
 }
 
 export const output = {
   anchor: { path: [0, 0], offset: 0 },
-  focus: { path: [1, 0], offset: 28 },
+  focus: { path: [0, 2], offset: 0 },
 }

--- a/packages/slate/test/interfaces/Editor/unhangRange/multi-block-inline-at-end.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/multi-block-inline-at-end.tsx
@@ -6,24 +6,32 @@ export const input = (
   <editor>
     <block>
       <anchor />
-      This is a first paragraph
+      This is the first paragraph
+      <inline void>
+        <text />
+      </inline>
+      <text />
     </block>
     <block>
       This is the second paragraph
-      {/* unhang should move focus to here because, without `voids` set, it should skip over void block below */}
+      <inline void>
+        <text />
+      </inline>
+      <text />
+      {/* unhang should move focus to here */}
     </block>
-    <block void>This void paragraph gets skipped over</block>
     <block>
       <focus />
+      This is the third paragraph
     </block>
   </editor>
 )
 
 export const test = editor => {
-  return Editor.unhangRange(editor, editor.selection)
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
 }
 
 export const output = {
   anchor: { path: [0, 0], offset: 0 },
-  focus: { path: [1, 0], offset: 28 },
+  focus: { path: [1, 2], offset: 0 },
 }

--- a/packages/slate/test/interfaces/Editor/unhangRange/not-hanging-inline-at-end.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/not-hanging-inline-at-end.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+/* The starting selection range is not hanging, so should not be adjusted */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is the first paragraph
+      <inline void>
+        <text />
+      </inline>
+      <text>
+        <focus />
+      </text>
+    </block>
+    <block>This is the second paragraph</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [0, 2], offset: 0 },
+}

--- a/packages/slate/test/interfaces/Editor/unhangRange/not-hanging-multi-block-inline-at-end.tsx
+++ b/packages/slate/test/interfaces/Editor/unhangRange/not-hanging-multi-block-inline-at-end.tsx
@@ -1,0 +1,36 @@
+/** @jsx jsx */
+/* The starting selection range is not hanging, so should not be adjusted */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <anchor />
+      This is the first paragraph
+      <inline void>
+        <text />
+      </inline>
+      <text />
+    </block>
+    <block>
+      This is the second paragraph
+      <inline void>
+        <text />
+      </inline>
+      <text>
+        <focus />
+      </text>
+    </block>
+    <block>This is the third paragraph</block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.unhangRange(editor, editor.selection, { voids: true })
+}
+
+export const output = {
+  anchor: { path: [0, 0], offset: 0 },
+  focus: { path: [1, 2], offset: 0 },
+}

--- a/packages/slate/test/transforms/delete/voids-false/inline-over.tsx
+++ b/packages/slate/test/transforms/delete/voids-false/inline-over.tsx
@@ -28,4 +28,3 @@ export const output = (
     </block>
   </editor>
 )
-export const skip = true

--- a/packages/slate/test/transforms/insertText/selection/block-hanging.tsx
+++ b/packages/slate/test/transforms/insertText/selection/block-hanging.tsx
@@ -25,4 +25,3 @@ export const output = (
     <block>two</block>
   </editor>
 )
-export const skip = true

--- a/packages/slate/test/transforms/setNodes/marks/mark-void-range-hanging.tsx
+++ b/packages/slate/test/transforms/setNodes/marks/mark-void-range-hanging.tsx
@@ -47,5 +47,3 @@ export const output = (
     </block>
   </editor>
 )
-// TODO this has to be skipped because the second void and the final empty text fail to be marked bold
-export const skip = true


### PR DESCRIPTION
**Description**
`Editor.unhangRange()` could decide to proceed with an adjustment in cases where the range was not hanging. Because the algorithm it uses **always** skips over the first node it encounters, this meant the selection was adjusted in non-hanging cases. This change reduces the chances of an incorrect decision to adjust. Transforms now pass the `voids` flag to `unhangRange()` as it seems logical that the adjusted range should reflect the intention of the operation.

This change fixes a unit test I added for markable voids that had to be skipped because of the `unhangRange()` error, and fixes a couple other long-skipped tests.

**Example**
Previous code behavior in the Mentions example when the range is **not** hanging and the word "Test" is typed:
![BadUnhangRange](https://user-images.githubusercontent.com/139918/201200594-e6e8fcdc-c750-440d-a86e-74d527ce8111.gif)
Because the range gets adjusted even though it is not hanging, the inline element at the end of the line remains.

New code behavior in the same scenario:
![FixedUnhangRange](https://user-images.githubusercontent.com/139918/201201066-f65d92be-8b20-4474-aaa2-c656f606ab49.gif)

**Context**
The `unhangRange` logic error mostly centers around testing for `offset === 0` in the `end` of the range. This meant that if the end of the selection is in or after an inline void element the adjustment would be triggered incorrectly because of the empty Texts associated and adjacent to those.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

