### PR TITLE
Fix `markdown-shortcuts.test.ts` for webkit

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,7 +46,7 @@ const retries = process.env.PLAYWRIGHT_RETRIES
 const config: PlaywrightTestConfig = {
   testDir: './playwright',
   /* Maximum time one test can run for. */
-  timeout: 10 * 1000,
+  timeout: 20 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/playwright/integration/examples/code-highlighting.test.ts
+++ b/playwright/integration/examples/code-highlighting.test.ts
@@ -1,5 +1,7 @@
 import { test, expect, Page } from '@playwright/test'
 
+test.setTimeout(60 * 1000)
+
 test.describe('code highlighting', () => {
   test.beforeEach(async ({ page }) => {
     page.goto('http://localhost:3000/examples/code-highlighting')

--- a/playwright/integration/examples/markdown-shortcuts.test.ts
+++ b/playwright/integration/examples/markdown-shortcuts.test.ts
@@ -14,7 +14,7 @@ test.describe('On markdown-shortcuts example', () => {
     ).toContain('A wise quote.')
   })
 
-  test('can add list items', async ({ page }) => {
+  test('can add list items', async ({ page }, testInfo) => {
     expect(
       await page
         .getByRole('textbox')
@@ -23,7 +23,9 @@ test.describe('On markdown-shortcuts example', () => {
     ).toBe(0)
 
     await page.getByRole('textbox').click()
-    await page.getByRole('textbox').press('Home')
+    await page
+      .getByRole('textbox')
+      .press(testInfo.project.name === 'webkit' ? 'Meta+ArrowLeft' : 'Home')
     await page.getByRole('textbox').type('* 1st Item')
     await page.keyboard.press('Enter')
     await page.getByRole('textbox').type('2nd Item')


### PR DESCRIPTION
**Description**
The `markdown-shortcuts.test.ts` Playwright test uses the `Home` key, which doesn't work in webkit. This PR changes the test to use `Meta+ArrowLeft` instead.

It also increases the default timeout from 10s to 20s, and 60s for the code highlighing tests. This was necessary to make the test suite pass consistently on my Mac.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] ~~You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)~~

