### PR TITLE
fix: cancel debounced listeners in Editable

### DIFF
--- a/.changeset/red-hats-guess.md
+++ b/.changeset/red-hats-guess.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Add checks to Editable selection change handler to avoid errors

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -701,6 +701,9 @@ export const Editable = (props: EditableProps) => {
   const callbackRef = useCallback(
     node => {
       if (node == null) {
+        onDOMSelectionChange.cancel()
+        scheduleOnDOMSelectionChange.cancel()
+
         EDITOR_TO_ELEMENT.delete(editor)
         NODE_TO_ELEMENT.delete(editor)
 
@@ -721,7 +724,7 @@ export const Editable = (props: EditableProps) => {
 
       ref.current = node
     },
-    [ref, onDOMBeforeInput]
+    [ref, onDOMBeforeInput, onDOMSelectionChange, scheduleOnDOMSelectionChange]
   )
 
   // Attach a native DOM event handler for `selectionchange`, because React's


### PR DESCRIPTION
`Editable` creates a couple debounced selection event listeners. 

With the recent changes to remove memory leaks, if the debounced event listeners are triggered but the editor is removed from the DOM before the debounce timer fires, errors are thrown: "Cannot resolve a DOM node from Slate node".

The event handlers have `cancel` methods that need to be called when an editor's node is removed from the DOM.  

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

