### PR TITLE
Firefox: fix wrong text highlighting with double-click (revived PR)

### DIFF
--- a/.changeset/thirty-starfishes-knock.md
+++ b/.changeset/thirty-starfishes-knock.md
@@ -1,0 +1,5 @@
+---
+'slate-react': major
+---
+
+Firefox: fix wrong text highlighting with double-click

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -535,9 +535,9 @@ export const ReactEditor = {
     domPoint: DOMPoint,
     options: {
       exactMatch: boolean
-      suppressThrow: boolean
+      suppressThrow: T
     }
-  ): Point | null {
+  ): T extends true ? Point | null : Point {
     const { exactMatch, suppressThrow } = options
     const [nearestNode, nearestOffset] = exactMatch
       ? domPoint
@@ -703,7 +703,7 @@ export const ReactEditor = {
     editor: ReactEditor,
     domRange: DOMRange | DOMStaticRange | DOMSelection,
     options: {
-      exactMatch: T
+      exactMatch: boolean
       suppressThrow: T
     }
   ): T extends true ? Range | null : Range {
@@ -797,18 +797,18 @@ export const ReactEditor = {
      */
 
     if (IS_FIREFOX && !isCollapsed && anchorNode !== focusNode) {
-      const isEnd = Editor.isEnd(editor, anchor, anchor.path)
-      const isStart = Editor.isStart(editor, focus, focus.path)
+      const isEnd = Editor.isEnd(editor, anchor!, anchor.path)
+      const isStart = Editor.isStart(editor, focus!, focus.path)
 
       if (isEnd) {
         const after = Editor.after(editor, anchor as Point)
         // Editor.after() might return undefined
-        anchor = after || anchor
+        anchor = (after || anchor!) as T extends true ? Point | null : Point
       }
 
       if (isStart) {
         const before = Editor.before(editor, focus as Point)
-        focus = before || focus
+        focus = (before || focus!) as T extends true ? Point | null : Point
       }
     }
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -534,10 +534,10 @@ export const ReactEditor = {
     editor: ReactEditor,
     domPoint: DOMPoint,
     options: {
-      exactMatch: T
-      suppressThrow: T
+      exactMatch: boolean
+      suppressThrow: boolean
     }
-  ): T extends true ? Point | null : Point {
+  ): Point | null {
     const { exactMatch, suppressThrow } = options
     const [nearestNode, nearestOffset] = exactMatch
       ? domPoint
@@ -754,16 +754,15 @@ export const ReactEditor = {
       )
     }
 
-    const anchor = ReactEditor.toSlatePoint(
-      editor,
-      [anchorNode, anchorOffset],
-      { exactMatch, suppressThrow }
-    )
+    let anchor = ReactEditor.toSlatePoint(editor, [anchorNode, anchorOffset], {
+      exactMatch,
+      suppressThrow,
+    })
     if (!anchor) {
       return null as T extends true ? Range | null : Range
     }
 
-    const focus = isCollapsed
+    let focus = isCollapsed
       ? anchor
       : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset], {
           exactMatch,
@@ -771,6 +770,46 @@ export const ReactEditor = {
         })
     if (!focus) {
       return null as T extends true ? Range | null : Range
+    }
+
+    /**
+     * suppose we have this document:
+     *
+     * { type: 'paragraph',
+     *   children: [
+     *     { text: 'foo ' },
+     *     { text: 'bar' },
+     *     { text: ' baz' }
+     *   ]
+     * }
+     *
+     * a double click on "bar" on chrome will create this range:
+     *
+     * anchor -> [0,1] offset 0
+     * focus  -> [0,1] offset 3
+     *
+     * while on firefox will create this range:
+     *
+     * anchor -> [0,0] offset 4
+     * focus  -> [0,2] offset 0
+     *
+     * let's try to fix it...
+     */
+
+    if (IS_FIREFOX && !isCollapsed && anchorNode !== focusNode) {
+      const isEnd = Editor.isEnd(editor, anchor, anchor.path)
+      const isStart = Editor.isStart(editor, focus, focus.path)
+
+      if (isEnd) {
+        const after = Editor.after(editor, anchor as Point)
+        // Editor.after() might return undefined
+        anchor = after || anchor
+      }
+
+      if (isStart) {
+        const before = Editor.before(editor, focus as Point)
+        focus = before || focus
+      }
     }
 
     let range: Range = { anchor: anchor as Point, focus: focus as Point }


### PR DESCRIPTION
**Description**
This is a revival of PR #4908, which itself is a revival of #3374, both of which are currently inactive.

This PR fixes the bug in Firefox where double-clicking a word creates a selection whose anchor is inside the preceeding text node. (This is similar to the concept of a "hanging range", but not an example of it as per #4852.)

**Issue**
Fixes #3336
Fixes #3840
Fixes #4634
Fixes [#1987](https://github.com/udecode/plate/issues/1987) (Plate)
Fixes [#1897](https://github.com/udecode/plate/issues/1897) (Plate)

**Example**
From #4908:

![Example](https://user-images.githubusercontent.com/21054523/159650729-fe733364-7e0d-40c4-9093-41c4853391f1.gif)

**Context**
PR #4908 had two requested changes (left by @BitPhinix) which were never addressed.

1. [Relating to type signatures](https://github.com/ianstormtaylor/slate/pull/4908#discussion_r857711656)

I've fixed this and the resulting type errors. If anyone more experienced with TypeScript than myself knows a more elegant way of handling the casts on [lines 806 and 811](https://github.com/12joan/slate/blob/firefox_selection/packages/slate-react/src/plugin/react-editor.ts#L806), please let me know.

2. ["Maybe we should replace this with a `Editor.hangRange` helper"](https://github.com/ianstormtaylor/slate/pull/4908#discussion_r857713507)

There's still no clear concensus on what `Editor.unhangRange` should and should not be responsible for. In the comments on #4703, @e1himself suggested that it should be modified to support text nodes and cases where the starting point of the range needs adjusting.

Adding a separate `Editor.hangRange` helper would probably confuse the terminology even further. (If to "unhang" a range is to move the end point inside some text node, then to "hang" it should probably mean to reverse that, which isn't the intended behaviour here.)

My suggestion would be to first add support for text nodes to `Editor.unhangRange`, perhaps conditional on a `texts: boolean` option, and second to add a `side: 'start' | 'end' | 'both'` option, defaulting to `'end'` if compatibility is a concern, controlling whether the start or end of the range is adjusted.

This should certainly happen in a separate PR, however. For now, I'd suggest we leave the logic in `toSlateRange` as it is unless anyone can spot a flaw in it.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)