### PR TITLE
fix: unexpected event triggered when using ReactEditor.focus

### DIFF
--- a/.changeset/mighty-trainers-juggle.md
+++ b/.changeset/mighty-trainers-juggle.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix unexpected event triggered when using `ReactEditor.focus`

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -445,7 +445,6 @@ export const ReactEditor: ReactEditorInterface = {
       // Create a new selection in the top of the document if missing
       if (!editor.selection) {
         Transforms.select(editor, Editor.start(editor, []))
-        editor.onChange()
       }
       // IS_FOCUSED should be set before calling el.focus() to ensure that
       // FocusedContext is updated to the correct value

--- a/packages/slate-react/test/react-editor.spec.tsx
+++ b/packages/slate-react/test/react-editor.spec.tsx
@@ -85,6 +85,43 @@ describe('slate-react', () => {
           expect(windowSelection?.focusOffset).toBe(testSelection.focus.offset)
         })
       })
+
+      test('should not trigger onValueChange when focus is called', async () => {
+        const editor = withReact(createEditor())
+        const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+        const onChange = jest.fn()
+        const onValueChange = jest.fn()
+        const onSlectionChange = jest.fn()
+
+        act(() => {
+          render(
+            <Slate
+              editor={editor}
+              initialValue={initialValue}
+              onValueChange={onValueChange}
+              onChange={onChange}
+              onSelectionChange={onSlectionChange}
+            >
+              <Editable />
+            </Slate>
+          )
+        })
+
+        expect(editor.selection).toBe(null)
+
+        await act(async () => {
+          ReactEditor.focus(editor)
+        })
+
+        expect(editor.selection).toEqual({
+          anchor: { path: [0, 0], offset: 0 },
+          focus: { path: [0, 0], offset: 0 },
+        })
+
+        expect(onChange).toHaveBeenCalled()
+        expect(onSlectionChange).toHaveBeenCalled()
+        expect(onValueChange).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/site/examples/richtext.tsx
+++ b/site/examples/richtext.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 import isHotkey from 'is-hotkey'
-import { Editable, withReact, useSlate, Slate, ReactEditor } from 'slate-react'
+import { Editable, withReact, useSlate, Slate } from 'slate-react'
 import {
   Editor,
   Transforms,
@@ -27,27 +27,8 @@ const RichTextExample = () => {
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
 
-  // DEBUG: reproduce the problem env
-  useMemo(() => {
-    // @ts-expect-error debug
-    window.editor = editor
-    // @ts-expect-error debug
-    window.ReactEditor = ReactEditor
-    const { apply } = editor
-    editor.apply = operation => {
-      console.log('OnApply', operation)
-      apply(operation)
-    }
-  }, [editor])
-
   return (
-    <Slate
-      editor={editor}
-      initialValue={initialValue}
-      onChange={(...args) => console.log('OnChange', ...args)}
-      onValueChange={(...args) => console.log('OnValueChange', ...args)}
-      onSelectionChange={(...args) => console.log('OnSelectionChange', ...args)}
-    >
+    <Slate editor={editor} initialValue={initialValue}>
       <Toolbar>
         <MarkButton format="bold" icon="format_bold" />
         <MarkButton format="italic" icon="format_italic" />
@@ -68,7 +49,7 @@ const RichTextExample = () => {
         renderLeaf={renderLeaf}
         placeholder="Enter some rich text…"
         spellCheck
-        // autoFocus
+        autoFocus
         onKeyDown={event => {
           for (const hotkey in HOTKEYS) {
             if (isHotkey(hotkey, event as any)) {


### PR DESCRIPTION
**Description**
When opening the document for the first time, using `ReactEditor.focus` to focus on the document unexpectedly triggers the `onValueChange` event, and there will also be an additional `onChange `event triggered.

**Issue**
Fixes:  #5672

**Example**
The debug code is shown below, and the autoFocus property of Editable is turned off.

https://github.com/ianstormtaylor/slate/blob/631a911ca96e5ac55b80bb260e1e8d114ba76337/site/examples/richtext.tsx#L30-L50

The effect when calling ReactEditor.focus is shown in the image, where you can see the unexpected event triggers.

![bad59c70-1387-4948-8fd3-1e28937daeb4](https://github.com/ianstormtaylor/slate/assets/33169019/e540235a-29c6-490d-afce-243a5bc53444)


**Context**

Actually, calling `onChange` in `ReactEditor.focus` isn't necessary. If needed, `Transforms.select` will handle triggering the event.

![img_v3_02ci_bd5439c3-9fc0-4e56-9759-36ce9e8ab98g](https://github.com/ianstormtaylor/slate/assets/33169019/8d5ffde0-90d7-454a-8812-1ef1ed84f46f)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

