### PR TITLE
Fix default focus styles

### DIFF
--- a/.changeset/late-zebras-dream.md
+++ b/.changeset/late-zebras-dream.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Prevents default focus styles from being removed in Editable

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -903,8 +903,6 @@ export const Editable = (props: EditableProps) => {
                 : {
                     // Allow positioning relative to the editable element.
                     position: 'relative',
-                    // Prevent the default outline styles.
-                    outline: 'none',
                     // Preserve adjacent whitespace and new lines.
                     whiteSpace: 'pre-wrap',
                     // Allow words to break if they are too long.


### PR DESCRIPTION
Resolves #5146

**Description**
Prevents default focus styles from being removed, making the behaviour opt-in via `<Editable>`'s `style` prop or other CSS

**Issue**
Fixes: #5146

**Example**
<img width="737" alt="Screenshot 2023-05-12 at 19 43 04" src="https://github.com/ianstormtaylor/slate/assets/240422/f1be85b5-164e-4728-a3a8-ea4924083a29">

**Context**
Since Slate.js does not provide any custom focus styles for the editable area, it should not remove the built-in focus style which is required per WCAG criterion [Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)

If a particular focus styling technique is preferred by library authors (e.g. highlighting the whole area with `:focus-within`), it should be described in the relevant documentation article (e.g. https://www.slatejs.org/examples/styling) rather than being hard-coded in the Editable component.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)