### PR TITLE
Remove unnecessary dollar sign from Chromium bug fix

### DIFF
--- a/site/examples/inlines.tsx
+++ b/site/examples/inlines.tsx
@@ -245,7 +245,7 @@ const InlineChromiumBugfix = () => (
       font-size: 0;
     `}
   >
-    ${String.fromCodePoint(160) /* Non-breaking space */}
+    {String.fromCodePoint(160) /* Non-breaking space */}
   </span>
 )
 


### PR DESCRIPTION
**Description**
When copying inline nodes from the Slate example, you get a dollar sign around the Inline text you were copying. I believe this is because of the `$` in the `InlineChromiumBugfix` component. 
 
**Example**

Old behavior:

https://user-images.githubusercontent.com/10213761/231716884-36b739a9-99a9-4d82-a7f7-83526e1f779b.mov

New behavior: 

https://user-images.githubusercontent.com/10213761/231721835-7758507a-7895-4846-a6fd-0823b6a2bed6.mov


**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

