### PR TITLE
Use stylesheets to give Editable components default styles

### DIFF
--- a/.changeset/strange-pens-lie.md
+++ b/.changeset/strange-pens-lie.md
@@ -1,0 +1,6 @@
+---
+'slate': minor
+'slate-react': minor
+---
+
+Use stylesheet for default styles on Editable components

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^16.9.13",
     "@types/react-dom": "^16.9.4",
     "@types/react-test-renderer": "^16.8.0",
+    "@types/resize-observer-browser": "^0.1.7",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "react-test-renderer": ">=16.8.0",

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -55,6 +55,7 @@ import {
   EDITOR_TO_ELEMENT,
   EDITOR_TO_FORCE_RENDER,
   EDITOR_TO_PENDING_INSERTION_MARKS,
+  EDITOR_TO_STYLE_ELEMENT,
   EDITOR_TO_USER_MARKS,
   EDITOR_TO_USER_SELECTION,
   EDITOR_TO_WINDOW,
@@ -832,6 +833,16 @@ export const Editable = (props: EditableProps) => {
 
       if (mountedCount <= 0)
         document.querySelector('style[data-slate-default-styles]')?.remove()
+    }
+  }, [])
+
+  useEffect(() => {
+    const styleElement = document.createElement('style')
+    document.head.appendChild(styleElement)
+    EDITOR_TO_STYLE_ELEMENT.set(editor, styleElement)
+    return () => {
+      styleElement.remove()
+      EDITOR_TO_STYLE_ELEMENT.delete(editor)
     }
   }, [])
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -864,6 +864,7 @@ export const Editable = (props: EditableProps) => {
                 : 'false'
             }
             data-slate-editor
