### PR TITLE
Fix editor above with point

### DIFF
--- a/.changeset/wet-tigers-double.md
+++ b/.changeset/wet-tigers-double.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fixed Editor.above method that always returned undefined with Point location

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -359,7 +359,7 @@ export const Editor: EditorInterface = {
       match,
       reverse,
     })) {
-      if (Text.isText(n)) return
+      if (Text.isText(n)) continue
       if (Range.isRange(at)) {
         if (
           Path.isAncestor(p, at.anchor.path) &&

--- a/packages/slate/test/interfaces/Editor/above/point.tsx
+++ b/packages/slate/test/interfaces/Editor/above/point.tsx
@@ -1,0 +1,18 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <block>one</block>
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.above(editor, { at: { path: [0, 0, 0], offset: 1 } })
+}
+
+export const output = [<block>one</block>, [0, 0]]


### PR DESCRIPTION
**Description**
Fixes `Editor.above` with `Point` locations. Currently it always return `undefined`.

**Issue**
Fixes: #5215

**Example**
Without this change, following code would always return `undefined`:

```js
export const input = (
  <editor>
    <block>
      <block>one</block>
    </block>
  </editor>
)

export const test = editor => {
  // at could be any Point
  return Editor.above(editor, { at: { path: [0, 0, 0], offset: 0 } })
}
```

**Context**
`Editor.above` should ignore checking text nodes (they're never above anything) and continue looking for ancestors.
Otherwise it won't be able to find any above nodes when starting to look from a text node.

This is in line with how this method worked prior to #5168

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

