### PR TITLE
add `suppressThrow` to `ReactEditor`s `toDOMRange` and `toDOMPoint`

### DIFF
--- a/.changeset/twelve-mails-warn.md
+++ b/.changeset/twelve-mails-warn.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Suppressed error throwing on selection processing for externally updated DOM content

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -384,7 +384,13 @@ export const Editable = (props: EditableProps) => {
       state.isUpdatingSelection = true
 
       const newDomRange: DOMRange | null =
-        selection && ReactEditor.toDOMRange(editor, selection)
+        selection &&
+        ReactEditor.toDOMRange(editor, selection, {
+          // Even when we have a selection in Slate, the DOM might have moved
+          // underneath us, so we have to check that the anchor and focus nodes
+          // still exist.
+          suppressThrow: true,
+        })
 
       if (newDomRange) {
         if (ReactEditor.isComposing(editor) && !IS_ANDROID) {


### PR DESCRIPTION
**Description**
When the editor content is set externally, the DOM may not have the focus points the editor attempts to resolve. This is already handled for when [the current selection is null](https://github.com/ianstormtaylor/slate/blob/03125312fbbd36da629978d9da92c244ffc836af/packages/slate-react/src/components/editable.tsx#L389).

This is an implementation of the first suggestion noted [here](https://github.com/ianstormtaylor/slate/issues/3309#issuecomment-1832964997)

**Issue**
Fixes: Various issues that result from the DOM content changing under the editor and I believe [3309](https://github.com/ianstormtaylor/slate/issues/3309)

**Example**
Here is an example of the external value being reset to "Text" programmatically, with the cursor at the end of the input. Previously, this would have errored.
[Screencast from 30-11-23 14:29:54.webm](https://github.com/ianstormtaylor/slate/assets/11350169/17df3319-7b37-4b9e-8cf0-820da1047446)

**Context**
I have replicated the `suppressThrow` pattern on other methods and enabled it when reprocessing focus via the useLayoutEffect in the Editable component.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)