### PR TITLE
Add withMerging

### DIFF
--- a/.changeset/honest-rice-doubt.md
+++ b/.changeset/honest-rice-doubt.md
@@ -1,0 +1,5 @@
+---
+'slate-history': minor
+---
+
+Add `withMerging`

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -63,6 +63,17 @@ export const HistoryEditor = {
   },
 
   /**
+   * Apply a series of changes inside a synchronous `fn`, These operations will
+   * be merged into the previous history.
+   */
+  withMerging(editor: HistoryEditor, fn: () => void): void {
+    const prev = HistoryEditor.isMerging(editor)
+    MERGING.set(editor, true)
+    fn()
+    MERGING.set(editor, prev)
+  },
+
+  /**
    * Apply a series of changes inside a synchronous `fn`, without merging any of
    * the new operations into previous save point in the history.
    */


### PR DESCRIPTION
**Description**
Currently, Slate lacks an API to merge a series of history records to the top of the stack. In some cases, the withMerging function is very useful, for example the upload status from pending to success and AI generate a series of text  withMerging can make sure to remove it in one times redo.

**Issue**
Fixes: (link to issue)

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

