### PR TITLE
fix selecting mention element in android, can't evoke the keyboard

### DIFF
--- a/site/examples/mentions.tsx
+++ b/site/examples/mentions.tsx
@@ -8,10 +8,14 @@ import {
   withReact,
   useSelected,
   useFocused,
+  useReadOnly,
 } from 'slate-react'
 
 import { Portal } from '../components'
 import { MentionElement } from './custom-types'
+
+export const IS_ANDROID =
+  typeof navigator !== 'undefined' && /Android/.test(navigator.userAgent)
 
 const MentionExample = () => {
   const ref = useRef<HTMLDivElement | null>()
@@ -204,6 +208,7 @@ const Element = props => {
 const Mention = ({ attributes, children, element }) => {
   const selected = useSelected()
   const focused = useFocused()
+  const readOnly = useReadOnly()
   const style: React.CSSProperties = {
     padding: '3px 3px 2px',
     margin: '0 1px',
@@ -221,14 +226,18 @@ const Mention = ({ attributes, children, element }) => {
   if (element.children[0].italic) {
     style.fontStyle = 'italic'
   }
+
   return (
     <span
       {...attributes}
-      contentEditable={false}
+      contentEditable={!readOnly && IS_ANDROID}
       data-cy={`mention-${element.character.replace(' ', '-')}`}
       style={style}
     >
-      {children}@{element.character}
+      {children}
+      <span contentEditable="false" style={{ userSelect: 'none' }}>
+        @{element.character}
+      </span>
     </span>
   )
 }


### PR DESCRIPTION
**Description**
In android, once selecting an inline void element, the keyboard doesn't be evoked, unless we set it's contenteditable to be true, like below

<img width="683" alt="image" src="https://user-images.githubusercontent.com/11460856/219866497-bdbffadd-8001-4d10-8e51-303757a53a0a.png">

But it will make the children (a zero width node) to be contenteditable. So we should disable it's inputting at the beforeinput event.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5183

**Example**

https://www.slatejs.org/examples/mentions

before:

https://user-images.githubusercontent.com/11460856/219867021-ca1b3937-3fc1-4986-8c4d-1744e567d846.mp4

after:

https://user-images.githubusercontent.com/11460856/219867027-4848f8dd-bc28-4c69-bb57-c189f3fb7158.mp4


**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

