### PR TITLE
Check if getBoundingClientRect exist before trying to call bind

### DIFF
--- a/.changeset/curly-news-cover.md
+++ b/.changeset/curly-news-cover.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Check if getBoundingClientRect exist before trying to call bind on it. Makes unit testing experience agains Editable nicer

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1691,8 +1691,9 @@ const defaultScrollSelectionIntoView = (
   // This was affecting the selection of multiple blocks and dragging behavior,
   // so enabled only if the selection has been collapsed.
   if (
-    !editor.selection ||
-    (editor.selection && Range.isCollapsed(editor.selection))
+    domRange.getBoundingClientRect &&
+    (!editor.selection ||
+      (editor.selection && Range.isCollapsed(editor.selection)))
   ) {
     const leafEl = domRange.startContainer.parentElement!
     leafEl.getBoundingClientRect = domRange.getBoundingClientRect.bind(domRange)


### PR DESCRIPTION
**Description**
The current implementation of defaultScrollSelectionIntoView makes tests run by node fail. 

```
/home/circleci/repo/node_modules/slate-react/dist/index.js:4937
    leafEl.getBoundingClientRect = domRange.getBoundingClientRect.bind(domRange);
                                                                  ^

TypeError: Cannot read properties of undefined (reading 'bind')
    at scrollSelectionIntoView (/home/circleci/repo/node_modules/slate-react/src/components/editable.tsx:1698:67)
    at setDomSelection (/home/circleci/repo/node_modules/slate-react/src/components/editable.tsx:368:9)
    at /home/circleci/repo/node_modules/slate-react/src/components/editable.tsx:376:25
    at commitHookEffectListMount (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:20573:26)
    at commitLifeCycles (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:20634:11)
    at commitLayoutEffects (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:23426:7)
    at HTMLUnknownElement.callCallback (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:3945:14)
    at HTMLUnknownElement.callTheUserObjectsOperation (/home/circleci/repo/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
    at innerInvokeEventListeners (/home/circleci/repo/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)
    at invokeEventListeners (/home/circleci/repo/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:274:3)
    at HTMLUnknownElementImpl._dispatch (/home/circleci/repo/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:221:9)
    at HTMLUnknownElementImpl.dispatchEvent (/home/circleci/repo/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:94:17)
    at HTMLUnknownElement.dispatchEvent (/home/circleci/repo/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:231:34)
    at Object.invokeGuardedCallbackDev (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:3994:16)
    at invokeGuardedCallback (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:4056:31)
    at commitRootImpl (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:23151:9)
    at unstable_runWithPriority (/home/circleci/repo/node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js:468:12)
    at runWithPriority$1 (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:11276:10)
    at commitRoot (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:22990:3)
    at performSyncWorkOnRoot (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:22329:3)
    at /home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:11327:26
    at unstable_runWithPriority (/home/circleci/repo/node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js:468:12)
    at runWithPriority$1 (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:11276:10)
    at flushSyncCallbackQueueImpl (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:11322:9)
    at flushSyncCallbackQueue (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:11309:3)
    at Object.unstable_batchedUpdates (/home/circleci/repo/node_modules/react-dom/cjs/react-dom.development.js:22387:7)
    at Object.onChange (/home/circleci/repo/node_modules/slate-react/src/plugin/with-react.ts:326:14)
    at /home/circleci/repo/node_modules/slate/src/create-editor.ts:99:18
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Exited with code exit status 1

```

 By checking if domRange.getBoundingClientRect exists before going into this logic we don't need to mock or send in a custom scrollSelectionIntoView function into the Editable component

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

