### PR TITLE
remove duplicate useState import

### DIFF
--- a/docs/concepts/12-typescript.md
+++ b/docs/concepts/12-typescript.md
@@ -38,7 +38,7 @@ declare module 'slate' {
 Annotate the editor's initial value w/ `Descendant[]`.
 
 ```tsx
-import React, { useState, useState } from 'react'
+import React, { useState } from 'react'
 import { createEditor, Descendant } from 'slate'
 import { Slate, Editable, withReact } from 'slate-react'
 


### PR DESCRIPTION
**Description**
Remove duplicate useState import from React.

**Example**
![image](https://user-images.githubusercontent.com/42255099/201225498-dafe5474-b4ad-4660-aa51-7bc2bdfa4a83.png)


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)


