### PR TITLE
Fix the cursor jump to an unexpected position after deleting in android

### DIFF
--- a/.changeset/unlucky-chairs-promise.md
+++ b/.changeset/unlucky-chairs-promise.md
@@ -1,6 +1,6 @@
 ---
-"slate-react": patch
-"slate": patch
+'slate-react': patch
+'slate': patch
 ---
 
 Fix the cursor jump to an unexpected position after deleting in android

--- a/.changeset/unlucky-chairs-promise.md
+++ b/.changeset/unlucky-chairs-promise.md
@@ -1,0 +1,6 @@
+---
+"slate-react": patch
+"slate": patch
+---
+
+Fix the cursor jump to an unexpected position after deleting in android

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -392,6 +392,11 @@ export function createAndroidInputManager({
     if (Range.isExpanded(targetRange) && type.startsWith('delete')) {
       if (Path.equals(targetRange.anchor.path, targetRange.focus.path)) {
         const [start, end] = Range.edges(targetRange)
+
+        const point = { path: targetRange.anchor.path, offset: start.offset }
+        const range = Editor.range(editor, point, point)
+        handleUserSelect(range)
+
         return storeDiff(targetRange.anchor.path, {
           text: '',
           end: end.offset,


### PR DESCRIPTION
**Description**
In Android, deleting text doesn't trigger the selectionchange event, so EDITOR_TO_PENDING_SELECTION doesn't be updated when deleting text.  And after deleting all the input that it makes hasPendingDiffs to be false, will triggers applyPendingSelection and it makes the the cursor jump to an unexpected position. So i have to force update EDITOR_TO_PENDING_SELECTION when deleting text.

**Issue**
Fixes: #5249 

**Example**
before:

https://user-images.githubusercontent.com/11460856/211196919-1d65e01b-fd89-49b3-a91a-3d50048619ed.mp4

after:

https://user-images.githubusercontent.com/11460856/211197195-9070f9b7-e540-43e7-8761-e7fc6e8daf50.mp4


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

