### PR TITLE
Fix onCompositionEnd not updating isComposing

### DIFF
--- a/.changeset/light-bulldogs-refuse.md
+++ b/.changeset/light-bulldogs-refuse.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix onCompositionEnd not updating isComposing

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1114,7 +1114,7 @@ export const Editable = (props: EditableProps) => {
               (event: React.CompositionEvent<HTMLDivElement>) => {
                 if (ReactEditor.hasSelectableTarget(editor, event.target)) {
                   if (ReactEditor.isComposing(editor)) {
-                    Promise.resolve(() => {
+                    Promise.resolve().then(() => {
                       setIsComposing(false)
                       IS_COMPOSING.set(editor, false)
                     })


### PR DESCRIPTION
**Description**
After `compositionend` event completion, `isComposing` fails to update.

**Issue**
https://github.com/ianstormtaylor/slate/pull/5576

**Example**
After using IME for input, mouse clicking does not trigger the update of the selection, resulting in subsequent input being placed in the wrong position.

![example](https://github.com/ianstormtaylor/slate/assets/56380896/3d61c68a-cae1-4601-8dc8-075ff7baaefd)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)


