### PR TITLE
Add `HistoryEditor.withMerging` to docs

### DIFF
--- a/docs/libraries/slate-history/history-editor.md
+++ b/docs/libraries/slate-history/history-editor.md
@@ -39,6 +39,11 @@ Undo to the previous saved state.
 
 ### Merging and Saving
 
+#### `HistoryEditor.withMerging(editor: HistoryEditor, fn: () => void): void`
+
+Apply a series of changes inside a synchronous `fn`, These operations will
+be merged into the previous history.
+
 #### `HistoryEditor.withoutMerging(editor: HistoryEditor, fn: () => void): void`
 
 Apply a series of changes inside a synchronous `fn`, without merging any of


### PR DESCRIPTION
## Description

[`withMerging`](https://github.com/ianstormtaylor/slate/blob/8c7f7ea6ac491d6e1325810ef11fc2b3455b1304/packages/slate-history/src/history-editor.ts#L65-L74) is currently missing from the [`HistoryEditor` docs](https://docs.slatejs.org/libraries/slate-history/history-editor).