### PR TITLE
fix: no composing text inserted on mac wechat browser

### DIFF
--- a/.changeset/grumpy-seahorses-love.md
+++ b/.changeset/grumpy-seahorses-love.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix the bug that user cannot input chinese on mac wechat browser.

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -52,9 +52,9 @@ export const IS_FIREFOX_LEGACY =
 export const IS_UC_MOBILE =
   typeof navigator !== 'undefined' && /.*UCBrowser/.test(navigator.userAgent)
 
-// Wechat browser
+// Wechat browser (not including mac wechat)
 export const IS_WECHATBROWSER =
-  typeof navigator !== 'undefined' && /.*Wechat/.test(navigator.userAgent)
+  typeof navigator !== 'undefined' && /.*(?<!Mac)Wechat/.test(navigator.userAgent)
 
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -54,7 +54,8 @@ export const IS_UC_MOBILE =
 
 // Wechat browser (not including mac wechat)
 export const IS_WECHATBROWSER =
-  typeof navigator !== 'undefined' && /.*(?<!Mac)Wechat/.test(navigator.userAgent)
+  typeof navigator !== 'undefined' &&
+  /.*(?<!Mac)Wechat/.test(navigator.userAgent)
 
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js


### PR DESCRIPTION
**Description**
Fix the bug: cannot input chinese on mac wechat browser

**Example**

https://github.com/ianstormtaylor/slate/assets/42238241/baa5594d-7545-4a06-a5d6-6680271af614


**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

