### PR TITLE
Bugfix/cancel debounced and throttled function when unmounting component

### DIFF
--- a/.changeset/cancel-throttled-and-debounced-functions-on-unmount.md
+++ b/.changeset/cancel-throttled-and-debounced-functions-on-unmount.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Cancel throttled and debounced functions when the component is unmounted

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -704,6 +704,9 @@ export const Editable = (props: EditableProps) => {
         EDITOR_TO_ELEMENT.delete(editor)
         NODE_TO_ELEMENT.delete(editor)
 
+        onDOMSelectionChange.cancel()
+        scheduleOnDOMSelectionChange.cancel()
+
         if (ref.current && HAS_BEFORE_INPUT_SUPPORT) {
           // @ts-ignore The `beforeinput` event isn't recognized.
           ref.current.removeEventListener('beforeinput', onDOMBeforeInput)


### PR DESCRIPTION
**Description**
When unmunting the Slate component directly after mounting it, (In my case it was the"key" props that change too quickly) some functions was still running after the component was unmounted. Raising uncaught execption.

**Issue**
Fixes: [(link to issue)](https://github.com/ianstormtaylor/slate/issues/5319)

**Example**
![image](https://user-images.githubusercontent.com/20936586/221564818-dbc04444-decd-49e3-87a7-083b0b34c10b.png)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

