### PR TITLE
test: fix shadow-dom example test

### DIFF
--- a/playwright/integration/examples/shadow-dom.test.ts
+++ b/playwright/integration/examples/shadow-dom.test.ts
@@ -24,10 +24,9 @@ test.describe('shadow-dom example', () => {
     await expect(textbox).toHaveCount(1)
 
     // Clear any existing text and type new text into the textbox
-    await textbox.fill('') // Clears the textbox
-    await textbox.type('Hello, Playwright!')
+    await textbox.fill('Hello, Playwright!')
 
     // Assert that the textbox contains the correct text
-    await expect(textbox).toHaveValue('Hello, Playwright!')
+    await expect(textbox).toHaveText('Hello, Playwright!')
   })
 })


### PR DESCRIPTION
**Description**
Fixes an integration test introduced in #5648 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)