### PR TITLE
fix: fix onCompositionEnd update error

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1114,8 +1114,10 @@ export const Editable = (props: EditableProps) => {
               (event: React.CompositionEvent<HTMLDivElement>) => {
                 if (ReactEditor.hasSelectableTarget(editor, event.target)) {
                   if (ReactEditor.isComposing(editor)) {
-                    setIsComposing(false)
-                    IS_COMPOSING.set(editor, false)
+                    Promise.resolve(()=>{
+                      setIsComposing(false)
+                      IS_COMPOSING.set(editor, false)
+                    })
                   }
 
                   androidInputManagerRef.current?.handleCompositionEnd(event)


### PR DESCRIPTION
**Description**
When user is compositing, The code-block updating is not work correctly.
![Dec-02-2023 21-23-41](https://github.com/ianstormtaylor/slate/assets/91405589/29c4cb98-9992-44fd-a59d-4efb95e8ac9d)


**Context**
The onEompositionEnd  Event will trigger two react update，one is `setIsComposing(false)` and anthor is `Editor.insertText(editor, event.data)`，`Editor.insertText(editor, event.data)` should update first or it will cause update error（selection is not update) that in `slate/packages/slate-react/src/components/element.tsx` MemoizedElement。
So I use Promise to delay `setIsComposing(false)` and  exec `Editor.insertText(editor, event.data)` first to make it resolve selection correctly when onEompositionEnd is triggered.

```slate/packages/slate-react/src/components/element.tsx
const MemoizedElement = React.memo(Element, (prev, next) => {
  return (
    prev.element === next.element &&
    prev.renderElement === next.renderElement &&
    prev.renderLeaf === next.renderLeaf &&
    prev.renderPlaceholder === next.renderPlaceholder &&
    isElementDecorationsEqual(prev.decorations, next.decorations) &&
// The selection is not update correctly when onEompositionEnd is triggered
    (prev.selection === next.selection ||
      (!!prev.selection &&
        !!next.selection &&
        Range.equals(prev.selection, next.selection)))
  )
})
```
