### PR TITLE
Do not try to batch updates in React >= 18

### DIFF
--- a/.changeset/nice-shirts-flash.md
+++ b/.changeset/nice-shirts-flash.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Do not attempt to batch updates manually in React >= 18

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -9,7 +9,7 @@ import {
 } from '../hooks/use-slate-selector'
 import { EditorContext } from '../hooks/use-slate-static'
 import { ReactEditor } from '../plugin/react-editor'
-import { IS_REACT_VERSION_17_OR_ABOVE } from '../utils/environment'
+import { REACT_MAJOR_VERSION } from '../utils/environment'
 import { EDITOR_TO_ON_CHANGE } from '../utils/weak-maps'
 
 /**
@@ -78,7 +78,7 @@ export const Slate = (props: {
 
   useIsomorphicLayoutEffect(() => {
     const fn = () => setIsFocused(ReactEditor.isFocused(editor))
-    if (IS_REACT_VERSION_17_OR_ABOVE) {
+    if (REACT_MAJOR_VERSION >= 17) {
       // In React >= 17 onFocus and onBlur listen to the focusin and focusout events during the bubbling phase.
       // Therefore in order for <Editable />'s handlers to run first, which is necessary for ReactEditor.isFocused(editor)
       // to return the correct value, we have to listen to the focusin and focusout events without useCapture here.

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -36,6 +36,7 @@ import {
   NODE_TO_KEY,
 } from '../utils/weak-maps'
 import { ReactEditor } from './react-editor'
+import { REACT_MAJOR_VERSION } from '../utils/environment'
 
 /**
  * `withReact` adds React and DOM specific behaviors to the editor.
@@ -324,11 +325,16 @@ export const withReact = <T extends BaseEditor>(
   }
 
   e.onChange = options => {
-    // COMPAT: React doesn't batch `setState` hook calls, which means that the
-    // children and selection can get out of sync for one render pass. So we
-    // have to use this unstable API to ensure it batches them. (2019/12/03)
+    // COMPAT: React < 18 doesn't batch `setState` hook calls, which means
+    // that the children and selection can get out of sync for one render
+    // pass. So we have to use this unstable API to ensure it batches them.
+    // (2019/12/03)
     // https://github.com/facebook/react/issues/14259#issuecomment-439702367
-    ReactDOM.unstable_batchedUpdates(() => {
+    const maybeBatchUpdates = REACT_MAJOR_VERSION < 18
+      ? ReactDOM.unstable_batchedUpdates
+      : (callback: () => void) => callback()
+
+    maybeBatchUpdates(() => {
       const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
 
       if (onContextChange) {

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -330,9 +330,10 @@ export const withReact = <T extends BaseEditor>(
     // pass. So we have to use this unstable API to ensure it batches them.
     // (2019/12/03)
     // https://github.com/facebook/react/issues/14259#issuecomment-439702367
-    const maybeBatchUpdates = REACT_MAJOR_VERSION < 18
-      ? ReactDOM.unstable_batchedUpdates
-      : (callback: () => void) => callback()
+    const maybeBatchUpdates =
+      REACT_MAJOR_VERSION < 18
+        ? ReactDOM.unstable_batchedUpdates
+        : (callback: () => void) => callback()
 
     maybeBatchUpdates(() => {
       const onContextChange = EDITOR_TO_ON_CHANGE.get(e)

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -1,7 +1,6 @@
 import React from 'react'
 
-export const IS_REACT_VERSION_17_OR_ABOVE =
-  parseInt(React.version.split('.')[0], 10) >= 17
+export const REACT_MAJOR_VERSION = parseInt(React.version.split('.')[0], 10)
 
 export const IS_IOS =
   typeof navigator !== 'undefined' &&


### PR DESCRIPTION
**Description**
Checks if `React.version` is < 18 before calling `unstable_batchedUpdates` in `with-react.ts`.

**Context**
Updates are batched automatically in React >= 18. Calling `unstable_batchedUpdates` in React 18 produces an error in some circumstances:
```
[1] - error unhandledRejection: Error [TypeError]: ReactDOM__default.default.unstable_batchedUpdates is not a function
[1]     at e.onChange (webpack-internal:///(sc_client)/../../node_modules/slate-react/dist/index.js:5747:34)
[1]     at eval (webpack-internal:///(sc_client)/../../node_modules/slate/dist/index.js:3006:14) {
[1]   digest: undefined
[1] }
```

**Environment**
The above error was observed in the following environment:
```
react 18.2.0
react-dom 18.2.0
slate 0.94.1
slate-react 0.97.0
```

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

