### PR TITLE
include missed import in docs walkthrough

### DIFF
--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -120,7 +120,7 @@ Okay, but now we'll need a way for the user to actually turn a block into a code
 
 ```jsx
 // Import the `Editor` and `Transforms` helpers from Slate.
-import { Editor, Transforms } from 'slate'
+import { Editor, Transforms, Element } from 'slate'
 
 const initialValue = [
   {


### PR DESCRIPTION
**Description**
Imports Element from slate, as it is used in the given code sample of the walkthrough:
```ts
// docs/walkthroughs/03-defining-custom-elements.md
// line 156
  { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
```

Prevents the following TS error:
```
Property 'isElement' does not exist on type '{ new (): Element; prototype: Element; }'.ts(2339)
```