### PR TITLE
fix: invalidate node maps when nodes change in-between paints #5694.

### DIFF
--- a/.changeset/bright-fishes-protect.md
+++ b/.changeset/bright-fishes-protect.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Invalidate node maps when nodes change until next react paint

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -22,6 +22,7 @@ import {
   EDITOR_TO_PLACEHOLDER_ELEMENT,
   EDITOR_TO_USER_MARKS,
   IS_COMPOSING,
+  IS_NODE_MAP_DIRTY,
 } from '../../utils/weak-maps'
 
 export type Action = { at?: Point | Range; run: () => void }
@@ -343,6 +344,10 @@ export function createAndroidInputManager({
     if (flushTimeoutId) {
       clearTimeout(flushTimeoutId)
       flushTimeoutId = null
+    }
+
+    if (IS_NODE_MAP_DIRTY.get(editor)) {
+      return
     }
 
     const { inputType: type } = event

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -9,7 +9,11 @@ import {
 import ElementComponent from '../components/element'
 import TextComponent from '../components/text'
 import { ReactEditor } from '../plugin/react-editor'
-import { NODE_TO_INDEX, NODE_TO_PARENT } from '../utils/weak-maps'
+import {
+  IS_NODE_MAP_DIRTY,
+  NODE_TO_INDEX,
+  NODE_TO_PARENT,
+} from '../utils/weak-maps'
 import { useDecorate } from './use-decorate'
 import { SelectedContext } from './use-selected'
 import { useSlateStatic } from './use-slate-static'
@@ -36,6 +40,7 @@ const useChildren = (props: {
   } = props
   const decorate = useDecorate()
   const editor = useSlateStatic()
+  IS_NODE_MAP_DIRTY.set(editor as ReactEditor, false)
   const path = ReactEditor.findPath(editor, node)
   const children = []
   const isLeafBlock =

--- a/packages/slate-react/src/plugin/with-react.ts
+++ b/packages/slate-react/src/plugin/with-react.ts
@@ -25,6 +25,7 @@ import {
 import { Key } from '../utils/key'
 import { findCurrentLineRange } from '../utils/lines'
 import {
+  IS_NODE_MAP_DIRTY,
   EDITOR_TO_KEY_TO_ELEMENT,
   EDITOR_TO_ON_CHANGE,
   EDITOR_TO_PENDING_ACTION,
@@ -205,6 +206,16 @@ export const withReact = <T extends BaseEditor>(
     }
 
     apply(op)
+
+    switch (op.type) {
+      case 'insert_node':
+      case 'remove_node':
+      case 'merge_node':
+      case 'move_node':
+      case 'split_node': {
+        IS_NODE_MAP_DIRTY.set(e, true)
+      }
+    }
 
     for (const [path, key] of matches) {
       const [node] = Editor.node(e, path)

--- a/packages/slate-react/src/utils/weak-maps.ts
+++ b/packages/slate-react/src/utils/weak-maps.ts
@@ -7,7 +7,7 @@ import { Key } from './key'
  * Two weak maps that allow us rebuild a path given a node. They are populated
  * at render time such that after a render occurs we can always backtrack.
  */
-
+export const IS_NODE_MAP_DIRTY: WeakMap<Editor, boolean> = new WeakMap()
 export const NODE_TO_INDEX: WeakMap<Node, number> = new WeakMap()
 export const NODE_TO_PARENT: WeakMap<Node, Ancestor> = new WeakMap()
 


### PR DESCRIPTION
**Description**
This fixes an editor crash where the user types quickly after earlier nodes have been added, split or deleted, but the node maps have not yet been regenerated on React render. 

**Issue**
Fixes: [(link to issue)](https://github.com/ianstormtaylor/slate/issues/5694)

**Example**
Recording (from issue linked above)
https://github.com/user-attachments/assets/a68453b1-df47-4324-a542-9313569958ca

Sandbox (from issue linked above)
https://codesandbox.io/s/slate-selection-change-repro-ztssmp

**Context**
The `NODE_TO_INDEX` WeakMap is built on each React render as part of the `useChildren` hook. Both `onDOMBeforeInput` and `onDOMSelectionChange` use these maps to set the selection. This change introduces a new `WeakMap` called `IS_NODE_MAP_DIRTY` to track whether the underlying nodes have changed (eg: `remove_node` or `insert_node`), allowing those methods to skip attempts to `setSelection` that could crash the component. 

Recommend you compare with "Ignore white space" selected.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

