### PR TITLE
Enable Shadow DOM fix for Safari 17.

### DIFF
--- a/.changeset/weak-files-jam.md
+++ b/.changeset/weak-files-jam.md
@@ -1,0 +1,5 @@
+---
+"slate-react": minor
+---
+
+Enable Shadow DOM fix for all Safari versions.

--- a/.changeset/weak-files-jam.md
+++ b/.changeset/weak-files-jam.md
@@ -1,5 +1,5 @@
 ---
-"slate-react": minor
+'slate-react': minor
 ---
 
 Enable Shadow DOM fix for all Safari versions.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -51,7 +51,6 @@ import {
   IS_WEBKIT,
   IS_UC_MOBILE,
   IS_WECHATBROWSER,
-  IS_SAFARI_LEGACY,
 } from '../utils/environment'
 import Hotkeys from '../utils/hotkeys'
 import {
@@ -208,12 +207,7 @@ export const Editable = (props: EditableProps) => {
         const el = ReactEditor.toDOMNode(editor, editor)
         const root = el.getRootNode()
 
-        if (
-          IS_SAFARI_LEGACY &&
-          !processing.current &&
-          IS_WEBKIT &&
-          root instanceof ShadowRoot
-        ) {
+        if (!processing.current && IS_WEBKIT && root instanceof ShadowRoot) {
           processing.current = true
 
           const active = getActiveElement()
@@ -500,12 +494,7 @@ export const Editable = (props: EditableProps) => {
       const el = ReactEditor.toDOMNode(editor, editor)
       const root = el.getRootNode()
 
-      if (
-        IS_SAFARI_LEGACY &&
-        processing?.current &&
-        IS_WEBKIT &&
-        root instanceof ShadowRoot
-      ) {
+      if (processing?.current && IS_WEBKIT && root instanceof ShadowRoot) {
         const ranges = event.getTargetRanges()
         const range = ranges[0]
 


### PR DESCRIPTION
**Description**
#5648 Implements a workaround that will be applied only for Safari inside shadow root to improve the editor experience inside Safari, but it was applied to Safari < 17, and this PR enables it for Safari 17 as well, so that the editor works.

Ideally, the fix should include utilizing `Selection: getComposedRanges()` (I think), but that would require some work and thorough testing, so it can be scheduled for later.

**Issue**
Fixes: (part of) https://github.com/ianstormtaylor/slate/issues/5321

**Example**
![193604958-b87f0802-8e8f-465b-9f50-904b9220cf2f](https://github.com/ianstormtaylor/slate/assets/36645103/91f2ed80-4ba5-4e89-b8b8-8cd45bc749b5)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

