### PR TITLE
docs(walkthroughs): fix broken code example

### DIFF
--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -214,7 +214,7 @@ const App = () => {
             Transforms.setNodes(
               editor,
               { type: match ? 'paragraph' : 'code' },
-              { match: n => Editor.isBlock(editor, n) }
+              { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
             )
           }
         }}


### PR DESCRIPTION
**Description**

In the Walkthroughs / Defining Custom Elements documentation page, the last code example didn't work for me: the type of a node didn't change when I pressed the Ctrl+\` key combination. I looked at the differences between this example and the previous one that was working, and found that the `match` condition of the last example for missing a part that was there in the example before.

I added it and it fixed the example.

**Issue**
It doesn't seem there is an existing issue for that.

**Example**
I don't think it is needed for this change

**Context**
I don't think it is needed for this change

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

