### PR TITLE
bugfix: moves EDITOR_TO_ON_CHANGE.set(editor, onContextChange) into useEffect 

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -61,9 +61,9 @@ export const Slate = (props: {
     handleSelectorChange(editor)
   }, [onChange])
 
-  EDITOR_TO_ON_CHANGE.set(editor, onContextChange)
-
   useEffect(() => {
+    EDITOR_TO_ON_CHANGE.set(editor, onContextChange)
+
     return () => {
       EDITOR_TO_ON_CHANGE.set(editor, () => {})
       unmountRef.current = true


### PR DESCRIPTION
**Description**
With Strict Mode starting in React 18, whenever a component mounts in development, React will simulate immediately unmounting and remounting the component. This change in behavior results in the `EDITOR_TO_ON_CHANGE` map getting set to a `NoOp` function due to the unmount call and does not reset to the correct callback function until the next state change happens within the `Slate` component. 

The fix for this is to put `EDITOR_TO_ON_CHANGE.set(editor, onContextChange)` into `useEffect` so that the correct `onContextChange` callback gets added back into the `EDITOR_TO_ON_CHANGE` map when effects get re-created on a mounted component.

[Link to read more about this change in React 18.](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state)

**Example**

**This is what the `EDITOR_TO_ON_CHANGE` callbacks look like within the lifecycle before the fix:**

<img width="510" alt="Screenshot 2023-01-15 at 9 14 06 AM" src="https://user-images.githubusercontent.com/1928424/212545873-53f4ed1d-e0cf-4689-a576-0215f76fd16f.png">

**After the fix:**

<img width="446" alt="Screenshot 2023-01-15 at 9 14 39 AM" src="https://user-images.githubusercontent.com/1928424/212545892-f5d23766-f765-4279-9506-1c9ae3ef05d4.png">


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

