### PR TITLE
fix(slate-react): add top css to placeholder

### DIFF
--- a/.changeset/few-queens-fold.md
+++ b/.changeset/few-queens-fold.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix placeholder position in Safari 16.x

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -119,6 +119,7 @@ const Leaf = (props: {
         'data-slate-placeholder': true,
         style: {
           position: 'absolute',
+          top: 0,
           pointerEvents: 'none',
           width: '100%',
           maxWidth: '100%',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5222,17 +5222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001248":
-  version: 1.0.30001251
-  resolution: "caniuse-lite@npm:1.0.30001251"
-  checksum: 918e1b1662c26c11291206146bc305d7fd1ca351aa9231c2e21cb1526d87b444830e2d8dc54416ebb8ecf7e0addea12d66a1c41493476229987e5e6922f0c14b
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001332":
-  version: 1.0.30001363
-  resolution: "caniuse-lite@npm:1.0.30001363"
-  checksum: 8dfcb2fa97724349cbbe61d988810bd90bfb40106a289ed6613188fa96dd1f5885c7e9924e46bb30a641bd1579ec34096fdc2b21b47d8500f8a2bfb0db069323
+"caniuse-lite@npm:^1.0.30001248, caniuse-lite@npm:^1.0.30001332":
+  version: 1.0.30001486
+  resolution: "caniuse-lite@npm:1.0.30001486"
+  checksum: 5e8c2ba2679e4ad17dea6d2761a6449b814441bfeac81af6cc9d58af187df6af4b79b27befcbfc4a557e720b21c0399a7d1911c8705922e38938dcc0f40b5d4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description**
Placeholder position in Safari 16.4 is not correct. this PR aims to fix that. I also checked that in other versions of Safari there's no regression.

**Issue**
Fixes: #5386 

**Example**
Before:
![image](https://github.com/ianstormtaylor/slate/assets/725120/cab15e3d-dbd8-4a93-b4f6-7808a6763788)

After:
![image](https://github.com/ianstormtaylor/slate/assets/725120/f393d360-3a41-4e59-b3a0-04e659ac15ce)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

