### PR TITLE
Revert to prev behavior on Android to fix caret

### DIFF
--- a/.changeset/ten-dryers-marry.md
+++ b/.changeset/ten-dryers-marry.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix Android caret placement regression when inputting into empty editor

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -366,7 +366,7 @@ export const Editable = (props: EditableProps) => {
         selection && ReactEditor.toDOMRange(editor, selection)
 
       if (newDomRange) {
-        if (ReactEditor.isComposing(editor)) {
+        if (ReactEditor.isComposing(editor) && !IS_ANDROID) {
           domSelection.collapseToEnd()
         } else if (Range.isBackward(selection!)) {
           domSelection.setBaseAndExtent(


### PR DESCRIPTION
**Description**
Reverts behavior for Android to before #5443 which introduced incorrect caret behavior for Android -- see issue #5469 for details.

**Issue**
Fixes: #5469 

**Example**
See bad behavior in issue, fixed behavior:


https://github.com/ianstormtaylor/slate/assets/28637598/fe9ec83b-086c-4d9d-8664-7de8b11f172e



**Context**
Please see issue #5469 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

