### PR TITLE
bugfix: Slate breaks on load on Safari < 16.4

### DIFF
--- a/.changeset/quick-eyes-count.md
+++ b/.changeset/quick-eyes-count.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+bugfix: slate breaks on load on safari < 16.4

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -55,7 +55,8 @@ export const IS_UC_MOBILE =
 // Wechat browser (not including mac wechat)
 export const IS_WECHATBROWSER =
   typeof navigator !== 'undefined' &&
-  /.*(?<!Mac)Wechat/.test(navigator.userAgent)
+  /.*Wechat/.test(navigator.userAgent) &&
+  !/.*MacWechat/.test(navigator.userAgent) // avoid lookbehind (buggy in safari < 16.4)
 
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js


### PR DESCRIPTION
**Description**
This is a very serious issue, as it breaks the app using slate on load, not even when interacting with certain parts of slate.

For details see issue below.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5502

**Example**
<img width="453" alt="image" src="https://github.com/ianstormtaylor/slate/assets/3076177/38c0e0c2-d837-4f57-8ebe-b03bd1ce34f7">

**Context**
The change makes the check a little bit more verbose but works in exactly the same way: We're testing the user agent for 'Wechat' but exclude 'MacWechat'.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

