### PR TITLE
Improve compatibility for browsers that do not support `ResizeObserver` or `:where` selector

### DIFF
--- a/.changeset/witty-tips-work.md
+++ b/.changeset/witty-tips-work.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Improve compatibility for browsers that do not support ResizeObserver or :where selector

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -14,6 +14,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@juggle/resize-observer": "^3.4.0",
     "@types/is-hotkey": "^0.1.1",
     "@types/lodash": "^4.14.149",
     "direction": "^1.0.3",

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -66,6 +66,7 @@ import {
   NODE_TO_ELEMENT,
   PLACEHOLDER_SYMBOL,
 } from '../utils/weak-maps'
+import { whereIfSupported } from '../utils/where-if-supported'
 import { RestoreDOM } from './restore-dom/restore-dom'
 import { useAndroidInputManager } from '../hooks/android-input-manager/use-android-input-manager'
 import { useTrackUserInput } from '../hooks/use-track-user-input'
@@ -812,9 +813,8 @@ export const Editable = (props: EditableProps) => {
       // Set global default styles for editors.
       const defaultStylesElement = document.createElement('style')
       defaultStylesElement.setAttribute('data-slate-default-styles', 'true')
-      defaultStylesElement.innerHTML =
-        // :where is used to give these rules lower specificity so user stylesheets can override them.
-        `:where([data-slate-editor]) {` +
+      const selector = '[data-slate-editor]'
+      const defaultStyles =
         // Allow positioning relative to the editable element.
         `position: relative;` +
         // Prevent the default outline styles.
@@ -822,8 +822,9 @@ export const Editable = (props: EditableProps) => {
         // Preserve adjacent whitespace and new lines.
         `white-space: pre-wrap;` +
         // Allow words to break if they are too long.
-        `word-wrap: break-word;` +
-        `}`
+        `word-wrap: break-word;`
+      defaultStylesElement.innerHTML = whereIfSupported(selector, defaultStyles)
+
       document.head.appendChild(defaultStylesElement)
     }
 

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react'
 import { Element, Text } from 'slate'
+import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer'
 import String from './string'
 import {
   PLACEHOLDER_SYMBOL,
@@ -60,6 +61,7 @@ const Leaf = (props: {
         placeholderResizeObserver.current.observe(placeholderEl)
     } else if (placeholderEl) {
       // Create a new observer and observe the placeholder element.
+      const ResizeObserver = window.ResizeObserver || ResizeObserverPolyfill
       placeholderResizeObserver.current = new ResizeObserver(([{ target }]) => {
         const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
         if (styleElement) {

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -8,6 +8,7 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
+import { whereIfSupported } from '../utils/where-if-supported'
 
 /**
  * Individual leaves in a text node with unique formatting.
@@ -63,8 +64,9 @@ const Leaf = (props: {
         const styleElement = EDITOR_TO_STYLE_ELEMENT.get(editor)
         if (styleElement) {
           // Make the min-height the height of the placeholder.
-          const minHeight = `${target.clientHeight}px`
-          styleElement.innerHTML = `:where([data-slate-editor-id="${editor.id}"]) { min-height: ${minHeight}; }`
+          const selector = `[data-slate-editor-id="${editor.id}"]`
+          const styles = `min-height: ${target.clientHeight}px;`
+          styleElement.innerHTML = whereIfSupported(selector, styles)
         }
       })
 

--- a/packages/slate-react/src/utils/where-if-supported.ts
+++ b/packages/slate-react/src/utils/where-if-supported.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns a set of rules that use the `:where` selector if it is supported,
+ * otherwise it falls back to the provided selector on its own.
+ *
+ * The `:where` selector is used to give a selector a lower specificity,
+ * allowing the rule to be overridden by a user-defined stylesheet.
+ *
+ * Older browsers do not support the `:where` selector.
+ * If it is not supported, the selector will be used without `:where`,
+ * which means that the rule will have a higher specificity and a user-defined
+ * stylesheet will not be able to override it easily.
+ */
+export function whereIfSupported(selector: string, styles: string): string {
+  return (
+    `@supports (selector(:where(${selector}))) {` +
+    `:where(${selector}) { ${styles} }` +
+    `}` +
+    `@supports not (selector(:where(${selector}))) {` +
+    `${selector} { ${styles} }` +
+    `}`
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,6 +2268,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@juggle/resize-observer@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@juggle/resize-observer@npm:3.4.0"
+  checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
+  languageName: node
+  linkType: hard
+
 "@lerna/add@npm:3.21.0":
   version: 3.21.0
   resolution: "@lerna/add@npm:3.21.0"
@@ -13904,6 +13911,7 @@ resolve@^2.0.0-next.3:
   resolution: "slate-react@workspace:packages/slate-react"
   dependencies:
     "@babel/runtime": ^7.7.4
+    "@juggle/resize-observer": ^3.4.0
     "@types/is-hotkey": ^0.1.1
     "@types/jest": ^27.4.1
     "@types/jsdom": ^16.2.14


### PR DESCRIPTION
**Description**
#5206 made Editable components use stylesheets for default styles instead of inline styles. However, it also inadvertently reduced compatibility with browsers that lack support for `ResizeObserver` and the `:where` CSS selector (mainly Safari versions released before September 2020). The result was that browsers that did not support `ResizeObserver` would throw a `ReferenceError` when rendering a placeholder element, and browsers that did not support `:where` would not see default styles for Editable components.

This PR adds a polyfill for `ResizeObserver` and a fallback for browsers that do not support `:where` to fix both of those problems.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/pull/5206#issuecomment-1384361788

**Context**
The latest major browser to add support for `ResizeObserver` is Safari in version 13.1, released March 2020. (https://caniuse.com/resizeobserver) On browsers that do not support it, a `ReferenceError` is thrown when a placeholder element is rendered. This problem is fixed by adding a polyfill for `ResizeObserver`: the npm package [`@juggle/resize-observer`](https://www.npmjs.com/package/@juggle/resize-observer). Note that the native `ResizeObserver` will be used if it exists.

The latest major browser to add support for `:where` is Safari in version 14, released September 2020. (https://caniuse.com/mdn-css_selectors_where) Browsers that do not support `:where` do not parse the default styles for Editable components and placeholder elements, and thus their default styles do not appear.

Default stylesheets using `:where` were introduced in #5206 to give the default styles for Editable components and placeholder elements a specificity of 0, which allows for user-defined stylesheets to override them by simply adding their own class to the Editable component. I do not know of a way to implement this behavior without support for `:where` or CSS layers, so I instead opted to just fix the default styles not being applied.

The fallback for the `:where` selector is implemented by checking support for it using a `@supports` rule. If there is no support, the default styles for Editable components and placeholder elements is set without `:where`. This means that after this change, browsers that do not support `:where` will see default styles, but the specificity of the default styles will be high enough that a user-defined stylesheet with a class for an Editable component will not override the default style. However, inline styles on the Editable component should still override the default styles.

I tested these changes on Firefox 68.9.0 ESR, which supports neither `ResizeObserver` nor `:where`, and both problems appear to be fixed.

Note: it is unclear to me which browser versions Slate intends to support, but [the FAQ](https://docs.slatejs.org/general/faq) only rules out support for IE11, and in the issue linked above at least one person has expressed a desire for Slate to support pre-13.1 Safari.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
