### PR TITLE
feat(normalize-node): Adding `children` field to prevent erronous nodes from breaking notebooks.

### DIFF
--- a/.changeset/lazy-radios-smile.md
+++ b/.changeset/lazy-radios-smile.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Making `normalizeNode` capable of normalizing erronous nodes, making slate more resilient.

--- a/packages/slate/src/core/normalize-node.ts
+++ b/packages/slate/src/core/normalize-node.ts
@@ -75,6 +75,19 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
         }
       }
     } else {
+      // If the child is not a text node, and doesn't have a `children` field,
+      // then we have an invalid node that will upset slate.
+      //
+      // eg: `{ type: 'some_node' }`.
+      //
+      // To prevent slate from breaking, we can add the `children` field,
+      // and now that it is valid, we can to many more operations easily,
+      // such as extend normalizers to fix erronous structure.
+      if (!Text.isText(child) && !('children' in child)) {
+        const elementChild = child as Element
+        elementChild.children = []
+      }
+
       // Merge adjacent text nodes that are empty or match.
       if (prev != null && Text.isText(prev)) {
         if (Text.equals(child, prev, { loose: true })) {


### PR DESCRIPTION
**Description**
Sometimes, when working with other tools such as Yjs, it so happens that we enter nodes into `editor.children` that slate cannot recover from. The most common case I come across is erronous nodes that are elements, and somewhere along the process the `children` field was dropped.

This could happen for various reasons, but IMO slate should be able to recover from them.

**Example**
Let's say you have the following:

```ts
editor.children = [
    {
      type: "table",
      children: [
        {
          type: "row",
          children: [{ text: "empty " }],
        },
        {
          type: "not_row",
        },
      ],
    }
  ]
  ```
  
Using `editor.normalize` won't touch the `not_row` element, but if you attempt `editor.normalize({ force: true })`, slate will throw an error, and rightfully so.

This at least prepares the node, making it acceptable by `Element.isElement`, and allowing normalizer plugins the user might make, to easily normalize away these nodes, because otherwise they will not be able to be normalized.

## Disclaimer
I've used Slate for a while, and I know a fair bit about it. But this could have missed the mark.

The way in which I do this doesn't seem ideal to me. It seems like an anti-pattern. But using the `Transforms` will result in the same error being thrown, because we assume that this `Node` has a `children` field.

Any help would be greatly appreciated.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

