### PR TITLE
reduce unnecessary rendering

### DIFF
--- a/.changeset/loud-moons-fix.md
+++ b/.changeset/loud-moons-fix.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Extract the default placeholder render prop to a constant to reduce unnecessary rendering.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -137,7 +137,7 @@ export const Editable = (props: EditableProps) => {
     readOnly = false,
     renderElement,
     renderLeaf,
-    renderPlaceholder = props => <DefaultPlaceholder {...props} />,
+    renderPlaceholder = renderDefaultPlaceholder,
     scrollSelectionIntoView = defaultScrollSelectionIntoView,
     style: userStyle = {},
     as: Component = 'div',
@@ -1670,6 +1670,10 @@ export const DefaultPlaceholder = ({
     {children}
     {IS_ANDROID && <br />}
   </span>
+)
+
+const renderDefaultPlaceholder = (props: RenderPlaceholderProps) => (
+  <DefaultPlaceholder {...props} />
 )
 
 /**


### PR DESCRIPTION
**Description**
Extract the default  placeholder render prop to a constant to reduce unnecessary rendering.

Using react devtool profile for the huge-document example:
before:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/11460856/222964482-3dae79da-efcc-4d31-a9d0-e2b0cb788e0e.png">

after:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/11460856/222964523-04ccb856-400f-4b99-9109-9565ad27ac28.png">


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

