### PR TITLE
Add initial value with children in install tutorial

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -71,7 +71,12 @@ Next up is to render a `<Slate>` context provider.
 The provider component keeps track of your Slate editor, its plugins, its value, its selection, and any changes that occur. It **must** be rendered above any `<Editable>` components. But it can also provide the editor state to other components like toolbars, menus, etc. using the `useSlate` hook.
 
 ```jsx
-const initialValue = []
+const initialValue = [
+  {
+    type: 'paragraph',
+    children: [{ text: 'A line of text in a paragraph.' }],
+  },
+]
 
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
@@ -88,30 +93,9 @@ This is a slightly different mental model than things like `<input>` or `<textar
 
 By having a shared context, those other components can execute commands, query the editor's state, etc.
 
-Okay, so the next step is to render the `<Editable>` component itself:
+The next step is to render the `<Editable>` component itself. The component acts like `contenteditable`; anywhere you render it will render an editable richtext document for the nearest editor context.
 
 ```jsx
-const initialValue = []
-
-const App = () => {
-  const [editor] = useState(() => withReact(createEditor()))
-  return (
-    // Add the editable component inside the context.
-    <Slate editor={editor} value={initialValue}>
-      <Editable />
-    </Slate>
-  )
-}
-```
-
-The `<Editable>` component acts like `contenteditable`. Anywhere you render it will render an editable richtext document for the nearest editor context.
-
-There's only one last step. So far we've been using an empty `[]` array as the initial value of the editor, so it has no content. Let's fix that by defining an initial value.
-
-The value is just plain JSON. Here's one containing a single paragraph block with some text in it:
-
-```jsx
-// Add the initial value.
 const initialValue = [
   {
     type: 'paragraph',
@@ -121,8 +105,8 @@ const initialValue = [
 
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
-
   return (
+    // Add the editable component inside the context.
     <Slate editor={editor} value={initialValue}>
       <Editable />
     </Slate>


### PR DESCRIPTION
**Description**
The "Installing Slate" tutorial starts off with an empty array for the initial editor state. I think a lot of people (including myself) assume the initial state can *always* be an empty array, but this breaks if you go straight to implementing other code samples that attempt to manipulate the state children.

For example, I implemented most of the logic in the [rich text editor sample](https://github.com/ianstormtaylor/slate/blob/main/site/examples/richtext.tsx), but it will fail with `Uncaught Error: Cannot resolve a Slate point from DOM point:` if your initial state is set to `[]`.

This PR cleans up the tutorial so that users simply start with an initial state that has children defined, so other code samples don't break. This will make it more likely that a user's first experience installing, running, and tinkering with other Slate code samples works first try without errors.

**Issue**
Fixes: [3421](https://github.com/ianstormtaylor/slate/issues/3421)

This doesn't fix every possible occurrence of this error, but in this issue you can see many people ran into this pitfall.

**Example**
Not too much to show here, but you can run [rich text editor sample](https://github.com/ianstormtaylor/slate/blob/main/site/examples/richtext.tsx) and just change `initialValue` to an empty array, and it will error.

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

