### PR TITLE
chore: add mocha tests launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,15 +13,13 @@
         "--grep",
         "${fileBasenameNoExtension}",
         "--timeout",
-        "999999",
+        "999999"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/.yarn/releases/yarn-4.0.2.cjs",
       "request": "launch",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "type": "node"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,26 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "args": [
+        "mocha",
+        "--require",
+        "${workspaceFolder}/config/babel/register.cjs",
+        "${workspaceFolder}/packages/{slate,slate-history,slate-hyperscript}/test/**/*.{js,ts}",
+        "--grep",
+        "${fileBasenameNoExtension}",
+        "--timeout",
+        "999999",
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "name": "Mocha Tests",
+      "program": "${workspaceFolder}/.yarn/releases/yarn-4.0.2.cjs",
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
+    },
+    {
       "type": "firefox",
       "request": "launch",
       "reAttach": true,


### PR DESCRIPTION
**Description**
Add Visual Studio Code launch configuration for mocha tests.

**Context**
Needed to easily start/attach a debugger.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

