### PR TITLE
Update hotkeys util to use isHotkey for non-Latin keyboards

### DIFF
--- a/.changeset/many-cows-add.md
+++ b/.changeset/many-cows-add.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Update hotkeys util to use isHotkey for better support for non-latin keyboards

--- a/packages/slate-react/src/utils/hotkeys.ts
+++ b/packages/slate-react/src/utils/hotkeys.ts
@@ -1,4 +1,4 @@
-import { isKeyHotkey } from 'is-hotkey'
+import { isHotkey } from 'is-hotkey'
 import { IS_APPLE } from './environment'
 
 /**
@@ -53,9 +53,9 @@ const create = (key: string) => {
   const generic = HOTKEYS[key]
   const apple = APPLE_HOTKEYS[key]
   const windows = WINDOWS_HOTKEYS[key]
-  const isGeneric = generic && isKeyHotkey(generic)
-  const isApple = apple && isKeyHotkey(apple)
-  const isWindows = windows && isKeyHotkey(windows)
+  const isGeneric = generic && isHotkey(generic)
+  const isApple = apple && isHotkey(apple)
+  const isWindows = windows && isHotkey(windows)
 
   return (event: KeyboardEvent) => {
     if (isGeneric && isGeneric(event)) return true


### PR DESCRIPTION
**Description**
Changes the hotkeys util to use `isHotkey` instead of `isKeyHotkey`. This should give better support for non-Latin keyboards.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4591

**Context**
`isKeyHotkey` checks against `event.key`, which varies for keyboards of different alphabets. For example, trying to use the undo shortcut on a Russian keyboard on Windows would emit an `event.key` of `я` which fails to match the `mod+z` hotkey.

Using `isHotkey` instead checks against `event.which`, which doesn't vary across alphabets.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

