### PR TITLE
fix: Editable not calling decorate as it should

### DIFF
--- a/.changeset/dry-bugs-protect.md
+++ b/.changeset/dry-bugs-protect.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix a problem with Editable not calling the decorate function passed as a prop when it should.

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -704,7 +704,7 @@ export function createAndroidInputManager({
       insertPositionHint = false
     }
 
-    if (pathChanged || !hasPendingDiffs()) {
+    if (pathChanged || hasPendingDiffs()) {
       flushTimeoutId = setTimeout(flush, FLUSH_DELAY)
     }
   }


### PR DESCRIPTION
Fixes this problem:

1. On an Android phone, open the "Search Highlighting" example page.
2. Search for test.  For example, "search".
3. Place the cursor immediately after one of the highlighted strings.
4. Type additional text.

The additional text will be highlighted as if it matched the search string.

The problem was `Editable` was not calling the `decorate` function that was passed to it when it should.

One thing to note with the fix.  If you follow the steps above and you type additional text quickly, some of it will appear highlighted for a split second.  The gif below demonstrates that.

![2023-03-07 15 23 16](https://user-images.githubusercontent.com/4441986/223559866-a21b8cad-d981-48c6-8b72-aeb09ccc1fa5.gif)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

