### PR TITLE
Fix move_node triggers nodes re-render (#5513)

### DIFF
--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -6,6 +6,7 @@ import {
   Node,
   Operation,
   Path,
+  PathRef,
   Point,
   Range,
   Transforms,
@@ -122,6 +123,7 @@ export const withReact = <T extends BaseEditor>(
   // as apply() changes the object reference and hence invalidates the NODE_TO_KEY entry
   e.apply = (op: Operation) => {
     const matches: [Path, Key][] = []
+    const pathRefMatches: [PathRef, Key][] = []
 
     const pendingDiffs = EDITOR_TO_PENDING_DIFFS.get(e)
     if (pendingDiffs?.length) {
@@ -183,6 +185,21 @@ export const withReact = <T extends BaseEditor>(
           Path.parent(op.newPath)
         )
         matches.push(...getMatches(e, commonPath))
+
+        let changedPath: Path
+        if (Path.isBefore(op.path, op.newPath)) {
+          matches.push(...getMatches(e, Path.parent(op.path)))
+          changedPath = op.newPath
+        } else {
+          matches.push(...getMatches(e, Path.parent(op.newPath)))
+          changedPath = op.path
+        }
+
+        const changedNode = Node.get(editor, Path.parent(changedPath))
+        const changedNodeKey = ReactEditor.findKey(e, changedNode)
+        const changedPathRef = Editor.pathRef(e, Path.parent(changedPath))
+        pathRefMatches.push([changedPathRef, changedNodeKey])
+
         break
       }
     }
@@ -192,6 +209,13 @@ export const withReact = <T extends BaseEditor>(
     for (const [path, key] of matches) {
       const [node] = Editor.node(e, path)
       NODE_TO_KEY.set(node, key)
+    }
+
+    for (const [pathRef, key] of pathRefMatches) {
+      if (pathRef.current) {
+        const [node] = Editor.node(e, pathRef.current)
+        NODE_TO_KEY.set(node, key)
+      }
     }
   }
 


### PR DESCRIPTION
**Description**
Reset the source parent element and the target parent element of the moved node to NODE_TO_KEY, for prevent them to re-render

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5513

**Example**
Using the official example https://www.slatejs.org/examples/richtext . After deleting the paragraph behide the list element, the list element's key will not change anymore.
![企业微信截图_617ae87a-93ce-49af-b10a-d419d8705827](https://github.com/ianstormtaylor/slate/assets/11460856/abe051be-1cea-46a6-a48c-21c5557f1e29)
![企业微信截图_a0a55074-9833-4176-86ac-c3ab4597ddff](https://github.com/ianstormtaylor/slate/assets/11460856/9f7ac702-36b7-4f4d-9cc6-7b2960529be4)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

