### PR TITLE
fix: automatically inserts an empty text node after inserting an image

### DIFF
--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -83,7 +83,7 @@ const insertImage = (editor, url) => {
   const image: ImageElement = { type: 'image', url, children: [text] }
   Transforms.insertNodes(editor, image)
   Transforms.insertNodes(editor, {
-    type: "paragraph",
+    type: 'paragraph',
     children: [{ text: "" }],
   });
 }

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -82,6 +82,10 @@ const insertImage = (editor, url) => {
   const text = { text: '' }
   const image: ImageElement = { type: 'image', url, children: [text] }
   Transforms.insertNodes(editor, image)
+  Transforms.insertNodes(editor, {
+    type: "paragraph",
+    children: [{ text: "" }],
+  });
 }
 
 const Element = props => {

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -84,7 +84,7 @@ const insertImage = (editor, url) => {
   Transforms.insertNodes(editor, image)
   Transforms.insertNodes(editor, {
     type: 'paragraph',
-    children: [{ text: "" }],
+    children: [{ text: '' }],
   });
 }
 

--- a/site/examples/images.tsx
+++ b/site/examples/images.tsx
@@ -85,7 +85,7 @@ const insertImage = (editor, url) => {
   Transforms.insertNodes(editor, {
     type: 'paragraph',
     children: [{ text: '' }],
-  });
+  })
 }
 
 const Element = props => {


### PR DESCRIPTION
**Description**
Automatically adds an empty text node after inserting an image in the example code for using images in Slate. 

**Issue**
Fixes #5597

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

