### PR TITLE
[editable] Fix Memory Leak when switching between focused editables

### DIFF
--- a/.changeset/empty-shirts-mate.md
+++ b/.changeset/empty-shirts-mate.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix Memory Leak when switching between focused editables

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -4,6 +4,7 @@ import throttle from 'lodash/throttle'
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useRef,
@@ -175,6 +176,21 @@ export const Editable = (props: EditableProps) => {
     }),
     []
   )
+
+  useLayoutEffect(() => {
+    return () => {
+      if (state == null) {
+        return
+      }
+      // Avoid leaking DOM nodes when this component is unmounted.
+      if (state.latestElement != null) {
+        state.latestElement.remove();
+      }
+      if (state.latestElement != null) {
+        state.latestElement = null;
+      }
+    }
+  }, [])
 
   // The autoFocus TextareaHTMLAttribute doesn't do anything on a div, so it
   // needs to be manually focused.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -184,10 +184,10 @@ export const Editable = (props: EditableProps) => {
       }
       // Avoid leaking DOM nodes when this component is unmounted.
       if (state.latestElement != null) {
-        state.latestElement.remove();
+        state.latestElement.remove()
       }
       if (state.latestElement != null) {
-        state.latestElement = null;
+        state.latestElement = null
       }
     }
   }, [])


### PR DESCRIPTION
**Description**
I've found a memory leak in `slate-react` where-in when you'd switch between two pages, each with their own editor instance, auto-focusing on these elements causes a memory leak, where there would be a lot of Detached HTML Element's just floating around.

At first I thought it a bunch of different bugs with chromium, but noticed that when I force removed the input elements from the dom before the component would unmount, we would still see small leak referencing "latestElement" (while simultaneously, I would still the element & children references in the `IS_FOCUSED` WeakMap) Looking at editable's code, I realized that we're storing state in a weird way, directly mutating it using `useMemo`, and React isn't removing all references (probably because its still stored in the WeakMap.).

The simple fix for this is what I've commited; using `useLayoutEffect`, we forcably remove the `latestElement` and references to it, _before_ react unmounts the component.

**Example**
(Both of these examples were run using memlab, in an isolated test environment)
__Before (Has Big Dom Leak)__
https://github.com/ianstormtaylor/slate/assets/1474758/1ac76419-c48d-48ff-a759-994c268ea72f

__After (No Memory Leak)__
https://github.com/ianstormtaylor/slate/assets/1474758/e0a3961c-18cb-42d2-93a5-b01edbb3e52c


**Context**
We're using an older version of slate (0.91), but even when doing an upgrade in an isolated branch, we still see this issue. We're also using the most recent version of React (18.2.0). 

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

