### PR TITLE
Drop a leftover `useRef()` call

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Descendant, Editor, Node, Scrubber } from 'slate'
 import { FocusedContext } from '../hooks/use-focused'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
@@ -24,7 +24,6 @@ export const Slate = (props: {
   onChange?: (value: Descendant[]) => void
 }) => {
   const { editor, children, onChange, initialValue, ...rest } = props
-  const unmountRef = useRef(false)
 
   const [context, setContext] = React.useState<SlateContextValue>(() => {
     if (!Node.isNodeList(initialValue)) {
@@ -66,7 +65,6 @@ export const Slate = (props: {
 
     return () => {
       EDITOR_TO_ON_CHANGE.set(editor, () => {})
-      unmountRef.current = true
     }
   }, [editor, onContextChange])
 


### PR DESCRIPTION
**Description**

The ref was initialized with `useRef()` and updated in an effect but was never read. 

**Issue**
Fixes: ---

**Example**

Nothing changes in the behavior.

**Context**

It was first introduced in #4819 but then the usage of this ref was removed with #4874. So it remained unused since then.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

