### PR TITLE
Call unref on pathRefs created for move_node

### DIFF
--- a/.changeset/old-frogs-run.md
+++ b/.changeset/old-frogs-run.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Call unref on pathRefs created for move_node to remove memory leak

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -216,6 +216,8 @@ export const withReact = <T extends BaseEditor>(
         const [node] = Editor.node(e, pathRef.current)
         NODE_TO_KEY.set(node, key)
       }
+
+      pathRef.unref()
     }
   }
 


### PR DESCRIPTION
**Description**
Adds an `unref` call on `pathRef`s created for the `move_node` operation after they're used, preventing a memory leak.

**Issue**
Fixes: #5726

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

