### PR TITLE
fix slack links in readme and contributing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,8 +26,8 @@
   <a href="https://unpkg.com/slate/dist/slate.min.js">
     <img src="http://img.badgesize.io/https://unpkg.com/slate/dist/slate.min.js?compression=gzip&amp;label=size">
   </a>
-  <a href="https://slate-slack.herokuapp.com">
-    <img src="https://slate-slack.herokuapp.com/badge.svg">
+  <a href="https://join.slack.com/t/slate-js/shared_invite/zt-f8t986ip-7dA1DyiqPpzootz1snKXkw">
+    <img src="https://img.shields.io/badge/slack-slate--js-brightgreen.svg?logo=slack">
   </a>
   <a href="./packages/slate/package.json">
     <img src="https://img.shields.io/npm/v/slate.svg?maxAge=3600&label=version&colorB=007ec6">

--- a/docs/general/contributing.md
+++ b/docs/general/contributing.md
@@ -32,9 +32,9 @@ Here's a [JSFiddle template for Slate](https://jsfiddle.net/01pLxfzu/) to get yo
 
 ## Asking Questions
 
-We've also got a [Slate Slack team](https://slate-slack.herokuapp.com) where you can ask questions and get answers from other people using Slate:
+We've also got a [Slate Slack team](https://join.slack.com/t/slate-js/shared_invite/zt-f8t986ip-7dA1DyiqPpzootz1snKXkw) where you can ask questions and get answers from other people using Slate:
 
-[![](../.gitbook/assets/slack.png)](https://slate-slack.herokuapp.com)
+[![](../.gitbook/assets/slack.png)](https://join.slack.com/t/slate-js/shared_invite/zt-f8t986ip-7dA1DyiqPpzootz1snKXkw)
 
 Please use the Slack instead of asking questions in issues, since we want to reserve issues for keeping track of bugs and features. We close questions in issues so that maintaining the project isn't overwhelming.
 


### PR DESCRIPTION
**Description**
There were several places in the docs linking to a broken Heroku app for access to Slack. This PR replaces those links with the direct Slack invite link that had already been updated in the [GH issue config](https://github.com/ianstormtaylor/slate/blob/main/.github/ISSUE_TEMPLATE/config.yml#L4).

**Issue**
Fixes:
- Slack link in [readme](https://github.com/ianstormtaylor/slate/blob/main/Readme.md)
- Slack links in [contributing](https://github.com/ianstormtaylor/slate/blob/main/docs/general/contributing.md) 

**Context**
In the readme the link was part of a badge which was also broken as it was coming from the heroku app, this is now replaced with a badge from badge.io

Before
![image](https://user-images.githubusercontent.com/4660500/211879494-2bf23e8f-a84d-45e7-800a-326ee6aa6e27.png)

After
![image](https://user-images.githubusercontent.com/4660500/211879651-9011b369-1aae-44ce-9e70-a5ce9911d33d.png)


**Checks**
- [ ] The new code matches the existing patterns and styles. - N/A only changes docs
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.) - N/A docs only

