### PR TITLE
Fix issue when tabbing into editor in Safari

### DIFF
--- a/.changeset/cool-baboons-turn.md
+++ b/.changeset/cool-baboons-turn.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix issue when tabbing into editor in Safari (https://github.com/udecode/plate/issues/2315)

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -15,6 +15,7 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
+import { IS_SAFARI } from '../utils/environment'
 
 function disconnectPlaceholderResizeObserver(
   placeholderResizeObserver: MutableRefObject<ResizeObserver | null>,
@@ -125,6 +126,8 @@ const Leaf = (props: {
           opacity: '0.333',
           userSelect: 'none',
           textDecoration: 'none',
+          // Fixes https://github.com/udecode/plate/issues/2315
+          WebkitUserModify: IS_SAFARI ? 'inherit' : undefined,
         },
         contentEditable: false,
         ref: callbackPlaceholderRef,


### PR DESCRIPTION
**Description**
Fixes an issue in Safari making it imposible to focus the editor using the Tab key when the editor is empty and has a placeholder.

**Issue**
Fixes: https://github.com/udecode/plate/issues/2315

**Example**
Before:
https://user-images.githubusercontent.com/4272090/229171039-c9b535b2-9100-41c9-8e81-487eafd2be35.mov

After:
https://user-images.githubusercontent.com/4272090/229171068-a57c2064-4ead-469d-9414-80b0cfc228ca.mov

**Context**
Safari attempts to place the selection inside the placeholder element, which resulted in a null DOM selection prior to this fix, making it impossible to type even though the editor is technically focused. The simplest solution seems to be to allow Safari to place the selection inside the placeholder, which is what this fix does. (Thanks for discovering this workaround, @hb250131!)

Notice that the caret in the second video is grey and appears at the start of the placeholder, rather than in the middle of it. This is a side effect of the selection being inside the placeholder and happens only when focusing the editor using the Tab key in Safari. It seems to be harmless, but a more robust fix would ensure that the resulting selection is consistent across browsers.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)