### PR TITLE
feat: add controls provider to render controls outside slate context

### DIFF
--- a/.changeset/dirty-swans-allow.md
+++ b/.changeset/dirty-swans-allow.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Add a ToolbarProvider component to render toolbar outside the slate context.

--- a/packages/slate-react/src/components/controls-provider.tsx
+++ b/packages/slate-react/src/components/controls-provider.tsx
@@ -1,33 +1,22 @@
 import React from 'react'
-import { Descendant, Editor, Node, Scrubber } from 'slate'
+import { Editor, Scrubber } from 'slate'
 import { SlateContextValue } from '../hooks/use-slate'
 import { ReactEditor } from '../plugin/react-editor'
 
 import { Provider } from './provider'
 
-export const Slate = (props: {
+export const ControlsProvider = (props: {
   editor: ReactEditor
-  initialValue: Descendant[]
   children: React.ReactNode
-  onChange?: (value: Descendant[]) => void
 }) => {
-  const { editor, children, onChange, initialValue, ...rest } = props
+  const { editor, children } = props
 
   const [context, setContext] = React.useState<SlateContextValue>(() => {
-    if (!Node.isNodeList(initialValue)) {
-      throw new Error(
-        `[Slate] initialValue is invalid! Expected a list of elements but got: ${Scrubber.stringify(
-          initialValue
-        )}`
-      )
-    }
     if (!Editor.isEditor(editor)) {
       throw new Error(
         `[Slate] editor is invalid! You passed: ${Scrubber.stringify(editor)}`
       )
     }
-    editor.children = initialValue
-    Object.assign(editor, rest)
     return { v: 0, editor }
   })
 
@@ -35,7 +24,6 @@ export const Slate = (props: {
     <Provider
       editor={editor}
       context={context}
-      onChange={onChange}
       children={children}
       setContext={setContext}
     />

--- a/packages/slate-react/src/components/provider.tsx
+++ b/packages/slate-react/src/components/provider.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Descendant } from 'slate'
+import { FocusedContext } from '../hooks/use-focused'
+import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
+import { SlateContext, SlateContextValue } from '../hooks/use-slate'
+import {
+  useSelectorContext,
+  SlateSelectorContext,
+} from '../hooks/use-slate-selector'
+import { EditorContext } from '../hooks/use-slate-static'
+import { ReactEditor } from '../plugin/react-editor'
+import { IS_REACT_VERSION_17_OR_ABOVE } from '../utils/environment'
+import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
+
+/**
+ * A wrapper around the provider to handle `onChange` events, because the editor
+ * is a mutable singleton so it won't ever register as "changed" otherwise.
+ */
+export const Provider = (props: {
+  editor: ReactEditor
+  context: SlateContextValue
+  children: React.ReactNode
+  onChange?: (value: Descendant[]) => void
+  setContext: React.Dispatch<SlateContextValue>
+}) => {
+  const { editor, context, children, onChange, setContext } = props
+  const unmountRef = useRef(false)
+
+  const {
+    selectorContext,
+    onChange: handleSelectorChange,
+  } = useSelectorContext(editor)
+
+  const onContextChange = useCallback(() => {
+    if (onChange) {
+      onChange(editor.children)
+    }
+
+    setContext(prevContext => ({
+      v: prevContext.v + 1,
+      editor,
+    }))
+    handleSelectorChange(editor)
+  }, [editor, handleSelectorChange, onChange])
+
+  useEffect(() => {
+    const onChangesSet = EDITOR_TO_ON_CHANGE.get(editor) ?? new Set()
+
+    onChangesSet.add(onContextChange)
+
+    EDITOR_TO_ON_CHANGE.set(editor, onChangesSet)
+
+    return () => {
+      const onChangesSet = EDITOR_TO_ON_CHANGE.get(editor) ?? new Set()
+
+      onChangesSet.delete(onContextChange)
+
+      EDITOR_TO_ON_CHANGE.set(editor, onChangesSet)
+      unmountRef.current = true
+    }
+  }, [editor, onContextChange])
+
+  const [isFocused, setIsFocused] = useState(ReactEditor.isFocused(editor))
+
+  useEffect(() => {
+    setIsFocused(ReactEditor.isFocused(editor))
+  }, [editor])
+
+  useIsomorphicLayoutEffect(() => {
+    const fn = () => setIsFocused(ReactEditor.isFocused(editor))
+    if (IS_REACT_VERSION_17_OR_ABOVE) {
+      // In React >= 17 onFocus and onBlur listen to the focusin and focusout events during the bubbling phase.
+      // Therefore in order for <Editable />'s handlers to run first, which is necessary for ReactEditor.isFocused(editor)
+      // to return the correct value, we have to listen to the focusin and focusout events without useCapture here.
+      document.addEventListener('focusin', fn)
+      document.addEventListener('focusout', fn)
+      return () => {
+        document.removeEventListener('focusin', fn)
+        document.removeEventListener('focusout', fn)
+      }
+    } else {
+      document.addEventListener('focus', fn, true)
+      document.addEventListener('blur', fn, true)
+      return () => {
+        document.removeEventListener('focus', fn, true)
+        document.removeEventListener('blur', fn, true)
+      }
+    }
+  }, [])
+
+  return (
+    <SlateSelectorContext.Provider value={selectorContext}>
+      <SlateContext.Provider value={context}>
+        <EditorContext.Provider value={context.editor}>
+          <FocusedContext.Provider value={isFocused}>
+            {children}
+          </FocusedContext.Provider>
+        </EditorContext.Provider>
+      </SlateContext.Provider>
+    </SlateSelectorContext.Provider>
+  )
+}

--- a/packages/slate-react/src/components/provider.tsx
+++ b/packages/slate-react/src/components/provider.tsx
@@ -9,7 +9,7 @@ import {
 } from '../hooks/use-slate-selector'
 import { EditorContext } from '../hooks/use-slate-static'
 import { ReactEditor } from '../plugin/react-editor'
-import { IS_REACT_VERSION_17_OR_ABOVE } from '../utils/environment'
+import { REACT_MAJOR_VERSION } from '../utils/environment'
 import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
 
 /**
@@ -68,7 +68,7 @@ export const Provider = (props: {
 
   useIsomorphicLayoutEffect(() => {
     const fn = () => setIsFocused(ReactEditor.isFocused(editor))
-    if (IS_REACT_VERSION_17_OR_ABOVE) {
+    if (REACT_MAJOR_VERSION >= 17) {
       // In React >= 17 onFocus and onBlur listen to the focusin and focusout events during the bubbling phase.
       // Therefore in order for <Editable />'s handlers to run first, which is necessary for ReactEditor.isFocused(editor)
       // to return the correct value, we have to listen to the focusin and focusout events without useCapture here.

--- a/packages/slate-react/src/components/toolbar-provider.tsx
+++ b/packages/slate-react/src/components/toolbar-provider.tsx
@@ -5,7 +5,7 @@ import { ReactEditor } from '../plugin/react-editor'
 
 import { Provider } from './provider'
 
-export const ControlsProvider = (props: {
+export const ToolbarProvider = (props: {
   editor: ReactEditor
   children: React.ReactNode
 }) => {

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -10,7 +10,7 @@ export {
 export { DefaultElement } from './components/element'
 export { DefaultLeaf } from './components/leaf'
 export { Slate } from './components/slate'
-export { ControlsProvider } from './components/controls-provider'
+export { ToolbarProvider } from './components/toolbar-provider'
 
 // Hooks
 export { useEditor } from './hooks/use-editor'

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -10,6 +10,7 @@ export {
 export { DefaultElement } from './components/element'
 export { DefaultLeaf } from './components/leaf'
 export { Slate } from './components/slate'
+export { ControlsProvider } from './components/controls-provider'
 
 // Hooks
 export { useEditor } from './hooks/use-editor'

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -338,8 +338,8 @@ export const withReact = <T extends BaseEditor>(
     maybeBatchUpdates(() => {
       const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
 
-      if (onContextChange) {
-        onContextChange()
+      if (onContextChange?.size) {
+        onContextChange.forEach(callback => callback())
       }
 
       onChange(options)

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -47,7 +47,7 @@ export const EDITOR_TO_USER_SELECTION: WeakMap<
  * Weak map for associating the context `onChange` context with the plugin.
  */
 
-export const EDITOR_TO_ON_CHANGE = new WeakMap<Editor, () => void>()
+export const EDITOR_TO_ON_CHANGE = new WeakMap<Editor, Set<() => void>>()
 
 /**
  * Weak maps for saving pending state on composition stage.

--- a/site/examples/richtext-detached-controls.tsx
+++ b/site/examples/richtext-detached-controls.tsx
@@ -1,0 +1,284 @@
+import React, { useCallback, useMemo } from 'react'
+import isHotkey from 'is-hotkey'
+import {
+  Editable,
+  withReact,
+  useSlate,
+  Slate,
+  ControlsProvider,
+} from 'slate-react'
+import {
+  Editor,
+  Transforms,
+  createEditor,
+  Descendant,
+  Element as SlateElement,
+} from 'slate'
+import { withHistory } from 'slate-history'
+
+import { Button, Icon, Toolbar } from '../components'
+
+const HOTKEYS = {
+  'mod+b': 'bold',
+  'mod+i': 'italic',
+  'mod+u': 'underline',
+  'mod+`': 'code',
+}
+
+const LIST_TYPES = ['numbered-list', 'bulleted-list']
+const TEXT_ALIGN_TYPES = ['left', 'center', 'right', 'justify']
+
+const RichTextDetachedControlsExample = () => {
+  const renderElement = useCallback(props => <Element {...props} />, [])
+  const renderLeaf = useCallback(props => <Leaf {...props} />, [])
+  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+
+  return (
+    <>
+      <ControlsProvider editor={editor}>
+        <Toolbar style={{ marginBottom: 20 }}>
+          <MarkButton format="bold" icon="format_bold" />
+          <MarkButton format="italic" icon="format_italic" />
+          <MarkButton format="underline" icon="format_underlined" />
+          <MarkButton format="code" icon="code" />
+          <BlockButton format="heading-one" icon="looks_one" />
+          <BlockButton format="heading-two" icon="looks_two" />
+          <BlockButton format="block-quote" icon="format_quote" />
+          <BlockButton format="numbered-list" icon="format_list_numbered" />
+          <BlockButton format="bulleted-list" icon="format_list_bulleted" />
+          <BlockButton format="left" icon="format_align_left" />
+          <BlockButton format="center" icon="format_align_center" />
+          <BlockButton format="right" icon="format_align_right" />
+          <BlockButton format="justify" icon="format_align_justify" />
+        </Toolbar>
+      </ControlsProvider>
+
+      <Slate editor={editor} initialValue={initialValue}>
+        <Editable
+          renderElement={renderElement}
+          renderLeaf={renderLeaf}
+          placeholder="Enter some rich text…"
+          spellCheck
+          autoFocus
+          onKeyDown={event => {
+            for (const hotkey in HOTKEYS) {
+              if (isHotkey(hotkey, event as any)) {
+                event.preventDefault()
+                const mark = HOTKEYS[hotkey]
+                toggleMark(editor, mark)
+              }
+            }
+          }}
+        />
+      </Slate>
+    </>
+  )
+}
+
+const toggleBlock = (editor, format) => {
+  const isActive = isBlockActive(
+    editor,
+    format,
+    TEXT_ALIGN_TYPES.includes(format) ? 'align' : 'type'
+  )
+  const isList = LIST_TYPES.includes(format)
+
+  Transforms.unwrapNodes(editor, {
+    match: n =>
+      !Editor.isEditor(n) &&
+      SlateElement.isElement(n) &&
+      LIST_TYPES.includes(n.type) &&
+      !TEXT_ALIGN_TYPES.includes(format),
+    split: true,
+  })
+  let newProperties: Partial<SlateElement>
+  if (TEXT_ALIGN_TYPES.includes(format)) {
+    newProperties = {
+      align: isActive ? undefined : format,
+    }
+  } else {
+    newProperties = {
+      type: isActive ? 'paragraph' : isList ? 'list-item' : format,
+    }
+  }
+  Transforms.setNodes<SlateElement>(editor, newProperties)
+
+  if (!isActive && isList) {
+    const block = { type: format, children: [] }
+    Transforms.wrapNodes(editor, block)
+  }
+}
+
+const toggleMark = (editor, format) => {
+  const isActive = isMarkActive(editor, format)
+
+  if (isActive) {
+    Editor.removeMark(editor, format)
+  } else {
+    Editor.addMark(editor, format, true)
+  }
+}
+
+const isBlockActive = (editor, format, blockType = 'type') => {
+  const { selection } = editor
+  if (!selection) return false
+
+  const [match] = Array.from(
+    Editor.nodes(editor, {
+      at: Editor.unhangRange(editor, selection),
+      match: n =>
+        !Editor.isEditor(n) &&
+        SlateElement.isElement(n) &&
+        n[blockType] === format,
+    })
+  )
+
+  return !!match
+}
+
+const isMarkActive = (editor, format) => {
+  const marks = Editor.marks(editor)
+  return marks ? marks[format] === true : false
+}
+
+const Element = ({ attributes, children, element }) => {
+  const style = { textAlign: element.align }
+  switch (element.type) {
+    case 'block-quote':
+      return (
+        <blockquote style={style} {...attributes}>
+          {children}
+        </blockquote>
+      )
+    case 'bulleted-list':
+      return (
+        <ul style={style} {...attributes}>
+          {children}
+        </ul>
+      )
+    case 'heading-one':
+      return (
+        <h1 style={style} {...attributes}>
+          {children}
+        </h1>
+      )
+    case 'heading-two':
+      return (
+        <h2 style={style} {...attributes}>
+          {children}
+        </h2>
+      )
+    case 'list-item':
+      return (
+        <li style={style} {...attributes}>
+          {children}
+        </li>
+      )
+    case 'numbered-list':
+      return (
+        <ol style={style} {...attributes}>
+          {children}
+        </ol>
+      )
+    default:
+      return (
+        <p style={style} {...attributes}>
+          {children}
+        </p>
+      )
+  }
+}
+
+const Leaf = ({ attributes, children, leaf }) => {
+  if (leaf.bold) {
+    children = <strong>{children}</strong>
+  }
+
+  if (leaf.code) {
+    children = <code>{children}</code>
+  }
+
+  if (leaf.italic) {
+    children = <em>{children}</em>
+  }
+
+  if (leaf.underline) {
+    children = <u>{children}</u>
+  }
+
+  return <span {...attributes}>{children}</span>
+}
+
+const BlockButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isBlockActive(
+        editor,
+        format,
+        TEXT_ALIGN_TYPES.includes(format) ? 'align' : 'type'
+      )}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleBlock(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+const MarkButton = ({ format, icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isMarkActive(editor, format)}
+      onMouseDown={event => {
+        event.preventDefault()
+        toggleMark(editor, format)
+      }}
+    >
+      <Icon>{icon}</Icon>
+    </Button>
+  )
+}
+
+const initialValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      { text: 'This is editable ' },
+      { text: 'rich', bold: true },
+      { text: ' text, ' },
+      { text: 'much', italic: true },
+      { text: ' better than a ' },
+      { text: '<textarea>', code: true },
+      { text: '!' },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text:
+          "Since it's rich text, you can do things like turn a selection of text ",
+      },
+      { text: 'bold', bold: true },
+      {
+        text:
+          ', or add a semantically rendered block quote in the middle of the page, like this:',
+      },
+    ],
+  },
+  {
+    type: 'block-quote',
+    children: [{ text: 'A wise quote.' }],
+  },
+  {
+    type: 'paragraph',
+    align: 'center',
+    children: [{ text: 'Try it out for yourself!' }],
+  },
+]
+
+export default RichTextDetachedControlsExample

--- a/site/examples/richtext-detached-toolbar.tsx
+++ b/site/examples/richtext-detached-toolbar.tsx
@@ -5,7 +5,7 @@ import {
   withReact,
   useSlate,
   Slate,
-  ControlsProvider,
+  ToolbarProvider,
 } from 'slate-react'
 import {
   Editor,
@@ -28,14 +28,14 @@ const HOTKEYS = {
 const LIST_TYPES = ['numbered-list', 'bulleted-list']
 const TEXT_ALIGN_TYPES = ['left', 'center', 'right', 'justify']
 
-const RichTextDetachedControlsExample = () => {
+const RichTextDetachedToolbarExample = () => {
   const renderElement = useCallback(props => <Element {...props} />, [])
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
 
   return (
     <>
-      <ControlsProvider editor={editor}>
+      <ToolbarProvider editor={editor}>
         <Toolbar style={{ marginBottom: 20 }}>
           <MarkButton format="bold" icon="format_bold" />
           <MarkButton format="italic" icon="format_italic" />
@@ -51,7 +51,7 @@ const RichTextDetachedControlsExample = () => {
           <BlockButton format="right" icon="format_align_right" />
           <BlockButton format="justify" icon="format_align_justify" />
         </Toolbar>
-      </ControlsProvider>
+      </ToolbarProvider>
 
       <Slate editor={editor} initialValue={initialValue}>
         <Editable
@@ -281,4 +281,4 @@ const initialValue: Descendant[] = [
   },
 ]
 
-export default RichTextDetachedControlsExample
+export default RichTextDetachedToolbarExample

--- a/site/pages/examples/[example].tsx
+++ b/site/pages/examples/[example].tsx
@@ -29,6 +29,7 @@ import Styling from '../../examples/styling'
 import Tables from '../../examples/tables'
 import IFrames from '../../examples/iframe'
 import CustomPlaceholder from '../../examples/custom-placeholder'
+import ReachTextDetachedControls from '../../examples/richtext-detached-controls'
 
 // node
 import { getAllExamples } from '../api'
@@ -50,6 +51,11 @@ const EXAMPLES = [
   ['Plain Text', PlainText, 'plaintext'],
   ['Read-only', ReadOnly, 'read-only'],
   ['Rich Text', RichText, 'richtext'],
+  [
+    'Rich Text Detached Controls',
+    ReachTextDetachedControls,
+    'richtext-detached-controls',
+  ],
   ['Search Highlighting', SearchHighlighting, 'search-highlighting'],
   ['Shadow DOM', ShadowDOM, 'shadow-dom'],
   ['Styling', Styling, 'styling'],

--- a/site/pages/examples/[example].tsx
+++ b/site/pages/examples/[example].tsx
@@ -29,7 +29,7 @@ import Styling from '../../examples/styling'
 import Tables from '../../examples/tables'
 import IFrames from '../../examples/iframe'
 import CustomPlaceholder from '../../examples/custom-placeholder'
-import ReachTextDetachedControls from '../../examples/richtext-detached-controls'
+import RichTextDetachedToolbarExample from '../../examples/richtext-detached-toolbar'
 
 // node
 import { getAllExamples } from '../api'
@@ -52,9 +52,9 @@ const EXAMPLES = [
   ['Read-only', ReadOnly, 'read-only'],
   ['Rich Text', RichText, 'richtext'],
   [
-    'Rich Text Detached Controls',
-    ReachTextDetachedControls,
-    'richtext-detached-controls',
+    'Rich Text Detached Toolbar',
+    RichTextDetachedToolbarExample,
+    'richtext-detached-toolbar',
   ],
   ['Search Highlighting', SearchHighlighting, 'search-highlighting'],
   ['Shadow DOM', ShadowDOM, 'shadow-dom'],


### PR DESCRIPTION
**Description**
This pull request adds a new `ToolbarProvider` component to render controls/toolbar outside the slate context.


**Example**
```tsx
<>
      <ToolbarProvider editor={editor}>
        <Toolbar style={{ marginBottom: 20 }}>
          <MarkButton format="bold" icon="format_bold" />
          <MarkButton format="italic" icon="format_italic" />
          <MarkButton format="underline" icon="format_underlined" />
          <MarkButton format="code" icon="code" />
          <BlockButton format="heading-one" icon="looks_one" />
          <BlockButton format="heading-two" icon="looks_two" />
          <BlockButton format="block-quote" icon="format_quote" />
          <BlockButton format="numbered-list" icon="format_list_numbered" />
          <BlockButton format="bulleted-list" icon="format_list_bulleted" />
          <BlockButton format="left" icon="format_align_left" />
          <BlockButton format="center" icon="format_align_center" />
          <BlockButton format="right" icon="format_align_right" />
          <BlockButton format="justify" icon="format_align_justify" />
        </Toolbar>
      </ControlsProvider>

      <Slate editor={editor} initialValue={initialValue}>
        <Editable
          renderElement={renderElement}
          renderLeaf={renderLeaf}
          placeholder="Enter some rich text…"
          spellCheck
          autoFocus
          onKeyDown={event => {
            for (const hotkey in HOTKEYS) {
              if (isHotkey(hotkey, event as any)) {
                event.preventDefault()
                const mark = HOTKEYS[hotkey]
                toggleMark(editor, mark)
              }
            }
          }}
        />
      </Slate>
    </>
```

**Context**
- Moved most of the `slate` component logic into a `provider` component to reuse it in the `toolbar-provider`. 
- `toolbar-provider` is a simpler version of `slate`, it doesn't mutate the `editor` since it must be mutated in the `slate` component only. 
- changed `EDITOR_TO_ON_CHANGE` map to be a map of sets, this way we can have multiple listeners for the same editor

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

