### PR TITLE
Add `onSelectionChange` and `onValueChange` in Slate React component

### DIFF
--- a/.changeset/curly-ligers-lay.md
+++ b/.changeset/curly-ligers-lay.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Add `onSelectorChange` and `onValueChange` in Slate React component

--- a/.changeset/curly-ligers-lay.md
+++ b/.changeset/curly-ligers-lay.md
@@ -2,4 +2,4 @@
 'slate-react': minor
 ---
 
-Add `onSelectorChange` and `onValueChange` in Slate React component
+Add `onSelectionChange` and `onValueChange` in Slate React component

--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Descendant, Editor, Node, Operation, Scrubber } from 'slate'
+import { Descendant, Editor, Node, Operation, Scrubber, Selection } from 'slate'
 import { FocusedContext } from '../hooks/use-focused'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
 import { SlateContext, SlateContextValue } from '../hooks/use-slate'
@@ -22,14 +22,14 @@ export const Slate = (props: {
   initialValue: Descendant[]
   children: React.ReactNode
   onChange?: (value: Descendant[]) => void
-  onSelectorChange?: (value: Descendant[]) => void
+  onSelectionChange?: (selection: Selection) => void
   onValueChange?: (value: Descendant[]) => void
 }) => {
   const {
     editor,
     children,
     onChange,
-    onSelectorChange,
+    onSelectionChange,
     onValueChange,
     initialValue,
     ...rest
@@ -66,7 +66,7 @@ export const Slate = (props: {
 
       switch (options?.operation?.type) {
         case 'set_selection':
-          onSelectorChange?.(editor.children)
+          onSelectionChange?.(editor.selection)
           break
         default:
           onValueChange?.(editor.children)
@@ -78,7 +78,7 @@ export const Slate = (props: {
       }))
       handleSelectorChange(editor)
     },
-    [editor, handleSelectorChange, onChange, onSelectorChange, onValueChange]
+    [editor, handleSelectorChange, onChange, onSelectionChange, onValueChange]
   )
 
   useEffect(() => {

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -363,7 +363,7 @@ export const withReact = <T extends BaseEditor>(
       const onContextChange = EDITOR_TO_ON_CHANGE.get(e)
 
       if (onContextChange) {
-        onContextChange()
+        onContextChange(options)
       }
 
       onChange(options)

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -47,7 +47,10 @@ export const EDITOR_TO_USER_SELECTION: WeakMap<
  * Weak map for associating the context `onChange` context with the plugin.
  */
 
-export const EDITOR_TO_ON_CHANGE = new WeakMap<Editor, (options?: { operation?: Operation }) => void>()
+export const EDITOR_TO_ON_CHANGE = new WeakMap<
+  Editor,
+  (options?: { operation?: Operation }) => void
+>()
 
 /**
  * Weak maps for saving pending state on composition stage.

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -1,4 +1,4 @@
-import { Ancestor, Editor, Node, Range, RangeRef, Text } from 'slate'
+import { Ancestor, Editor, Node, Operation, Range, RangeRef, Text } from 'slate'
 import { Action } from '../hooks/android-input-manager/android-input-manager'
 import { TextDiff } from './diff-text'
 import { Key } from './key'
@@ -47,7 +47,7 @@ export const EDITOR_TO_USER_SELECTION: WeakMap<
  * Weak map for associating the context `onChange` context with the plugin.
  */
 
-export const EDITOR_TO_ON_CHANGE = new WeakMap<Editor, () => void>()
+export const EDITOR_TO_ON_CHANGE = new WeakMap<Editor, (options?: { operation?: Operation }) => void>()
 
 /**
  * Weak maps for saving pending state on composition stage.

--- a/packages/slate-react/test/index.spec.tsx
+++ b/packages/slate-react/test/index.spec.tsx
@@ -95,4 +95,49 @@ describe('slate-react', () => {
       })
     })
   })
+
+  test('calls onSelectorChange when editor select change', async () => {
+    const editor = withReact(createEditor())
+    const initialValue = [
+      { type: 'block', children: [{ text: 'te' }] },
+      { type: 'block', children: [{ text: 'st' }] },
+    ]
+    const onSelectorChange = jest.fn()
+    act(() => {
+      create(
+        <Slate
+          editor={editor}
+          initialValue={initialValue}
+          onSelectorChange={onSelectorChange}
+        >
+          <Editable />
+        </Slate>,
+        { createNodeMock }
+      )
+    })
+    await act(async () =>
+      Transforms.select(editor, { path: [0, 0], offset: 2 })
+    )
+    expect(onSelectorChange).toHaveBeenCalled()
+  })
+
+  test('calls onValueChange when editor children change', async () => {
+    const editor = withReact(createEditor())
+    const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+    const onValueChange = jest.fn()
+    act(() => {
+      create(
+        <Slate
+          editor={editor}
+          initialValue={initialValue}
+          onValueChange={onValueChange}
+        >
+          <Editable />
+        </Slate>,
+        { createNodeMock }
+      )
+    })
+    await act(async () => Transforms.insertText(editor, 'Hello word!'))
+    expect(onValueChange).toHaveBeenCalled()
+  })
 })

--- a/packages/slate-react/test/index.spec.tsx
+++ b/packages/slate-react/test/index.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { createEditor, Element, Transforms } from 'slate'
+import { createEditor, Text, Transforms } from 'slate'
 import { create, act, ReactTestRenderer } from 'react-test-renderer'
 import { Slate, withReact, Editable } from '../src'
 
@@ -96,48 +96,106 @@ describe('slate-react', () => {
     })
   })
 
-  test('calls onSelectorChange when editor select change', async () => {
+  test('calls onSelectionChange when editor select change', async () => {
     const editor = withReact(createEditor())
     const initialValue = [
       { type: 'block', children: [{ text: 'te' }] },
       { type: 'block', children: [{ text: 'st' }] },
     ]
-    const onSelectorChange = jest.fn()
+    const onChange = jest.fn()
+    const onValueChange = jest.fn()
+    const onSelectionChange = jest.fn()
+
     act(() => {
       create(
         <Slate
           editor={editor}
           initialValue={initialValue}
-          onSelectorChange={onSelectorChange}
+          onChange={onChange}
+          onValueChange={onValueChange}
+          onSelectionChange={onSelectionChange}
         >
           <Editable />
         </Slate>,
         { createNodeMock }
       )
     })
+
     await act(async () =>
       Transforms.select(editor, { path: [0, 0], offset: 2 })
     )
-    expect(onSelectorChange).toHaveBeenCalled()
+
+    expect(onSelectionChange).toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalled()
+    expect(onValueChange).not.toHaveBeenCalled()
   })
 
   test('calls onValueChange when editor children change', async () => {
     const editor = withReact(createEditor())
     const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+    const onChange = jest.fn()
     const onValueChange = jest.fn()
+    const onSelectionChange = jest.fn()
+
     act(() => {
       create(
         <Slate
           editor={editor}
           initialValue={initialValue}
+          onChange={onChange}
           onValueChange={onValueChange}
+          onSelectionChange={onSelectionChange}
         >
           <Editable />
         </Slate>,
         { createNodeMock }
       )
     })
+
     await act(async () => Transforms.insertText(editor, 'Hello word!'))
+
     expect(onValueChange).toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  test('calls onValueChange when editor setNodes', async () => {
+    const editor = withReact(createEditor())
+    const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+    const onChange = jest.fn()
+    const onValueChange = jest.fn()
+    const onSelectionChange = jest.fn()
+
+    act(() => {
+      create(
+        <Slate
+          editor={editor}
+          initialValue={initialValue}
+          onChange={onChange}
+          onValueChange={onValueChange}
+          onSelectionChange={onSelectionChange}
+        >
+          <Editable />
+        </Slate>,
+        { createNodeMock }
+      )
+    })
+
+    await act(async () =>
+      Transforms.setNodes(
+        editor,
+        // @ts-ignore
+        { bold: true },
+        {
+          at: { path: [0, 0], offset: 2 },
+          match: Text.isText,
+          split: true,
+        }
+      )
+    )
+
+    expect(onChange).toHaveBeenCalled()
+    expect(onValueChange).toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
**Description**
Add `onSelectionChange` and `onValueChange` in Slate React component

**Issue**
Fixes:  #5521 
/claim udecode/plate#2700

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

