### PR TITLE
feat: allow to change clipboard fragment format name

### DIFF
--- a/.changeset/afraid-cougars-smell.md
+++ b/.changeset/afraid-cougars-smell.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Allow to change clipboard fragment format name

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -44,7 +44,10 @@ import { ReactEditor } from './react-editor'
  * See https://docs.slatejs.org/concepts/11-typescript to learn how.
  */
 
-export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
+export const withReact = <T extends BaseEditor>(
+  editor: T,
+  clipboardFormatKey = 'x-slate-fragment'
+): T & ReactEditor => {
   const e = editor as T & ReactEditor
   const { apply, onChange, deleteBackward, addMark, removeMark } = e
 
@@ -262,7 +265,7 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
     const string = JSON.stringify(fragment)
     const encoded = window.btoa(encodeURIComponent(string))
     attach.setAttribute('data-slate-fragment', encoded)
-    data.setData('application/x-slate-fragment', encoded)
+    data.setData(`application/${clipboardFormatKey}`, encoded)
 
     // Add the content to a <div> so that we can get its inner HTML.
     const div = contents.ownerDocument.createElement('div')
@@ -286,7 +289,7 @@ export const withReact = <T extends BaseEditor>(editor: T): T & ReactEditor => {
      * Checking copied fragment from application/x-slate-fragment or data-slate-fragment
      */
     const fragment =
-      data.getData('application/x-slate-fragment') ||
+      data.getData(`application/${clipboardFormatKey}`) ||
       getSlateFragmentAttribute(data)
 
     if (fragment) {

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -256,15 +256,18 @@ export const getSlateFragmentAttribute = (
  * Get the x-slate-fragment attribute that exist in text/html data
  * and append it to the DataTransfer object
  */
-export const getClipboardData = (dataTransfer: DataTransfer): DataTransfer => {
-  if (!dataTransfer.getData('application/x-slate-fragment')) {
+export const getClipboardData = (
+  dataTransfer: DataTransfer,
+  clipboardFormatKey = 'x-slate-fragment'
+): DataTransfer => {
+  if (!dataTransfer.getData(`application/${clipboardFormatKey}`)) {
     const fragment = getSlateFragmentAttribute(dataTransfer)
     if (fragment) {
       const clipboardData = new DataTransfer()
       dataTransfer.types.forEach(type => {
         clipboardData.setData(type, dataTransfer.getData(type))
       })
-      clipboardData.setData('application/x-slate-fragment', fragment)
+      clipboardData.setData(`application/${clipboardFormatKey}`, fragment)
       return clipboardData
     }
   }


### PR DESCRIPTION
**Description**
Allow customization of clipboard fragment format name. Based on #5233 and [slate-angular](https://github.com/worktile/slate-angular/blob/master/packages/src/plugins/with-angular.ts#L22)

**Issue**
#5233

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

