### PR TITLE
Fix crash when deleting paragraph ending `\n` in Firefox

### DIFF
--- a/.changeset/chatty-chefs-sneeze.md
+++ b/.changeset/chatty-chefs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Firefox compat: Fix incorrect focus.offset when text node ends with \n

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -943,6 +943,17 @@ export const ReactEditor: ReactEditorInterface = {
       )
     }
 
+    // COMPAT: Firefox sometimes includes an extra \n (rendered by TextString
+    // when isTrailing is true) in the focusOffset, resulting in an invalid
+    // Slate point. (2023/11/01)
+    if (
+      IS_FIREFOX &&
+      focusNode.textContent?.endsWith('\n\n') &&
+      focusOffset === focusNode.textContent.length
+    ) {
+      focusOffset--
+    }
+
     // COMPAT: Triple-clicking a word in chrome will sometimes place the focus
     // inside a `contenteditable="false"` DOM node following the word, which
     // will cause `toSlatePoint` to throw an error. (2023/03/07)


### PR DESCRIPTION
**Description**
Due to a [Firefox browser quirk](https://github.com/ianstormtaylor/slate/issues/5273#issuecomment-1789494609), the DOM selection sometimes includes the additional `\n` added when `isTrailing` is true in `TextString`. This results in an invalid focus point, causing a crash during delete operations.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5273

**Example**
Before:

https://github.com/ianstormtaylor/slate/assets/4272090/5195ec18-a630-48ef-8e8d-579ba471b832

After:

https://github.com/ianstormtaylor/slate/assets/4272090/32c15c50-52af-4c1a-92e5-43a50d6dfe10

**Context**
It's possible that the logic for the check I added might not be perfect. However, I'm 99% sure that any new bugs it introduces will be harder to reproduce accidentally than the bug it fixes.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

