### PR TITLE
Update `isHistory` to match new interface.

### DIFF
--- a/.changeset/real-badgers-pull.md
+++ b/.changeset/real-badgers-pull.md
@@ -1,0 +1,5 @@
+---
+'slate-history': patch
+---
+
+Fix isHistory check.

--- a/packages/slate-history/src/history.ts
+++ b/packages/slate-history/src/history.ts
@@ -27,8 +27,10 @@ export const History = {
       isPlainObject(value) &&
       Array.isArray(value.redos) &&
       Array.isArray(value.undos) &&
-      (value.redos.length === 0 || Operation.isOperationList(value.redos[0])) &&
-      (value.undos.length === 0 || Operation.isOperationList(value.undos[0]))
+      (value.redos.length === 0 ||
+        Operation.isOperationList(value.redos[0].operations)) &&
+      (value.undos.length === 0 ||
+        Operation.isOperationList(value.undos[0].operations))
     )
   },
 }

--- a/packages/slate-history/test/index.js
+++ b/packages/slate-history/test/index.js
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import { fixtures } from '../../../support/fixtures'
 import { createHyperscript } from 'slate-hyperscript'
-import { withHistory } from '..'
+import { History, withHistory } from '..'
 
 describe('slate-history', () => {
   fixtures(__dirname, 'undo', ({ module }) => {
@@ -11,6 +11,14 @@ describe('slate-history', () => {
     editor.undo()
     assert.deepEqual(editor.children, output.children)
     assert.deepEqual(editor.selection, output.selection)
+  })
+
+  fixtures(__dirname, 'isHistory', ({ module }) => {
+    const { input, run, output } = module
+    const editor = withTest(withHistory(input))
+    run(editor)
+    const result = History.isHistory(editor.history)
+    assert.strictEqual(result, output)
   })
 })
 

--- a/packages/slate-history/test/isHistory/after-edit.js
+++ b/packages/slate-history/test/isHistory/after-edit.js
@@ -1,0 +1,18 @@
+/** @jsx jsx */
+
+import { Transforms } from 'slate'
+import { jsx } from '..'
+
+export const input = (
+  <editor>
+    <block>
+      Initial text <cursor />
+    </block>
+  </editor>
+)
+
+export const run = editor => {
+  Transforms.insertText(editor, 'additional text')
+}
+
+export const output = true

--- a/packages/slate-history/test/isHistory/after-redo.js
+++ b/packages/slate-history/test/isHistory/after-redo.js
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+
+import { Transforms } from 'slate'
+import { jsx } from '..'
+
+export const input = (
+  <editor>
+    <block>
+      Initial text <cursor />
+    </block>
+  </editor>
+)
+
+export const run = editor => {
+  Transforms.insertText(editor, 'additional text')
+
+  editor.undo()
+  editor.redo()
+}
+
+export const output = true

--- a/packages/slate-history/test/isHistory/after-undo.js
+++ b/packages/slate-history/test/isHistory/after-undo.js
@@ -1,0 +1,20 @@
+/** @jsx jsx */
+
+import { Transforms } from 'slate'
+import { jsx } from '..'
+
+export const input = (
+  <editor>
+    <block>
+      Initial text <cursor />
+    </block>
+  </editor>
+)
+
+export const run = editor => {
+  Transforms.insertText(editor, 'additional text')
+
+  editor.undo()
+}
+
+export const output = true

--- a/packages/slate-history/test/isHistory/before-edit.js
+++ b/packages/slate-history/test/isHistory/before-edit.js
@@ -1,0 +1,14 @@
+/** @jsx jsx */
+import { jsx } from '..'
+
+export const input = (
+  <editor>
+    <block>
+      Initial text <cursor />
+    </block>
+  </editor>
+)
+
+export const run = () => {}
+
+export const output = true


### PR DESCRIPTION
**Description**
This change preserves the original functionality of `isHistory`, but does not add verification of `History` `Batch`'s new `selectionBefore` property.

**Issue**
Fixes: #5177

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
