### PR TITLE
fix an image example bug that user can't use 'mod + a' to select or delete all nodes…

### DIFF
--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import imageExtensions from 'image-extensions'
 import isUrl from 'is-url'
+import isHotkey from 'is-hotkey'
 import { Transforms, createEditor, Descendant } from 'slate'
 import {
   Slate,
@@ -29,6 +30,12 @@ const ImagesExample = () => {
         <InsertImageButton />
       </Toolbar>
       <Editable
+        onKeyDown={event => {
+          if (isHotkey('mod+a', event)) {
+            event.preventDefault()
+            Transforms.select(editor, [])
+          }
+        }}
         renderElement={props => <Element {...props} />}
         placeholder="Enter some text..."
       />


### PR DESCRIPTION
I can't use 'mod + a' to select all the slate elements when I learn slate by image example. So here is a pull  request to solve this problem.