### PR TITLE
Fix the nodeName from lower to upper case

### DIFF
--- a/docs/concepts/10-serializing.md
+++ b/docs/concepts/10-serializing.md
@@ -173,7 +173,7 @@ const deserialize = (el, markAttributes = {}) => {
 
   // define attributes for text nodes
   switch (el.nodeName) {
-    case 'strong':
+    case 'STRONG':
       nodeAttributes.bold = true
   }
 


### PR DESCRIPTION
The node name should be `STRONG` instead of `strong` in the example deserialize function.

**Description**
In the given deserialize section of the docs, the `el.nodeName` should be upper case. Instead of `strong` it should be `STRONG`. 

**Issue**
Fixes: the deserialize function mentioned in the [Deserializing](https://docs.slatejs.org/concepts/10-serializing#deserializing) section of the docs. 


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

