### PR TITLE
Fix/suggested text closes keyboard

### DIFF
--- a/packages/slate-react/src/components/restore-dom/restore-dom-manager.ts
+++ b/packages/slate-react/src/components/restore-dom/restore-dom-manager.ts
@@ -23,8 +23,11 @@ export const createRestoreDomManager = (
       return
     }
 
-    const trackedMutations = mutations.filter(mutation =>
-      isTrackedMutation(editor, mutation, mutations)
+    const trackedMutations = mutations.filter(
+      mutation =>
+        isTrackedMutation(editor, mutation, mutations) &&
+        mutation.type !== 'characterData' &&
+        (mutation.removedNodes.length || mutation.addedNodes.length)
     )
 
     bufferedMutations.push(...trackedMutations)
@@ -33,12 +36,6 @@ export const createRestoreDomManager = (
   function restoreDOM() {
     if (bufferedMutations.length > 0) {
       bufferedMutations.reverse().forEach(mutation => {
-        if (mutation.type === 'characterData') {
-          // We don't want to restore the DOM for characterData mutations
-          // because this interrupts the composition.
-          return
-        }
-
         mutation.removedNodes.forEach(node => {
           mutation.target.insertBefore(node, mutation.nextSibling)
         })


### PR DESCRIPTION
As we all know, Android devices deal with content-editable divs in undesired ways.  There is a bug in `Editable` that causes the keyboard to close when you delete all of the text.  The same thing happens if you do the following while using the Samsung keyboard using one of the example pages:

1. Delete all of the text.
2. Type a word like "Engineering".
3. Delete some of that word leaving "Enginee".
4.  Select "Engineering" from the keyboard's suggested words.

The keyboard will hide.  This is because the Samsung keyboard is generating two input events.  First it deletes the "Enginee" and then it inserts "Engineering". Because of the keyboard hiding bug described above, the keyboard hides when you follow the test steps above as well.

When all of the text is deleted, the placeholder text is inserted into the editor as a span with `contentEditable` set to false.  Given that the only thing contained in the editable <div> is a <span> that can't be edited, the keyboard is hidden.

The goal of this PR is to move the placeholder text outside of the editable <div> to avoid the keyboard hiding problem.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

