### PR TITLE
fix(normalize-node): Adding extra validation

### DIFF
--- a/.changeset/weak-seahorses-exercise.md
+++ b/.changeset/weak-seahorses-exercise.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Extra validation before checking child has children node

--- a/packages/slate/src/core/normalize-node.ts
+++ b/packages/slate/src/core/normalize-node.ts
@@ -83,7 +83,12 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       // To prevent slate from breaking, we can add the `children` field,
       // and now that it is valid, we can to many more operations easily,
       // such as extend normalizers to fix erronous structure.
-      if (!Text.isText(child) && !('children' in child)) {
+      if (
+        !Text.isText(child) &&
+        child != null &&
+        typeof child === 'object' &&
+        !('children' in child)
+      ) {
         const elementChild = child as Element
         elementChild.children = []
       }


### PR DESCRIPTION
**Description**
Very similar to this: https://github.com/ianstormtaylor/slate/pull/5620

But added some extra validation, as I was running into some errors in a work project.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

