### PR TITLE
Reset `state.isDraggingInternally` using global event handlers

### DIFF
--- a/.changeset/grumpy-icons-refuse.md
+++ b/.changeset/grumpy-icons-refuse.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix: `state.isDraggingInternally` is stale if a drop handler outside the editor causes the dragged DOM element to unmount

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -26,4 +26,4 @@ export { ReactEditor } from './plugin/react-editor'
 export { withReact } from './plugin/with-react'
 
 // Utils
-export { NODE_TO_INDEX, NODE_TO_PARENT } from "./utils/weak-maps"
+export { NODE_TO_INDEX, NODE_TO_PARENT } from './utils/weak-maps'


### PR DESCRIPTION
**Description**
Listen for `dragend` and `drop` events globally to reset `state.isDraggingInternally`. In Firefox, if a drop handler initiates an operation that causes the originally dragged element to unmount, that element will not emit a `dragend` event.

**Issue**
Fixes: #5663 

**Example**
See issue

**Context**
We may want to remove the React `onDragEnd` handler, since after this change, all it does is delegate the event if certain conditions are met.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

