### PR TITLE
fix: marks at the start of the selection

### DIFF
--- a/.changeset/odd-falcons-hang.md
+++ b/.changeset/odd-falcons-hang.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+fix marks at the start of the selection

--- a/packages/slate/src/editor/marks.ts
+++ b/packages/slate/src/editor/marks.ts
@@ -19,6 +19,10 @@ export const marks: EditorInterface['marks'] = (editor, options = {}) => {
   }
 
   if (Range.isExpanded(selection)) {
+    const isBackward = Range.isBackward(selection)
+    if (isBackward) {
+      ;[focus, anchor] = [anchor, focus]
+    }
     /**
      * COMPAT: Make sure hanging ranges (caused by double clicking in Firefox)
      * do not adversely affect the returned marks.

--- a/packages/slate/test/interfaces/Editor/marks/focus-block-end.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/focus-block-end.tsx
@@ -1,0 +1,36 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../..'
+
+/**
+ * This test verifies that when double clicking a marked word in Firefox,
+ * Editor.marks for the resulting selection includes the marked word. Double
+ * clicking a marked word in Firefox results in a selection that starts at the
+ * end of the previous text node and ends at the end of the marked text node.
+ */
+
+export const input = (
+  <editor>
+    <block>
+      <text>
+        block one
+        <focus />
+      </text>
+    </block>
+    <block>
+      <text bold>block two</text>
+    </block>
+    <block>
+      <text bold>
+        block three
+        <anchor />
+      </text>
+    </block>
+  </editor>
+)
+
+export const test = editor => {
+  return Editor.marks(editor)
+}
+
+export const output = { bold: true }

--- a/packages/slate/test/interfaces/Editor/marks/focus-block-end.tsx
+++ b/packages/slate/test/interfaces/Editor/marks/focus-block-end.tsx
@@ -3,10 +3,10 @@ import { Editor } from 'slate'
 import { jsx } from '../../..'
 
 /**
- * This test verifies that when double clicking a marked word in Firefox,
- * Editor.marks for the resulting selection includes the marked word. Double
- * clicking a marked word in Firefox results in a selection that starts at the
- * end of the previous text node and ends at the end of the marked text node.
+ * Similar to firefox-double-click.tsx, when the selection is at the end of
+ * the previous node's path, using Editor.marks retrieves the marks of that node.
+ * However, when addMark is triggered, that node is not within the range for
+ * adding marks,  thus failing to transfer the state correctly.
  */
 
 export const input = (


### PR DESCRIPTION
**Description**
When the selection is at the end of the previous node, using Editor.marks retrieves the marks of the previous node. In this case, calling Editor.addMark does not override the previous node, thus causing the states to be out of sync.

**Issue**
Fixes: #5724

**Example**

Before the fix:

<img src="https://github.com/user-attachments/assets/acd38059-ee5e-43f9-a39c-a9609898c488" width="400px" >

When fixed:

<img src="https://github.com/user-attachments/assets/b2afb04d-826f-4c60-84a6-c2b088aa90f3" width="400px" >


**Context**

Thanks to the fix in #5580 , we can easily address this issue. By swapping the positions of anchor and focus according to Range.isBackward, we can then proceed with the original correction logic.

Additionally, since Editor.nodes calls Range.edges to recalibrate the order of anchor and focus, it won't affect the original Editor.marks logic.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

