### PR TITLE
Fix broken selection transforms link in editor docs

### DIFF
--- a/docs/concepts/07-editor.md
+++ b/docs/concepts/07-editor.md
@@ -35,7 +35,7 @@ It is slightly more complex than the others, because it contains all of the top-
 The `children` property contains the document tree of nodes that make up the editor's content.
 
 The `selection` property contains the user's current selection, if any.
-Don't set it directly; use [Transforms.select](04-transforms#selection-transforms)
+Don't set it directly; use [Transforms.select](04-transforms.md#selection-transforms)
 
 The `operations` property contains all of the operations that have been applied since the last "change" was flushed. \(Since Slate batches operations up into ticks of the event loop.\)
 


### PR DESCRIPTION
**Description**

The existing link was dead, this references the current location of the selection transforms docs.

**Issue**
N/A

**Example**
Before
![CleanShot 2022-12-20 at 09 19 11](https://user-images.githubusercontent.com/58009357/208727203-63f6211f-48d3-4676-b9c2-682db85215e1.png)

After:
![CleanShot 2022-12-20 at 09 19 41](https://user-images.githubusercontent.com/58009357/208727288-6f1f2dd3-c859-408c-8557-6689d3ff2f8b.png)

**Context**
N/A

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

