### PR TITLE
add tripdocs link to resources

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -61,5 +61,6 @@ These pre-packaged editors are built on top of Slate, and can be helpful to see 
 - [React Force Slate Editor](https://github.com/nareshbhatia/react-force/tree/master/packages/slate-editor) is a light-weight medium-style editor with no editor chrome.
 - [React Page](https://github.com/react-page/react-page) is a self-contained, customizable inline WYSIWYG editor library.
 - [Slate Plugins Next](https://github.com/zbeyens/slate-plugins-next) provides an editor with configurable and extendable plugins.
+- [Tripdocs](https://github.com/ctripcorp/tripdocs): It's a modern, production-ready rich text editor.
 
 \(Or, if you have their exact use case, can be a drop-in editor for you.\)


### PR DESCRIPTION
**Description**
add tripdocs link to docs resources

**Issue**
Fixes: null

**Example**
add a line
![image](https://user-images.githubusercontent.com/18424614/215417420-f0c1a6f4-8285-4e73-abb3-eb5fb67bdc08.png)

**Context**
This introduces an open source, modern, production-ready rich text editor

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

