### PR TITLE
fix: The content with `\n` pasted from the clipboard is empty.

### DIFF
--- a/.changeset/lazy-files-repeat.md
+++ b/.changeset/lazy-files-repeat.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fix: The content with `\n` pasted from the clipboard is empty. #5190

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -539,13 +539,19 @@ export function createAndroidInputManager({
           })
         }
 
-        if (typeof data === 'string' && data.includes('\n')) {
+        if (typeof data === 'string' && data === '\n') {
           return scheduleAction(() => Editor.insertSoftBreak(editor), {
             at: Range.end(targetRange),
           })
         }
 
         let text = data ?? ''
+
+        if (typeof data === 'string' && data.includes('\n')) {
+          return scheduleAction(() => Editor.insertText(editor, text), {
+            at: targetRange,
+          })
+        }
 
         // COMPAT: If we are writing inside a placeholder, the ime inserts the text inside
         // the placeholder itself and thus includes the zero-width space inside edit events.


### PR DESCRIPTION
**Description**
The problem with pasting from the clipboard on Android has been located, and this PR resolved my problem on my phone. Maybe need @BitPhinix  to review this too.

**Issue**
Fixes: #5190 

**Context**

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

