### PR TITLE
docs(walkthroughs): fix incomplete code block keyboard shortcut example

### DIFF
--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -153,7 +153,7 @@ const App = () => {
             Transforms.setNodes(
               editor,
               { type: 'code' },
-              { match: n => Editor.isBlock(editor, n) }
+              { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
             )
           }
         }}


### PR DESCRIPTION
**Description**
A code example in [Defining Custom Elements](https://docs.slatejs.org/walkthroughs/03-defining-custom-elements) documentation page has code that doesn't work.
The code example in question explains how to enable adding code blocks with a keyboard shortcut.
This PR updates the documentation so that the code example has working code.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5293

**Example**
No new behavior, it's just a documentation fix.

**Context**
It is explained in [this comment](https://github.com/ianstormtaylor/slate/issues/5293#issuecomment-1439401672).

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

