### PR TITLE
Fix error when triple-clicking a word preceding a `contenteditable="false"` DOM node in Chrome

### DIFF
--- a/.changeset/lucky-falcons-reflect.md
+++ b/.changeset/lucky-falcons-reflect.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix error when triple-clicking a word preceding a `contenteditable="false"` DOM node in Chrome

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -754,6 +754,17 @@ export const ReactEditor = {
       )
     }
 
+    // COMPAT: Triple-clicking a word in chrome will sometimes place the focus
+    // inside a `contenteditable="false"` DOM node following the word, which
+    // will cause `toSlatePoint` to throw an error. (2023/03/07)
+    if (
+      'getAttribute' in focusNode &&
+      (focusNode as HTMLElement).getAttribute('contenteditable') === 'false'
+    ) {
+      focusNode = anchorNode
+      focusOffset = anchorNode.textContent?.length || 0
+    }
+
     let anchor = ReactEditor.toSlatePoint(editor, [anchorNode, anchorOffset], {
       exactMatch,
       suppressThrow,


### PR DESCRIPTION
**Description**
Triple-clicking a word in Chrome will sometimes place the focus inside a `contenteditable="false"` DOM node following the word, which causes `toSlatePoint` to throw an error. This PR checks for this and adjusts the `focusNode` if necessary.

**Issue**
Fixes #5341 

**Context**
https://github.com/ianstormtaylor/slate/issues/4329#issuecomment-894212249

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

