### PR TITLE
Test for WebKit based browsers instead of Safari

### DIFF
--- a/.changeset/six-dryers-raise.md
+++ b/.changeset/six-dryers-raise.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Detect all WebKit based browsers for COMPAT behavior

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -46,7 +46,7 @@ import {
   IS_FIREFOX,
   IS_FIREFOX_LEGACY,
   IS_IOS,
-  IS_SAFARI,
+  IS_WEBKIT,
   IS_UC_MOBILE,
   IS_WECHATBROWSER,
 } from '../utils/environment'
@@ -1014,7 +1014,7 @@ export const Editable = (props: EditableProps) => {
                 // COMPAT: Safari doesn't always remove the selection even if the content-
                 // editable element no longer has focus. Refer to:
                 // https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web
-                if (IS_SAFARI) {
+                if (IS_WEBKIT) {
                   const domSelection = root.getSelection()
                   domSelection?.removeAllRanges()
                 }
@@ -1112,7 +1112,7 @@ export const Editable = (props: EditableProps) => {
                   // type that we need. So instead, insert whenever a composition
                   // ends since it will already have been committed to the DOM.
                   if (
-                    !IS_SAFARI &&
+                    !IS_WEBKIT &&
                     !IS_FIREFOX_LEGACY &&
                     !IS_IOS &&
                     !IS_WECHATBROWSER &&
@@ -1621,7 +1621,7 @@ export const Editable = (props: EditableProps) => {
                       return
                     }
                   } else {
-                    if (IS_CHROME || IS_SAFARI) {
+                    if (IS_CHROME || IS_WEBKIT) {
                       // COMPAT: Chrome and Safari support `beforeinput` event but do not fire
                       // an event when deleting backwards in a selected void inline node
                       if (
@@ -1670,7 +1670,7 @@ export const Editable = (props: EditableProps) => {
                   if (
                     !HAS_BEFORE_INPUT_SUPPORT ||
                     isPlainTextOnlyPaste(event.nativeEvent) ||
-                    IS_SAFARI
+                    IS_WEBKIT
                   ) {
                     event.preventDefault()
                     ReactEditor.insertData(editor, event.clipboardData)

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -15,7 +15,7 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
-import { IS_SAFARI } from '../utils/environment'
+import { IS_WEBKIT } from '../utils/environment'
 
 function disconnectPlaceholderResizeObserver(
   placeholderResizeObserver: MutableRefObject<ResizeObserver | null>,
@@ -128,7 +128,7 @@ const Leaf = (props: {
           userSelect: 'none',
           textDecoration: 'none',
           // Fixes https://github.com/udecode/plate/issues/2315
-          WebkitUserModify: IS_SAFARI ? 'inherit' : undefined,
+          WebkitUserModify: IS_WEBKIT ? 'inherit' : undefined,
         },
         contentEditable: false,
         ref: callbackPlaceholderRef,

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -19,9 +19,8 @@ export const IS_FIREFOX =
   typeof navigator !== 'undefined' &&
   /^(?!.*Seamonkey)(?=.*Firefox).*/i.test(navigator.userAgent)
 
-export const IS_SAFARI =
-  typeof navigator !== 'undefined' &&
-  /Version\/[\d\.]+.*Safari/.test(navigator.userAgent)
+export const IS_WEBKIT =
+  typeof navigator !== 'undefined' && /AppleWebKit/.test(navigator.userAgent)
 
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =


### PR DESCRIPTION
**Description**
The previous `IS_SAFARI` test did not catch some WebKit based environments that should have the special cased behavior. For example, running Slate inside a webview on iOS would result in a userAgent like: `"Mozilla/5.0 (iPhone; CPU iPhone OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"` which would not match the previous `IS_SAFARI` definition, but **does** have the same quirks since it is WebKit based.

**Issue**
No matching issue reported.

**Example**
One manifestation of this is the special behavior for Chrome/Safari (i.e. WebKit) for handling deleting selected inline voids [relevant code](https://github.com/ianstormtaylor/slate/blob/b7fd322f01fde36ff65f3c75a47a9972257f76e7/packages/slate-react/src/components/editable.tsx#L1627-L1628).

Prior to this change in a webview on iOS it would fail to delete a selected inline void since this special cased behavior wouldn't fire -- in these videos the input is a webview inside a react-native application; the webview is then using Slate and "design-triage" is an inline void element:

https://github.com/ianstormtaylor/slate/assets/28637598/56f90504-183a-40d2-a5d8-f3b4fd55f4fa

After this change it deletes as expected:

https://github.com/ianstormtaylor/slate/assets/28637598/bb773c6b-8603-4024-8d43-f2c8944b79ff

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

