### PR TITLE
docs(concepts): fix code example on the Editor page

### DIFF
--- a/docs/concepts/07-editor.md
+++ b/docs/concepts/07-editor.md
@@ -77,7 +77,7 @@ If you have void "mention" elements that can accept marks like bold or italic:
 const { isVoid, markableVoid } = editor
 
 editor.isVoid = element => {
-  return element.type === 'mention' ? true : isInline(element)
+  return element.type === 'mention' ? true : isVoid(element)
 }
 
 editor.markableVoid = element => {


### PR DESCRIPTION
just little mistake in the code example