### PR TITLE
Fix: Calling `ReactEditor.focus` doesn't update `useFocused` when running in @testing-library/react

### DIFF
--- a/.changeset/shiny-numbers-matter.md
+++ b/.changeset/shiny-numbers-matter.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix: Calling `ReactEditor.focus` doesn't update `useFocused` when running in @testing-library/react

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -447,8 +447,10 @@ export const ReactEditor: ReactEditorInterface = {
         Transforms.select(editor, Editor.start(editor, []))
         editor.onChange()
       }
-      el.focus({ preventScroll: true })
+      // IS_FOCUSED should be set before calling el.focus() to ensure that
+      // FocusedContext is updated to the correct value
       IS_FOCUSED.set(editor, true)
+      el.focus({ preventScroll: true })
     }
   },
 


### PR DESCRIPTION
**Description**
Sometimes, when calling `ReactEditor.focus` in [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/), the value of `useFocused` doesn't get updated. This PR addresses this issue by setting `IS_FOCUSED` to true prior to dispatching a DOM focus event.

**Context**
The `isFocused` state variable controlling `useFocused` (via `FocusedContext`) is [updated in `slate.tsx`](https://github.com/ianstormtaylor/slate/blob/8f2ad02db32f348eb9499e8db1e46d1b705d4d5d/packages/slate-react/src/components/slate.tsx#L96-L116) in response to focus and blur events, but the value of `isFocused` is always pulled from `IS_FOCUSED`, regardless of which event triggered the update. This stopped working in #5527 when the `ReactEditor.focus` line setting `IS_FOCUSED` was moved to after `el.focus({ preventScroll: true })`.

When running in a real browser, `IS_FOCUSED` is already set to true when `domSelection?.addRange(domRange)` is called higher up in `ReactEditor.focus`, [via `onDOMSelectionChange`](https://github.com/ianstormtaylor/slate/blob/8f2ad02db32f348eb9499e8db1e46d1b705d4d5d/packages/slate-react/src/components/editable.tsx#L218).

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

