### PR TITLE
fix QQ browser IME characters input failure

### DIFF
--- a/.changeset/fix-qq-browser-ime-input.md
+++ b/.changeset/fix-qq-browser-ime-input.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+remove qq browser from `beforeinput` compat list because it had updated its chromium core to version 94

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -45,7 +45,6 @@ import {
   IS_FIREFOX,
   IS_FIREFOX_LEGACY,
   IS_IOS,
-  IS_QQBROWSER,
   IS_SAFARI,
   IS_UC_MOBILE,
   IS_WECHATBROWSER,
@@ -1070,7 +1069,6 @@ export const Editable = (props: EditableProps) => {
                     !IS_SAFARI &&
                     !IS_FIREFOX_LEGACY &&
                     !IS_IOS &&
-                    !IS_QQBROWSER &&
                     !IS_WECHATBROWSER &&
                     !IS_UC_MOBILE &&
                     event.data

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -44,10 +44,6 @@ export const IS_FIREFOX_LEGACY =
     navigator.userAgent
   )
 
-// qq browser
-export const IS_QQBROWSER =
-  typeof navigator !== 'undefined' && /.*QQBrowser/.test(navigator.userAgent)
-
 // UC mobile browser
 export const IS_UC_MOBILE =
   typeof navigator !== 'undefined' && /.*UCBrowser/.test(navigator.userAgent)


### PR DESCRIPTION
**Description**
Users cannot input any Chinese charactors on latest version(11.5.0) of QQ browser.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/pull/3730#issuecomment-1074819628 and #4962

**Example**
before:
![before](https://user-images.githubusercontent.com/1101456/211287189-99d3d5fa-c8e4-42d8-9053-f2ed10173ea2.gif)
after:
![after](https://user-images.githubusercontent.com/1101456/211287379-d05efb5a-58bc-4a1c-8e08-e5fd8447d834.gif)


**Context**
The problem is caused by an earlier commit #3730. The changes could work for legacy versions. But for now, as mentioned in https://github.com/ianstormtaylor/slate/pull/3730#issuecomment-1074819628 and #4962, QQ browser might has changed its behavior of `beforeinput` since version 10.8.x in early 2022. And now in latest version of QQ browser, its chromium core version had updated to 94(And it's really hard to find legacy version installer of QQ browser except http://web.archive.org). So it's OK to remove these campat codes.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

