### PR TITLE
fix: remove memory leaks in Text and Editable

### DIFF
--- a/.changeset/grumpy-pianos-sit.md
+++ b/.changeset/grumpy-pianos-sit.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix memory leaks by adding clean-up code that looks for ref resets in Editable and Text.

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useCallback } from 'react'
 import { Element, Range, Text as SlateText } from 'slate'
 import { ReactEditor, useSlateStatic } from '..'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
@@ -32,7 +32,7 @@ const Text = (props: {
     text,
   } = props
   const editor = useSlateStatic()
-  const ref = useRef<HTMLSpanElement>(null)
+  const ref = useRef<HTMLSpanElement | null>(null)
   const leaves = SlateText.decorations(text, decorations)
   const key = ReactEditor.findKey(editor, text)
   const children = []
@@ -54,20 +54,26 @@ const Text = (props: {
   }
 
   // Update element-related weak maps with the DOM element ref.
-  useIsomorphicLayoutEffect(() => {
-    const KEY_TO_ELEMENT = EDITOR_TO_KEY_TO_ELEMENT.get(editor)
-    if (ref.current) {
-      KEY_TO_ELEMENT?.set(key, ref.current)
-      NODE_TO_ELEMENT.set(text, ref.current)
-      ELEMENT_TO_NODE.set(ref.current, text)
-    } else {
-      KEY_TO_ELEMENT?.delete(key)
-      NODE_TO_ELEMENT.delete(text)
-    }
-  })
-
+  const callbackRef = useCallback(
+    (span: HTMLSpanElement | null) => {
+      const KEY_TO_ELEMENT = EDITOR_TO_KEY_TO_ELEMENT.get(editor)
+      if (span) {
+        KEY_TO_ELEMENT?.set(key, span)
+        NODE_TO_ELEMENT.set(text, span)
+        ELEMENT_TO_NODE.set(span, text)
+      } else {
+        KEY_TO_ELEMENT?.delete(key)
+        NODE_TO_ELEMENT.delete(text)
+        if (ref.current) {
+          ELEMENT_TO_NODE.delete(ref.current)
+        }
+      }
+      ref.current = span
+    },
+    [ref, editor, key, text]
+  )
   return (
-    <span data-slate-node="text" ref={ref}>
+    <span data-slate-node="text" ref={callbackRef}>
       {children}
     </span>
   )


### PR DESCRIPTION
**Description**
It was discovered that slate-react was leaving behind detached spans and divs as the edited text was being updated causing  memory leaks.

The cause of the leaks were in the weak maps used in `packages/slate-react/src/components/editable.tsx` and `packages/slate-react/src/components/text.tsx`.  DOM nodes stored in the maps were detached but the keys still had strong references.

This PR adds callback refs to remove DOM nodes from the maps when the refs are set to null.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

