### PR TITLE
Fix forced-layout example trigger insert untitle node

### DIFF
--- a/site/examples/forced-layout.tsx
+++ b/site/examples/forced-layout.tsx
@@ -6,6 +6,7 @@ import {
   Node,
   Element as SlateElement,
   Descendant,
+  Editor,
 } from 'slate'
 import { withHistory } from 'slate-history'
 import { ParagraphElement, TitleElement } from './custom-types'
@@ -15,12 +16,15 @@ const withLayout = editor => {
 
   editor.normalizeNode = ([node, path]) => {
     if (path.length === 0) {
-      if (editor.children.length < 1) {
+      if (editor.children.length <= 1 && Editor.string(editor, [0, 0]) === '') {
         const title: TitleElement = {
           type: 'title',
           children: [{ text: 'Untitled' }],
         }
-        Transforms.insertNodes(editor, title, { at: path.concat(0) })
+        Transforms.insertNodes(editor, title, {
+          at: path.concat(0),
+          select: true,
+        })
       }
 
       if (editor.children.length < 2) {


### PR DESCRIPTION
**Description**
Updates the forced-layout example so that it can insert untitle node.
When `Editor.before()` return null, Slate will not actually delete. So `editor.children.length < 1` never trigger.
Now if you delete after `cmd+a`, also you delete the last paragraph when title is empty,  it can insert untitle node.

**Example**
before: 

https://user-images.githubusercontent.com/33490722/213435182-a9d757cd-430e-44f1-a9b1-294fd5c5d214.mov

after:

https://user-images.githubusercontent.com/33490722/213435161-311a65d0-f85a-46b1-b16a-b1bc09e2ec32.mov

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

