### PR TITLE
Fix ReactEditor.focus triggering onValueChange unexpectedly

### DIFF
--- a/packages/slate-react/src/components/slate.tsx
+++ b/packages/slate-react/src/components/slate.tsx
@@ -66,8 +66,14 @@ export const Slate = (props: {
         case 'set_selection':
           onSelectionChange?.(editor.selection)
           break
-        default:
+        case 'insert_node':
+        case 'remove_node':
+        case 'merge_node':
+        case 'split_node':
+        case 'move_node':
+        case 'set_node':
           onValueChange?.(editor.children)
+          break
       }
 
       setContext(prevContext => ({

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -443,7 +443,6 @@ export const ReactEditor: ReactEditorInterface = {
       // Create a new selection in the top of the document if missing
       if (!editor.selection) {
         Transforms.select(editor, Editor.start(editor, []))
-        editor.onChange()
       }
       // IS_FOCUSED should be set before calling el.focus() to ensure that
       // FocusedContext is updated to the correct value

--- a/packages/slate-react/test/react-editor.spec.tsx
+++ b/packages/slate-react/test/react-editor.spec.tsx
@@ -85,6 +85,37 @@ describe('slate-react', () => {
           expect(windowSelection?.focusOffset).toBe(testSelection.focus.offset)
         })
       })
+
+      test('should not trigger onValueChange when focus is called', async () => {
+        const editor = withReact(createEditor())
+        const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+        const onValueChange = jest.fn()
+
+        act(() => {
+          render(
+            <Slate
+              editor={editor}
+              initialValue={initialValue}
+              onValueChange={onValueChange}
+            >
+              <Editable />
+            </Slate>
+          )
+        })
+
+        expect(editor.selection).toBe(null)
+
+        await act(async () => {
+          ReactEditor.focus(editor)
+        })
+
+        expect(editor.selection).toEqual({
+          anchor: { path: [0, 0], offset: 0 },
+          focus: { path: [0, 0], offset: 0 },
+        })
+
+        expect(onValueChange).not.toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
Related to #5672

Fix the issue where `ReactEditor.focus` triggers `onValueChange` unexpectedly.

* Update `ReactEditor.focus` in `packages/slate-react/src/plugin/react-editor.ts` to set the editor's selection without triggering `onValueChange`.
* Modify `onContextChange` function in `packages/slate-react/src/components/slate.tsx` to call `onValueChange` only for operations that modify the editor's children.
* Add a test in `packages/slate-react/test/react-editor.spec.tsx` to ensure `ReactEditor.focus` does not trigger `onValueChange`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ianstormtaylor/slate/issues/5672?shareId=4c5ff5f3-268a-4436-b452-692b309e8b84).