### PR TITLE
fix: allow copying from editable void input

### DIFF
--- a/.changeset/funny-students-sparkle.md
+++ b/.changeset/funny-students-sparkle.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Allow copying from editable void input

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1157,7 +1157,8 @@ export const Editable = (props: EditableProps) => {
               (event: React.ClipboardEvent<HTMLDivElement>) => {
                 if (
                   ReactEditor.hasSelectableTarget(editor, event.target) &&
-                  !isEventHandled(event, attributes.onCopy)
+                  !isEventHandled(event, attributes.onCopy) &&
+                  !isDOMEventTargetInput(event)
                 ) {
                   event.preventDefault()
                   ReactEditor.setFragmentData(
@@ -1174,7 +1175,8 @@ export const Editable = (props: EditableProps) => {
                 if (
                   !readOnly &&
                   ReactEditor.hasSelectableTarget(editor, event.target) &&
-                  !isEventHandled(event, attributes.onCut)
+                  !isEventHandled(event, attributes.onCut) &&
+                  !isDOMEventTargetInput(event)
                 ) {
                   event.preventDefault()
                   ReactEditor.setFragmentData(
@@ -1734,6 +1736,21 @@ export const isEventHandled = <
   }
 
   return event.isDefaultPrevented() || event.isPropagationStopped()
+}
+
+/**
+ * Check if the event's target is an input element
+ */
+export const isDOMEventTargetInput = <
+  EventType extends React.SyntheticEvent<unknown, unknown>
+>(
+  event: EventType
+) => {
+  return (
+    isDOMNode(event.target) &&
+    (event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement)
+  )
 }
 
 /**


### PR DESCRIPTION
**Description**
Copying from an editable void ends up with the whole void element being copied instead of the selected text only. I added a fix so that, when the target of the event is an input field it won't apply the regular Slate logic for copying and instead will just rely on the default browser's functionality.

You'll notice in the video that there is still a not-ideal use case where, if a section of text is selected from an editable void it still ends up copying the whole element, not just the text. This kind of approach is useful to enable, for example, copying a non-editable void element such as a mention. Let me know please if someone has a better idea of how to better handle it.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5366

**Example**

https://user-images.githubusercontent.com/20068819/225943020-6037354b-fc67-4264-be9a-646228c40c35.mov


**Context**


**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

