### PR TITLE
fix: isVoid, isBlock, isInline types

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -522,7 +522,7 @@ export const Editable = (props: EditableProps) => {
           ) {
             const block = Editor.above(editor, {
               at: anchor.path,
-              match: n => Editor.isBlock(editor, n),
+              match: n => Element.isElement(n) && Editor.isBlock(editor, n),
             })
 
             if (block && Node.string(block[0]).includes('\t')) {
@@ -1010,9 +1010,12 @@ export const Editable = (props: EditableProps) => {
 
                   if (event.detail === TRIPLE_CLICK && path.length >= 1) {
                     let blockPath = path
-                    if (!Editor.isBlock(editor, node)) {
+                    if (
+                      !(Element.isElement(node) && Editor.isBlock(editor, node))
+                    ) {
                       const block = Editor.above(editor, {
-                        match: n => Editor.isBlock(editor, n),
+                        match: n =>
+                          Element.isElement(n) && Editor.isBlock(editor, n),
                         at: path,
                       })
 
@@ -1133,7 +1136,8 @@ export const Editable = (props: EditableProps) => {
                       return
                     }
                     const inline = Editor.above(editor, {
-                      match: n => Editor.isInline(editor, n),
+                      match: n =>
+                        Element.isElement(n) && Editor.isInline(editor, n),
                       mode: 'highest',
                     })
                     if (inline) {
@@ -1207,7 +1211,7 @@ export const Editable = (props: EditableProps) => {
                   // default, and calling `preventDefault` hides the cursor.
                   const node = ReactEditor.toSlateNode(editor, event.target)
 
-                  if (Editor.isVoid(editor, node)) {
+                  if (Element.isElement(node) && Editor.isVoid(editor, node)) {
                     event.preventDefault()
                   }
                 }
@@ -1224,7 +1228,7 @@ export const Editable = (props: EditableProps) => {
                   const node = ReactEditor.toSlateNode(editor, event.target)
                   const path = ReactEditor.findPath(editor, node)
                   const voidMatch =
-                    Editor.isVoid(editor, node) ||
+                    (Element.isElement(node) && Editor.isVoid(editor, node)) ||
                     Editor.void(editor, { at: path, voids: true })
 
                   // If starting a drag on a void node, make sure it is selected

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -7,6 +7,7 @@ import {
   Range,
   Scrubber,
   Transforms,
+  Element,
 } from 'slate'
 
 import { Key } from '../utils/key'
@@ -477,7 +478,7 @@ export const ReactEditor = {
     // If the drop target is inside a void node, move it into either the
     // next or previous node, depending on which side the `x` and `y`
     // coordinates are closest to.
-    if (Editor.isVoid(editor, node)) {
+    if (Element.isElement(node) && Editor.isVoid(editor, node)) {
       const rect = target.getBoundingClientRect()
       const isPrev = editor.isInline(node)
         ? x - rect.left < rect.left + rect.width - x
@@ -844,7 +845,7 @@ export const ReactEditor = {
     const slateNode =
       ReactEditor.hasTarget(editor, target) &&
       ReactEditor.toSlateNode(editor, target)
-    return Editor.isVoid(editor, slateNode)
+    return Element.isElement(slateNode) && Editor.isVoid(editor, slateNode)
   },
 
   /**

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -8,6 +8,7 @@ import {
   Point,
   Range,
   Transforms,
+  Element,
 } from 'slate'
 import {
   TextDiff,
@@ -91,7 +92,7 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
 
     if (e.selection && Range.isCollapsed(e.selection)) {
       const parentBlockEntry = Editor.above(e, {
-        match: n => Editor.isBlock(e, n),
+        match: n => Element.isElement(n) && Editor.isBlock(e, n),
         at: e.selection,
       })
 

--- a/packages/slate-react/src/utils/diff-text.ts
+++ b/packages/slate-react/src/utils/diff-text.ts
@@ -1,4 +1,13 @@
-import { Editor, Node, Operation, Path, Point, Range, Text } from 'slate'
+import {
+  Editor,
+  Node,
+  Operation,
+  Path,
+  Point,
+  Range,
+  Text,
+  Element,
+} from 'slate'
 import { EDITOR_TO_PENDING_DIFFS } from './weak-maps'
 
 export type StringDiff = {
@@ -166,7 +175,7 @@ export function normalizePoint(editor: Editor, point: Point): Point | null {
   }
 
   const parentBlock = Editor.above(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     at: path,
   })
 

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -964,7 +964,7 @@ export const NodeTransforms: NodeTransforms = {
           at,
           match: editor.isInline(element)
             ? n => Element.isElement(n) && Editor.isBlock(editor, n)
-            : n => Element.isElement(n) && Editor.isEditor(n),
+            : n => Editor.isEditor(n),
           mode: 'lowest',
           voids,
         })

--- a/packages/slate/src/transforms/node.ts
+++ b/packages/slate/src/transforms/node.ts
@@ -201,7 +201,7 @@ export const NodeTransforms: NodeTransforms = {
           } else if (editor.isInline(node)) {
             match = n => Text.isText(n) || Editor.isInline(editor, n)
           } else {
-            match = n => Editor.isBlock(editor, n)
+            match = n => Element.isElement(n) && Editor.isBlock(editor, n)
           }
         }
 
@@ -270,7 +270,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : n => Element.isElement(n) && Editor.isBlock(editor, n)
       }
 
       if (!at) {
@@ -341,7 +341,7 @@ export const NodeTransforms: NodeTransforms = {
           const [parent] = Editor.parent(editor, at)
           match = n => parent.children.includes(n)
         } else {
-          match = n => Editor.isBlock(editor, n)
+          match = n => Element.isElement(n) && Editor.isBlock(editor, n)
         }
       }
 
@@ -484,7 +484,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : n => Element.isElement(n) && Editor.isBlock(editor, n)
       }
 
       const toRef = Editor.pathRef(editor, to)
@@ -540,7 +540,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : n => Element.isElement(n) && Editor.isBlock(editor, n)
       }
 
       if (!hanging && Range.isRange(at)) {
@@ -595,7 +595,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : n => Element.isElement(n) && Editor.isBlock(editor, n)
       }
 
       if (!hanging && Range.isRange(at)) {
@@ -707,7 +707,7 @@ export const NodeTransforms: NodeTransforms = {
       let { match, at = editor.selection, height = 0, always = false } = options
 
       if (match == null) {
-        match = n => Editor.isBlock(editor, n)
+        match = n => Element.isElement(n) && Editor.isBlock(editor, n)
       }
 
       if (Range.isRange(at)) {
@@ -782,7 +782,7 @@ export const NodeTransforms: NodeTransforms = {
           if (
             path.length < highestPath.length ||
             path.length === 0 ||
-            (!voids && Editor.isVoid(editor, node))
+            (!voids && Element.isElement(node) && Editor.isVoid(editor, node))
           ) {
             break
           }
@@ -870,7 +870,7 @@ export const NodeTransforms: NodeTransforms = {
       if (match == null) {
         match = Path.isPath(at)
           ? matchPath(editor, at)
-          : n => Editor.isBlock(editor, n)
+          : n => Element.isElement(n) && Editor.isBlock(editor, n)
       }
 
       if (Path.isPath(at)) {
@@ -937,9 +937,11 @@ export const NodeTransforms: NodeTransforms = {
         if (Path.isPath(at)) {
           match = matchPath(editor, at)
         } else if (editor.isInline(element)) {
-          match = n => Editor.isInline(editor, n) || Text.isText(n)
+          match = n =>
+            (Element.isElement(n) && Editor.isInline(editor, n)) ||
+            Text.isText(n)
         } else {
-          match = n => Editor.isBlock(editor, n)
+          match = n => Element.isElement(n) && Editor.isBlock(editor, n)
         }
       }
 
@@ -961,8 +963,8 @@ export const NodeTransforms: NodeTransforms = {
         Editor.nodes(editor, {
           at,
           match: editor.isInline(element)
-            ? n => Editor.isBlock(editor, n)
-            : n => Editor.isEditor(n),
+            ? n => Element.isElement(n) && Editor.isBlock(editor, n)
+            : n => Element.isElement(n) && Editor.isEditor(n),
           mode: 'lowest',
           voids,
         })

--- a/packages/slate/src/transforms/text.ts
+++ b/packages/slate/src/transforms/text.ts
@@ -108,12 +108,12 @@ export const TextTransforms: TextTransforms = {
 
       let [start, end] = Range.edges(at)
       const startBlock = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: n => Element.isElement(n) && Editor.isBlock(editor, n),
         at: start,
         voids,
       })
       const endBlock = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: n => Element.isElement(n) && Editor.isBlock(editor, n),
         at: end,
         voids,
       })
@@ -161,7 +161,7 @@ export const TextTransforms: TextTransforms = {
         }
 
         if (
-          (!voids && Editor.isVoid(editor, node)) ||
+          (!voids && Element.isElement(node) && Editor.isVoid(editor, node)) ||
           (!Path.isCommon(path, start.path) && !Path.isCommon(path, end.path))
         ) {
           matches.push(entry)
@@ -293,7 +293,7 @@ export const TextTransforms: TextTransforms = {
       // instead since it will need to be split otherwise.
       const inlineElementMatch = Editor.above(editor, {
         at,
-        match: n => Editor.isInline(editor, n),
+        match: n => Element.isElement(n) && Editor.isInline(editor, n),
         mode: 'highest',
         voids,
       })
@@ -311,7 +311,7 @@ export const TextTransforms: TextTransforms = {
       }
 
       const blockMatch = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: n => Element.isElement(n) && Editor.isBlock(editor, n),
         at,
         voids,
       })!
@@ -410,7 +410,7 @@ export const TextTransforms: TextTransforms = {
         at,
         match: n =>
           hasBlocks
-            ? Editor.isBlock(editor, n)
+            ? Element.isElement(n) && Editor.isBlock(editor, n)
             : Text.isText(n) || Editor.isInline(editor, n),
         mode: hasBlocks ? 'lowest' : 'highest',
         always:
@@ -440,7 +440,7 @@ export const TextTransforms: TextTransforms = {
 
       Transforms.insertNodes(editor, middles, {
         at: middleRef.current!,
-        match: n => Editor.isBlock(editor, n),
+        match: n => Element.isElement(n) && Editor.isBlock(editor, n),
         mode: 'lowest',
         voids,
       })

--- a/packages/slate/test/interfaces/Editor/above/block-highest.tsx
+++ b/packages/slate/test/interfaces/Editor/above/block-highest.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -12,7 +12,7 @@ export const input = (
 export const test = editor => {
   return Editor.above(editor, {
     at: [0, 0, 0],
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     mode: 'highest',
   })
 }

--- a/packages/slate/test/interfaces/Editor/above/block-lowest.tsx
+++ b/packages/slate/test/interfaces/Editor/above/block-lowest.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -14,7 +14,7 @@ export const input = (
 export const test = editor => {
   return Editor.above(editor, {
     at: [0, 0, 0],
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     mode: 'lowest',
   })
 }

--- a/packages/slate/test/interfaces/Editor/above/inline.tsx
+++ b/packages/slate/test/interfaces/Editor/above/inline.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -14,7 +14,7 @@ export const input = (
 export const test = editor => {
   return Editor.above(editor, {
     at: [0, 1, 0],
-    match: n => Editor.isInline(editor, n),
+    match: n => Element.isElement(n) && Editor.isInline(editor, n),
   })
 }
 

--- a/packages/slate/test/interfaces/Editor/above/range.tsx
+++ b/packages/slate/test/interfaces/Editor/above/range.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -19,7 +19,7 @@ const range = {
 export const test = editor => {
   return Editor.above(editor, {
     at: range,
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
   })
 }
 export const output = [

--- a/packages/slate/test/interfaces/Editor/isBlock/block.tsx
+++ b/packages/slate/test/interfaces/Editor/isBlock/block.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -9,6 +9,6 @@ export const input = (
 )
 export const test = editor => {
   const block = editor.children[0]
-  return Editor.isBlock(editor, block)
+  return Element.isElement(block) && Editor.isBlock(editor, block)
 }
 export const output = true

--- a/packages/slate/test/interfaces/Editor/isBlock/inline.tsx
+++ b/packages/slate/test/interfaces/Editor/isBlock/inline.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -11,6 +11,6 @@ export const input = (
 )
 export const test = editor => {
   const inline = editor.children[0].children[1]
-  return Editor.isBlock(editor, inline)
+  return Element.isElement(inline) && Editor.isBlock(editor, inline)
 }
 export const output = false

--- a/packages/slate/test/interfaces/Editor/next/block.tsx
+++ b/packages/slate/test/interfaces/Editor/next/block.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -11,7 +11,7 @@ export const input = (
 export const test = editor => {
   return Editor.next(editor, {
     at: [0],
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
   })
 }
 export const output = [<block>two</block>, [1]]

--- a/packages/slate/test/interfaces/Editor/nodes/match-function/block.tsx
+++ b/packages/slate/test/interfaces/Editor/nodes/match-function/block.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../../..'
 
 export const input = (
@@ -11,7 +11,7 @@ export const test = editor => {
   return Array.from(
     Editor.nodes(editor, {
       at: [],
-      match: n => Editor.isBlock(editor, n),
+      match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     })
   )
 }

--- a/packages/slate/test/interfaces/Editor/nodes/match-function/inline.tsx
+++ b/packages/slate/test/interfaces/Editor/nodes/match-function/inline.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../../..'
 
 export const input = (
@@ -13,7 +13,7 @@ export const test = editor => {
   return Array.from(
     Editor.nodes(editor, {
       at: [],
-      match: n => Editor.isInline(editor, n),
+      match: n => Element.isElement(n) && Editor.isInline(editor, n),
     })
   )
 }

--- a/packages/slate/test/interfaces/Editor/previous/block.tsx
+++ b/packages/slate/test/interfaces/Editor/previous/block.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -11,7 +11,7 @@ export const input = (
 export const test = editor => {
   return Editor.previous(editor, {
     at: [1],
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
   })
 }
 export const output = [<block>one</block>, [0]]

--- a/packages/slate/test/transforms/mergeNodes/depth-block/block.tsx
+++ b/packages/slate/test/transforms/mergeNodes/depth-block/block.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -12,7 +12,9 @@ export const input = (
   </editor>
 )
 export const run = editor => {
-  Transforms.mergeNodes(editor, { match: n => Editor.isBlock(editor, n) })
+  Transforms.mergeNodes(editor, {
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+  })
 }
 export const output = (
   <editor>

--- a/packages/slate/test/transforms/moveNodes/selection/block-nested-after.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-nested-after.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     to: [1],
   })
 }

--- a/packages/slate/test/transforms/moveNodes/selection/block-nested-before.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-nested-before.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     to: [0],
   })
 }

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-after.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     to: [2],
   })
 }

--- a/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block-siblings-before.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     to: [0],
   })
 }

--- a/packages/slate/test/transforms/moveNodes/selection/block.tsx
+++ b/packages/slate/test/transforms/moveNodes/selection/block.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const input = (
@@ -13,7 +13,7 @@ export const input = (
 )
 export const run = editor => {
   Transforms.moveNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     to: [1],
   })
 }

--- a/packages/slate/test/transforms/setNodes/block/block-across.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-across.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isBlock(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/block/block-hanging.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-hanging.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isBlock(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/block/block-nested.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-nested.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isBlock(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/block/block-void.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block-void.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isBlock(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/block/block.tsx
+++ b/packages/slate/test/transforms/setNodes/block/block.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isBlock(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline-across.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-across.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline-block-hanging.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-block-hanging.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline-hanging.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-hanging.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline-nested.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-nested.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline-void-2.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-void-2.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline-void.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline-void.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/setNodes/inline/inline.tsx
+++ b/packages/slate/test/transforms/setNodes/inline/inline.tsx
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.setNodes(
     editor,
     { someKey: true },
-    { match: n => Editor.isInline(editor, n) }
+    { match: n => Element.isElement(n) && Editor.isInline(editor, n) }
   )
 }
 export const input = (

--- a/packages/slate/test/transforms/splitNodes/always/after-inline-void.tsx
+++ b/packages/slate/test/transforms/splitNodes/always/after-inline-void.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.splitNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     always: true,
   })
 }

--- a/packages/slate/test/transforms/splitNodes/always/after-inline.tsx
+++ b/packages/slate/test/transforms/splitNodes/always/after-inline.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.splitNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     always: true,
   })
 }

--- a/packages/slate/test/transforms/splitNodes/always/before-inline.tsx
+++ b/packages/slate/test/transforms/splitNodes/always/before-inline.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.splitNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     always: true,
   })
 }

--- a/packages/slate/test/transforms/splitNodes/always/block-end.tsx
+++ b/packages/slate/test/transforms/splitNodes/always/block-end.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.splitNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     always: true,
   })
 }

--- a/packages/slate/test/transforms/splitNodes/always/block-start.tsx
+++ b/packages/slate/test/transforms/splitNodes/always/block-start.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.splitNodes(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     always: true,
   })
 }

--- a/packages/slate/test/transforms/splitNodes/match-block/block-middle-multiple-texts.tsx
+++ b/packages/slate/test/transforms/splitNodes/match-block/block-middle-multiple-texts.tsx
@@ -1,9 +1,11 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.splitNodes(editor, { match: n => Editor.isBlock(editor, n) })
+  Transforms.splitNodes(editor, {
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+  })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/splitNodes/match-block/block-middle.tsx
+++ b/packages/slate/test/transforms/splitNodes/match-block/block-middle.tsx
@@ -1,9 +1,11 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.splitNodes(editor, { match: n => Editor.isBlock(editor, n) })
+  Transforms.splitNodes(editor, {
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+  })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/splitNodes/match-block/inline-middle.tsx
+++ b/packages/slate/test/transforms/splitNodes/match-block/inline-middle.tsx
@@ -1,9 +1,11 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.splitNodes(editor, { match: n => Editor.isBlock(editor, n) })
+  Transforms.splitNodes(editor, {
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+  })
 }
 export const input = (
   <editor>

--- a/packages/slate/test/transforms/splitNodes/match-inline/inline-middle.js
+++ b/packages/slate/test/transforms/splitNodes/match-inline/inline-middle.js
@@ -1,10 +1,12 @@
 /** @jsx jsx */
 
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
-  Transforms.splitNodes(editor, { match: n => Editor.isInline(editor, n) })
+  Transforms.splitNodes(editor, {
+    match: n => Element.isElement(n) && Editor.isInline(editor, n),
+  })
 }
 
 export const input = (

--- a/packages/slate/test/transforms/splitNodes/point/inline.tsx
+++ b/packages/slate/test/transforms/splitNodes/point/inline.tsx
@@ -1,11 +1,11 @@
 /** @jsx jsx */
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 import { jsx } from '../../..'
 
 export const run = editor => {
   Transforms.splitNodes(editor, {
     at: { path: [0, 1, 0], offset: 2 },
-    match: n => Editor.isInline(editor, n),
+    match: n => Element.isElement(n) && Editor.isInline(editor, n),
   })
 }
 export const input = (

--- a/site/examples/markdown-shortcuts.tsx
+++ b/site/examples/markdown-shortcuts.tsx
@@ -50,7 +50,7 @@ const MarkdownShortcutsExample = () => {
 
         const blockEntry = Editor.above(editor, {
           at: path,
-          match: n => Editor.isBlock(editor, n),
+          match: n => SlateElement.isElement(n) && Editor.isBlock(editor, n),
         })
         if (!blockEntry) {
           return false
@@ -88,7 +88,7 @@ const withShortcuts = editor => {
     if (text.endsWith(' ') && selection && Range.isCollapsed(selection)) {
       const { anchor } = selection
       const block = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: n => SlateElement.isElement(n) && Editor.isBlock(editor, n),
       })
       const path = block ? block[1] : []
       const start = Editor.start(editor, path)
@@ -107,7 +107,7 @@ const withShortcuts = editor => {
           type,
         }
         Transforms.setNodes<SlateElement>(editor, newProperties, {
-          match: n => Editor.isBlock(editor, n),
+          match: n => SlateElement.isElement(n) && Editor.isBlock(editor, n),
         })
 
         if (type === 'list-item') {
@@ -135,7 +135,7 @@ const withShortcuts = editor => {
 
     if (selection && Range.isCollapsed(selection)) {
       const match = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: n => SlateElement.isElement(n) && Editor.isBlock(editor, n),
       })
 
       if (match) {


### PR DESCRIPTION
**Description**
This PR tries to solve this [issue](https://github.com/ianstormtaylor/slate/issues/5219).
Basically trying to fix the types for isVoid, isBlock and isInline which today expects value(element) of any type.
And use a value is Element which cause issue like this.

```ts
const element = {} as Element; // this is element but not void
if(!Editor.isVoid(editor, element)) {
  // here the type of element becomes never
}
```

This is done by separating isElement checks from above functions.
A clear and concise description of what this pull request solves. (Please do not just link to a long issue thread. Instead include a clear description here or your pull request will likely not be reviewed as quickly.)

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5219

**Context**
Basically we will be going a way that isVoid, isBlock or isInline will only check for void, block, inline and not Element.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

