### PR TITLE
fix: Prevent domSelection.collapseToEnd crash in setDomSelection

### DIFF
--- a/.changeset/healthy-lizards-clap.md
+++ b/.changeset/healthy-lizards-clap.md
@@ -1,0 +1,5 @@
+---
+"slate-react": patch
+---
+
+fix: Prevent domSelection.collapseToEnd crash in setDomSelection

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -416,7 +416,11 @@ export const Editable = forwardRef(
           selection && ReactEditor.toDOMRange(editor, selection)
 
         if (newDomRange) {
-          if (ReactEditor.isComposing(editor) && domSelection.type !== 'None' && !IS_ANDROID) {
+          if (
+            ReactEditor.isComposing(editor) &&
+            hasDomSelection &&
+            !IS_ANDROID
+          ) {
             domSelection.collapseToEnd()
           } else if (Range.isBackward(selection!)) {
             domSelection.setBaseAndExtent(

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -416,7 +416,7 @@ export const Editable = forwardRef(
           selection && ReactEditor.toDOMRange(editor, selection)
 
         if (newDomRange) {
-          if (ReactEditor.isComposing(editor) && !IS_ANDROID) {
+          if (ReactEditor.isComposing(editor) && domSelection.type !== 'None' && !IS_ANDROID) {
             domSelection.collapseToEnd()
           } else if (Range.isBackward(selection!)) {
             domSelection.setBaseAndExtent(


### PR DESCRIPTION
**Description**
At the beginning of the paragraph, composing text and then deleting all unconfirmed characters causes the value of <code>domSelection.type</code> to be <code>None</code>, leading to an error.

![iShot_2024-10-28_20 31 19](https://github.com/user-attachments/assets/bb09793a-fdcb-4786-b1d4-b424822f1f08)

![image](https://github.com/user-attachments/assets/49241b44-5ed7-4f2d-ba08-77dc96cb42ff)




**Issue**
Fixes: (link to issue)

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

