### PR TITLE
chore: corrects return type for the use-slate-static hook

### DIFF
--- a/.changeset/stupid-lies-search.md
+++ b/.changeset/stupid-lies-search.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+corrects return type for the useSlateStatic hook

--- a/packages/slate-react/src/hooks/use-slate-static.tsx
+++ b/packages/slate-react/src/hooks/use-slate-static.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext } from 'react'
-import { Editor } from 'slate'
 import { ReactEditor } from '../plugin/react-editor'
 
 /**
@@ -12,7 +11,7 @@ export const EditorContext = createContext<ReactEditor | null>(null)
  * Get the current editor object from the React context.
  */
 
-export const useSlateStatic = (): Editor => {
+export const useSlateStatic = (): ReactEditor => {
   const editor = useContext(EditorContext)
 
   if (!editor) {


### PR DESCRIPTION
**Description**
Aligns the return type listed in the docs with the return type used in code for the `useSlateStatic` hook.

**Issue**
Fixes: #5404 

**Example**
Docs: https://docs.slatejs.org/libraries/slate-react/hooks#useslatestatic-reacteditor

![CleanShot 2023-04-26 at 16 01 10](https://user-images.githubusercontent.com/30633324/234689246-2a126545-fb05-44fc-9c07-e2bf5121b5bf.png)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)