### PR TITLE
Note that leaves must be inline elements

### DIFF
--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -133,7 +133,7 @@ const Leaf = props => {
 }
 ```
 
-Pretty familiar, right?
+Pretty familiar, right?  Note that it is described with a `span` - This is because all leaves must be an [inline element](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements). You can learn more about leaves in the [Rendering section](../concepts/09-rendering.md#leaves).
 
 And now, let's tell Slate about that leaf. To do that, we'll pass in the `renderLeaf` prop to our editor.
 

--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -133,7 +133,7 @@ const Leaf = props => {
 }
 ```
 
-Pretty familiar, right?  Note that it is described with a `span` - This is because all leaves must be an [inline element](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements). You can learn more about leaves in the [Rendering section](../concepts/09-rendering.md#leaves).
+Pretty familiar, right? Note that it is described with a `span` - This is because all leaves must be an [inline element](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements). You can learn more about leaves in the [Rendering section](../concepts/09-rendering.md#leaves).
 
 And now, let's tell Slate about that leaf. To do that, we'll pass in the `renderLeaf` prop to our editor.
 


### PR DESCRIPTION
**Description**
Adds a note in the walkthrough section of the documentation that leaves must return inline elements.

**Issue**
This fixes no existing issues.

**Context**
One of the things I struggled with in my project was figuring out why arrow navigations between nodes were failing. I soon realized it was because my leaves were described as a `div` element, not an inline element. Not only did I have no idea where to find information about leaves, but the section itself doesn't seem to document this behavior. I believe this change can at least help prevent the same mistake and give a little more insight as to how and where to find more information regarding leaves.

I also believe updating the Leaves section to include information about this behavior will be great as well. Being new to the repo, I don't understand the logic surrounding leaves enough to contribute to that section.

**Checks**
- [ x] The new code matches the existing patterns and styles.
- [ x] The tests pass with `yarn test`.
- [ x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

---
I'm not 100% if leaves must be inline elements. That is what I inferred from its behavior. Please let me know if that is not the case.