### PR TITLE
Apply placeholder delay only on Android devices

### DIFF
--- a/.changeset/gold-bottles-collect.md
+++ b/.changeset/gold-bottles-collect.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Apply 300ms placeholder delay only on Android devices

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -16,7 +16,11 @@ import {
 } from '../utils/weak-maps'
 import { RenderLeafProps, RenderPlaceholderProps } from './editable'
 import { useSlateStatic } from '../hooks/use-slate-static'
-import { IS_WEBKIT } from '../utils/environment'
+import { IS_WEBKIT, IS_ANDROID } from '../utils/environment'
+
+// Delay the placeholder on Android to prevent the keyboard from closing.
+// (https://github.com/ianstormtaylor/slate/pull/5368)
+const PLACEHOLDER_DELAY = IS_ANDROID ? 300 : 0
 
 function disconnectPlaceholderResizeObserver(
   placeholderResizeObserver: MutableRefObject<ResizeObserver | null>,
@@ -104,7 +108,7 @@ const Leaf = (props: {
         showPlaceholderTimeoutRef.current = setTimeout(() => {
           setShowPlaceholder(true)
           showPlaceholderTimeoutRef.current = null
-        }, 300)
+        }, PLACEHOLDER_DELAY)
       }
     } else {
       clearTimeoutRef(showPlaceholderTimeoutRef)


### PR DESCRIPTION
**Description**
In PR #5368, a 300ms delay was added before showing the placeholder to prevent issues relating to mobile phone keyboards. This isn't great UX, and as far as I can tell (@edhager Can you confirm?) it's only needed on Android devices. This PR reduces the delay to 0ms on non-Android devices.

**Example**

https://github.com/ianstormtaylor/slate/assets/4272090/11f03149-cebb-4fba-8e54-bfb5855ab901

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

