### PR TITLE
Fix shadow DOM - drag-and-drop text throws error

### DIFF
--- a/packages/slate-react/src/custom-types.ts
+++ b/packages/slate-react/src/custom-types.ts
@@ -34,7 +34,11 @@ declare global {
   }
 
   interface Document {
-    caretPositionFromPoint(x: number, y: number): CaretPosition | null
+    caretPositionFromPoint(
+      x: number,
+      y: number,
+      options?: { shadowRoots?: ShadowRoot[] }
+    ): CaretPosition | null
   }
 
   interface Node {

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -341,7 +341,6 @@ export const ReactEditor: ReactEditorInterface = {
 
     const { textNode, offset } = closestChar
 
-    console.log('closestChar', textNode)
     const selection = getSelection(shadowRoot)
     selection?.setBaseAndExtent(textNode, offset, textNode, offset)
     const range = selection?.getRangeAt(0)

--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -355,3 +355,10 @@ export const isAfter = (node: DOMNode, otherNode: DOMNode): boolean =>
     node.compareDocumentPosition(otherNode) &
       DOMNode.DOCUMENT_POSITION_FOLLOWING
   )
+
+export const findTextNodesInNode = (node: Node): Text[] => {
+  if (isDOMText(node)) {
+    return [node as Text]
+  }
+  return Array.from(node.childNodes).flatMap(findTextNodesInNode)
+}

--- a/packages/slate-react/src/utils/find-closest-character-in-element-by-cursor-point.ts
+++ b/packages/slate-react/src/utils/find-closest-character-in-element-by-cursor-point.ts
@@ -1,0 +1,99 @@
+import { findTextNodesInNode } from './dom'
+
+export type CursorPoint = {
+  x: number
+  y: number
+}
+
+export type ClosestCharacter = {
+  offset: number
+  distance: number
+  textNode: Text
+}
+
+type CharDistanceFromCursorPoint = {
+  distanceX: number
+  distanceY: number
+  charCenterX: number
+  charCenterY: number
+  isCursorOnSameLine: boolean
+}
+
+const calculateCharDistance = (
+  cursorPoint: CursorPoint,
+  range: Range
+): CharDistanceFromCursorPoint => {
+  const rect = range.getBoundingClientRect()
+  const charCenterX = (rect.left + rect.right) / 2
+  const charCenterY = (rect.top + rect.bottom) / 2
+
+  return {
+    distanceX: Math.abs(cursorPoint.x - charCenterX),
+    distanceY: Math.abs(cursorPoint.y - charCenterY),
+    charCenterX,
+    charCenterY,
+    isCursorOnSameLine:
+      rect.top <= cursorPoint.y && rect.bottom >= cursorPoint.y,
+  }
+}
+
+const findClosestCharacterInSingleTextNode = (
+  textNode: Text,
+  cursorPoint: CursorPoint
+): ClosestCharacter | null => {
+  let closestChar: ClosestCharacter | null = null
+  let textLength = textNode.textContent?.length ?? 0
+
+  for (let i = 0; i < textLength; i++) {
+    const range = document.createRange()
+    range.setStart(textNode, i)
+    range.setEnd(textNode, i + 1)
+
+    const { distanceX, charCenterX, isCursorOnSameLine } =
+      calculateCharDistance(cursorPoint, range)
+
+    if (isCursorOnSameLine) {
+      const prevDistance: number = closestChar?.distance ?? Infinity
+      const newDistance: number = distanceX
+      const isCloser = newDistance < prevDistance
+
+      const isOnLeftSideOfCursor = cursorPoint.x < charCenterX
+      const offset = isOnLeftSideOfCursor ? i : i + 1
+
+      closestChar = isCloser
+        ? { offset, distance: newDistance, textNode }
+        : closestChar
+    }
+  }
+
+  return closestChar
+}
+
+const findClosestCharacterForTextNodes = (
+  textNodes: Text[],
+  cursorPoint: CursorPoint
+): ClosestCharacter | null => {
+  let closestInNode = null
+
+  for (const textNode of textNodes) {
+    const newResult = findClosestCharacterInSingleTextNode(
+      textNode,
+      cursorPoint
+    )
+    const prevDistance: number = closestInNode?.distance ?? Infinity
+    const newDistance: number = newResult?.distance ?? Infinity
+    const isCloser = newDistance < prevDistance
+
+    closestInNode = isCloser ? newResult : closestInNode
+  }
+
+  return closestInNode
+}
+
+export const findClosestCharacterToCursorPoint = (
+  elementUnderCursor: Element,
+  cursorPoint: CursorPoint
+): ClosestCharacter | null => {
+  const textNodes = findTextNodesInNode(elementUnderCursor)
+  return findClosestCharacterForTextNodes(textNodes, cursorPoint)
+}

--- a/packages/slate-react/src/utils/find-closest-character-in-element-by-cursor-point.ts
+++ b/packages/slate-react/src/utils/find-closest-character-in-element-by-cursor-point.ts
@@ -42,7 +42,7 @@ const findClosestCharacterInSingleTextNode = (
   cursorPoint: CursorPoint
 ): ClosestCharacter | null => {
   let closestChar: ClosestCharacter | null = null
-  let textLength = textNode.textContent?.length ?? 0
+  const textLength = textNode.textContent?.length ?? 0
 
   for (let i = 0; i < textLength; i++) {
     const range = document.createRange()

--- a/playwright/integration/examples/shadow-dom.test.ts
+++ b/playwright/integration/examples/shadow-dom.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { dispatchDropEvent } from '../../playwrightTestHelpers'
 
 test.describe('shadow-dom example', () => {
   test.beforeEach(
@@ -28,5 +29,26 @@ test.describe('shadow-dom example', () => {
 
     // Assert that the textbox contains the correct text
     await expect(textbox).toHaveText('Hello, Playwright!')
+  })
+  test('drag and drop text above the textbox', async ({ page }) => {
+    const outerShadow = page.locator('[data-cy="outer-shadow-root"]')
+    const innerShadow = outerShadow.locator('> div')
+
+    const textbox = innerShadow.getByRole('textbox')
+    await textbox.fill('test ')
+
+    const droppedText = 'droppedText'
+    const textboxEl = (await textbox.elementHandle()) as HTMLElement
+    const { x, y, width, height } = await textbox.boundingBox()
+    await dispatchDropEvent({
+      page,
+      element: textboxEl,
+      droppedText: droppedText,
+      clientX: x + width - 5,
+      clientY: y + height / 2,
+    })
+
+    const expectedText = `test ${droppedText}`
+    await expect(textbox).toHaveText(expectedText)
   })
 })

--- a/playwright/playwrightTestHelpers.ts
+++ b/playwright/playwrightTestHelpers.ts
@@ -1,0 +1,43 @@
+import { Page } from '@playwright/test'
+
+export type DisptachDropEvent = {
+  page: Page
+  element: Element
+  droppedText: string
+  clientX: number
+  clientY: number
+}
+
+export const dispatchDropEvent = async ({
+  page,
+  element,
+  droppedText,
+  clientX,
+  clientY,
+}: DisptachDropEvent) =>
+  page.evaluate(
+    ({
+      element,
+      droppedText,
+      clientX,
+      clientY,
+    }: Omit<DisptachDropEvent, 'page'>) => {
+      const fragmentData = JSON.stringify([{ type: 'text', text: droppedText }])
+      const encodedFragment = btoa(encodeURIComponent(fragmentData))
+
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData(`application/x-slate-fragment`, encodedFragment)
+      const eventInit: DragEventInit = {
+        bubbles: true,
+        cancelable: true,
+        clientX,
+        clientY,
+        dataTransfer: dataTransfer,
+      }
+
+      const event = new DragEvent('drop', eventInit)
+
+      element.dispatchEvent(event)
+    },
+    { element, droppedText, clientX, clientY }
+  )


### PR DESCRIPTION
Fix an error when dragging and dropping text in a Slate editor inside a Shadow DOM, resulting in:
Error: Cannot resolve a Slate point from DOM point: [object HTMLDivElement],0.

**Issue**
Fixes: [[Link to issue]](https://github.com/ianstormtaylor/slate/issues/5749#issue-2600783236)

![Screencastfrom2024-10-2020-38-28-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/46c94e87-18d6-4c5e-9b26-446f023d765b)

**Context**

The existing support for the third parameter options in caretPositionFromPoint is limited. To address this issue, additional logic was implemented to find the nearest character next to the cursor at the time of the drop event. This ensures that the drag-and-drop functionality works as expected within the constraints of the Shadow DOM.

**Checks**
- [x] The new code matches the existing patterns and styles. 
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

