### PR TITLE
Extracts history push to own function

### DIFF
--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -17,6 +17,7 @@ export interface HistoryEditor extends BaseEditor {
   history: History
   undo: () => void
   redo: () => void
+  writeHistory: (stack: 'undos' | 'redos', batch: any) => void
 }
 
 // eslint-disable-next-line no-redeclare

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -37,7 +37,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
       })
 
       history.redos.pop()
-      history.undos.push(batch)
+      e.writeHistory('undos', batch)
     }
   }
 
@@ -61,7 +61,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
         })
       })
 
-      history.redos.push(batch)
+      e.writeHistory('redos', batch)
       history.undos.pop()
     }
   }
@@ -97,7 +97,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
           operations: [op],
           selectionBefore: e.selection,
         }
-        undos.push(batch)
+        e.writeHistory('undos', batch)
       }
 
       while (undos.length > 100) {
@@ -108,6 +108,10 @@ export const withHistory = <T extends Editor>(editor: T) => {
     }
 
     apply(op)
+  }
+
+  e.writeHistory = (stack: 'undos' | 'redos', batch: any) => {
+    e.history[stack].push(batch)
   }
 
   return e


### PR DESCRIPTION
**Description**

This PR extracts pushing to `history.undos` and `history.redos` into its own function. This allows interception of writing to the editor history in other plugins.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

