### PR TITLE
Add Safari workaround inside shadow DOM.

### DIFF
--- a/.changeset/red-poems-wave.md
+++ b/.changeset/red-poems-wave.md
@@ -1,0 +1,5 @@
+---
+"slate-react": minor
+---
+
+Fix Safari selection inside Shadow DOM.

--- a/.changeset/red-poems-wave.md
+++ b/.changeset/red-poems-wave.md
@@ -1,5 +1,5 @@
 ---
-"slate-react": minor
+'slate-react': minor
 ---
 
 Fix Safari selection inside Shadow DOM.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,12 +3,12 @@ compressionLevel: mixed
 packageExtensions:
   eslint-module-utils@*:
     dependencies:
-      eslint-import-resolver-node: "*"
+      eslint-import-resolver-node: '*'
   next@*:
     dependencies:
-      eslint-import-resolver-node: "*"
+      eslint-import-resolver-node: '*'
   react-error-boundary@*:
     dependencies:
-      prop-types: "*"
+      prop-types: '*'
 
 yarnPath: .yarn/releases/yarn-4.0.2.cjs

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -51,6 +51,7 @@ import {
   IS_WEBKIT,
   IS_UC_MOBILE,
   IS_WECHATBROWSER,
+  IS_SAFARI_LEGACY,
 } from '../utils/environment'
 import Hotkeys from '../utils/hotkeys'
 import {
@@ -206,12 +207,9 @@ export const Editable = (props: EditableProps) => {
       throttle(() => {
         const el = ReactEditor.toDOMNode(editor, editor)
         const root = el.getRootNode()
-        const safariVersion = navigator.userAgent.match(/Version\/(\d+\.\d+)/)
-        const isSafariVersionLessThan17 =
-          IS_WEBKIT && safariVersion && parseFloat(safariVersion[1]) < 17.0
 
         if (
-          isSafariVersionLessThan17 &&
+          IS_SAFARI_LEGACY &&
           !processing.current &&
           IS_WEBKIT &&
           root instanceof ShadowRoot
@@ -501,12 +499,9 @@ export const Editable = (props: EditableProps) => {
     (event: InputEvent) => {
       const el = ReactEditor.toDOMNode(editor, editor)
       const root = el.getRootNode()
-      const safariVersion = navigator.userAgent.match(/Version\/(\d+\.\d+)/)
-      const isSafariVersionLessThan17 =
-        IS_WEBKIT && safariVersion && parseFloat(safariVersion[1]) < 17.0
 
       if (
-        isSafariVersionLessThan17 &&
+        IS_SAFARI_LEGACY &&
         processing?.current &&
         IS_WEBKIT &&
         root instanceof ShadowRoot

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -506,7 +506,6 @@ export const Editable = (props: EditableProps) => {
         IS_WEBKIT &&
         root instanceof ShadowRoot
       ) {
-        // @ts-ignore
         const ranges = event.getTargetRanges()
         const range = ranges[0]
 
@@ -977,17 +976,17 @@ export const Editable = (props: EditableProps) => {
               ...(disableDefaultStyles
                 ? {}
                 : {
-                  // Allow positioning relative to the editable element.
-                  position: 'relative',
-                  // Preserve adjacent whitespace and new lines.
-                  whiteSpace: 'pre-wrap',
-                  // Allow words to break if they are too long.
-                  wordWrap: 'break-word',
-                  // Make the minimum height that of the placeholder.
-                  ...(placeholderHeight
-                    ? { minHeight: placeholderHeight }
-                    : {}),
-                }),
+                    // Allow positioning relative to the editable element.
+                    position: 'relative',
+                    // Preserve adjacent whitespace and new lines.
+                    whiteSpace: 'pre-wrap',
+                    // Allow words to break if they are too long.
+                    wordWrap: 'break-word',
+                    // Make the minimum height that of the placeholder.
+                    ...(placeholderHeight
+                      ? { minHeight: placeholderHeight }
+                      : {}),
+                  }),
               // Allow for passed-in styles to override anything.
               ...userStyle,
             }}
@@ -1470,7 +1469,7 @@ export const Editable = (props: EditableProps) => {
                   const element =
                     editor.children[
                       selection !== null ? selection.focus.path[0] : 0
-                      ]
+                    ]
                   const isRTL = getDirection(Node.string(element)) === 'rtl'
 
                   // COMPAT: Since we prevent the default behavior on
@@ -1778,9 +1777,9 @@ export type RenderPlaceholderProps = {
  */
 
 export const DefaultPlaceholder = ({
-                                     attributes,
-                                     children,
-                                   }: RenderPlaceholderProps) => (
+  attributes,
+  children,
+}: RenderPlaceholderProps) => (
   // COMPAT: Artificially add a line-break to the end on the placeholder element
   // to prevent Android IMEs to pick up its content in autocorrect and to auto-capitalize the first letter
   <span {...attributes}>

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -170,7 +170,7 @@ export const getEditableChildAndIndex = (
     isDOMComment(child) ||
     (isDOMElement(child) && child.childNodes.length === 0) ||
     (isDOMElement(child) && child.getAttribute('contenteditable') === 'false')
-    ) {
+  ) {
     if (triedForward && triedBackward) {
       break
     }

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -170,7 +170,7 @@ export const getEditableChildAndIndex = (
     isDOMComment(child) ||
     (isDOMElement(child) && child.childNodes.length === 0) ||
     (isDOMElement(child) && child.getAttribute('contenteditable') === 'false')
-  ) {
+    ) {
     if (triedForward && triedBackward) {
       break
     }
@@ -313,4 +313,19 @@ export const isTrackedMutation = (
 
   // Target add/remove is tracked. Track the mutation if we track the parent mutation.
   return isTrackedMutation(editor, parentMutation, batch)
+}
+
+export function getActiveElement() {
+  let active = document.activeElement
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (active && active.shadowRoot && active.shadowRoot.activeElement) {
+      active = active.shadowRoot.activeElement
+    } else {
+      break
+    }
+  }
+
+  return active
 }

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -315,17 +315,15 @@ export const isTrackedMutation = (
   return isTrackedMutation(editor, parentMutation, batch)
 }
 
-export function getActiveElement() {
-  let active = document.activeElement
+/**
+ * Retrieves the deepest active element in the DOM, considering nested shadow DOMs.
+ */
+export const getActiveElement = () => {
+  let activeElement = document.activeElement
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    if (active && active.shadowRoot && active.shadowRoot.activeElement) {
-      active = active.shadowRoot.activeElement
-    } else {
-      break
-    }
+  while (activeElement?.shadowRoot && activeElement.shadowRoot?.activeElement) {
+    activeElement = activeElement?.shadowRoot?.activeElement
   }
 
-  return active
+  return activeElement
 }

--- a/packages/slate-react/src/utils/environment.ts
+++ b/packages/slate-react/src/utils/environment.ts
@@ -66,6 +66,15 @@ export const CAN_USE_DOM = !!(
   typeof window.document.createElement !== 'undefined'
 )
 
+// Check if the browser is Safari and older than 17
+export const IS_SAFARI_LEGACY =
+  typeof navigator !== 'undefined' &&
+  /Safari/.test(navigator.userAgent) &&
+  /Version\/(\d+)/.test(navigator.userAgent) &&
+  (navigator.userAgent.match(/Version\/(\d+)/)?.[1]
+    ? parseInt(navigator.userAgent.match(/Version\/(\d+)/)?.[1]!, 10) < 17
+    : false)
+
 // COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
 // Chrome Legacy doesn't support `beforeinput` correctly
 export const HAS_BEFORE_INPUT_SUPPORT =

--- a/playwright/integration/examples/shadow-dom.test.ts
+++ b/playwright/integration/examples/shadow-dom.test.ts
@@ -12,4 +12,25 @@ test.describe('shadow-dom example', () => {
 
     await expect(innerShadow.getByRole('textbox')).toHaveCount(1)
   })
+
+  test('renders slate editor inside nested shadow and edits content', async ({
+    page,
+  }) => {
+    const outerShadow = page.locator('[data-cy="outer-shadow-root"]')
+    const innerShadow = outerShadow.locator('> div')
+    const textbox = innerShadow.getByRole('textbox')
+
+    // Ensure the textbox is present
+    await expect(textbox).toHaveCount(1)
+
+    // Clear any existing text and type new text into the textbox
+    await textbox.fill('') // Clears the textbox
+    await textbox.type('Hello, Playwright!')
+
+    // Assert that the textbox contains the correct text
+    await expect(textbox).toHaveValue('Hello, Playwright!')
+
+    // Optionally, if you want to assert just the presence of text, not exact match
+    await expect(textbox).toContainText('Hello, Playwright!')
+  })
 })

--- a/playwright/integration/examples/shadow-dom.test.ts
+++ b/playwright/integration/examples/shadow-dom.test.ts
@@ -29,8 +29,5 @@ test.describe('shadow-dom example', () => {
 
     // Assert that the textbox contains the correct text
     await expect(textbox).toHaveValue('Hello, Playwright!')
-
-    // Optionally, if you want to assert just the presence of text, not exact match
-    await expect(textbox).toContainText('Hello, Playwright!')
   })
 })


### PR DESCRIPTION
**Description**
Safari doesn't support access for selection inside shadow root, this PR implements a workaround that will be applied only for Safari inside shadow root to improve the editor experience inside Safari.

**Issue**
Fixes: #5144 #5321 

**Example**
![image](https://github.com/ianstormtaylor/slate/assets/36645103/ad67dfbf-c53d-4809-8843-110305597cf5)

**Context**
This PR introduces a workaround for the absence of the getSelection method in Safari versions prior to 17 when used inside a shadow DOM, which causes the behavior in the example above. By implementing a workaround, this fix ensures consistent behavior.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

