### PR TITLE
fix: chromium interrupt IME when moving cursor

### DIFF
--- a/site/examples/js/mentions.jsx
+++ b/site/examples/js/mentions.jsx
@@ -220,18 +220,22 @@ const Mention = ({ attributes, children, element }) => {
       data-cy={`mention-${element.character.replace(' ', '-')}`}
       style={style}
     >
-      {IS_MAC ? (
-        // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
-        <Fragment>
-          {children}@{element.character}
-        </Fragment>
-      ) : (
-        // Others like Android https://github.com/ianstormtaylor/slate/pull/5360
-        <Fragment>
-          @{element.character}
-          {children}
-        </Fragment>
-      )}
+      {/* Prevent Chromium from interrupting IME when moving the cursor */}
+      {/* 1. span + inline-block 2. div + contenteditable=false */}
+      <div contentEditable={false}>
+        {IS_MAC ? (
+          // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
+          <Fragment>
+            {children}@{element.character}
+          </Fragment>
+        ) : (
+          // Others like Android https://github.com/ianstormtaylor/slate/pull/5360
+          <Fragment>
+            @{element.character}
+            {children}
+          </Fragment>
+        )}
+      </div>
     </span>
   )
 }

--- a/site/examples/ts/mentions.tsx
+++ b/site/examples/ts/mentions.tsx
@@ -242,18 +242,22 @@ const Mention = ({ attributes, children, element }) => {
       data-cy={`mention-${element.character.replace(' ', '-')}`}
       style={style}
     >
-      {IS_MAC ? (
-        // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
-        <Fragment>
-          {children}@{element.character}
-        </Fragment>
-      ) : (
-        // Others like Android https://github.com/ianstormtaylor/slate/pull/5360
-        <Fragment>
-          @{element.character}
-          {children}
-        </Fragment>
-      )}
+      {/* Prevent Chromium from interrupting IME when moving the cursor */}
+      {/* 1. span + inline-block 2. div + contenteditable=false */}
+      <div contentEditable={false}>
+        {IS_MAC ? (
+          // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
+          <Fragment>
+            {children}@{element.character}
+          </Fragment>
+        ) : (
+          // Others like Android https://github.com/ianstormtaylor/slate/pull/5360
+          <Fragment>
+            @{element.character}
+            {children}
+          </Fragment>
+        )}
+      </div>
     </span>
   )
 }


### PR DESCRIPTION
**Description**
I found an issue in Chromium: when a node (A) is set to contenteditable=false and is followed by a text node (B), activating the IME between A and B and then holding the left arrow key to adjust input causes the IME to disappear and leads to unexpected state issues, such as composition events. 

This problem does not occur in Firefox and Safari, only in browsers with the Chromium engine. 

This issue is also mentioned in https://github.com/ianstormtaylor/slate/issues/3490#issuecomment-2241179871.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/3490#issuecomment-2241179871

**Example**
The current issues.

<img src="https://github.com/user-attachments/assets/cd34d523-8030-4824-a39e-ad3a0e0e814a" width="600px" />

After making adjustments.

<img src="https://github.com/user-attachments/assets/2bfe00ea-4fb0-4d58-886a-e630c0cfc78b" width="600px" />


**Context**
Here's the minimal demo for this issue: when you activate the IME before the "!" character and then hold the left arrow key, the input method gets interrupted and disappears.

```html
<div contenteditable="true"><span contenteditable="false" style="background: #eee;">Void</span><span>!</span></div>
```

To fix this issue, you need to create the following DOM structure. The key is that the outer span tag has a display:inline-block style, and the child div tag has a contenteditable=false attribute. This is magic.

```html
<div contenteditable="true"><span contenteditable="false" style="background: #eee; display: inline-block;"><div contenteditable="false">Void</div></span><span>!</span></div>
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

