### PR TITLE
feat: add useComposing hook

### DIFF
--- a/.changeset/ten-queens-walk.md
+++ b/.changeset/ten-queens-walk.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+feat: Add useComposing hook"

--- a/docs/libraries/slate-react/hooks.md
+++ b/docs/libraries/slate-react/hooks.md
@@ -8,6 +8,10 @@
 
 React hooks for Slate editors
 
+#### `useComposing(): boolean`
+
+Get the current `composing` state of the editor. It deals with `compositionstart`, `compositionupdate`, `compositionend` events.
+
 #### `useFocused(): boolean`
 
 Get the current `focused` state of the editor.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -73,6 +73,7 @@ import {
 } from '../utils/weak-maps'
 import { RestoreDOM } from './restore-dom/restore-dom'
 import { AndroidInputManager } from '../hooks/android-input-manager/android-input-manager'
+import { ComposingContext } from '../hooks/use-composing'
 
 type DeferredOperation = () => void
 
@@ -949,838 +950,854 @@ export const Editable = forwardRef(
 
     return (
       <ReadOnlyContext.Provider value={readOnly}>
-        <DecorateContext.Provider value={decorate}>
-          <RestoreDOM node={ref} receivedUserInput={receivedUserInput}>
-            <Component
-              role={readOnly ? undefined : 'textbox'}
-              aria-multiline={readOnly ? undefined : true}
-              {...attributes}
-              // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
-              // have to use hacks to make these replacement-based features work.
-              // For SSR situations HAS_BEFORE_INPUT_SUPPORT is false and results in prop
-              // mismatch warning app moves to browser. Pass-through consumer props when
-              // not CAN_USE_DOM (SSR) and default to falsy value
-              spellCheck={
-                HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
-                  ? attributes.spellCheck
-                  : false
-              }
-              autoCorrect={
-                HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
-                  ? attributes.autoCorrect
-                  : 'false'
-              }
-              autoCapitalize={
-                HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
-                  ? attributes.autoCapitalize
-                  : 'false'
-              }
-              data-slate-editor
-              data-slate-node="value"
-              // explicitly set this
-              contentEditable={!readOnly}
-              // in some cases, a decoration needs access to the range / selection to decorate a text node,
-              // then you will select the whole text node when you select part the of text
-              // this magic zIndex="-1" will fix it
-              zindex={-1}
-              suppressContentEditableWarning
-              ref={callbackRef}
-              style={{
-                ...(disableDefaultStyles
-                  ? {}
-                  : {
-                      // Allow positioning relative to the editable element.
-                      position: 'relative',
-                      // Preserve adjacent whitespace and new lines.
-                      whiteSpace: 'pre-wrap',
-                      // Allow words to break if they are too long.
-                      wordWrap: 'break-word',
-                      // Make the minimum height that of the placeholder.
-                      ...(placeholderHeight
-                        ? { minHeight: placeholderHeight }
-                        : {}),
-                    }),
-                // Allow for passed-in styles to override anything.
-                ...userStyle,
-              }}
-              onBeforeInput={useCallback(
-                (event: React.FormEvent<HTMLDivElement>) => {
-                  // COMPAT: Certain browsers don't support the `beforeinput` event, so we
-                  // fall back to React's leaky polyfill instead just for it. It
-                  // only works for the `insertText` input type.
-                  if (
-                    !HAS_BEFORE_INPUT_SUPPORT &&
-                    !readOnly &&
-                    !isEventHandled(event, attributes.onBeforeInput) &&
-                    ReactEditor.hasSelectableTarget(editor, event.target)
-                  ) {
-                    event.preventDefault()
-                    if (!ReactEditor.isComposing(editor)) {
-                      const text = (event as any).data as string
-                      Editor.insertText(editor, text)
-                    }
-                  }
-                },
-                [attributes.onBeforeInput, editor, readOnly]
-              )}
-              onInput={useCallback(
-                (event: React.FormEvent<HTMLDivElement>) => {
-                  if (isEventHandled(event, attributes.onInput)) {
-                    return
-                  }
-
-                  if (androidInputManagerRef.current) {
-                    androidInputManagerRef.current.handleInput()
-                    return
-                  }
-
-                  // Flush native operations, as native events will have propogated
-                  // and we can correctly compare DOM text values in components
-                  // to stop rendering, so that browser functions like autocorrect
-                  // and spellcheck work as expected.
-                  for (const op of deferredOperations.current) {
-                    op()
-                  }
-                  deferredOperations.current = []
-                },
-                [attributes.onInput]
-              )}
-              onBlur={useCallback(
-                (event: React.FocusEvent<HTMLDivElement>) => {
-                  if (
-                    readOnly ||
-                    state.isUpdatingSelection ||
-                    !ReactEditor.hasSelectableTarget(editor, event.target) ||
-                    isEventHandled(event, attributes.onBlur)
-                  ) {
-                    return
-                  }
-
-                  // COMPAT: If the current `activeElement` is still the previous
-                  // one, this is due to the window being blurred when the tab
-                  // itself becomes unfocused, so we want to abort early to allow to
-                  // editor to stay focused when the tab becomes focused again.
-                  const root = ReactEditor.findDocumentOrShadowRoot(editor)
-                  if (state.latestElement === root.activeElement) {
-                    return
-                  }
-
-                  const { relatedTarget } = event
-                  const el = ReactEditor.toDOMNode(editor, editor)
-
-                  // COMPAT: The event should be ignored if the focus is returning
-                  // to the editor from an embedded editable element (eg. an <input>
-                  // element inside a void node).
-                  if (relatedTarget === el) {
-                    return
-                  }
-
-                  // COMPAT: The event should be ignored if the focus is moving from
-                  // the editor to inside a void node's spacer element.
-                  if (
-                    isDOMElement(relatedTarget) &&
-                    relatedTarget.hasAttribute('data-slate-spacer')
-                  ) {
-                    return
-                  }
-
-                  // COMPAT: The event should be ignored if the focus is moving to a
-                  // non- editable section of an element that isn't a void node (eg.
-                  // a list item of the check list example).
-                  if (
-                    relatedTarget != null &&
-                    isDOMNode(relatedTarget) &&
-                    ReactEditor.hasDOMNode(editor, relatedTarget)
-                  ) {
-                    const node = ReactEditor.toSlateNode(editor, relatedTarget)
-
-                    if (Element.isElement(node) && !editor.isVoid(node)) {
-                      return
-                    }
-                  }
-
-                  // COMPAT: Safari doesn't always remove the selection even if the content-
-                  // editable element no longer has focus. Refer to:
-                  // https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web
-                  if (IS_WEBKIT) {
-                    const domSelection = getSelection(root)
-                    domSelection?.removeAllRanges()
-                  }
-
-                  IS_FOCUSED.delete(editor)
-                },
-                [
-                  readOnly,
-                  state.isUpdatingSelection,
-                  state.latestElement,
-                  editor,
-                  attributes.onBlur,
-                ]
-              )}
-              onClick={useCallback(
-                (event: React.MouseEvent<HTMLDivElement>) => {
-                  if (
-                    ReactEditor.hasTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onClick) &&
-                    isDOMNode(event.target)
-                  ) {
-                    const node = ReactEditor.toSlateNode(editor, event.target)
-                    const path = ReactEditor.findPath(editor, node)
-
-                    // At this time, the Slate document may be arbitrarily different,
-                    // because onClick handlers can change the document before we get here.
-                    // Therefore we must check that this path actually exists,
-                    // and that it still refers to the same node.
-                    if (
-                      !Editor.hasPath(editor, path) ||
-                      Node.get(editor, path) !== node
-                    ) {
-                      return
-                    }
-
-                    if (event.detail === TRIPLE_CLICK && path.length >= 1) {
-                      let blockPath = path
-                      if (
-                        !(
-                          Element.isElement(node) &&
-                          Editor.isBlock(editor, node)
-                        )
-                      ) {
-                        const block = Editor.above(editor, {
-                          match: n =>
-                            Element.isElement(n) && Editor.isBlock(editor, n),
-                          at: path,
-                        })
-
-                        blockPath = block?.[1] ?? path.slice(0, 1)
-                      }
-
-                      const range = Editor.range(editor, blockPath)
-                      Transforms.select(editor, range)
-                      return
-                    }
-
-                    if (readOnly) {
-                      return
-                    }
-
-                    const start = Editor.start(editor, path)
-                    const end = Editor.end(editor, path)
-                    const startVoid = Editor.void(editor, { at: start })
-                    const endVoid = Editor.void(editor, { at: end })
-
-                    if (
-                      startVoid &&
-                      endVoid &&
-                      Path.equals(startVoid[1], endVoid[1])
-                    ) {
-                      const range = Editor.range(editor, start)
-                      Transforms.select(editor, range)
-                    }
-                  }
-                },
-                [editor, attributes.onClick, readOnly]
-              )}
-              onCompositionEnd={useCallback(
-                (event: React.CompositionEvent<HTMLDivElement>) => {
-                  if (ReactEditor.hasSelectableTarget(editor, event.target)) {
-                    if (ReactEditor.isComposing(editor)) {
-                      Promise.resolve().then(() => {
-                        setIsComposing(false)
-                        IS_COMPOSING.set(editor, false)
-                      })
-                    }
-
-                    androidInputManagerRef.current?.handleCompositionEnd(event)
-
-                    if (
-                      isEventHandled(event, attributes.onCompositionEnd) ||
-                      IS_ANDROID
-                    ) {
-                      return
-                    }
-
-                    // COMPAT: In Chrome, `beforeinput` events for compositions
-                    // aren't correct and never fire the "insertFromComposition"
-                    // type that we need. So instead, insert whenever a composition
-                    // ends since it will already have been committed to the DOM.
-                    if (
-                      !IS_WEBKIT &&
-                      !IS_FIREFOX_LEGACY &&
-                      !IS_IOS &&
-                      !IS_WECHATBROWSER &&
-                      !IS_UC_MOBILE &&
-                      event.data
-                    ) {
-                      const placeholderMarks =
-                        EDITOR_TO_PENDING_INSERTION_MARKS.get(editor)
-                      EDITOR_TO_PENDING_INSERTION_MARKS.delete(editor)
-
-                      // Ensure we insert text with the marks the user was actually seeing
-                      if (placeholderMarks !== undefined) {
-                        EDITOR_TO_USER_MARKS.set(editor, editor.marks)
-                        editor.marks = placeholderMarks
-                      }
-
-                      Editor.insertText(editor, event.data)
-
-                      const userMarks = EDITOR_TO_USER_MARKS.get(editor)
-                      EDITOR_TO_USER_MARKS.delete(editor)
-                      if (userMarks !== undefined) {
-                        editor.marks = userMarks
-                      }
-                    }
-                  }
-                },
-                [attributes.onCompositionEnd, editor]
-              )}
-              onCompositionUpdate={useCallback(
-                (event: React.CompositionEvent<HTMLDivElement>) => {
-                  if (
-                    ReactEditor.hasSelectableTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onCompositionUpdate)
-                  ) {
-                    if (!ReactEditor.isComposing(editor)) {
-                      setIsComposing(true)
-                      IS_COMPOSING.set(editor, true)
-                    }
-                  }
-                },
-                [attributes.onCompositionUpdate, editor]
-              )}
-              onCompositionStart={useCallback(
-                (event: React.CompositionEvent<HTMLDivElement>) => {
-                  if (ReactEditor.hasSelectableTarget(editor, event.target)) {
-                    androidInputManagerRef.current?.handleCompositionStart(
-                      event
-                    )
-
-                    if (
-                      isEventHandled(event, attributes.onCompositionStart) ||
-                      IS_ANDROID
-                    ) {
-                      return
-                    }
-
-                    setIsComposing(true)
-
-                    const { selection } = editor
-                    if (selection && Range.isExpanded(selection)) {
-                      Editor.deleteFragment(editor)
-                      return
-                    }
-                  }
-                },
-                [attributes.onCompositionStart, editor]
-              )}
-              onCopy={useCallback(
-                (event: React.ClipboardEvent<HTMLDivElement>) => {
-                  if (
-                    ReactEditor.hasSelectableTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onCopy) &&
-                    !isDOMEventTargetInput(event)
-                  ) {
-                    event.preventDefault()
-                    ReactEditor.setFragmentData(
-                      editor,
-                      event.clipboardData,
-                      'copy'
-                    )
-                  }
-                },
-                [attributes.onCopy, editor]
-              )}
-              onCut={useCallback(
-                (event: React.ClipboardEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    ReactEditor.hasSelectableTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onCut) &&
-                    !isDOMEventTargetInput(event)
-                  ) {
-                    event.preventDefault()
-                    ReactEditor.setFragmentData(
-                      editor,
-                      event.clipboardData,
-                      'cut'
-                    )
-                    const { selection } = editor
-
-                    if (selection) {
-                      if (Range.isExpanded(selection)) {
-                        Editor.deleteFragment(editor)
-                      } else {
-                        const node = Node.parent(editor, selection.anchor.path)
-                        if (Editor.isVoid(editor, node)) {
-                          Transforms.delete(editor)
-                        }
-                      }
-                    }
-                  }
-                },
-                [readOnly, editor, attributes.onCut]
-              )}
-              onDragOver={useCallback(
-                (event: React.DragEvent<HTMLDivElement>) => {
-                  if (
-                    ReactEditor.hasTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onDragOver)
-                  ) {
-                    // Only when the target is void, call `preventDefault` to signal
-                    // that drops are allowed. Editable content is droppable by
-                    // default, and calling `preventDefault` hides the cursor.
-                    const node = ReactEditor.toSlateNode(editor, event.target)
-
-                    if (
-                      Element.isElement(node) &&
-                      Editor.isVoid(editor, node)
-                    ) {
-                      event.preventDefault()
-                    }
-                  }
-                },
-                [attributes.onDragOver, editor]
-              )}
-              onDragStart={useCallback(
-                (event: React.DragEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    ReactEditor.hasTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onDragStart)
-                  ) {
-                    const node = ReactEditor.toSlateNode(editor, event.target)
-                    const path = ReactEditor.findPath(editor, node)
-                    const voidMatch =
-                      (Element.isElement(node) &&
-                        Editor.isVoid(editor, node)) ||
-                      Editor.void(editor, { at: path, voids: true })
-
-                    // If starting a drag on a void node, make sure it is selected
-                    // so that it shows up in the selection's fragment.
-                    if (voidMatch) {
-                      const range = Editor.range(editor, path)
-                      Transforms.select(editor, range)
-                    }
-
-                    state.isDraggingInternally = true
-
-                    ReactEditor.setFragmentData(
-                      editor,
-                      event.dataTransfer,
-                      'drag'
-                    )
-                  }
-                },
-                [readOnly, editor, attributes.onDragStart, state]
-              )}
-              onDrop={useCallback(
-                (event: React.DragEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    ReactEditor.hasTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onDrop)
-                  ) {
-                    event.preventDefault()
-
-                    // Keep a reference to the dragged range before updating selection
-                    const draggedRange = editor.selection
-
-                    // Find the range where the drop happened
-                    const range = ReactEditor.findEventRange(editor, event)
-                    const data = event.dataTransfer
-
-                    Transforms.select(editor, range)
-
-                    if (state.isDraggingInternally) {
-                      if (
-                        draggedRange &&
-                        !Range.equals(draggedRange, range) &&
-                        !Editor.void(editor, { at: range, voids: true })
-                      ) {
-                        Transforms.delete(editor, {
-                          at: draggedRange,
-                        })
-                      }
-                    }
-
-                    ReactEditor.insertData(editor, data)
-
-                    // When dragging from another source into the editor, it's possible
-                    // that the current editor does not have focus.
-                    if (!ReactEditor.isFocused(editor)) {
-                      ReactEditor.focus(editor)
-                    }
-                  }
-                },
-                [readOnly, editor, attributes.onDrop, state]
-              )}
-              onDragEnd={useCallback(
-                (event: React.DragEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    state.isDraggingInternally &&
-                    attributes.onDragEnd &&
-                    ReactEditor.hasTarget(editor, event.target)
-                  ) {
-                    attributes.onDragEnd(event)
-                  }
-                },
-                [readOnly, state, attributes, editor]
-              )}
-              onFocus={useCallback(
-                (event: React.FocusEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    !state.isUpdatingSelection &&
-                    ReactEditor.hasEditableTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onFocus)
-                  ) {
-                    const el = ReactEditor.toDOMNode(editor, editor)
-                    const root = ReactEditor.findDocumentOrShadowRoot(editor)
-                    state.latestElement = root.activeElement
-
-                    // COMPAT: If the editor has nested editable elements, the focus
-                    // can go to them. In Firefox, this must be prevented because it
-                    // results in issues with keyboard navigation. (2017/03/30)
-                    if (IS_FIREFOX && event.target !== el) {
-                      el.focus()
-                      return
-                    }
-
-                    IS_FOCUSED.set(editor, true)
-                  }
-                },
-                [readOnly, state, editor, attributes.onFocus]
-              )}
-              onKeyDown={useCallback(
-                (event: React.KeyboardEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    ReactEditor.hasEditableTarget(editor, event.target)
-                  ) {
-                    androidInputManagerRef.current?.handleKeyDown(event)
-
-                    const { nativeEvent } = event
-
-                    // COMPAT: The composition end event isn't fired reliably in all browsers,
-                    // so we sometimes might end up stuck in a composition state even though we
-                    // aren't composing any more.
-                    if (
-                      ReactEditor.isComposing(editor) &&
-                      nativeEvent.isComposing === false
-                    ) {
-                      IS_COMPOSING.set(editor, false)
-                      setIsComposing(false)
-                    }
-
-                    if (
-                      isEventHandled(event, attributes.onKeyDown) ||
-                      ReactEditor.isComposing(editor)
-                    ) {
-                      return
-                    }
-
-                    const { selection } = editor
-                    const element =
-                      editor.children[
-                        selection !== null ? selection.focus.path[0] : 0
-                      ]
-                    const isRTL = getDirection(Node.string(element)) === 'rtl'
-
-                    // COMPAT: Since we prevent the default behavior on
-                    // `beforeinput` events, the browser doesn't think there's ever
-                    // any history stack to undo or redo, so we have to manage these
-                    // hotkeys ourselves. (2019/11/06)
-                    if (Hotkeys.isRedo(nativeEvent)) {
-                      event.preventDefault()
-                      const maybeHistoryEditor: any = editor
-
-                      if (typeof maybeHistoryEditor.redo === 'function') {
-                        maybeHistoryEditor.redo()
-                      }
-
-                      return
-                    }
-
-                    if (Hotkeys.isUndo(nativeEvent)) {
-                      event.preventDefault()
-                      const maybeHistoryEditor: any = editor
-
-                      if (typeof maybeHistoryEditor.undo === 'function') {
-                        maybeHistoryEditor.undo()
-                      }
-
-                      return
-                    }
-
-                    // COMPAT: Certain browsers don't handle the selection updates
-                    // properly. In Chrome, the selection isn't properly extended.
-                    // And in Firefox, the selection isn't properly collapsed.
-                    // (2017/10/17)
-                    if (Hotkeys.isMoveLineBackward(nativeEvent)) {
-                      event.preventDefault()
-                      Transforms.move(editor, { unit: 'line', reverse: true })
-                      return
-                    }
-
-                    if (Hotkeys.isMoveLineForward(nativeEvent)) {
-                      event.preventDefault()
-                      Transforms.move(editor, { unit: 'line' })
-                      return
-                    }
-
-                    if (Hotkeys.isExtendLineBackward(nativeEvent)) {
-                      event.preventDefault()
-                      Transforms.move(editor, {
-                        unit: 'line',
-                        edge: 'focus',
-                        reverse: true,
-                      })
-                      return
-                    }
-
-                    if (Hotkeys.isExtendLineForward(nativeEvent)) {
-                      event.preventDefault()
-                      Transforms.move(editor, { unit: 'line', edge: 'focus' })
-                      return
-                    }
-
-                    // COMPAT: If a void node is selected, or a zero-width text node
-                    // adjacent to an inline is selected, we need to handle these
-                    // hotkeys manually because browsers won't be able to skip over
-                    // the void node with the zero-width space not being an empty
-                    // string.
-                    if (Hotkeys.isMoveBackward(nativeEvent)) {
-                      event.preventDefault()
-
-                      if (selection && Range.isCollapsed(selection)) {
-                        Transforms.move(editor, { reverse: !isRTL })
-                      } else {
-                        Transforms.collapse(editor, {
-                          edge: isRTL ? 'end' : 'start',
-                        })
-                      }
-
-                      return
-                    }
-
-                    if (Hotkeys.isMoveForward(nativeEvent)) {
-                      event.preventDefault()
-
-                      if (selection && Range.isCollapsed(selection)) {
-                        Transforms.move(editor, { reverse: isRTL })
-                      } else {
-                        Transforms.collapse(editor, {
-                          edge: isRTL ? 'start' : 'end',
-                        })
-                      }
-
-                      return
-                    }
-
-                    if (Hotkeys.isMoveWordBackward(nativeEvent)) {
-                      event.preventDefault()
-
-                      if (selection && Range.isExpanded(selection)) {
-                        Transforms.collapse(editor, { edge: 'focus' })
-                      }
-
-                      Transforms.move(editor, { unit: 'word', reverse: !isRTL })
-                      return
-                    }
-
-                    if (Hotkeys.isMoveWordForward(nativeEvent)) {
-                      event.preventDefault()
-
-                      if (selection && Range.isExpanded(selection)) {
-                        Transforms.collapse(editor, { edge: 'focus' })
-                      }
-
-                      Transforms.move(editor, { unit: 'word', reverse: isRTL })
-                      return
-                    }
-
+        <ComposingContext.Provider value={isComposing}>
+          <DecorateContext.Provider value={decorate}>
+            <RestoreDOM node={ref} receivedUserInput={receivedUserInput}>
+              <Component
+                role={readOnly ? undefined : 'textbox'}
+                aria-multiline={readOnly ? undefined : true}
+                {...attributes}
+                // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
+                // have to use hacks to make these replacement-based features work.
+                // For SSR situations HAS_BEFORE_INPUT_SUPPORT is false and results in prop
+                // mismatch warning app moves to browser. Pass-through consumer props when
+                // not CAN_USE_DOM (SSR) and default to falsy value
+                spellCheck={
+                  HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
+                    ? attributes.spellCheck
+                    : false
+                }
+                autoCorrect={
+                  HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
+                    ? attributes.autoCorrect
+                    : 'false'
+                }
+                autoCapitalize={
+                  HAS_BEFORE_INPUT_SUPPORT || !CAN_USE_DOM
+                    ? attributes.autoCapitalize
+                    : 'false'
+                }
+                data-slate-editor
+                data-slate-node="value"
+                // explicitly set this
+                contentEditable={!readOnly}
+                // in some cases, a decoration needs access to the range / selection to decorate a text node,
+                // then you will select the whole text node when you select part the of text
+                // this magic zIndex="-1" will fix it
+                zindex={-1}
+                suppressContentEditableWarning
+                ref={callbackRef}
+                style={{
+                  ...(disableDefaultStyles
+                    ? {}
+                    : {
+                        // Allow positioning relative to the editable element.
+                        position: 'relative',
+                        // Preserve adjacent whitespace and new lines.
+                        whiteSpace: 'pre-wrap',
+                        // Allow words to break if they are too long.
+                        wordWrap: 'break-word',
+                        // Make the minimum height that of the placeholder.
+                        ...(placeholderHeight
+                          ? { minHeight: placeholderHeight }
+                          : {}),
+                      }),
+                  // Allow for passed-in styles to override anything.
+                  ...userStyle,
+                }}
+                onBeforeInput={useCallback(
+                  (event: React.FormEvent<HTMLDivElement>) => {
                     // COMPAT: Certain browsers don't support the `beforeinput` event, so we
-                    // fall back to guessing at the input intention for hotkeys.
-                    // COMPAT: In iOS, some of these hotkeys are handled in the
-                    if (!HAS_BEFORE_INPUT_SUPPORT) {
-                      // We don't have a core behavior for these, but they change the
-                      // DOM if we don't prevent them, so we have to.
+                    // fall back to React's leaky polyfill instead just for it. It
+                    // only works for the `insertText` input type.
+                    if (
+                      !HAS_BEFORE_INPUT_SUPPORT &&
+                      !readOnly &&
+                      !isEventHandled(event, attributes.onBeforeInput) &&
+                      ReactEditor.hasSelectableTarget(editor, event.target)
+                    ) {
+                      event.preventDefault()
+                      if (!ReactEditor.isComposing(editor)) {
+                        const text = (event as any).data as string
+                        Editor.insertText(editor, text)
+                      }
+                    }
+                  },
+                  [attributes.onBeforeInput, editor, readOnly]
+                )}
+                onInput={useCallback(
+                  (event: React.FormEvent<HTMLDivElement>) => {
+                    if (isEventHandled(event, attributes.onInput)) {
+                      return
+                    }
+
+                    if (androidInputManagerRef.current) {
+                      androidInputManagerRef.current.handleInput()
+                      return
+                    }
+
+                    // Flush native operations, as native events will have propogated
+                    // and we can correctly compare DOM text values in components
+                    // to stop rendering, so that browser functions like autocorrect
+                    // and spellcheck work as expected.
+                    for (const op of deferredOperations.current) {
+                      op()
+                    }
+                    deferredOperations.current = []
+                  },
+                  [attributes.onInput]
+                )}
+                onBlur={useCallback(
+                  (event: React.FocusEvent<HTMLDivElement>) => {
+                    if (
+                      readOnly ||
+                      state.isUpdatingSelection ||
+                      !ReactEditor.hasSelectableTarget(editor, event.target) ||
+                      isEventHandled(event, attributes.onBlur)
+                    ) {
+                      return
+                    }
+
+                    // COMPAT: If the current `activeElement` is still the previous
+                    // one, this is due to the window being blurred when the tab
+                    // itself becomes unfocused, so we want to abort early to allow to
+                    // editor to stay focused when the tab becomes focused again.
+                    const root = ReactEditor.findDocumentOrShadowRoot(editor)
+                    if (state.latestElement === root.activeElement) {
+                      return
+                    }
+
+                    const { relatedTarget } = event
+                    const el = ReactEditor.toDOMNode(editor, editor)
+
+                    // COMPAT: The event should be ignored if the focus is returning
+                    // to the editor from an embedded editable element (eg. an <input>
+                    // element inside a void node).
+                    if (relatedTarget === el) {
+                      return
+                    }
+
+                    // COMPAT: The event should be ignored if the focus is moving from
+                    // the editor to inside a void node's spacer element.
+                    if (
+                      isDOMElement(relatedTarget) &&
+                      relatedTarget.hasAttribute('data-slate-spacer')
+                    ) {
+                      return
+                    }
+
+                    // COMPAT: The event should be ignored if the focus is moving to a
+                    // non- editable section of an element that isn't a void node (eg.
+                    // a list item of the check list example).
+                    if (
+                      relatedTarget != null &&
+                      isDOMNode(relatedTarget) &&
+                      ReactEditor.hasDOMNode(editor, relatedTarget)
+                    ) {
+                      const node = ReactEditor.toSlateNode(
+                        editor,
+                        relatedTarget
+                      )
+
+                      if (Element.isElement(node) && !editor.isVoid(node)) {
+                        return
+                      }
+                    }
+
+                    // COMPAT: Safari doesn't always remove the selection even if the content-
+                    // editable element no longer has focus. Refer to:
+                    // https://stackoverflow.com/questions/12353247/force-contenteditable-div-to-stop-accepting-input-after-it-loses-focus-under-web
+                    if (IS_WEBKIT) {
+                      const domSelection = getSelection(root)
+                      domSelection?.removeAllRanges()
+                    }
+
+                    IS_FOCUSED.delete(editor)
+                  },
+                  [
+                    readOnly,
+                    state.isUpdatingSelection,
+                    state.latestElement,
+                    editor,
+                    attributes.onBlur,
+                  ]
+                )}
+                onClick={useCallback(
+                  (event: React.MouseEvent<HTMLDivElement>) => {
+                    if (
+                      ReactEditor.hasTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onClick) &&
+                      isDOMNode(event.target)
+                    ) {
+                      const node = ReactEditor.toSlateNode(editor, event.target)
+                      const path = ReactEditor.findPath(editor, node)
+
+                      // At this time, the Slate document may be arbitrarily different,
+                      // because onClick handlers can change the document before we get here.
+                      // Therefore we must check that this path actually exists,
+                      // and that it still refers to the same node.
                       if (
-                        Hotkeys.isBold(nativeEvent) ||
-                        Hotkeys.isItalic(nativeEvent) ||
-                        Hotkeys.isTransposeCharacter(nativeEvent)
+                        !Editor.hasPath(editor, path) ||
+                        Node.get(editor, path) !== node
                       ) {
-                        event.preventDefault()
                         return
                       }
 
-                      if (Hotkeys.isSoftBreak(nativeEvent)) {
-                        event.preventDefault()
-                        Editor.insertSoftBreak(editor)
-                        return
-                      }
-
-                      if (Hotkeys.isSplitBlock(nativeEvent)) {
-                        event.preventDefault()
-                        Editor.insertBreak(editor)
-                        return
-                      }
-
-                      if (Hotkeys.isDeleteBackward(nativeEvent)) {
-                        event.preventDefault()
-
-                        if (selection && Range.isExpanded(selection)) {
-                          Editor.deleteFragment(editor, {
-                            direction: 'backward',
-                          })
-                        } else {
-                          Editor.deleteBackward(editor)
-                        }
-
-                        return
-                      }
-
-                      if (Hotkeys.isDeleteForward(nativeEvent)) {
-                        event.preventDefault()
-
-                        if (selection && Range.isExpanded(selection)) {
-                          Editor.deleteFragment(editor, {
-                            direction: 'forward',
-                          })
-                        } else {
-                          Editor.deleteForward(editor)
-                        }
-
-                        return
-                      }
-
-                      if (Hotkeys.isDeleteLineBackward(nativeEvent)) {
-                        event.preventDefault()
-
-                        if (selection && Range.isExpanded(selection)) {
-                          Editor.deleteFragment(editor, {
-                            direction: 'backward',
-                          })
-                        } else {
-                          Editor.deleteBackward(editor, { unit: 'line' })
-                        }
-
-                        return
-                      }
-
-                      if (Hotkeys.isDeleteLineForward(nativeEvent)) {
-                        event.preventDefault()
-
-                        if (selection && Range.isExpanded(selection)) {
-                          Editor.deleteFragment(editor, {
-                            direction: 'forward',
-                          })
-                        } else {
-                          Editor.deleteForward(editor, { unit: 'line' })
-                        }
-
-                        return
-                      }
-
-                      if (Hotkeys.isDeleteWordBackward(nativeEvent)) {
-                        event.preventDefault()
-
-                        if (selection && Range.isExpanded(selection)) {
-                          Editor.deleteFragment(editor, {
-                            direction: 'backward',
-                          })
-                        } else {
-                          Editor.deleteBackward(editor, { unit: 'word' })
-                        }
-
-                        return
-                      }
-
-                      if (Hotkeys.isDeleteWordForward(nativeEvent)) {
-                        event.preventDefault()
-
-                        if (selection && Range.isExpanded(selection)) {
-                          Editor.deleteFragment(editor, {
-                            direction: 'forward',
-                          })
-                        } else {
-                          Editor.deleteForward(editor, { unit: 'word' })
-                        }
-
-                        return
-                      }
-                    } else {
-                      if (IS_CHROME || IS_WEBKIT) {
-                        // COMPAT: Chrome and Safari support `beforeinput` event but do not fire
-                        // an event when deleting backwards in a selected void inline node
+                      if (event.detail === TRIPLE_CLICK && path.length >= 1) {
+                        let blockPath = path
                         if (
-                          selection &&
-                          (Hotkeys.isDeleteBackward(nativeEvent) ||
-                            Hotkeys.isDeleteForward(nativeEvent)) &&
-                          Range.isCollapsed(selection)
+                          !(
+                            Element.isElement(node) &&
+                            Editor.isBlock(editor, node)
+                          )
                         ) {
-                          const currentNode = Node.parent(
+                          const block = Editor.above(editor, {
+                            match: n =>
+                              Element.isElement(n) && Editor.isBlock(editor, n),
+                            at: path,
+                          })
+
+                          blockPath = block?.[1] ?? path.slice(0, 1)
+                        }
+
+                        const range = Editor.range(editor, blockPath)
+                        Transforms.select(editor, range)
+                        return
+                      }
+
+                      if (readOnly) {
+                        return
+                      }
+
+                      const start = Editor.start(editor, path)
+                      const end = Editor.end(editor, path)
+                      const startVoid = Editor.void(editor, { at: start })
+                      const endVoid = Editor.void(editor, { at: end })
+
+                      if (
+                        startVoid &&
+                        endVoid &&
+                        Path.equals(startVoid[1], endVoid[1])
+                      ) {
+                        const range = Editor.range(editor, start)
+                        Transforms.select(editor, range)
+                      }
+                    }
+                  },
+                  [editor, attributes.onClick, readOnly]
+                )}
+                onCompositionEnd={useCallback(
+                  (event: React.CompositionEvent<HTMLDivElement>) => {
+                    if (ReactEditor.hasSelectableTarget(editor, event.target)) {
+                      if (ReactEditor.isComposing(editor)) {
+                        Promise.resolve().then(() => {
+                          setIsComposing(false)
+                          IS_COMPOSING.set(editor, false)
+                        })
+                      }
+
+                      androidInputManagerRef.current?.handleCompositionEnd(
+                        event
+                      )
+
+                      if (
+                        isEventHandled(event, attributes.onCompositionEnd) ||
+                        IS_ANDROID
+                      ) {
+                        return
+                      }
+
+                      // COMPAT: In Chrome, `beforeinput` events for compositions
+                      // aren't correct and never fire the "insertFromComposition"
+                      // type that we need. So instead, insert whenever a composition
+                      // ends since it will already have been committed to the DOM.
+                      if (
+                        !IS_WEBKIT &&
+                        !IS_FIREFOX_LEGACY &&
+                        !IS_IOS &&
+                        !IS_WECHATBROWSER &&
+                        !IS_UC_MOBILE &&
+                        event.data
+                      ) {
+                        const placeholderMarks =
+                          EDITOR_TO_PENDING_INSERTION_MARKS.get(editor)
+                        EDITOR_TO_PENDING_INSERTION_MARKS.delete(editor)
+
+                        // Ensure we insert text with the marks the user was actually seeing
+                        if (placeholderMarks !== undefined) {
+                          EDITOR_TO_USER_MARKS.set(editor, editor.marks)
+                          editor.marks = placeholderMarks
+                        }
+
+                        Editor.insertText(editor, event.data)
+
+                        const userMarks = EDITOR_TO_USER_MARKS.get(editor)
+                        EDITOR_TO_USER_MARKS.delete(editor)
+                        if (userMarks !== undefined) {
+                          editor.marks = userMarks
+                        }
+                      }
+                    }
+                  },
+                  [attributes.onCompositionEnd, editor]
+                )}
+                onCompositionUpdate={useCallback(
+                  (event: React.CompositionEvent<HTMLDivElement>) => {
+                    if (
+                      ReactEditor.hasSelectableTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onCompositionUpdate)
+                    ) {
+                      if (!ReactEditor.isComposing(editor)) {
+                        setIsComposing(true)
+                        IS_COMPOSING.set(editor, true)
+                      }
+                    }
+                  },
+                  [attributes.onCompositionUpdate, editor]
+                )}
+                onCompositionStart={useCallback(
+                  (event: React.CompositionEvent<HTMLDivElement>) => {
+                    if (ReactEditor.hasSelectableTarget(editor, event.target)) {
+                      androidInputManagerRef.current?.handleCompositionStart(
+                        event
+                      )
+
+                      if (
+                        isEventHandled(event, attributes.onCompositionStart) ||
+                        IS_ANDROID
+                      ) {
+                        return
+                      }
+
+                      setIsComposing(true)
+
+                      const { selection } = editor
+                      if (selection && Range.isExpanded(selection)) {
+                        Editor.deleteFragment(editor)
+                        return
+                      }
+                    }
+                  },
+                  [attributes.onCompositionStart, editor]
+                )}
+                onCopy={useCallback(
+                  (event: React.ClipboardEvent<HTMLDivElement>) => {
+                    if (
+                      ReactEditor.hasSelectableTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onCopy) &&
+                      !isDOMEventTargetInput(event)
+                    ) {
+                      event.preventDefault()
+                      ReactEditor.setFragmentData(
+                        editor,
+                        event.clipboardData,
+                        'copy'
+                      )
+                    }
+                  },
+                  [attributes.onCopy, editor]
+                )}
+                onCut={useCallback(
+                  (event: React.ClipboardEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      ReactEditor.hasSelectableTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onCut) &&
+                      !isDOMEventTargetInput(event)
+                    ) {
+                      event.preventDefault()
+                      ReactEditor.setFragmentData(
+                        editor,
+                        event.clipboardData,
+                        'cut'
+                      )
+                      const { selection } = editor
+
+                      if (selection) {
+                        if (Range.isExpanded(selection)) {
+                          Editor.deleteFragment(editor)
+                        } else {
+                          const node = Node.parent(
                             editor,
                             selection.anchor.path
                           )
-
-                          if (
-                            Element.isElement(currentNode) &&
-                            Editor.isVoid(editor, currentNode) &&
-                            (Editor.isInline(editor, currentNode) ||
-                              Editor.isBlock(editor, currentNode))
-                          ) {
-                            event.preventDefault()
-                            Editor.deleteBackward(editor, { unit: 'block' })
-
-                            return
+                          if (Editor.isVoid(editor, node)) {
+                            Transforms.delete(editor)
                           }
                         }
                       }
                     }
-                  }
-                },
-                [readOnly, editor, attributes.onKeyDown]
-              )}
-              onPaste={useCallback(
-                (event: React.ClipboardEvent<HTMLDivElement>) => {
-                  if (
-                    !readOnly &&
-                    ReactEditor.hasEditableTarget(editor, event.target) &&
-                    !isEventHandled(event, attributes.onPaste)
-                  ) {
-                    // COMPAT: Certain browsers don't support the `beforeinput` event, so we
-                    // fall back to React's `onPaste` here instead.
-                    // COMPAT: Firefox, Chrome and Safari don't emit `beforeinput` events
-                    // when "paste without formatting" is used, so fallback. (2020/02/20)
-                    // COMPAT: Safari InputEvents generated by pasting won't include
-                    // application/x-slate-fragment items, so use the
-                    // ClipboardEvent here. (2023/03/15)
+                  },
+                  [readOnly, editor, attributes.onCut]
+                )}
+                onDragOver={useCallback(
+                  (event: React.DragEvent<HTMLDivElement>) => {
                     if (
-                      !HAS_BEFORE_INPUT_SUPPORT ||
-                      isPlainTextOnlyPaste(event.nativeEvent) ||
-                      IS_WEBKIT
+                      ReactEditor.hasTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onDragOver)
+                    ) {
+                      // Only when the target is void, call `preventDefault` to signal
+                      // that drops are allowed. Editable content is droppable by
+                      // default, and calling `preventDefault` hides the cursor.
+                      const node = ReactEditor.toSlateNode(editor, event.target)
+
+                      if (
+                        Element.isElement(node) &&
+                        Editor.isVoid(editor, node)
+                      ) {
+                        event.preventDefault()
+                      }
+                    }
+                  },
+                  [attributes.onDragOver, editor]
+                )}
+                onDragStart={useCallback(
+                  (event: React.DragEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      ReactEditor.hasTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onDragStart)
+                    ) {
+                      const node = ReactEditor.toSlateNode(editor, event.target)
+                      const path = ReactEditor.findPath(editor, node)
+                      const voidMatch =
+                        (Element.isElement(node) &&
+                          Editor.isVoid(editor, node)) ||
+                        Editor.void(editor, { at: path, voids: true })
+
+                      // If starting a drag on a void node, make sure it is selected
+                      // so that it shows up in the selection's fragment.
+                      if (voidMatch) {
+                        const range = Editor.range(editor, path)
+                        Transforms.select(editor, range)
+                      }
+
+                      state.isDraggingInternally = true
+
+                      ReactEditor.setFragmentData(
+                        editor,
+                        event.dataTransfer,
+                        'drag'
+                      )
+                    }
+                  },
+                  [readOnly, editor, attributes.onDragStart, state]
+                )}
+                onDrop={useCallback(
+                  (event: React.DragEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      ReactEditor.hasTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onDrop)
                     ) {
                       event.preventDefault()
-                      ReactEditor.insertData(editor, event.clipboardData)
+
+                      // Keep a reference to the dragged range before updating selection
+                      const draggedRange = editor.selection
+
+                      // Find the range where the drop happened
+                      const range = ReactEditor.findEventRange(editor, event)
+                      const data = event.dataTransfer
+
+                      Transforms.select(editor, range)
+
+                      if (state.isDraggingInternally) {
+                        if (
+                          draggedRange &&
+                          !Range.equals(draggedRange, range) &&
+                          !Editor.void(editor, { at: range, voids: true })
+                        ) {
+                          Transforms.delete(editor, {
+                            at: draggedRange,
+                          })
+                        }
+                      }
+
+                      ReactEditor.insertData(editor, data)
+
+                      // When dragging from another source into the editor, it's possible
+                      // that the current editor does not have focus.
+                      if (!ReactEditor.isFocused(editor)) {
+                        ReactEditor.focus(editor)
+                      }
                     }
-                  }
-                },
-                [readOnly, editor, attributes.onPaste]
-              )}
-            >
-              <Children
-                decorations={decorations}
-                node={editor}
-                renderElement={renderElement}
-                renderPlaceholder={renderPlaceholder}
-                renderLeaf={renderLeaf}
-                selection={editor.selection}
-              />
-            </Component>
-          </RestoreDOM>
-        </DecorateContext.Provider>
+                  },
+                  [readOnly, editor, attributes.onDrop, state]
+                )}
+                onDragEnd={useCallback(
+                  (event: React.DragEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      state.isDraggingInternally &&
+                      attributes.onDragEnd &&
+                      ReactEditor.hasTarget(editor, event.target)
+                    ) {
+                      attributes.onDragEnd(event)
+                    }
+                  },
+                  [readOnly, state, attributes, editor]
+                )}
+                onFocus={useCallback(
+                  (event: React.FocusEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      !state.isUpdatingSelection &&
+                      ReactEditor.hasEditableTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onFocus)
+                    ) {
+                      const el = ReactEditor.toDOMNode(editor, editor)
+                      const root = ReactEditor.findDocumentOrShadowRoot(editor)
+                      state.latestElement = root.activeElement
+
+                      // COMPAT: If the editor has nested editable elements, the focus
+                      // can go to them. In Firefox, this must be prevented because it
+                      // results in issues with keyboard navigation. (2017/03/30)
+                      if (IS_FIREFOX && event.target !== el) {
+                        el.focus()
+                        return
+                      }
+
+                      IS_FOCUSED.set(editor, true)
+                    }
+                  },
+                  [readOnly, state, editor, attributes.onFocus]
+                )}
+                onKeyDown={useCallback(
+                  (event: React.KeyboardEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      ReactEditor.hasEditableTarget(editor, event.target)
+                    ) {
+                      androidInputManagerRef.current?.handleKeyDown(event)
+
+                      const { nativeEvent } = event
+
+                      // COMPAT: The composition end event isn't fired reliably in all browsers,
+                      // so we sometimes might end up stuck in a composition state even though we
+                      // aren't composing any more.
+                      if (
+                        ReactEditor.isComposing(editor) &&
+                        nativeEvent.isComposing === false
+                      ) {
+                        IS_COMPOSING.set(editor, false)
+                        setIsComposing(false)
+                      }
+
+                      if (
+                        isEventHandled(event, attributes.onKeyDown) ||
+                        ReactEditor.isComposing(editor)
+                      ) {
+                        return
+                      }
+
+                      const { selection } = editor
+                      const element =
+                        editor.children[
+                          selection !== null ? selection.focus.path[0] : 0
+                        ]
+                      const isRTL = getDirection(Node.string(element)) === 'rtl'
+
+                      // COMPAT: Since we prevent the default behavior on
+                      // `beforeinput` events, the browser doesn't think there's ever
+                      // any history stack to undo or redo, so we have to manage these
+                      // hotkeys ourselves. (2019/11/06)
+                      if (Hotkeys.isRedo(nativeEvent)) {
+                        event.preventDefault()
+                        const maybeHistoryEditor: any = editor
+
+                        if (typeof maybeHistoryEditor.redo === 'function') {
+                          maybeHistoryEditor.redo()
+                        }
+
+                        return
+                      }
+
+                      if (Hotkeys.isUndo(nativeEvent)) {
+                        event.preventDefault()
+                        const maybeHistoryEditor: any = editor
+
+                        if (typeof maybeHistoryEditor.undo === 'function') {
+                          maybeHistoryEditor.undo()
+                        }
+
+                        return
+                      }
+
+                      // COMPAT: Certain browsers don't handle the selection updates
+                      // properly. In Chrome, the selection isn't properly extended.
+                      // And in Firefox, the selection isn't properly collapsed.
+                      // (2017/10/17)
+                      if (Hotkeys.isMoveLineBackward(nativeEvent)) {
+                        event.preventDefault()
+                        Transforms.move(editor, { unit: 'line', reverse: true })
+                        return
+                      }
+
+                      if (Hotkeys.isMoveLineForward(nativeEvent)) {
+                        event.preventDefault()
+                        Transforms.move(editor, { unit: 'line' })
+                        return
+                      }
+
+                      if (Hotkeys.isExtendLineBackward(nativeEvent)) {
+                        event.preventDefault()
+                        Transforms.move(editor, {
+                          unit: 'line',
+                          edge: 'focus',
+                          reverse: true,
+                        })
+                        return
+                      }
+
+                      if (Hotkeys.isExtendLineForward(nativeEvent)) {
+                        event.preventDefault()
+                        Transforms.move(editor, { unit: 'line', edge: 'focus' })
+                        return
+                      }
+
+                      // COMPAT: If a void node is selected, or a zero-width text node
+                      // adjacent to an inline is selected, we need to handle these
+                      // hotkeys manually because browsers won't be able to skip over
+                      // the void node with the zero-width space not being an empty
+                      // string.
+                      if (Hotkeys.isMoveBackward(nativeEvent)) {
+                        event.preventDefault()
+
+                        if (selection && Range.isCollapsed(selection)) {
+                          Transforms.move(editor, { reverse: !isRTL })
+                        } else {
+                          Transforms.collapse(editor, {
+                            edge: isRTL ? 'end' : 'start',
+                          })
+                        }
+
+                        return
+                      }
+
+                      if (Hotkeys.isMoveForward(nativeEvent)) {
+                        event.preventDefault()
+
+                        if (selection && Range.isCollapsed(selection)) {
+                          Transforms.move(editor, { reverse: isRTL })
+                        } else {
+                          Transforms.collapse(editor, {
+                            edge: isRTL ? 'start' : 'end',
+                          })
+                        }
+
+                        return
+                      }
+
+                      if (Hotkeys.isMoveWordBackward(nativeEvent)) {
+                        event.preventDefault()
+
+                        if (selection && Range.isExpanded(selection)) {
+                          Transforms.collapse(editor, { edge: 'focus' })
+                        }
+
+                        Transforms.move(editor, {
+                          unit: 'word',
+                          reverse: !isRTL,
+                        })
+                        return
+                      }
+
+                      if (Hotkeys.isMoveWordForward(nativeEvent)) {
+                        event.preventDefault()
+
+                        if (selection && Range.isExpanded(selection)) {
+                          Transforms.collapse(editor, { edge: 'focus' })
+                        }
+
+                        Transforms.move(editor, {
+                          unit: 'word',
+                          reverse: isRTL,
+                        })
+                        return
+                      }
+
+                      // COMPAT: Certain browsers don't support the `beforeinput` event, so we
+                      // fall back to guessing at the input intention for hotkeys.
+                      // COMPAT: In iOS, some of these hotkeys are handled in the
+                      if (!HAS_BEFORE_INPUT_SUPPORT) {
+                        // We don't have a core behavior for these, but they change the
+                        // DOM if we don't prevent them, so we have to.
+                        if (
+                          Hotkeys.isBold(nativeEvent) ||
+                          Hotkeys.isItalic(nativeEvent) ||
+                          Hotkeys.isTransposeCharacter(nativeEvent)
+                        ) {
+                          event.preventDefault()
+                          return
+                        }
+
+                        if (Hotkeys.isSoftBreak(nativeEvent)) {
+                          event.preventDefault()
+                          Editor.insertSoftBreak(editor)
+                          return
+                        }
+
+                        if (Hotkeys.isSplitBlock(nativeEvent)) {
+                          event.preventDefault()
+                          Editor.insertBreak(editor)
+                          return
+                        }
+
+                        if (Hotkeys.isDeleteBackward(nativeEvent)) {
+                          event.preventDefault()
+
+                          if (selection && Range.isExpanded(selection)) {
+                            Editor.deleteFragment(editor, {
+                              direction: 'backward',
+                            })
+                          } else {
+                            Editor.deleteBackward(editor)
+                          }
+
+                          return
+                        }
+
+                        if (Hotkeys.isDeleteForward(nativeEvent)) {
+                          event.preventDefault()
+
+                          if (selection && Range.isExpanded(selection)) {
+                            Editor.deleteFragment(editor, {
+                              direction: 'forward',
+                            })
+                          } else {
+                            Editor.deleteForward(editor)
+                          }
+
+                          return
+                        }
+
+                        if (Hotkeys.isDeleteLineBackward(nativeEvent)) {
+                          event.preventDefault()
+
+                          if (selection && Range.isExpanded(selection)) {
+                            Editor.deleteFragment(editor, {
+                              direction: 'backward',
+                            })
+                          } else {
+                            Editor.deleteBackward(editor, { unit: 'line' })
+                          }
+
+                          return
+                        }
+
+                        if (Hotkeys.isDeleteLineForward(nativeEvent)) {
+                          event.preventDefault()
+
+                          if (selection && Range.isExpanded(selection)) {
+                            Editor.deleteFragment(editor, {
+                              direction: 'forward',
+                            })
+                          } else {
+                            Editor.deleteForward(editor, { unit: 'line' })
+                          }
+
+                          return
+                        }
+
+                        if (Hotkeys.isDeleteWordBackward(nativeEvent)) {
+                          event.preventDefault()
+
+                          if (selection && Range.isExpanded(selection)) {
+                            Editor.deleteFragment(editor, {
+                              direction: 'backward',
+                            })
+                          } else {
+                            Editor.deleteBackward(editor, { unit: 'word' })
+                          }
+
+                          return
+                        }
+
+                        if (Hotkeys.isDeleteWordForward(nativeEvent)) {
+                          event.preventDefault()
+
+                          if (selection && Range.isExpanded(selection)) {
+                            Editor.deleteFragment(editor, {
+                              direction: 'forward',
+                            })
+                          } else {
+                            Editor.deleteForward(editor, { unit: 'word' })
+                          }
+
+                          return
+                        }
+                      } else {
+                        if (IS_CHROME || IS_WEBKIT) {
+                          // COMPAT: Chrome and Safari support `beforeinput` event but do not fire
+                          // an event when deleting backwards in a selected void inline node
+                          if (
+                            selection &&
+                            (Hotkeys.isDeleteBackward(nativeEvent) ||
+                              Hotkeys.isDeleteForward(nativeEvent)) &&
+                            Range.isCollapsed(selection)
+                          ) {
+                            const currentNode = Node.parent(
+                              editor,
+                              selection.anchor.path
+                            )
+
+                            if (
+                              Element.isElement(currentNode) &&
+                              Editor.isVoid(editor, currentNode) &&
+                              (Editor.isInline(editor, currentNode) ||
+                                Editor.isBlock(editor, currentNode))
+                            ) {
+                              event.preventDefault()
+                              Editor.deleteBackward(editor, { unit: 'block' })
+
+                              return
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  [readOnly, editor, attributes.onKeyDown]
+                )}
+                onPaste={useCallback(
+                  (event: React.ClipboardEvent<HTMLDivElement>) => {
+                    if (
+                      !readOnly &&
+                      ReactEditor.hasEditableTarget(editor, event.target) &&
+                      !isEventHandled(event, attributes.onPaste)
+                    ) {
+                      // COMPAT: Certain browsers don't support the `beforeinput` event, so we
+                      // fall back to React's `onPaste` here instead.
+                      // COMPAT: Firefox, Chrome and Safari don't emit `beforeinput` events
+                      // when "paste without formatting" is used, so fallback. (2020/02/20)
+                      // COMPAT: Safari InputEvents generated by pasting won't include
+                      // application/x-slate-fragment items, so use the
+                      // ClipboardEvent here. (2023/03/15)
+                      if (
+                        !HAS_BEFORE_INPUT_SUPPORT ||
+                        isPlainTextOnlyPaste(event.nativeEvent) ||
+                        IS_WEBKIT
+                      ) {
+                        event.preventDefault()
+                        ReactEditor.insertData(editor, event.clipboardData)
+                      }
+                    }
+                  },
+                  [readOnly, editor, attributes.onPaste]
+                )}
+              >
+                <Children
+                  decorations={decorations}
+                  node={editor}
+                  renderElement={renderElement}
+                  renderPlaceholder={renderPlaceholder}
+                  renderLeaf={renderLeaf}
+                  selection={editor.selection}
+                />
+              </Component>
+            </RestoreDOM>
+          </DecorateContext.Provider>
+        </ComposingContext.Provider>
       </ReadOnlyContext.Provider>
     )
   }

--- a/packages/slate-react/src/hooks/use-composing.ts
+++ b/packages/slate-react/src/hooks/use-composing.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * A React context for sharing the `composing` state of the editor.
+ */
+
+export const ComposingContext = createContext(false)
+
+/**
+ * Get the current `composing` state of the editor.
+ */
+
+export const useComposing = (): boolean => {
+  return useContext(ComposingContext)
+}


### PR DESCRIPTION
Expose isComposing for external packages.

https://github.com/udecode/plate/discussions/3425

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

