### PR TITLE
Fix contenteditalbe firefox table selection

### DIFF
--- a/.changeset/itchy-falcons-dream.md
+++ b/.changeset/itchy-falcons-dream.md
@@ -1,5 +1,5 @@
 ---
-'slate-react': minor
+'slate-react': patch
 ---
 
 Fix firefox table selection if table is contentedtiable

--- a/.changeset/itchy-falcons-dream.md
+++ b/.changeset/itchy-falcons-dream.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Fix firefox table selection if table is contentedtiable


### PR DESCRIPTION
**Description**
This PR fixes the contenteditable table selection in firefox. Firefox uses a custom editor when table is contenteditable and this adds support for this custom editor.

**Issue**
Fixes: None, but it does fix [this](https://github.com/udecode/plate/pull/2538)

**Example**

https://github.com/ianstormtaylor/slate/assets/50914789/a6d0cb31-32d4-4be1-825a-8cce7e5cf781

Before this PR it threw some exception IIRC


**Context**
Firefox basically uses rows in the contenteditable table selection and `startOffset` is the cell offset. By walking down the DOM tree we can get the sames values as in chrome. I also added some checks to make sure this does not crash. 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

