### PR TITLE
Fix firefox disconnected selection api usage

### DIFF
--- a/.changeset/two-tomatoes-deliver.md
+++ b/.changeset/two-tomatoes-deliver.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fix invalid usage of the selection API in firefox

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -309,6 +309,8 @@ export const Editable = (props: EditableProps) => {
       const focusNode = domSelection.focusNode
       let anchorNode
 
+      // COMPAT: In firefox the normal seletion way does not work
+      // (https://github.com/ianstormtaylor/slate/pull/5486#issue-1820720223)
       if (IS_FIREFOX && domSelection.rangeCount > 1) {
         const firstRange = domSelection.getRangeAt(0)
         const lastRange = domSelection.getRangeAt(domSelection.rangeCount - 1)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -411,6 +411,11 @@ export const Editable = (props: EditableProps) => {
       return newDomRange
     }
 
+    // In firefox if there is more then 1 range and we call setDomSelection we remove the ability to select more cells in a table
+    if (domSelection.rangeCount <= 1) {
+      setDomSelection()
+    }
+
     const ensureSelection =
       androidInputManagerRef.current?.isFlushing() === 'action'
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -830,6 +830,7 @@ export const ReactEditor: ReactEditorInterface = {
     if (el) {
       if (isDOMSelection(domRange)) {
         // COMPAT: In firefox the normal seletion way does not work
+        // (https://github.com/ianstormtaylor/slate/pull/5486#issue-1820720223)
         if (IS_FIREFOX && domRange.rangeCount > 1) {
           focusNode = domRange.focusNode // Focus node works fine
           const firstRange = domRange.getRangeAt(0)
@@ -857,7 +858,7 @@ export const ReactEditor: ReactEditorInterface = {
         // `isCollapsed` for a Selection that comes from a ShadowRoot.
         // (2020/08/08)
         // https://bugs.chromium.org/p/chromium/issues/detail?id=447523
-        // IsColapsed might not work in firefox, but this will
+        // IsCollapsed might not work in firefox, but this will
         if ((IS_CHROME && hasShadowRoot(anchorNode)) || IS_FIREFOX) {
           isCollapsed =
             domRange.anchorNode === domRange.focusNode &&

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -829,15 +829,36 @@ export const ReactEditor: ReactEditorInterface = {
 
     if (el) {
       if (isDOMSelection(domRange)) {
-        anchorNode = domRange.anchorNode
-        anchorOffset = domRange.anchorOffset
-        focusNode = domRange.focusNode
-        focusOffset = domRange.focusOffset
+        // COMPAT: In firefox the normal seletion way does not work
+        if (IS_FIREFOX && domRange.rangeCount > 1) {
+          focusNode = domRange.focusNode // Focus node works fine
+          const firstRange = domRange.getRangeAt(0)
+          const lastRange = domRange.getRangeAt(domRange.rangeCount - 1)
+
+          // Right to left
+          if (firstRange.startContainer === focusNode) {
+            anchorNode = lastRange.endContainer
+            anchorOffset = lastRange.endOffset
+            focusOffset = firstRange.startOffset
+          } else {
+            // Left to right
+            anchorNode = firstRange.startContainer
+            anchorOffset = firstRange.endOffset
+            focusOffset = lastRange.startOffset
+          }
+        } else {
+          anchorNode = domRange.anchorNode
+          anchorOffset = domRange.anchorOffset
+          focusNode = domRange.focusNode
+          focusOffset = domRange.focusOffset
+        }
+
         // COMPAT: There's a bug in chrome that always returns `true` for
         // `isCollapsed` for a Selection that comes from a ShadowRoot.
         // (2020/08/08)
         // https://bugs.chromium.org/p/chromium/issues/detail?id=447523
-        if (IS_CHROME && hasShadowRoot(anchorNode)) {
+        // IsColapsed might not work in firefox, but this will
+        if ((IS_CHROME && hasShadowRoot(anchorNode)) || IS_FIREFOX) {
           isCollapsed =
             domRange.anchorNode === domRange.focusNode &&
             domRange.anchorOffset === domRange.focusOffset
@@ -876,15 +897,19 @@ export const ReactEditor: ReactEditorInterface = {
       focusOffset = anchorNode.textContent?.length || 0
     }
 
-    let anchor = ReactEditor.toSlatePoint(editor, [anchorNode, anchorOffset], {
-      exactMatch,
-      suppressThrow,
-    })
+    const anchor = ReactEditor.toSlatePoint(
+      editor,
+      [anchorNode, anchorOffset],
+      {
+        exactMatch,
+        suppressThrow,
+      }
+    )
     if (!anchor) {
       return null as T extends true ? Range | null : Range
     }
 
-    let focus = isCollapsed
+    const focus = isCollapsed
       ? anchor
       : ReactEditor.toSlatePoint(editor, [focusNode, focusOffset], {
           exactMatch,
@@ -892,46 +917,6 @@ export const ReactEditor: ReactEditorInterface = {
         })
     if (!focus) {
       return null as T extends true ? Range | null : Range
-    }
-
-    /**
-     * suppose we have this document:
-     *
-     * { type: 'paragraph',
-     *   children: [
-     *     { text: 'foo ' },
-     *     { text: 'bar' },
-     *     { text: ' baz' }
-     *   ]
-     * }
-     *
-     * a double click on "bar" on chrome will create this range:
-     *
-     * anchor -> [0,1] offset 0
-     * focus  -> [0,1] offset 3
-     *
-     * while on firefox will create this range:
-     *
-     * anchor -> [0,0] offset 4
-     * focus  -> [0,2] offset 0
-     *
-     * let's try to fix it...
-     */
-
-    if (IS_FIREFOX && !isCollapsed && anchorNode !== focusNode) {
-      const isEnd = Editor.isEnd(editor, anchor!, anchor.path)
-      const isStart = Editor.isStart(editor, focus!, focus.path)
-
-      if (isEnd) {
-        const after = Editor.after(editor, anchor as Point)
-        // Editor.after() might return undefined
-        anchor = (after || anchor!) as T extends true ? Point | null : Point
-      }
-
-      if (isStart) {
-        const before = Editor.before(editor, focus as Point)
-        focus = (before || focus!) as T extends true ? Point | null : Point
-      }
     }
 
     let range: Range = { anchor: anchor as Point, focus: focus as Point }


### PR DESCRIPTION
**Description**
This PR fixes the invalid usage of the selection API in firefox. Firefox allows disconnected ranges that cause problems with slate. I originally started to work on this to fix . [this issue](https://github.com/udecode/plate/issues/560)

**Issue**
Fixes: (I do not think this fixes any slate issue, however I am not sure. I did not checked)

**Example**
Before my changes:

https://github.com/ianstormtaylor/slate/assets/50914789/54a02c0a-4211-4d87-b5bc-197433eafd62

After my changes:

https://github.com/ianstormtaylor/slate/assets/50914789/84c69ec1-3088-480f-a75e-7e73ab93bab7


**Context**
1:\
`anchorNode`, `anchorOffset`, `focusOffset`. Do not behave the same in chrome and in firefox. In firefox if there is more then 1 range said values would be invalid. I fixed this by using the `getRangeAt` function (see `toSlateRange` changes).
2:\
I reversed [this pr](https://github.com/ianstormtaylor/slate/pull/5275/files) as it was interfering with my  changes (I believe this PR relies on broke selection api in firefox)
3:\
I removed the usage of `setDomSelection`. This is because `setBaseAndExtent` removed all ranges leaving only 1 range (this removed the ability to select more cells)
4:\
I removed the `el.focus()` because it relied on the `setDomSelection`
5:\
The slight refactoring was at some point done by eslint

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.) (I will soon, this will be the next commit)

