### PR TITLE
Fix selections with non-void non-editable focus

### DIFF
--- a/.changeset/brown-ears-tap.md
+++ b/.changeset/brown-ears-tap.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix selections with non-void non-editable focus

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -255,9 +255,9 @@ export const Editable = forwardRef(
               ReactEditor.hasEditableTarget(editor, anchorNode) ||
               ReactEditor.isTargetInsideNonReadonlyVoid(editor, anchorNode)
 
-            const focusNodeSelectable = ReactEditor.hasTarget(editor, focusNode)
+            const focusNodeInEditor = ReactEditor.hasTarget(editor, focusNode)
 
-            if (anchorNodeSelectable && focusNodeSelectable) {
+            if (anchorNodeSelectable && focusNodeInEditor) {
               const range = ReactEditor.toSlateRange(editor, domSelection, {
                 exactMatch: false,
                 suppressThrow: true,
@@ -277,7 +277,7 @@ export const Editable = forwardRef(
             }
 
             // Deselect the editor if the dom selection is not selectable in readonly mode
-            if (readOnly && (!anchorNodeSelectable || !focusNodeSelectable)) {
+            if (readOnly && (!anchorNodeSelectable || !focusNodeInEditor)) {
               Transforms.deselect(editor)
             }
           }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -255,9 +255,7 @@ export const Editable = forwardRef(
               ReactEditor.hasEditableTarget(editor, anchorNode) ||
               ReactEditor.isTargetInsideNonReadonlyVoid(editor, anchorNode)
 
-            const focusNodeSelectable =
-              ReactEditor.hasEditableTarget(editor, focusNode) ||
-              ReactEditor.isTargetInsideNonReadonlyVoid(editor, focusNode)
+            const focusNodeSelectable = ReactEditor.hasTarget(editor, focusNode)
 
             if (anchorNodeSelectable && focusNodeSelectable) {
               const range = ReactEditor.toSlateRange(editor, domSelection, {

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -794,8 +794,7 @@ export const ReactEditor: ReactEditorInterface = {
           })
         }
       } else if (nonEditableNode) {
-        // Find the edge of the nearest leaf in `searchDirection` from the
-        // non-editable node
+        // Find the edge of the nearest leaf in `searchDirection`
         const getLeafNodes = (node: DOMElement | null | undefined) =>
           node
             ? node.querySelectorAll(

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -823,9 +823,7 @@ export const ReactEditor: ReactEditorInterface = {
             leafNodes.findLast(leaf => isBefore(nonEditableNode, leaf)) ?? null
         }
 
-        if (!leafNode) {
-          offset = 1
-        } else {
+        if (leafNode) {
           textNode = leafNode.closest('[data-slate-node="text"]')!
           domNode = leafNode
           if (searchDirection === 'forward') {

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -337,3 +337,21 @@ export const getActiveElement = () => {
 
   return activeElement
 }
+
+/**
+ * @returns `true` if `otherNode` is before `node` in the document; otherwise, `false`.
+ */
+export const isBefore = (node: DOMNode, otherNode: DOMNode): boolean =>
+  Boolean(
+    node.compareDocumentPosition(otherNode) &
+      DOMNode.DOCUMENT_POSITION_PRECEDING
+  )
+
+/**
+ * @returns `true` if `otherNode` is after `node` in the document; otherwise, `false`.
+ */
+export const isAfter = (node: DOMNode, otherNode: DOMNode): boolean =>
+  Boolean(
+    node.compareDocumentPosition(otherNode) &
+      DOMNode.DOCUMENT_POSITION_FOLLOWING
+  )


### PR DESCRIPTION
## Description

Currently, when I drag my browser selection focus into a `contentEditable={false}` DOM element that's being rendered by a non-void Slate element renderer, Slate's selection doesn't get updated. At times, this causes non-highlighted text to be deleted when pressing <kbd>Backspace</kbd> (first example below). At other times, this causes a <kbd>Backspace</kbd> press to crash the page (second example below).

The fix in this PR is to set the focus point to the edge of the nearest Slate leaf when the selection focus is in a non-void, non-editable node, instead of disregarding such selections.

## Issue

Fixes #5714

## Example

These examples use https://www.slatejs.org/examples/check-lists, where the “non-void, non-editable” node is [this `<span>`](https://github.com/ianstormtaylor/slate/blob/7e77a932f0489a9fff2d8a1957aa2dd9b324aa78/site/examples/check-lists.tsx#L153-L170).

### Incorrect deletion

#### Before

![A demonstration of the bug in Slate's checklists example, in which pressing Backspace causes non-highlighted text to be deleted](https://github.com/user-attachments/assets/886c9ea8-15c7-436e-9b8f-169e26ce2ff3)

#### After

![A demonstration of this PR's fix of the incorrect deletion, in which pressing Backspace only deletes the highlighted text](https://github.com/user-attachments/assets/c4eb262d-20af-4a84-923e-2d34ec22ef8b)

### Page crash

#### Before

![A demonstration of the bug in Slate's checklists example, in which pressing Backspace causes the page to crash](https://github.com/user-attachments/assets/46a2285b-a832-45a7-9f1d-3457b4291784)

#### After

![A demonstration of this PR's fix of the page crash, in which pressing Backspace only deletes the highlighted text](https://github.com/user-attachments/assets/491e85cf-1db5-4590-9234-86633909dcb1)

## Checks

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

