### PR TITLE
Use memoization to avoid unnecessary `textContent` updates in `TextString` component

### DIFF
--- a/.changeset/text-leaf-memoization.md
+++ b/.changeset/text-leaf-memoization.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Use memoization to avoid unnecessary `textContent` updates in `<TextString>` component.


### PR DESCRIPTION
**Description**
This PR changes the approach used in the `<TextString>` component to synchronize the DOM and the Virtual DOM. 

Previously, the initial render of the `<TextString>` component would render the initial text, but the second render would remove the text from the DOM, before quickly being re-committed to the DOM in the layout effect before the browser had time to paint.

This PR takes a different approach that avoids ever having to render an empty `textContent` on the second render. Instead, we render a memoized component in `<TextString>` (`<MemoizedText>`), that receives props that are referentially stable across re-renders, such that React never updates the DOM across re-renders.

This PR provides a significant performance improvement over the current implementation, as previously the first update to an element would cause all its text leaves to re-render and wastefully update their `textContent` even if it had not changed.

**Issue**
I couldn't find any related tickets.

**Example**

_Before_


https://user-images.githubusercontent.com/1416436/220776950-0b1838d9-9a06-48b0-9f33-bffff87c3ece.mov




_After_


https://user-images.githubusercontent.com/1416436/220776966-d9429718-122d-44c2-90b5-ed7721ed1f72.mov



**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

