### PR TITLE
fix: Add missing dependencies to useEffect and React.memo calls (#5289)

### DIFF
--- a/.changeset/pretty-buses-stare.md
+++ b/.changeset/pretty-buses-stare.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix to ensure that the latest versions of onChange and renderPlaceholder are used

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -139,6 +139,7 @@ const MemoizedElement = React.memo(Element, (prev, next) => {
     prev.element === next.element &&
     prev.renderElement === next.renderElement &&
     prev.renderLeaf === next.renderLeaf &&
+    prev.renderPlaceholder === next.renderPlaceholder &&
     isElementDecorationsEqual(prev.decorations, next.decorations) &&
     (prev.selection === next.selection ||
       (!!prev.selection &&

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -68,7 +68,7 @@ export const Slate = (props: {
       EDITOR_TO_ON_CHANGE.set(editor, () => {})
       unmountRef.current = true
     }
-  }, [])
+  }, [onContextChange])
 
   const [isFocused, setIsFocused] = useState(ReactEditor.isFocused(editor))
 

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -84,6 +84,7 @@ const MemoizedText = React.memo(Text, (prev, next) => {
     next.parent === prev.parent &&
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
+    next.renderPlaceholder === prev.renderPlaceholder &&
     next.text === prev.text &&
     isTextDecorationsEqual(next.decorations, prev.decorations)
   )


### PR DESCRIPTION
**Description**
The merge of #5261 caused a regression where the first value of onChange is cached indefinitely because it is not used as a dependency of the effect that is supposed to maintain it. This fixes that bug, and similar bugs in the React.memo comparisons for MemoizedElement and MemoizedText where a cached `renderPlaceholder` is passed down to the leaf.

**Issue**
Fixes: #5289

**Example**
See the recording in #5289 for an example of the bug. A similar one could be crafted with renderPlaceholder being cached if necessary, but it should be pretty clear from the code.

**Context**
There aren't really other ways to fix these issues in a localized manner. I did look into adding the eslint plugin that can help check hook dependencies but there are violations in the code that would require distracting workarounds or API changes so I opted to keep it concise.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

