### PR TITLE
Fix: hovering-toolbar playwright integration test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -78,6 +78,9 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+
+    /* Name of attribute for selecting elements by page.getByTestId */
+    testIdAttribute: 'data-test-id',
   },
 
   /* Configure projects for major browsers */

--- a/playwright/integration/examples/hovering-toolbar.test.ts
+++ b/playwright/integration/examples/hovering-toolbar.test.ts
@@ -7,24 +7,18 @@ test.describe('hovering toolbar example', () => {
 
   test('hovering toolbar appears', async ({ page }) => {
     await page.pause()
-    await expect(page.locator('div').nth(12)).toHaveCSS('opacity', '0')
+    await expect(page.getByTestId('menu')).toHaveCSS('opacity', '0')
 
     await page
       .locator('span[data-slate-string="true"]')
       .nth(0)
       .selectText()
-    expect(
-      await page
-        .locator('div')
-        .nth(12)
-        .count()
-    ).toBe(1)
+    expect(await page.getByTestId('menu').count()).toBe(1)
 
-    await expect(page.locator('div').nth(12)).toHaveCSS('opacity', '1')
+    await expect(page.getByTestId('menu')).toHaveCSS('opacity', '1')
     expect(
       await page
-        .locator('div')
-        .nth(12)
+        .getByTestId('menu')
         .locator('span.material-icons')
         .count()
     ).toBe(3)
@@ -35,7 +29,7 @@ test.describe('hovering toolbar example', () => {
       .locator('span[data-slate-string="true"]')
       .nth(0)
       .selectText()
-    await expect(page.locator('div').nth(12)).toHaveCSS('opacity', '1')
+    await expect(page.getByTestId('menu')).toHaveCSS('opacity', '1')
     await page
       .locator('span[data-slate-string="true"]')
       .nth(0)
@@ -43,7 +37,7 @@ test.describe('hovering toolbar example', () => {
     await page
       .locator('div')
       .nth(0)
-      .click({ force: true })
-    await expect(page.locator('div').nth(12)).toHaveCSS('opacity', '0')
+      .click({ force: true, position: { x: 0, y: 0 } })
+    await expect(page.getByTestId('menu')).toHaveCSS('opacity', '0')
   })
 })

--- a/site/components.tsx
+++ b/site/components.tsx
@@ -149,6 +149,7 @@ export const Menu = React.forwardRef(
   ) => (
     <div
       {...props}
+      data-test-id="menu"
       ref={ref}
       className={cx(
         className,


### PR DESCRIPTION
**Description**
There was an issue with playwright integration test. There was wrong menu selection locator

**Issue**

**Example**
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/9424830/217258098-83c2a96d-3ff2-4b57-be2d-d5b0891733c1.png">


**Context**

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

