### PR TITLE
fix:  the 'select' parameter of the insertNodes function has been overridden

### DIFF
--- a/.changeset/quick-eels-leave.md
+++ b/.changeset/quick-eels-leave.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix the 'select' parameter of the insertNodes function has been overridden

--- a/packages/slate/src/transforms-node/insert-nodes.ts
+++ b/packages/slate/src/transforms-node/insert-nodes.ts
@@ -30,7 +30,9 @@ export const insertNodes: NodeTransforms['insertNodes'] = (
 
     if (!at) {
       at = getDefaultInsertLocation(editor)
-      select = true
+      if (select !== false) {
+        select = true
+      }
     }
 
     if (select == null) {


### PR DESCRIPTION
**Description**

The "select" parameter not works
```
editor.insertNodes(content, { select: false });
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

