### PR TITLE
fix: prevent IME input interruption on MacOS

### DIFF
--- a/site/examples/mentions.tsx
+++ b/site/examples/mentions.tsx
@@ -1,4 +1,11 @@
-import React, { useMemo, useCallback, useRef, useEffect, useState } from 'react'
+import React, {
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  useState,
+  Fragment,
+} from 'react'
 import { Editor, Transforms, Range, createEditor, Descendant } from 'slate'
 import { withHistory } from 'slate-history'
 import {
@@ -12,6 +19,7 @@ import {
 
 import { Portal } from '../components'
 import { MentionElement } from './custom-types.d'
+import { IS_MAC } from '../utils/environment'
 
 const MentionExample = () => {
   const ref = useRef<HTMLDivElement | null>()
@@ -133,6 +141,7 @@ const MentionExample = () => {
                 style={{
                   padding: '1px 3px',
                   borderRadius: '3px',
+                  cursor: 'pointer',
                   background: i === index ? '#B4D5FF' : 'transparent',
                 }}
               >
@@ -233,8 +242,18 @@ const Mention = ({ attributes, children, element }) => {
       data-cy={`mention-${element.character.replace(' ', '-')}`}
       style={style}
     >
-      @{element.character}
-      {children}
+      {IS_MAC ? (
+        // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
+        <Fragment>
+          {children}@{element.character}
+        </Fragment>
+      ) : (
+        // Others like Android https://github.com/ianstormtaylor/slate/pull/5360
+        <Fragment>
+          @{element.character}
+          {children}
+        </Fragment>
+      )}
     </span>
   )
 }

--- a/site/utils/environment.ts
+++ b/site/utils/environment.ts
@@ -1,0 +1,5 @@
+export const IS_MAC =
+  typeof navigator !== 'undefined' && /Mac OS X/.test(navigator.userAgent)
+
+export const IS_ANDROID =
+  typeof navigator !== 'undefined' && /Android/.test(navigator.userAgent)


### PR DESCRIPTION
**Description**

In the current [Mentions Example](https://www.slatejs.org/examples/mentions), the issue with #3490 still persists. Although I noticed it was fixed in #5013, it was reverted back in #5360 .

So this seems to be a compatibility issue with MacOS. Therefore, we check the environment here and only modify the spacer tag position on MacOS.

**Issue**
Fixes: #3490

**Example**

The current issues.

![20240720192010_rec_](https://github.com/user-attachments/assets/f804dd4d-8855-4739-b8ed-28a1e58d1d50)

After making adjustments.

![20240720192658_rec_](https://github.com/user-attachments/assets/f0168cc5-1fbc-47df-ab4a-8e8e99b4d5ad)

 It's also running smoothly on my Android device.

<img src="https://github.com/user-attachments/assets/dc68553e-34e6-4068-8c4b-957196b6a37a" width="200px" />


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

