### PR TITLE
Fix relative url to normalizing-11.md

### DIFF
--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -346,7 +346,7 @@ Options: `{force?: boolean; operation?: Operation}`
 #### `Editor.withoutNormalizing(editor: Editor, fn: () => void) => void`
 
 Call a function, deferring normalization until after it completes.
-See [Normalization - Implications for Other Code](./11-normalizing.md#implications-for-other-code);
+See [Normalization - Implications for Other Code](../../concepts/11-normalizing.md#implications-for-other-code);
 
 ### Ref Methods
 


### PR DESCRIPTION
**Description**
Found a broken link while looking through docs

**Issue**
Fixes: relative pathing

**Example**
Link within [section](https://github.com/sunsheeppoplar/slate/blob/update-docs/docs/api/nodes/editor.md#editorwithoutnormalizingeditor-editor-fn---void--void) works now