### PR TITLE
fix:  caret jump to the start of composition string

### DIFF
--- a/.changeset/rare-glasses-tickle.md
+++ b/.changeset/rare-glasses-tickle.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+fix wrong caret position during composition.

--- a/.changeset/rare-glasses-tickle.md
+++ b/.changeset/rare-glasses-tickle.md
@@ -1,5 +1,5 @@
 ---
-'slate-react': minor
+'slate-react': patch
 ---
 
 fix wrong caret position during composition.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -366,7 +366,9 @@ export const Editable = (props: EditableProps) => {
         selection && ReactEditor.toDOMRange(editor, selection)
 
       if (newDomRange) {
-        if (Range.isBackward(selection!)) {
+        if (ReactEditor.isComposing(editor)) {
+          domSelection.collapseToEnd()
+        } else if (Range.isBackward(selection!)) {
           domSelection.setBaseAndExtent(
             newDomRange.endContainer,
             newDomRange.endOffset,


### PR DESCRIPTION
**Description**
Correct caret position during composition. 
When useIsomorphicLayoutEffect was triggered during composition, caret would jump to wrong position (jump to the start).
This commit fix the bug when using chinese IME.

More info about the bug is in the issue.

**Issue**
Fixes: [#5442](https://github.com/ianstormtaylor/slate/issues/5442)
