### PR TITLE
Fix pasting content with newlines on Android

### DIFF
--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -596,6 +596,13 @@ export function createAndroidInputManager({
           text = text.replace('\uFEFF', '')
         }
 
+        // Pastes from the Android clipboard will generate `insertText` events.
+        // If the copied text contains any newlines, Android will append an
+        // extra newline to the end of the copied text.
+        if (type === 'insertText' && /.*\n.*\n$/.test(text)) {
+          text = text.slice(0, -1)
+        }
+
         // If the text includes a newline, split it at newlines and paste each component
         // string, with soft breaks in between each.
         if (text.includes('\n')) {

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -36,6 +36,10 @@ const FLUSH_DELAY = 200
 // Replace with `const debug = console.log` to debug
 const debug = (..._: unknown[]) => {}
 
+// Type guard to check if a value is a DataTransfer
+const isDataTransfer = (value: any): value is DataTransfer =>
+  value?.constructor.name === 'DataTransfer'
+
 export type CreateAndroidInputManagerOptions = {
   editor: ReactEditor
 
@@ -343,7 +347,8 @@ export function createAndroidInputManager({
 
     const { inputType: type } = event
     let targetRange: Range | null = null
-    const data = (event as any).dataTransfer || event.data || undefined
+    const data: DataTransfer | string | undefined =
+      (event as any).dataTransfer || event.data || undefined
 
     if (
       insertPositionHint !== false &&
@@ -577,8 +582,7 @@ export function createAndroidInputManager({
       case 'insertFromYank':
       case 'insertReplacementText':
       case 'insertText': {
-        if (data?.constructor.name === 'DataTransfer') {
-          return scheduleAction(() => ReactEditor.insertData(editor, data), {
+        if (isDataTransfer(data)) {
             at: targetRange,
           })
         }


### PR DESCRIPTION
**Description**

This is another potential solution for #5190 (see also #5195).

The root issue is with how text with newlines is handled on Android. If an InputEvent's data is a simple string containing newlines, the event handler inserts a soft break and then drops the rest of the event data. 

https://github.com/ianstormtaylor/slate/blob/1d8010be8500ef5c98dbd4179354db1986d5c8f4/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts#L586-L590

This PR updates the InputEvent handling code on Android so that when newlines are involved, the insertion is broken into single-line text insertions with soft breaks between them. It also makes some minor type improvements around the affected code.

**Issue**

Fixes: #5190

**Example**

| Current behavior | New behavior |
|-|-|
| <img width="300" alt="current behavior" src="https://user-images.githubusercontent.com/1042866/225099661-c281d68c-ca15-4461-8fee-e5e25faae983.gif"> | <img width="300" alt="new behavior" src="https://user-images.githubusercontent.com/1042866/225099727-4b2a1cff-f141-47b8-9a9b-12787e21568c.gif"> |

**Context**

#5195 fixed this issue by scheduling an `insertText` for text containing newlines rather than updating the diff. This PR is similar, but it replaces any newlines with soft breaks. It also strips the trailing newline that Android appends to clipboard text that contains newlines. This approach seemed reasonable given its simplicity, and given that inserts involving newlines are much less common than inserts without newlines.

This fix has been tested on a Pixel 4 running Android 12 and a couple of Samsung Galaxies running Android 12 and 13, with Gboard, Swiftkey, and Samsung keyboard. Copying and then pasting text within a paragraph, after a paragraph, and pasting over a text selection all appear to work as expected, whether the copied text contains newlines or not.

In a [comment](https://github.com/ianstormtaylor/slate/pull/5195#issuecomment-1323430560), @BitPhinix suggested there might be issues with this general approach with certain IMEs when inserting newlines in paragraphs, but I've been unable reproduce this behavior. The keyboards I've tested generate `insertParagraph` events (Gboard, Swiftkey, Samsung) when pressing enter at the beginning of a word or within a word, or `insertCompositionText` events (Gboard, Swiftkey) when the return key is pressed (the Samsung keyboard still generates an `insertParagraph` for this case). An example that behaves differently would be very useful for testing.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

