### PR TITLE
Docs: fix Ctrl-` backticks issue on 03-defining-custom-elements page

### DIFF
--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -116,7 +116,7 @@ const DefaultElement = props => {
 }
 ```
 
-Okay, but now we'll need a way for the user to actually turn a block into a code block. So let's change our `onKeyDown` function to add a ``Ctrl-``` shortcut that does just that:
+Okay, but now we'll need a way for the user to actually turn a block into a code block. So let's change our `onKeyDown` function to add a `` Ctrl-` `` shortcut that does just that:
 
 ```jsx
 // Import the `Editor` and `Transforms` helpers from Slate.
@@ -175,9 +175,9 @@ const DefaultElement = props => {
 }
 ```
 
-Now, if you press ``Ctrl-``` the block your cursor is in should turn into a code block! Magic!
+Now, if you press `` Ctrl-` `` the block your cursor is in should turn into a code block! Magic!
 
-But we forgot one thing. When you hit ``Ctrl-``` again, it should change the code block back into a paragraph. To do that, we'll need to add a bit of logic to change the type we set based on whether any of the currently selected blocks are already a code block:
+But we forgot one thing. When you hit `` Ctrl-` `` again, it should change the code block back into a paragraph. To do that, we'll need to add a bit of logic to change the type we set based on whether any of the currently selected blocks are already a code block:
 
 ```jsx
 const initialValue = [
@@ -224,4 +224,4 @@ const App = () => {
 }
 ```
 
-And there you have it! If you press ``Ctrl-``` while inside a code block, it should turn back into a paragraph!
+And there you have it! If you press `` Ctrl-` `` while inside a code block, it should turn back into a paragraph!


### PR DESCRIPTION
**Description**
On this page (https://docs.slatejs.org/walkthroughs/03-defining-custom-elements) inline comments are not working as expected for `` Ctrl-` `` which is because of consecutive backticks with last backtick `` -` ``.

<img width="1440" alt="Screenshot 2022-11-28 at 12 32 52 PM" src="https://user-images.githubusercontent.com/44892121/204214747-3fba5583-a933-427d-900b-64cdad15b859.png">

**Example**
This PR fixes the issue by adding spaces around inline code which prevents the issue and works as expected ( without surrounding spaces being rendered around the mark )

Here are screen shots of the solution markdown on 

VS Code markdown Preview
<img width="919" alt="Screenshot 2022-11-28 at 12 37 44 PM" src="https://user-images.githubusercontent.com/44892121/204215236-30ee666f-cadf-4aba-a07a-993382e12b01.png">

Github markdown preview
<img width="816" alt="Screenshot 2022-11-28 at 12 37 55 PM" src="https://user-images.githubusercontent.com/44892121/204215286-24cb341e-0487-42cf-b543-98cbdb6b7e2d.png">


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

