### PR TITLE
Retain editor selection when using ReactEditor.focus()

### DIFF
--- a/.changeset/selfish-frogs-press.md
+++ b/.changeset/selfish-frogs-press.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Retain editor selection when using ReactEditor.focus()

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -417,7 +417,7 @@ export const ReactEditor: ReactEditorInterface = {
     IS_FOCUSED.set(editor, true)
 
     if (root.activeElement !== el) {
-      if (root instanceof Document) {
+      if (editor.selection && root instanceof Document) {
         const domSelection = root.getSelection()
         const domRange = ReactEditor.toDOMRange(editor, editor.selection)
         domSelection?.removeAllRanges()

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -417,6 +417,12 @@ export const ReactEditor: ReactEditorInterface = {
     IS_FOCUSED.set(editor, true)
 
     if (root.activeElement !== el) {
+      if (root instanceof Document) {
+        const domSelection = root.getSelection()
+        const domRange = ReactEditor.toDOMRange(editor, editor.selection)
+        domSelection?.removeAllRanges()
+        domSelection?.addRange(domRange)
+      }
       el.focus({ preventScroll: true })
     }
   },


### PR DESCRIPTION
**Description**
When calling `ReactEditor.focus()` the current editor selection is lost and the caret is placed at the beginning of the document. This change retains the current editor selection when giving the editor focus.

**Issue**
Fixes: [(link to issue)](https://github.com/ianstormtaylor/slate/issues/5169)

**Example**
Before:


https://github.com/ianstormtaylor/slate/assets/28637598/b68fc68d-90b5-4428-ae2d-e403988e74be



After:


https://github.com/ianstormtaylor/slate/assets/28637598/d55170ed-d200-4cf2-a6e1-77e534638091



**Context**
Before focusing the editor we set the DOM selection so that the corresponding `onDOMSelectionChange` handler in `editable.tsx` does not reset the editor selection when it fires after the `el.focus()` call.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

