### PR TITLE
Implement type predicate for `operationCanTransformPath`

### DIFF
--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -1,4 +1,11 @@
-import { Operation } from '..'
+import {
+  InsertNodeOperation,
+  MergeNodeOperation,
+  MoveNodeOperation,
+  RemoveNodeOperation,
+  SplitNodeOperation,
+  Operation,
+} from '..'
 import { TextDirection } from './types'
 
 /**
@@ -41,7 +48,14 @@ export interface PathInterface {
   isSibling: (path: Path, another: Path) => boolean
   levels: (path: Path, options?: PathLevelsOptions) => Path[]
   next: (path: Path) => Path
-  operationCanTransformPath: (operation: Operation) => boolean
+  operationCanTransformPath: (
+    operation: Operation
+  ) => operation is
+    | InsertNodeOperation
+    | RemoveNodeOperation
+    | MergeNodeOperation
+    | SplitNodeOperation
+    | MoveNodeOperation
   parent: (path: Path) => Path
   previous: (path: Path) => Path
   relative: (path: Path, ancestor: Path) => Path
@@ -302,7 +316,14 @@ export const Path: PathInterface = {
    * NOTE: This *must* be kept in sync with the implementation of 'transform'
    * below
    */
-  operationCanTransformPath(operation: Operation): boolean {
+  operationCanTransformPath(
+    operation: Operation
+  ): operation is
+    | InsertNodeOperation
+    | RemoveNodeOperation
+    | MergeNodeOperation
+    | SplitNodeOperation
+    | MoveNodeOperation {
     switch (operation.type) {
       case 'insert_node':
       case 'remove_node':


### PR DESCRIPTION
**Description**
This pull request implements a type predicate for the function `operationCanTransformPath` which lives within the `Path` interface.
We have figured, it helps us in writing cleaner code if the function would use a type predicate.

**Example**
```
if (Path.operationCanTransformPath(operation)) {
    // ts would complain here without the type predicate
    console.log(operation.path);
}
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)
