### PR TITLE
fix: focus loss inside Shadow DOM in Firefox.

### DIFF
--- a/.changeset/clean-rats-raise.md
+++ b/.changeset/clean-rats-raise.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Changed behaviour of ReactEditor.findDocumentOrShadowRoot. It returns shadow root or document without checking for the existence of the getSelection method.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -36,6 +36,7 @@ import {
   DOMText,
   getActiveElement,
   getDefaultView,
+  getSelection,
   isDOMElement,
   isDOMNode,
   isPlainTextOnlyPaste,
@@ -231,7 +232,7 @@ export const Editable = (props: EditableProps) => {
           const root = ReactEditor.findDocumentOrShadowRoot(editor)
           const { activeElement } = root
           const el = ReactEditor.toDOMNode(editor, editor)
-          const domSelection = root.getSelection()
+          const domSelection = getSelection(root)
 
           if (activeElement === el) {
             state.latestElement = activeElement
@@ -308,7 +309,7 @@ export const Editable = (props: EditableProps) => {
     // Make sure the DOM selection state is in sync.
     const { selection } = editor
     const root = ReactEditor.findDocumentOrShadowRoot(editor)
-    const domSelection = root.getSelection()
+    const domSelection = getSelection(root)
 
     if (
       !domSelection ||
@@ -1090,7 +1091,7 @@ export const Editable = (props: EditableProps) => {
                 // editable element no longer has focus. Refer to:
                 // https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web
                 if (IS_WEBKIT) {
-                  const domSelection = root.getSelection()
+                  const domSelection = getSelection(root)
                   domSelection?.removeAllRanges()
                 }
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -18,6 +18,7 @@ import {
   DOMSelection,
   DOMStaticRange,
   DOMText,
+  getSelection,
   hasShadowRoot,
   isDOMElement,
   isDOMNode,
@@ -280,7 +281,7 @@ export const ReactEditor: ReactEditorInterface = {
   deselect: editor => {
     const { selection } = editor
     const root = ReactEditor.findDocumentOrShadowRoot(editor)
-    const domSelection = root.getSelection()
+    const domSelection = getSelection(root)
 
     if (domSelection && domSelection.rangeCount > 0) {
       domSelection.removeAllRanges()
@@ -295,10 +296,7 @@ export const ReactEditor: ReactEditorInterface = {
     const el = ReactEditor.toDOMNode(editor, editor)
     const root = el.getRootNode()
 
-    if (
-      (root instanceof Document || root instanceof ShadowRoot) &&
-      root.getSelection != null
-    ) {
+    if (root instanceof Document || root instanceof ShadowRoot) {
       return root
     }
 
@@ -437,7 +435,7 @@ export const ReactEditor: ReactEditorInterface = {
     if (root.activeElement !== el) {
       // Ensure that the DOM selection state is set to the editor's selection
       if (editor.selection && root instanceof Document) {
-        const domSelection = root.getSelection()
+        const domSelection = getSelection(root)
         const domRange = ReactEditor.toDOMRange(editor, editor.selection)
         domSelection?.removeAllRanges()
         domSelection?.addRange(domRange)

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -275,6 +275,16 @@ export const getClipboardData = (
 }
 
 /**
+ * Get the dom selection from Shadow Root if possible, otherwise from the document
+ */
+export const getSelection = (root: Document | ShadowRoot): Selection | null => {
+  if (root.getSelection != null) {
+    return root.getSelection()
+  }
+  return document.getSelection()
+}
+
+/**
  * Check whether a mutation originates from a editable element inside the editor.
  */
 


### PR DESCRIPTION
**Description**
This pr fixes shadow dom example in firefox browser.

**Issue**
Fixes: #5321  

**Example**
![fix_firfox_shadow_dom](https://github.com/ianstormtaylor/slate/assets/11096229/9cd8d664-0880-47e8-8a4d-6ca0ae91c479)

**Context**
`ReactEditor.findDocumentOrShadowRoot` returns `document` instead of `ShadowRoot` in firefox. Because firefox doesn't support `getSelection` on `ShadowRoot`. 
This breaks the following: 
```
activeElement === el
```
Here, for example: 
https://github.com/ianstormtaylor/slate/blob/0dc5852da0c11186bc4c81380463658cfff47014/packages/slate-react/src/components/editable.tsx#L231-L241

So I decided to drop `root.getSelection != null` check from `ReactEditor.findDocumentOrShadowRoot` and added a separate function `getSelection` with it.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

