### PR TITLE
Take previously added/removed nodes into account when fetching child …

### DIFF
--- a/.changeset/tall-gorillas-deny.md
+++ b/.changeset/tall-gorillas-deny.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Correct core normalization that could cause wrong nodes to be removed

--- a/packages/slate/src/create-editor.ts
+++ b/packages/slate/src/create-editor.ts
@@ -245,7 +245,7 @@ export const createEditor = (): Editor => {
       for (let i = 0; i < node.children.length; i++, n++) {
         const currentNode = Node.get(editor, path)
         if (Text.isText(currentNode)) continue
-        const child = node.children[i] as Descendant
+        const child = currentNode.children[n] as Descendant
         const prev = currentNode.children[n - 1] as Descendant
         const isLast = i === node.children.length - 1
         const isInlineOrText =

--- a/packages/slate/test/normalization/block/remove-inline.tsx
+++ b/packages/slate/test/normalization/block/remove-inline.tsx
@@ -6,6 +6,8 @@ export const input = (
     <block>
       <block>one</block>
       <inline>two</inline>
+      <block>three</block>
+      <inline>four</inline>
     </block>
   </editor>
 )
@@ -13,6 +15,7 @@ export const output = (
   <editor>
     <block>
       <block>one</block>
+      <block>three</block>
     </block>
   </editor>
 )

--- a/packages/slate/test/normalization/editor/remove-inline.tsx
+++ b/packages/slate/test/normalization/editor/remove-inline.tsx
@@ -5,10 +5,13 @@ export const input = (
   <editor>
     <inline>one</inline>
     <block>two</block>
+    <inline>three</inline>
+    <block>four</block>
   </editor>
 )
 export const output = (
   <editor>
     <block>two</block>
+    <block>four</block>
   </editor>
 )

--- a/packages/slate/test/normalization/editor/remove-text.tsx
+++ b/packages/slate/test/normalization/editor/remove-text.tsx
@@ -5,10 +5,13 @@ export const input = (
   <editor>
     <text>one</text>
     <block>two</block>
+    <text>three</text>
+    <block>four</block>
   </editor>
 )
 export const output = (
   <editor>
     <block>two</block>
+    <block>four</block>
   </editor>
 )

--- a/packages/slate/test/normalization/inline/remove-block.tsx
+++ b/packages/slate/test/normalization/inline/remove-block.tsx
@@ -8,6 +8,8 @@ export const input = (
       <inline>
         <block>one</block>
         <text>two</text>
+        <block>three</block>
+        <text>four</text>
       </inline>
       <text />
     </block>
@@ -18,7 +20,7 @@ export const output = (
     <block>
       <text />
       <inline>
-        <text>two</text>
+        <text>twofour</text>
       </inline>
       <text />
     </block>


### PR DESCRIPTION
**Description**
When when a node has two child nodes that would violate the core constraints (i.e. two inline nodes as children of the Editor) this can cause other nodes to be deleted that do not violate any core constraints. 

**Example**
Input:
```
<editor>
    <inline>one</inline>
    <block>two</block>
    <inline>three</inline>
    <block>four</block>
</editor>
```
Normalized result before this change:
```
<editor>
    <block>four</block>
</editor>
```
Normalized result after this change:
```
<editor>
    <block>two</block>
    <block>four</block>
</editor>
```
See adapted unit tests for more examples.


**Context**
Disclaimer: I only know very little about Slates internal, so my understanding here might not be 100% correct. 

Looks to me like the current logic for iterating children in the normalization uses two sets of variables `node` & `i` and `currentNode` & `n`. I think `node` & `i` are referring to the state of the editor when `normalizeNode` was entered and `currentNode`& `n` are referring the "current" state, taking into account transforms from an earlier iteration.
The transforms that are executed when a constraint violation is detected are always using `n` to construct the path to the transformed node, but the constraint was checked on the child node at index `i` instead, which leads to the wrong nodes being transformed.


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

