### PR TITLE
Fix performance issue with `renderPlaceholder`

### DIFF
--- a/.changeset/small-timers-sin.md
+++ b/.changeset/small-timers-sin.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fixes #5335. To prevent performance issues, make sure to wrap custom `renderPlaceholder` values in `useCallback`.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -129,6 +129,10 @@ export type EditableProps = {
  */
 
 export const Editable = (props: EditableProps) => {
+  const defaultRenderPlaceholder = useCallback(
+    (props: RenderPlaceholderProps) => <DefaultPlaceholder {...props} />,
+    []
+  )
   const {
     autoFocus,
     decorate = defaultDecorate,
@@ -137,7 +141,7 @@ export const Editable = (props: EditableProps) => {
     readOnly = false,
     renderElement,
     renderLeaf,
-    renderPlaceholder = props => <DefaultPlaceholder {...props} />,
+    renderPlaceholder = defaultRenderPlaceholder,
     scrollSelectionIntoView = defaultScrollSelectionIntoView,
     style: userStyle = {},
     as: Component = 'div',


### PR DESCRIPTION
**Description**
PR #5310 introduced a performance issue when typing in large documents, caused by adding `renderPlaceholder` to `useMemo` in `element.tsx`. This PR fixes that performance issue by wrapping the default `renderPlaceholder` in a `useCallback`.

In addition, all custom `renderPlaceholder` functions passed to `Editable` should also be wrapped in `useCallback`. 

**Issue**
Fixes: #5335

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

