### PR TITLE
History: withNewBatch

### DIFF
--- a/.changeset/gold-cheetahs-rest.md
+++ b/.changeset/gold-cheetahs-rest.md
@@ -1,0 +1,5 @@
+---
+"slate-history": patch
+---
+
+Add `HistoryEditor.withNewBatch`

--- a/.changeset/gold-cheetahs-rest.md
+++ b/.changeset/gold-cheetahs-rest.md
@@ -1,5 +1,5 @@
 ---
-"slate-history": patch
+'slate-history': patch
 ---
 
 Add `HistoryEditor.withNewBatch`

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -8,6 +8,7 @@ import { History } from './history'
 export const HISTORY = new WeakMap<Editor, History>()
 export const SAVING = new WeakMap<Editor, boolean | undefined>()
 export const MERGING = new WeakMap<Editor, boolean | undefined>()
+export const SPLITTING_ONCE = new WeakMap<Editor, boolean | undefined>()
 
 /**
  * `HistoryEditor` contains helpers for history-enabled editors.
@@ -39,6 +40,18 @@ export const HistoryEditor = {
   },
 
   /**
+   * Get the splitting once flag's current value.
+   */
+
+  isSplittingOnce(editor: HistoryEditor): boolean | undefined {
+    return SPLITTING_ONCE.get(editor)
+  },
+
+  setSplittingOnce(editor: HistoryEditor, value: boolean | undefined): void {
+    SPLITTING_ONCE.set(editor, value)
+  },
+
+  /**
    * Get the saving flag's current value.
    */
 
@@ -67,10 +80,24 @@ export const HistoryEditor = {
    * be merged into the previous history.
    */
   withMerging(editor: HistoryEditor, fn: () => void): void {
-    const prev = HistoryEditor.isMerging(editor)
+    const prevMerging = HistoryEditor.isMerging(editor)
     MERGING.set(editor, true)
     fn()
-    MERGING.set(editor, prev)
+    MERGING.set(editor, prevMerging)
+  },
+
+  /**
+   * Apply a series of changes inside a synchronous `fn`, ensuring that the first
+   * operation starts a new batch in the history. Subsequent operations will be
+   * merged as usual.
+   */
+  withNewBatch(editor: HistoryEditor, fn: () => void): void {
+    const prevMerging = HistoryEditor.isMerging(editor)
+    MERGING.set(editor, true)
+    SPLITTING_ONCE.set(editor, true)
+    fn()
+    MERGING.set(editor, prevMerging)
+    SPLITTING_ONCE.delete(editor)
   },
 
   /**

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -80,10 +80,10 @@ export const HistoryEditor = {
    * be merged into the previous history.
    */
   withMerging(editor: HistoryEditor, fn: () => void): void {
-    const prevMerging = HistoryEditor.isMerging(editor)
+    const prev = HistoryEditor.isMerging(editor)
     MERGING.set(editor, true)
     fn()
-    MERGING.set(editor, prevMerging)
+    MERGING.set(editor, prev)
   },
 
   /**
@@ -92,11 +92,11 @@ export const HistoryEditor = {
    * merged as usual.
    */
   withNewBatch(editor: HistoryEditor, fn: () => void): void {
-    const prevMerging = HistoryEditor.isMerging(editor)
+    const prev = HistoryEditor.isMerging(editor)
     MERGING.set(editor, true)
     SPLITTING_ONCE.set(editor, true)
     fn()
-    MERGING.set(editor, prevMerging)
+    MERGING.set(editor, prev)
     SPLITTING_ONCE.delete(editor)
   },
 

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -1,4 +1,4 @@
-import { Editor, Operation, Path, Range, Transforms } from 'slate'
+import { Editor, Operation, Path, Transforms } from 'slate'
 
 import { HistoryEditor } from './history-editor'
 
@@ -88,6 +88,11 @@ export const withHistory = <T extends Editor>(editor: T) => {
         } else {
           merge = shouldMerge(op, lastOp)
         }
+      }
+
+      if (HistoryEditor.isSplittingOnce(e)) {
+        merge = false
+        HistoryEditor.setSplittingOnce(e, undefined)
       }
 
       if (lastBatch && merge) {


### PR DESCRIPTION
**Description**
Add a new method `withNewBatch` to `HistoryEditor`. This method allows users to explicitly start a new batch in the history for the first operation, while merging subsequent operations as usual. This provides more fine-grained control over history management, particularly useful for complex editing operations that should be treated as a single unit in the undo/redo history.

**Example**
```ts
HistoryEditor.withNewBatch(editor, () => {
  // The first operation here will start a new batch in the history
  editor.insertText('Hello')
  
  // These operations will be merged into the new batch
  editor.insertText(' ')
  editor.insertText('World')
})
```

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

_Disclaimer: AI generated_