### PR TITLE
Android mentions fixes

### DIFF
--- a/site/examples/mentions.tsx
+++ b/site/examples/mentions.tsx
@@ -233,7 +233,8 @@ const Mention = ({ attributes, children, element }) => {
       data-cy={`mention-${element.character.replace(' ', '-')}`}
       style={style}
     >
-      &#x200B;{children}@{element.character}&#x200B;
+      @{element.character}
+      {children}
     </span>
   )
 }

--- a/site/examples/mentions.tsx
+++ b/site/examples/mentions.tsx
@@ -125,6 +125,11 @@ const MentionExample = () => {
             {chars.map((char, i) => (
               <div
                 key={char}
+                onClick={() => {
+                  Transforms.select(editor, target)
+                  insertMention(editor, char)
+                  setTarget(null)
+                }}
                 style={{
                   padding: '1px 3px',
                   borderRadius: '3px',
@@ -228,7 +233,7 @@ const Mention = ({ attributes, children, element }) => {
       data-cy={`mention-${element.character.replace(' ', '-')}`}
       style={style}
     >
-      {children}@{element.character}
+      &#x200B;{children}@{element.character}&#x200B;
     </span>
   )
 }


### PR DESCRIPTION
**Description**
This fixes the Android keyboard handling of mentions by moving the non visible space character after the mention. This PR also adds a click handler to the mention dropdown to make it easier to test on mobile.

**Issue**
Solves the issue where typing immediately after a mention on Android causes the text of the mention to be repeated.

**Example**

As tested on Chrome on a Pixel 5A.

Before:

https://user-images.githubusercontent.com/11273838/225190460-8d7a1535-2afe-4dff-9482-812adb7e8a88.mp4



After:

https://user-images.githubusercontent.com/11273838/225190511-06bfbaba-9c7f-4b4f-bb9e-8229da326644.mp4


Note that an issue with a period before a mention still persists.

**Context**
The non-visible spacer is important for focus and mention styling. There are a lot of issues related to this character including possibly changing from the current \uFEFF character, but those changes should be orthogonal to this issue.

The reason this solution works is because the Android keyboard works with whole words rather than simply inputting one character at a time. This triggers before input events that compose multiple characters together. However in the case of void elements, the keyboard sees the text before the cursor and tries to include that in the autocomplete. When slate goes to enter the text, it assumes the text is entirely new and adds it on top of the existing text.

Closes #5357

**Related Issues and PRs**
- #5071 
- #5298

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

