### PR TITLE
Fix the issue of composition API and beforeinput event triggering between Chrome versions 60-75 on the Android platform.

### DIFF
--- a/.changeset/new-dryers-stare.md
+++ b/.changeset/new-dryers-stare.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix the issue of composition API and beforeinput event triggering between Chrome versions 60-75 on the Android platform.

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -68,11 +68,10 @@ export const CAN_USE_DOM = !!(
 // COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
 // Chrome Legacy doesn't support `beforeinput` correctly
 export const HAS_BEFORE_INPUT_SUPPORT =
-  (!IS_CHROME_LEGACY &&
-    !IS_EDGE_LEGACY &&
-    // globalThis is undefined in older browsers
-    typeof globalThis !== 'undefined' &&
-    globalThis.InputEvent &&
-    // @ts-ignore The `getTargetRanges` property isn't recognized.
-    typeof globalThis.InputEvent.prototype.getTargetRanges === 'function') ||
-  !IS_ANDROID_CHROME_LEGACY
+  (!IS_CHROME_LEGACY || !IS_ANDROID_CHROME_LEGACY) &&
+  !IS_EDGE_LEGACY &&
+  // globalThis is undefined in older browsers
+  typeof globalThis !== 'undefined' &&
+  globalThis.InputEvent &&
+  // @ts-ignore The `getTargetRanges` property isn't recognized.
+  typeof globalThis.InputEvent.prototype.getTargetRanges === 'function'

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -37,6 +37,11 @@ export const IS_CHROME_LEGACY =
   typeof navigator !== 'undefined' &&
   /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])(?:\.)/i.test(navigator.userAgent)
 
+export const IS_ANDROID_CHROME_LEGACY =
+  IS_ANDROID &&
+  typeof navigator !== 'undefined' &&
+  /Chrome?\/(?:[0-5]?\d)(?:\.)/i.test(navigator.userAgent)
+
 // Firefox did not support `beforeInput` until `v87`.
 export const IS_FIREFOX_LEGACY =
   typeof navigator !== 'undefined' &&
@@ -63,10 +68,11 @@ export const CAN_USE_DOM = !!(
 // COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
 // Chrome Legacy doesn't support `beforeinput` correctly
 export const HAS_BEFORE_INPUT_SUPPORT =
-  !IS_CHROME_LEGACY &&
-  !IS_EDGE_LEGACY &&
-  // globalThis is undefined in older browsers
-  typeof globalThis !== 'undefined' &&
-  globalThis.InputEvent &&
-  // @ts-ignore The `getTargetRanges` property isn't recognized.
-  typeof globalThis.InputEvent.prototype.getTargetRanges === 'function'
+  (!IS_CHROME_LEGACY &&
+    !IS_EDGE_LEGACY &&
+    // globalThis is undefined in older browsers
+    typeof globalThis !== 'undefined' &&
+    globalThis.InputEvent &&
+    // @ts-ignore The `getTargetRanges` property isn't recognized.
+    typeof globalThis.InputEvent.prototype.getTargetRanges === 'function') ||
+  !IS_ANDROID_CHROME_LEGACY


### PR DESCRIPTION
**Description**
We found that the code for determining the conditions of use of the `beforeinput` event is based on the following code.

https://github.com/ianstormtaylor/slate/blob/96ad964beee5b7c67d4aa18bdd9d6e7d2f9ef3bf/packages/slate-react/src/utils/environment.ts#L36
https://github.com/ianstormtaylor/slate/blob/96ad964beee5b7c67d4aa18bdd9d6e7d2f9ef3bf/packages/slate-react/src/utils/environment.ts#L65

Where `IS_CHROME_LEGACY` determines that Chrome versions smaller than 76 cannot use the `beforeinput` event. This results in the following example of Chrome version 68 not being able to use `beforeinput`, resulting in a crash.

**Example**

https://user-images.githubusercontent.com/22654945/222090911-73fe7c1e-8638-44cf-b7a9-7de096d8fd5d.mp4

**Context**
We know from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event#browser_compatibility) that beforeinput is supported on Android Chrome above version 60, the `IS_CHROME_LEGACY` method determines that there are some other compatibility considerations below version 76.

But this set of judgments may not apply to the Android side. So we added `IS_ANDROID_CHROME_LEGACY` judgment for Android side which condition becomes greater than version 59 to use both the beforeinput event, we tested it on version 58 and 68 and it works fine.

**Checks**

- [x]  The new code matches the existing patterns and styles.
- [x]  The tests pass with `yarn test`.
- [x]  The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x]  The relevant examples still work. (Run examples with `yarn start`.)
- [x]  You've [[added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md)](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)