### PR TITLE
fix a possible typescript typo in the docs

### DIFF
--- a/docs/walkthroughs/01-installing-slate.md
+++ b/docs/walkthroughs/01-installing-slate.md
@@ -54,7 +54,7 @@ Of course we haven't rendered anything, so you won't see any changes.
 import { BaseEditor, Descendant } from 'slate'
 import { ReactEditor } from 'slate-react'
 
-type CustomElement = { type: 'paragraph'; children: CustomText[] }
+type CustomElement = { type: string; children: CustomText[] }
 type CustomText = { text: string }
 
 declare module 'slate' {


### PR DESCRIPTION
**Description**
I noticed an error when following the introduction section in the docs, thought it might be a possible solution, have no idea though

**Example**
![image](https://github.com/ianstormtaylor/slate/assets/100872784/1052a2de-8f6d-4615-96cf-93a23c768c9b)



