### PR TITLE
marks on double click selection using firefox fix

### DIFF
--- a/.changeset/blue-flies-decide.md
+++ b/.changeset/blue-flies-decide.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Fix firefox double-click marks issue

--- a/.changeset/blue-flies-decide.md
+++ b/.changeset/blue-flies-decide.md
@@ -1,5 +1,5 @@
 ---
-'slate': minor
+'slate': patch
 ---
 
 Fix firefox double-click marks issue

--- a/packages/slate/src/editor/marks.ts
+++ b/packages/slate/src/editor/marks.ts
@@ -4,7 +4,7 @@ import { Range } from '../interfaces/range'
 import { Path } from '../interfaces/path'
 import { Text } from '../interfaces/text'
 import { Element } from '../interfaces/element'
-import {Point} from "../interfaces";
+import { Point } from '../interfaces'
 
 export const marks: EditorInterface['marks'] = (editor, options = {}) => {
   const { marks, selection } = editor
@@ -23,11 +23,15 @@ export const marks: EditorInterface['marks'] = (editor, options = {}) => {
     if (isEnd) {
       const after = Editor.after(editor, anchor as Point)
       // Editor.after() might return undefined
-      anchor = (after || anchor)
+      anchor = after || anchor
     }
-    const [match] = Editor.nodes(editor, { match: Text.isText, at: {
-      anchor, focus
-    } })
+    const [match] = Editor.nodes(editor, {
+      match: Text.isText,
+      at: {
+        anchor,
+        focus,
+      },
+    })
     if (match) {
       const [node] = match as NodeEntry<Text>
       const { text, ...rest } = node

--- a/packages/slate/src/editor/marks.ts
+++ b/packages/slate/src/editor/marks.ts
@@ -6,10 +6,6 @@ import { Text } from '../interfaces/text'
 import { Element } from '../interfaces/element'
 import {Point} from "../interfaces";
 
-export const IS_FIREFOX =
-  typeof navigator !== 'undefined' &&
-  /^(?!.*Seamonkey)(?=.*Firefox).*/i.test(navigator.userAgent)
-
 export const marks: EditorInterface['marks'] = (editor, options = {}) => {
   const { marks, selection } = editor
 
@@ -23,13 +19,11 @@ export const marks: EditorInterface['marks'] = (editor, options = {}) => {
   }
 
   if (Range.isExpanded(selection)) {
-    if (IS_FIREFOX) {
-      const isEnd = Editor.isEnd(editor, anchor, anchor.path)
-      if (isEnd) {
-        const after = Editor.after(editor, anchor as Point)
-        // Editor.after() might return undefined
-        anchor = (after || anchor)
-      }
+    const isEnd = Editor.isEnd(editor, anchor, anchor.path)
+    if (isEnd) {
+      const after = Editor.after(editor, anchor as Point)
+      // Editor.after() might return undefined
+      anchor = (after || anchor)
     }
     const [match] = Editor.nodes(editor, { match: Text.isText, at: {
       anchor, focus

--- a/packages/slate/src/editor/marks.ts
+++ b/packages/slate/src/editor/marks.ts
@@ -19,12 +19,18 @@ export const marks: EditorInterface['marks'] = (editor, options = {}) => {
   }
 
   if (Range.isExpanded(selection)) {
+    /**
+     * COMPAT: Make sure hanging ranges (caused by double clicking in Firefox)
+     * do not adversely affect the returned marks.
+     */
     const isEnd = Editor.isEnd(editor, anchor, anchor.path)
     if (isEnd) {
       const after = Editor.after(editor, anchor as Point)
-      // Editor.after() might return undefined
-      anchor = after || anchor
+      if (after) {
+        anchor = after
+      }
     }
+
     const [match] = Editor.nodes(editor, {
       match: Text.isText,
       at: {
@@ -32,6 +38,7 @@ export const marks: EditorInterface['marks'] = (editor, options = {}) => {
         focus,
       },
     })
+
     if (match) {
       const [node] = match as NodeEntry<Text>
       const { text, ...rest } = node

--- a/packages/slate/test/interfaces/Editor/marks/firefox-double-click.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/firefox-double-click.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+/**
+ * This test verifies that when double clicking a marked word in Firefox,
+ * Editor.marks for the resulting selection includes the marked word. Double
+ * clicking a marked word in Firefox results in a selection that starts at the
+ * end of the previous text node and ends at the end of the marked text node.
+ */
+
+export const input = (
+  <editor>
+    <block>
+      plain <anchor />
+      <text bold>
+        bold
+        <focus />
+      </text>
+      <text> plain</text>
+    </block>
+    <block>block two</block>
+  </editor>
+)
+export const test = editor => {
+  return Editor.marks(editor)
+}
+export const output = { bold: true }


### PR DESCRIPTION
**Description**

This PR contains a quick-fix of marks function using Firefox. This was already fixed, but the fix was removed inside of #5486. I put it back but this time only in marks code instead of selection handling one,  so it should not affect anything else. 

**Issue**
Fixes: #5574 #5560 

**Example**
Before the fix:

![Recording 2023-12-09 at 15 47 57](https://github.com/ianstormtaylor/slate/assets/34960023/9a640f00-5778-41ca-a65d-6c7c7d2518d6)



When fixed:
![Recording 2023-12-09 at 15 46 07](https://github.com/ianstormtaylor/slate/assets/34960023/06e34c1d-9406-4a01-89fd-5092eea50f36)


**Context**

This is related to firefox weird selection range when double clicking.
Explanation from original fix: 
    * suppose we have this document:
     *
     * { type: 'paragraph',
     *   children: [
     *     { text: 'foo ' },
     *     { text: 'bar' },
     *     { text: ' baz' }
     *   ]
     * }
     *
     * a double click on "bar" on chrome will create this range:
     *
     * anchor -> [0,1] offset 0
     * focus  -> [0,1] offset 3
     *
     * while on firefox will create this range:
     *
     * anchor -> [0,0] offset 4
     * focus  -> [0,2] offset 0

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

