### PR TITLE
Fixed triple click workaround breaking void elements selection

### DIFF
--- a/.changeset/popular-shrimps-give.md
+++ b/.changeset/popular-shrimps-give.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fixed occasional crashes when selecting void elements in Chrome

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -870,7 +870,7 @@ export const ReactEditor: ReactEditorInterface = {
     if (
       'getAttribute' in focusNode &&
       (focusNode as HTMLElement).getAttribute('contenteditable') === 'false' &&
-      !focusNode.matches('[data-slate-void]')
+      !(focusNode as HTMLElement).matches('[data-slate-void]')
     ) {
       focusNode = anchorNode
       focusOffset = anchorNode.textContent?.length || 0

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -869,7 +869,8 @@ export const ReactEditor: ReactEditorInterface = {
     // will cause `toSlatePoint` to throw an error. (2023/03/07)
     if (
       'getAttribute' in focusNode &&
-      (focusNode as HTMLElement).getAttribute('contenteditable') === 'false'
+      (focusNode as HTMLElement).getAttribute('contenteditable') === 'false' &&
+      !focusNode.matches('[data-slate-void]')
     ) {
       focusNode = anchorNode
       focusOffset = anchorNode.textContent?.length || 0

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -870,7 +870,7 @@ export const ReactEditor: ReactEditorInterface = {
     if (
       'getAttribute' in focusNode &&
       (focusNode as HTMLElement).getAttribute('contenteditable') === 'false' &&
-      !(focusNode as HTMLElement).matches('[data-slate-void]')
+      (focusNode as HTMLElement).getAttribute('data-slate-void') !== 'true'
     ) {
       focusNode = anchorNode
       focusOffset = anchorNode.textContent?.length || 0


### PR DESCRIPTION
**Description**
#5343 Introduced a workaround in `toSlateRange` with a purpose to fix [chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=608393)  with triple-clicking that sometimes moves cursor inside non content editable nodes `contentEditable="false"`. Unfortunately, the same workaround causes void elements to crash when being selected, since in the [official docs slates requires](https://docs.slatejs.org/api/nodes/element#rendering-void-elements) void nodes to also have `contentEditable="false"` attribute. Issue #5406 describes the problem in detail.

**Issue**
Fixes: #5406

**Proposed solution**
The original issue focused on fixing selection for `contentEditable="false"` nodes that **were not** void element root nodes at the same time. Also `toSlateRange` already can figure out the proper selection when domRange ends/starts in voids. I simply propose to check if a `focusedNode` is not a void element root node. In such case let Slate handle it the old way

**Example**
See  #5406

**Context**
I'd take a closer look at the workaround introduced in #5343. In my opinion, it causes more harm than profit. The algorithm for choosing `focusedNode` is very trivial. Just pick `anchorNode`. What if there are a couple of text nodes between anchorNode and a `contentEditable="false"` node? The selection collapses to a single node only even though the user selected multiple text nodes.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

