### PR TITLE
Make capitalizing work for iOS

### DIFF
--- a/.changeset/stale-bats-jog.md
+++ b/.changeset/stale-bats-jog.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Make capitalizing work for iOS

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -3,7 +3,7 @@ import { Editor, Text, Path, Element, Node } from 'slate'
 
 import { ReactEditor, useSlateStatic } from '..'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
-import { IS_ANDROID } from '../utils/environment'
+import { IS_ANDROID, IS_IOS } from '../utils/environment'
 import { MARK_PLACEHOLDER_SYMBOL } from '../utils/weak-maps'
 
 /**
@@ -129,7 +129,7 @@ export const ZeroWidthString = (props: {
 
   return (
     <span {...attributes}>
-      {!IS_ANDROID || !isLineBreak ? '\uFEFF' : null}
+      {!(IS_ANDROID || IS_IOS) || !isLineBreak ? '\uFEFF' : null}
       {isLineBreak ? <br /> : null}
     </span>
   )


### PR DESCRIPTION
**Description**
Capitalizing doesn't work for iOS if Editor has an empty initial state, see [Custom placeholder example](https://www.slatejs.org/examples/custom-placeholder)

**Issue**
Fixes: [#5199](https://github.com/ianstormtaylor/slate/issues/5199)

**Example**
***Before***

https://github.com/ianstormtaylor/slate/assets/19905096/19bf81a5-d57b-41d3-8451-9f4fcf6fba1f

***After***

https://github.com/ianstormtaylor/slate/assets/19905096/f07be158-ceb3-49e6-89a5-01311f135210

**Context**
There was a fix for Android but not for iOS. Basically `uFEFF` breaks capitalizing experience and it seems it can be removed for iOS devices as well

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

