### PR TITLE
fix: `normalizeNode`

### DIFF
--- a/.changeset/large-worms-jog.md
+++ b/.changeset/large-worms-jog.md
@@ -1,5 +1,5 @@
 ---
-"slate": patch
+'slate': patch
 ---
 
 Fix #5295 regression. `editor.shouldNormalize` new option: `initialDirtyPathsLength: number`

--- a/.changeset/large-worms-jog.md
+++ b/.changeset/large-worms-jog.md
@@ -2,6 +2,7 @@
 "slate": patch
 ---
 
-fix #5295 regression
+Fix #5295 regression.
+`editor.shouldNormalize` new option: `initialDirtyPathsLength: number`
 
 

--- a/.changeset/large-worms-jog.md
+++ b/.changeset/large-worms-jog.md
@@ -2,7 +2,4 @@
 "slate": patch
 ---
 
-Fix #5295 regression.
-`editor.shouldNormalize` new option: `initialDirtyPathsLength: number`
-
-
+Fix #5295 regression. `editor.shouldNormalize` new option: `initialDirtyPathsLength: number`

--- a/.changeset/large-worms-jog.md
+++ b/.changeset/large-worms-jog.md
@@ -1,0 +1,7 @@
+---
+"slate": patch
+---
+
+fix #5295 regression
+
+

--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -420,7 +420,7 @@ Check if a value is a void `Element` object.
 
 Override this method to prevent normalizing the editor.
 
-Options: `{ iteration: number; dirtyPaths: Path[]; operation?: Operation(entry: NodeEntry, { operation }`
+Options: `{ dirtyPaths: Path[]; initialDirtyPathsLength: number; iteration: number; operation?: Operation }`
 
 ### Callback method
 

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -414,8 +414,8 @@ export const createEditor = (): Editor => {
       }
     },
 
-    shouldNormalize: ({ iteration, dirtyPaths }) => {
-      const maxIterations = dirtyPaths.length * 42 // HACK: better way?
+    shouldNormalize: ({ iteration, initialDirtyPathsLength }) => {
+      const maxIterations = initialDirtyPathsLength * 42 // HACK: better way?
 
       if (iteration > maxIterations) {
         throw new Error(

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -85,6 +85,7 @@ export interface BaseEditor {
     operation,
   }: {
     iteration: number
+    initialDirtyPathsLength: number
     dirtyPaths: Path[]
     operation?: Operation
   }) => boolean
@@ -1072,15 +1073,15 @@ export const Editor: EditorInterface = {
         }
       }
 
-      const dirtyPaths = getDirtyPaths(editor)
-
+      const initialDirtyPathsLength = getDirtyPaths(editor).length
       let iteration = 0
 
       while (getDirtyPaths(editor).length !== 0) {
         if (
           !editor.shouldNormalize({
-            iteration,
             dirtyPaths: getDirtyPaths(editor),
+            iteration,
+            initialDirtyPathsLength,
             operation,
           })
         ) {

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -1073,13 +1073,14 @@ export const Editor: EditorInterface = {
         }
       }
 
-      const initialDirtyPathsLength = getDirtyPaths(editor).length
+      let dirtyPaths = getDirtyPaths(editor)
+      const initialDirtyPathsLength = dirtyPaths.length
       let iteration = 0
 
-      while (getDirtyPaths(editor).length !== 0) {
+      while (dirtyPaths.length !== 0) {
         if (
           !editor.shouldNormalize({
-            dirtyPaths: getDirtyPaths(editor),
+            dirtyPaths,
             iteration,
             initialDirtyPathsLength,
             operation,
@@ -1096,6 +1097,7 @@ export const Editor: EditorInterface = {
           editor.normalizeNode(entry, { operation })
         }
         iteration++
+        dirtyPaths = getDirtyPaths(editor)
       }
     })
   },


### PR DESCRIPTION
**Description**
The maximum number of iterations should be computed before the while loop, not inside.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

