### PR TITLE
[Android] Fix edge-cases when text leaf nodes are deleted

### DIFF
--- a/.changeset/android-removed-leaf.md
+++ b/.changeset/android-removed-leaf.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix edge-cases in the Android input manager when text leaf nodes are deleted, such as when deleting text leaf nodes adjacent to inline void nodes.

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -2,6 +2,7 @@ import { DebouncedFunc } from 'lodash'
 import { Editor, Node, Path, Point, Range, Text, Transforms } from 'slate'
 import { ReactEditor } from '../../plugin/react-editor'
 import {
+  applyStringDiff,
   mergeStringDiffs,
   normalizePoint,
   normalizeRange,
@@ -153,7 +154,7 @@ export function createAndroidInputManager({
       EDITOR_TO_PENDING_DIFFS.get(editor)
     )
 
-    let scheduleSelectionChange = !!EDITOR_TO_PENDING_DIFFS.get(editor)?.length
+    let scheduleSelectionChange = hasPendingDiffs()
 
     let diff: TextDiff | undefined
     while ((diff = EDITOR_TO_PENDING_DIFFS.get(editor)?.[0])) {
@@ -377,38 +378,75 @@ export function createAndroidInputManager({
       return
     }
 
-    if (Range.isExpanded(targetRange) && type.startsWith('delete')) {
-      const [start, end] = Range.edges(targetRange)
-      const leaf = Node.leaf(editor, start.path)
+    // By default, the input manager tries to store text diffs so that we can
+    // defer flushing them at a later point in time. We don't want to flush
+    // for every input event as this can be expensive. However, there are some
+    // scenarios where we cannot safely store the text diff and must instead
+    // schedule an action to let Slate normalize the editor state.
+    let canStoreDiff = true
 
-      if (leaf.text.length === start.offset && end.offset === 0) {
-        const next = Editor.next(editor, { at: start.path, match: Text.isText })
-        if (next && Path.equals(next[1], end.path)) {
-          targetRange = { anchor: end, focus: end }
-        }
-      }
-    }
-
-    if (Range.isExpanded(targetRange) && type.startsWith('delete')) {
-      if (Path.equals(targetRange.anchor.path, targetRange.focus.path)) {
+    if (type.startsWith('delete')) {
+      if (Range.isExpanded(targetRange)) {
         const [start, end] = Range.edges(targetRange)
+        const leaf = Node.leaf(editor, start.path)
 
-        const point = { path: targetRange.anchor.path, offset: start.offset }
-        const range = Editor.range(editor, point, point)
-        handleUserSelect(range)
-
-        return storeDiff(targetRange.anchor.path, {
-          text: '',
-          end: end.offset,
-          start: start.offset,
-        })
+        if (leaf.text.length === start.offset && end.offset === 0) {
+          const next = Editor.next(editor, {
+            at: start.path,
+            match: Text.isText,
+          })
+          if (next && Path.equals(next[1], end.path)) {
+            targetRange = { anchor: end, focus: end }
+          }
+        }
       }
 
       const direction = type.endsWith('Backward') ? 'backward' : 'forward'
-      return scheduleAction(
-        () => Editor.deleteFragment(editor, { direction }),
-        { at: targetRange }
+      const [start, end] = Range.edges(targetRange)
+      const [leaf, path] = Editor.leaf(editor, start.path)
+
+      const diff = {
+        text: '',
+        start: start.offset,
+        end: end.offset,
+      }
+      const pendingDiffs = EDITOR_TO_PENDING_DIFFS.get(editor)
+      const relevantPendingDiffs = pendingDiffs?.find(change =>
+        Path.equals(change.path, path)
       )
+      const diffs = relevantPendingDiffs
+        ? [relevantPendingDiffs.diff, diff]
+        : [diff]
+      const text = applyStringDiff(leaf.text, ...diffs)
+
+      if (text.length === 0) {
+        // Text leaf will be removed, so we need to schedule an
+        // action to remove it so that Slate can normalize instead
+        // of storing as a diff
+        canStoreDiff = false
+      }
+
+      if (Range.isExpanded(targetRange)) {
+        if (
+          canStoreDiff &&
+          Path.equals(targetRange.anchor.path, targetRange.focus.path)
+        ) {
+          const point = { path: targetRange.anchor.path, offset: start.offset }
+          const range = Editor.range(editor, point, point)
+          handleUserSelect(range)
+
+          return storeDiff(targetRange.anchor.path, {
+            text: '',
+            end: end.offset,
+            start: start.offset,
+          })
+        }
+
+        return scheduleAction(
+          () => Editor.deleteFragment(editor, { direction }),
+          { at: targetRange }
+        )
+      }
     }
 
     switch (type) {
@@ -423,7 +461,7 @@ export function createAndroidInputManager({
       case 'deleteContent':
       case 'deleteContentForward': {
         const { anchor } = targetRange
-        if (Range.isCollapsed(targetRange)) {
+        if (canStoreDiff && Range.isCollapsed(targetRange)) {
           const targetNode = Node.leaf(editor, anchor.path)
 
           if (anchor.offset < targetNode.text.length) {
@@ -451,6 +489,7 @@ export function createAndroidInputManager({
           : !!nativeTargetRange?.collapsed
 
         if (
+          canStoreDiff &&
           nativeCollapsed &&
           Range.isCollapsed(targetRange) &&
           anchor.offset > 0
@@ -610,8 +649,10 @@ export function createAndroidInputManager({
             insertPositionHint = false
           }
 
-          storeDiff(start.path, diff)
-          return
+          if (canStoreDiff) {
+            storeDiff(start.path, diff)
+            return
+          }
         }
 
         return scheduleAction(() => Editor.insertText(editor, text), {

--- a/packages/slate-react/src/utils/diff-text.ts
+++ b/packages/slate-react/src/utils/diff-text.ts
@@ -52,7 +52,7 @@ export function verifyDiffState(editor: Editor, textDiff: TextDiff): boolean {
   return Text.isText(nextNode) && nextNode.text.startsWith(diff.text)
 }
 
-function applyStringDiff(text: string, ...diffs: StringDiff[]) {
+export function applyStringDiff(text: string, ...diffs: StringDiff[]) {
   return diffs.reduce(
     (text, diff) =>
       text.slice(0, diff.start) + diff.text + text.slice(diff.end),


### PR DESCRIPTION
#### Description
This PR fixes edge-cases in the Android input manager when text leafs are deleted.

#### Issue
Fixes: 
- https://github.com/ianstormtaylor/slate/issues/5192

**Context**
Previously, text leaf deletions were stored in pending diffs and only reconciled when flushing as a result of a selection change or an action (such as inserting a line break). This could result in a number of different edge cases, such as the browser not knowing where to place the selection after deleting a text node before or after a void node.

In order to fix these edge cases, we detect when an input event would result in a text leaf being deleted, and schedule an action to allow Slate to reconcile its state with the DOM and apply normalization fixes (such as inserting zero-width spacers next to inline void nodes) rather than storing these events as deferred text diffs.

#### Example

##### Before

![Before](https://user-images.githubusercontent.com/69415032/201137252-0853d1aa-4cce-4150-a48e-cdb6a843f369.gif)

https://user-images.githubusercontent.com/1416436/221979804-5ebfc519-f87d-401c-b03c-ab54129677ac.mov

##### After

https://user-images.githubusercontent.com/1416436/221979578-dbe437b5-73bc-4172-93b1-1d91d47376a3.mov


##### Note

There is a separate issue for the keyboard being closed when the selection moves right before void nodes, this PR does not solve that separate issue:

- https://github.com/ianstormtaylor/slate/issues/5183
- https://github.com/ianstormtaylor/slate/pull/5298

If we apply the fix described in the PR linked above, we can see what the final desired behaviour would eventually look like once we find a solution to https://github.com/ianstormtaylor/slate/issues/5183:

https://user-images.githubusercontent.com/1416436/221980680-73b9be67-69dd-4330-8b03-6e8668a2b26c.mov


#### Checks

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

