### PR TITLE
fix: Prevent ReactEditor.toDOMRange crash in setDomSelection

### DIFF
--- a/.changeset/serious-eels-pay.md
+++ b/.changeset/serious-eels-pay.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix ReactEditor.toDOMRange crash in setDomSelection

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -333,7 +333,7 @@ export const Editable = forwardRef(
         const focusNode = domSelection.focusNode
         let anchorNode
 
-        // COMPAT: In firefox the normal seletion way does not work
+        // COMPAT: In firefox the normal selection way does not work
         // (https://github.com/ianstormtaylor/slate/pull/5486#issue-1820720223)
         if (IS_FIREFOX && domSelection.rangeCount > 1) {
           const firstRange = domSelection.getRangeAt(0)
@@ -406,8 +406,13 @@ export const Editable = forwardRef(
         // Otherwise the DOM selection is out of sync, so update it.
         state.isUpdatingSelection = true
 
-        const newDomRange: DOMRange | null =
-          selection && ReactEditor.toDOMRange(editor, selection)
+        let newDomRange: DOMRange | null = null
+
+        try {
+          newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
+        } catch (e) {
+          // Ignore, dom and state might be out of sync
+        }
 
         if (newDomRange) {
           if (ReactEditor.isComposing(editor) && !IS_ANDROID) {


### PR DESCRIPTION
**Description**
Somehow related to https://github.com/ianstormtaylor/slate/pull/5407 and https://github.com/ianstormtaylor/slate/pull/5571

I debugged an issue in our application where using the [TextExpander](https://textexpander.com/) extension on a Slate input would cause the editor to crash with `Cannot resolve a DOM point from Slate point` coming from `setDomSelection`'s call.

I was able to prevent the crash in our codebase using an ErrorBoundary as suggested [here](https://github.com/ianstormtaylor/slate/pull/5407#issuecomment-1673337395), but wondered why it was crashing to begin with. 

As far as I can tell, although the TextExpander text is not expanded, the editor recovers fine if we discard the error and the existing code supports having a null `newDomRange` so I figured I could let it be null if it can't calculate a `domPoint`.

This pattern is already used in `ensureDomSelection`:

```typescript
          const ensureDomSelection = (forceChange?: boolean) => {
            try {
              const el = ReactEditor.toDOMNode(editor, editor)
              el.focus()

              setDomSelection(forceChange)
            } catch (e) {
              // Ignore, dom and state might be out of sync
            }
          }
```

Please let me know if I missed something!

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

