### PR TITLE
fix: allow input into editable voids

### DIFF
--- a/.changeset/clean-socks-hammer.md
+++ b/.changeset/clean-socks-hammer.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix issue preventing editing and copy/paste into editable voids

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1311,7 +1311,7 @@ export const Editable = (props: EditableProps) => {
                 if (
                   !readOnly &&
                   !state.isUpdatingSelection &&
-                  ReactEditor.hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasEditableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onFocus)
                 ) {
                   const el = ReactEditor.toDOMNode(editor, editor)


### PR DESCRIPTION
**Description**
The editable voids and emded examples are currently broken and don't allow you to type anything into the input fields. With this change it should be editable again.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

