### PR TITLE
Adjust cursor position when on selection collapse for RTL direction

### DIFF
--- a/.changeset/unlucky-paws-allow.md
+++ b/.changeset/unlucky-paws-allow.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix cursor position on selection collapse for RTL direction

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1501,7 +1501,7 @@ export const Editable = (props: EditableProps) => {
                     if (selection && Range.isCollapsed(selection)) {
                       Transforms.move(editor, { reverse: !isRTL })
                     } else {
-                      Transforms.collapse(editor, { edge: 'start' })
+                      Transforms.collapse(editor, { edge: isRTL ? 'end' : 'start' })
                     }
 
                     return
@@ -1513,7 +1513,7 @@ export const Editable = (props: EditableProps) => {
                     if (selection && Range.isCollapsed(selection)) {
                       Transforms.move(editor, { reverse: isRTL })
                     } else {
-                      Transforms.collapse(editor, { edge: 'end' })
+                      Transforms.collapse(editor, { edge: isRTL ? 'start' : 'end' })
                     }
 
                     return

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1501,7 +1501,9 @@ export const Editable = (props: EditableProps) => {
                     if (selection && Range.isCollapsed(selection)) {
                       Transforms.move(editor, { reverse: !isRTL })
                     } else {
-                      Transforms.collapse(editor, { edge: isRTL ? 'end' : 'start' })
+                      Transforms.collapse(editor, {
+                        edge: isRTL ? 'end' : 'start',
+                      })
                     }
 
                     return
@@ -1513,7 +1515,9 @@ export const Editable = (props: EditableProps) => {
                     if (selection && Range.isCollapsed(selection)) {
                       Transforms.move(editor, { reverse: isRTL })
                     } else {
-                      Transforms.collapse(editor, { edge: isRTL ? 'start' : 'end' })
+                      Transforms.collapse(editor, {
+                        edge: isRTL ? 'start' : 'end',
+                      })
                     }
 
                     return


### PR DESCRIPTION
**Description**
This PR fixes cursor position when selection is collapsed for RTL direction text.

**Issue**
Fixes: #5566

**Example**
For old behaviour please refer to issue #5566. The new behaviour video is attached below:


https://github.com/ianstormtaylor/slate/assets/60817786/548ac60d-82cc-4f89-a013-dd36782e481d



**Context**
N/A

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