+            data-slate-editor-id={editor.id}
             data-slate-node="value"
             // explicitly set this
             contentEditable={!readOnly}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useMemo } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { Element, Text } from 'slate'
 import String from './string'
 import {
@@ -8,7 +8,6 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
-import { ReactEditor } from '..'
 
 /**
  * Individual leaves in a text node with unique formatting.
@@ -34,41 +33,55 @@ const Leaf = (props: {
   const placeholderRef = useRef<HTMLSpanElement | null>(null)
   const editor = useSlateStatic()
 
-  const placeholderResizeObserver = useMemo(
-    () =>
-      new ResizeObserver(([{ target }]) => {
-        const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
-        if (!styleElement) return
+  const placeholderResizeObserver = useRef<ResizeObserver | null>(null)
 
-        // Make the min-height the height of the placeholder.
-        const minHeight = `${target.clientHeight}px`
-        styleElement.innerHTML = `:where([data-slate-editor-id="${editor.id}"]) { min-height: ${minHeight}; }`
-      }),
-    []
-  )
+  useEffect(() => {
+    return () => {
+      if (placeholderResizeObserver.current) {
+        placeholderResizeObserver.current.disconnect()
+      }
+    }
+  }, [])
 
   useEffect(() => {
     const placeholderEl = placeholderRef?.current
-    const editorEl = ReactEditor.toDOMNode(editor, editor)
 
-    if (!placeholderEl || !editorEl) {
-      return
-    }
-
-    if (placeholderEl !== EDITOR_TO_PLACEHOLDER_ELEMENT.get(editor)) {
+    if (placeholderEl) {
       EDITOR_TO_PLACEHOLDER_ELEMENT.set(editor, placeholderEl)
-      placeholderResizeObserver.disconnect()
-      placeholderResizeObserver.observe(placeholderEl)
+    } else {
+      EDITOR_TO_PLACEHOLDER_ELEMENT.delete(editor)
     }
 
-    return () => {
-      EDITOR_TO_PLACEHOLDER_ELEMENT.delete(editor)
-      placeholderResizeObserver.disconnect()
+    if (placeholderResizeObserver.current) {
+      // Update existing observer.
+      placeholderResizeObserver.current.disconnect()
+      if (placeholderEl)
+        placeholderResizeObserver.current.observe(placeholderEl)
+    } else if (placeholderEl) {
+      // Create a new observer and observe the placeholder element.
+      placeholderResizeObserver.current = new ResizeObserver(([{ target }]) => {
+        const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
+        if (styleElement) {
+          // Make the min-height the height of the placeholder.
+          const minHeight = `${target.clientHeight}px`
+          styleElement.innerHTML = `:where([data-slate-editor-id="${editor.id}"]) { min-height: ${minHeight}; }`
+        }
+      })
+
+      placeholderResizeObserver.current.observe(placeholderEl)
+    }
+
+    if (!placeholderEl) {
+      // No placeholder element, so no need for a resize observer.
       const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
       if (styleElement) {
         // No min-height if there is no placeholder.
         styleElement.innerHTML = ''
       }
+    }
+
+    return () => {
+      EDITOR_TO_PLACEHOLDER_ELEMENT.delete(editor)
     }
   }, [placeholderRef, leaf])
 

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -4,6 +4,7 @@ import String from './string'
 import {
   PLACEHOLDER_SYMBOL,
   EDITOR_TO_PLACEHOLDER_ELEMENT,
+  EDITOR_TO_STYLE_ELEMENT,
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
@@ -41,12 +42,17 @@ const Leaf = (props: {
       return
     }
 
-    editorEl.style.minHeight = `${placeholderEl.clientHeight}px`
     EDITOR_TO_PLACEHOLDER_ELEMENT.set(editor, placeholderEl)
+    const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
+    if (styleElement) {
+      styleElement.innerHTML =
+        `:where([data-slate-editor-id="${editor.id}"]) { min-height: ${minHeight}; }`
+    }
 
     return () => {
-      editorEl.style.minHeight = 'auto'
       EDITOR_TO_PLACEHOLDER_ELEMENT.delete(editor)
+      const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
+      if (styleElement) styleElement.innerHTML = ''
     }
   }, [placeholderRef, leaf])
 

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -29,6 +29,10 @@ export const EDITOR_TO_KEY_TO_ELEMENT: WeakMap<
   Editor,
   WeakMap<Key, HTMLElement>
 > = new WeakMap()
+export const EDITOR_TO_STYLE_ELEMENT: WeakMap<
+  Editor,
+  HTMLStyleElement
+> = new WeakMap()
 
 /**
  * Weak maps for storing editor-related state.

--- a/packages/slate-react/test/index.spec.tsx
+++ b/packages/slate-react/test/index.spec.tsx
@@ -8,7 +8,15 @@ const createNodeMock = () => ({
   getRootNode: () => global.document,
 })
 
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 describe('slate-react', () => {
+  window.ResizeObserver = MockResizeObserver as any
+
   describe('Editable', () => {
     describe('NODE_TO_KEY logic', () => {
       it('should not unmount the node that gets split on a split_node operation', async () => {

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -16,6 +16,8 @@ import {
 import { DIRTY_PATHS, DIRTY_PATH_KEYS, FLUSHING } from './utils/weak-maps'
 import { TextUnit } from './interfaces/types'
 
+let nextEditorId = 0
+
 /**
  * Create a new Slate `Editor` object.
  */
@@ -26,6 +28,7 @@ export const createEditor = (): Editor => {
     operations: [],
     selection: null,
     marks: null,
+    id: nextEditorId++,
     isInline: () => false,
     isVoid: () => false,
     markableVoid: () => false,

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -57,6 +57,7 @@ export interface BaseEditor {
   selection: Selection
   operations: Operation[]
   marks: EditorMarks | null
+  readonly id: number
 
   // Schema-specific node behaviors.
   isInline: (element: Element) => boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -3739,6 +3739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/resize-observer-browser@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "@types/resize-observer-browser@npm:0.1.7"
+  checksum: 0377eaac8bb7a17b983b49a156006032380b459bfebefc54a5aa2f7f8a9786d2b60723e8837c61ef733330b478f4f26293e9edbdc8006238e4f80c878c56c988
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:0.0.8":
   version: 0.0.8
   resolution: "@types/resolve@npm:0.0.8"
@@ -14235,6 +14242,7 @@ resolve@^2.0.0-next.3:
     "@types/react": ^16.9.13
     "@types/react-dom": ^16.9.4
     "@types/react-test-renderer": ^16.8.0
+    "@types/resize-observer-browser": ^0.1.7
     direction: ^1.0.3
     is-hotkey: ^0.1.6
     is-plain-object: ^5.0.0


### PR DESCRIPTION
**Description**
This PR makes the default styles of an `Editable` component come from stylesheets added to the DOM rather than inline styles on the editor element.  This resolves an issue in which setting the `position`, `outline`, `white-space`, or `word-wrap` properties using the `className` prop would have no effect. It also resolves issue #4314 in which setting the `min-height` property on an editor would have no effect.

Additionally, a change was made to make the `min-height` of editors change when the size of their placeholder element changes.

**Issue**
Fixes: #4314

**Example**
Pictured is a modification of the custom placeholder example.

### Old
![Screenshot from 2022-12-01 02-58-32](https://user-images.githubusercontent.com/8977964/205059900-4adcaeba-9a5a-486c-8c88-80ca3a08951e.png)

The `min-height` changes have no effect, and the change to `outline` only has an effect when passed as part of the `style` prop.

### New
![Screenshot from 2022-12-01 02-59-10](https://user-images.githubusercontent.com/8977964/205059967-ef20188f-6d53-46c9-8fb1-696d25b078d3.png)

The `min-height` and `outline` changes have an effect, regardless of whether they are set as part of a CSS class or on the `style` prop.

**Context**
Previously, `Editable` components used inline styles to set their `position`, `outline`, `white-space`, and `word-wrap` CSS properties to some chosen default values. These properties could be overridden by setting them with the `style` prop on the component, but attempting to override them by setting the `className` prop would not work because inline styles take precedence.

Additionally, as detailed in #4314, code in the `Leaf` component sets the `min-height` property on editors to the height of their placeholder to prevent the placeholder from overflowing the editor bounds. However, because this was done by directly setting an inline style on the editor element, users were unable to set the `min-height` of an editor using `className` or `style` props on the editor.

I decided to solve the first issue by introducing a global `<style>` element that gets added to the DOM on the first `Editable` mount and removed on the last `Editable` unmount. It contains the `position`, `outline`, `white-space`, and `word-wrap` properties that were previously passed to the `style` prop of each editor. The CSS rule in this stylesheet uses the `:where` pseudoclass to target editors, giving it 0 specificity and thus allowing user stylesheets to override its styles.

The second issue required a bit more effort. Fixing the first issue allowed the `min-height` property to be changed by the user using a stylesheet or inline styles, but it still needed to be possible for the `min-height` to default to the height of the placeholder element, and it needed to be done without using an inline style. There can be more than one editor on a page, each with its own unique placeholder height, so each editor needs its own default `min-height`. In order to have each editor element have a different `min-height` without giving them inline styles, the editor elements need some sort of unique identifier. To accomplish this, I added an `id` field to the `Editor` type. When an editor is created, it simply uses a counter of the number of `Editor` instances created as its `id`, then increments a counter.

Editor elements expose their identifier through their new `data-slate-editor-id` attribute. When an `Editable` component mounts, it will now create a `<style>` element that targets only itself using its `data-slate-editor-id` attribute value. `Leaf` components access that `<style>` element through a `WeakMap` and set the `min-height` of the editor on it depending on the placeholder height. Because this stylesheet also uses the `:where` pseudoclass, the `min-height` can be overridden by a user stylesheet.

During testing, I discovered an issue where sometimes the placeholder height that is measured will be inaccurate on initial page load, leading to the set `min-height` being incorrect until the component renders again. This was resolved by having `Leaf` components create a `ResizeObserver` that updates the `min-height` of the editor element whenever the size of the placeholder element changes.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

