### PR TITLE
Fix: Handle deleteText for more than Thai language

### DIFF
--- a/packages/slate/src/transforms-text/delete-text.ts
+++ b/packages/slate/src/transforms-text/delete-text.ts
@@ -169,7 +169,7 @@ export const deleteText: TextTransforms['delete'] = (editor, options = {}) => {
       })
     }
 
-    // For Thai script, deleting N character(s) backward should delete
+    // For Thai, Khmer, Lao, Burmese script, deleting N character(s) backward should delete
     // N code point(s) instead of an entire grapheme cluster.
     // Therefore, the remaining code points should be inserted back.
     if (
@@ -177,7 +177,7 @@ export const deleteText: TextTransforms['delete'] = (editor, options = {}) => {
       reverse &&
       unit === 'character' &&
       removedText.length > 1 &&
-      removedText.match(/[\u0E00-\u0E7F]+/)
+      removedText.match(/[\u0E00-\u0E7F\u1780-\u17ff\u0E80-\u0EFF\u1000-\u109F]+/)
     ) {
       Transforms.insertText(
         editor,


### PR DESCRIPTION
**Description**

Currently, it deletes a grapheme cluster at a time for Khmer, Lao, and Burmese. Add the same functionality as Thai language.


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

