### PR TITLE
fix: site example(Search Highlighting) range

### DIFF
--- a/site/examples/search-highlighting.tsx
+++ b/site/examples/search-highlighting.tsx
@@ -13,38 +13,48 @@ const SearchHighlightingExample = () => {
     ([node, path]) => {
       const ranges = []
 
-      if (search && Array.isArray(node.children) && node.children.every(Text.isText)) {
-        const texts = node.children.map(it => it.text);
-        const str = texts.join('');
-        let start = str.indexOf(search);
+      if (
+        search &&
+        Array.isArray(node.children) &&
+        node.children.every(Text.isText)
+      ) {
+        const texts = node.children.map(it => it.text)
+        const str = texts.join('')
+        const length = search.length
+        let start = str.indexOf(search)
+        let index = 0
+        let iterated = 0
         while (start !== -1) {
-          let index = 0;
-          let offset = start;
-          let length = search.length;
+          // Skip already iterated strings
+          while (
+            index < texts.length &&
+            start >= iterated + texts[index].length
+          ) {
+            iterated = iterated + texts[index].length
+            index++
+          }
           // Find the index of array and relative position
-          while (length > 0 && index < texts.length) {
-            const currentText = texts[index];
-            const currentPath = [...path, index];
-            // May span multiple array elements
-            if (offset < currentText.length && index < texts.length) {
-              // Get the smaller value of boundary and remaining length
-              let taken = Math.min(currentText.length - offset, length);
-              ranges.push({
-                anchor: { path: currentPath, offset: offset },
-                focus: { path: currentPath, offset: offset + taken },
-                highlight: true,
-              });
-              length = length - taken;
+          let offset = start - iterated
+          let remaining = length
+          while (index < texts.length && remaining > 0) {
+            const currentText = texts[index]
+            const currentPath = [...path, index]
+            const taken = Math.min(remaining, currentText.length - offset)
+            ranges.push({
+              anchor: { path: currentPath, offset },
+              focus: { path: currentPath, offset: offset + taken },
+              highlight: true,
+            })
+            remaining = remaining - taken
+            if (remaining > 0) {
+              iterated = iterated + currentText.length
               // Next block will be indexed from 0
-              offset = 0;
-              index++;
-            } else {
-              offset = offset - currentText.length;
-              index++;
+              offset = 0
+              index++
             }
           }
           // Looking for next search block
-          start = str.indexOf(search, start + search.length);
+          start = str.indexOf(search, start + search.length)
         }
       }
 


### PR DESCRIPTION
**Description**
When I was testing the 'decorations' feature on the[ official website (search-highlighting)](https://www.slatejs.org/examples/search-highlighting), I noticed that there were some issues with supporting content that had been split into multiple formats.

**Issue**
none

**Example**
When I search for "adds", it works pretty well. However, when I perform a search that spans nodes, it doesn't highlight the content very effectively.

![20240628191020_rec_](https://github.com/ianstormtaylor/slate/assets/33169019/6117dcb8-a019-47cd-ba3e-72a3da940113)

**Context**
I think it's necessary to tackle this issue. Initially, I planned to start with [Range.intersection](https://github.com/ianstormtaylor/slate/blob/97c88d/packages/slate-react/src/hooks/use-children.tsx#L55), by calculating the overlapping ranges at the parent node and judging the intersection of multiple nodes to address this issue. However, I realized that this might impose a burden on the rendering performance of Slate, as it may need to constantly traverse nodes for searching.

Therefore, I resolved this issue here by modifying the example of the site. By clearly identifying the content to be searched and the boundaries of the split nodes to obtain smaller values to form a range, even if the content being searched is very long, it will only save the search content within its own range.

![20240628192046_rec_](https://github.com/ianstormtaylor/slate/assets/33169019/41b6276b-579e-4dfc-b64c-2457e9441a5e)

Additionally, I noticed that there's no option for `site` changes in the changeset config. Therefore, I believe that this change doesn't require a changeset.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

