### PR TITLE
fix: regular expression for testing Webkit based browser

### DIFF
--- a/.changeset/khaki-toys-unite.md
+++ b/.changeset/khaki-toys-unite.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix regular expression for testing Webkit based browser.

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -20,7 +20,7 @@ export const IS_FIREFOX =
   /^(?!.*Seamonkey)(?=.*Firefox).*/i.test(navigator.userAgent)
 
 export const IS_WEBKIT =
-  typeof navigator !== 'undefined' && /AppleWebKit/.test(navigator.userAgent)
+  typeof navigator !== 'undefined' && /AppleWebKit(?!.*Chrome)/i.test(navigator.userAgent)
 
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -20,7 +20,8 @@ export const IS_FIREFOX =
   /^(?!.*Seamonkey)(?=.*Firefox).*/i.test(navigator.userAgent)
 
 export const IS_WEBKIT =
-  typeof navigator !== 'undefined' && /AppleWebKit(?!.*Chrome)/i.test(navigator.userAgent)
+  typeof navigator !== 'undefined' &&
+  /AppleWebKit(?!.*Chrome)/i.test(navigator.userAgent)
 
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =


### PR DESCRIPTION
**Description**
Fix the regular expression for testing Webkit based browser. This bug was introduced in #5437 which changed `IS_SAFARI` environment constant to `IS_WEBKIT`, intending to apply all COMPATs for safari to Webkit based browsers like Chrome for ios. However, the regular expression for `IS_WEBKIT` is not correct, because it doesn't exclude blink based browser like Chrome for desktop. That makes some COMPATs for Chrome not work as expected.

**Issue**
Fixes: #5450 
Besides the problem mentioned in #5450, this bug breaks all user inputing behaviors using an IME which triggers a series of composition events in Chrome.

**Example**
**Video**
Chrome not working using an IME:
https://recordit.co/wYOq8Lj7RR
Safari works fine:
 https://recordit.co/auIGkmenlk
**Sandbox**
https://codesandbox.io/s/relaxed-poitras-ndspl8?file=/src/App.js

This bug breaks some COMPATs like
https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/src/components/editable.tsx#L1117-L1122

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

