### PR TITLE
fix: add support for pasting plain text into editable void

### DIFF
--- a/.changeset/large-steaks-try.md
+++ b/.changeset/large-steaks-try.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Allow pasting plain text into editable voids

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1610,7 +1610,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
                   !readOnly &&
-                  ReactEditor.hasSelectableTarget(editor, event.target) &&
+                  ReactEditor.hasEditableTarget(editor, event.target) &&
                   !isEventHandled(event, attributes.onPaste)
                 ) {
                   // COMPAT: Certain browsers don't support the `beforeinput` event, so we


### PR DESCRIPTION
**Description**
This is a fix for the issue preventing pasting plain text into editable voids. At the moment one can paste other Slate elements into an editable void, but nothing happens when plain text (e.g. copying a URL from browser's search bar).

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5294

**Example**

Before:
https://user-images.githubusercontent.com/3620639/219029517-0f7b11e3-78ae-4033-af74-61730103ae04.gif

After:

https://user-images.githubusercontent.com/20068819/220671252-af48f410-a5c1-4e57-8fcc-4cb88242c953.mov



**Context**

A change was introduced recently to support copying and pasting void elements, which seems to have changed the behaviour for the paste action as you can find it here https://github.com/ianstormtaylor/slate/pull/5121/files#diff-1d0c52ec4c5562d96965f789988bd4efd4a6d24b88527918987d06bcc43d15adL1576
It is not fully clear to me if that change was intentional or it was simply added to match the `onCopy` logic. I performed some testing according to the original PR's purpose and the copy-paste of void elements seems to still work as expected. Let me know if anyone has more insights and there is something that should be checked.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

