### PR TITLE
feat: add Node.getIf method

### DIFF
--- a/.changeset/clean-icons-bow.md
+++ b/.changeset/clean-icons-bow.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+feat: add Node.getIf method

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -132,6 +132,11 @@ export interface NodeInterface {
   get: (root: Node, path: Path) => Node
 
   /**
+   * Similar to get, but returns undefined if the node does not exist.
+   */
+  getIf: (root: Node, path: Path) => Node | undefined
+
+  /**
    * Check if a descendant node exists at a specific path.
    */
   has: (root: Node, path: Path) => boolean
@@ -400,6 +405,22 @@ export const Node: NodeInterface = {
             root
           )}`
         )
+      }
+
+      node = node.children[p]
+    }
+
+    return node
+  },
+
+  getIf(root: Node, path: Path): Node | undefined {
+    let node = root
+
+    for (let i = 0; i < path.length; i++) {
+      const p = path[i]
+
+      if (Text.isText(node) || !node.children[p]) {
+        return
       }
 
       node = node.children[p]

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -394,22 +394,14 @@ export const Node: NodeInterface = {
   },
 
   get(root: Node, path: Path): Node {
-    let node = root
-
-    for (let i = 0; i < path.length; i++) {
-      const p = path[i]
-
-      if (Text.isText(node) || !node.children[p]) {
-        throw new Error(
-          `Cannot find a descendant at path [${path}] in node: ${Scrubber.stringify(
-            root
-          )}`
-        )
-      }
-
-      node = node.children[p]
+    const node = Node.getIf(root, path)
+    if (node === undefined) {
+      throw new Error(
+        `Cannot find a descendant at path [${path}] in node: ${Scrubber.stringify(
+          root
+        )}`
+      )
     }
-
     return node
   },
 

--- a/packages/slate/test/interfaces/Node/getIf/root.tsx
+++ b/packages/slate/test/interfaces/Node/getIf/root.tsx
@@ -1,0 +1,17 @@
+/** @jsx jsx  */
+import { Node } from 'slate'
+import { jsx } from 'slate-hyperscript'
+import { cloneDeep } from 'lodash'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+    </element>
+  </editor>
+)
+export const test = value => {
+  return Node.getIf(value, [])
+}
+export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
+export const output = cloneDeep(input)

--- a/packages/slate/test/interfaces/Node/getIf/success.tsx
+++ b/packages/slate/test/interfaces/Node/getIf/success.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx  */
+import { Node } from 'slate'
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+    </element>
+  </editor>
+)
+export const test = value => {
+  return Node.getIf(value, [0])
+}
+export const output = (
+  <element>
+    <text />
+  </element>
+)

--- a/packages/slate/test/interfaces/Node/getIf/undefined.tsx
+++ b/packages/slate/test/interfaces/Node/getIf/undefined.tsx
@@ -1,0 +1,15 @@
+/** @jsx jsx  */
+import { Node } from 'slate'
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+    </element>
+  </editor>
+)
+export const test = value => {
+  return Node.getIf(value, [0, 0, 0])
+}
+export const output = undefined


### PR DESCRIPTION
**Description**
This PR is an attempt to solve below issue and provide a graceful method to get a Node.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/4845

**Example**
```ts
// If node exists
const node = Node.getIf(editor, [0]); // returns respective node

// If node doesn't exist
const node = Node.getIf(editor, [0]); // return undefined rather than error
```

**Context**
I simply used the existing logic of get method and instead of throwing any error returned undefined

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

