### PR TITLE
Use extended `Editor` type in `useSlateWithV` return type

### DIFF
--- a/.changeset/eleven-cycles-kneel.md
+++ b/.changeset/eleven-cycles-kneel.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Use extended `Editor` type in `useSlateWithV` return type

--- a/docs/libraries/slate-react/hooks.md
+++ b/docs/libraries/slate-react/hooks.md
@@ -28,15 +28,15 @@ Get the current `selected` state of an element.
 
 ### Editor hooks
 
-#### `useSlate(): ReactEditor`
+#### `useSlate(): Editor`
 
 Get the current editor object from the React context. Re-renders the context whenever changes occur in the editor.
 
-#### `useSlateWithV(): { editor: ReactEditor, v: number }`
+#### `useSlateWithV(): { editor: Editor, v: number }`
 
 The same as `useSlate()` but includes a version counter which you can use to prevent re-renders.
 
-#### `useSlateStatic(): ReactEditor`
+#### `useSlateStatic(): Editor`
 
 Get the current editor object from the React context. A version of useSlate that does not re-render the context. Previously called `useEditor`.
 

--- a/packages/slate-react/src/hooks/use-slate.tsx
+++ b/packages/slate-react/src/hooks/use-slate.tsx
@@ -34,7 +34,7 @@ export const useSlate = (): Editor => {
   return editor
 }
 
-export const useSlateWithV = () => {
+export const useSlateWithV = (): { editor: Editor; v: number } => {
   const context = useContext(SlateContext)
 
   if (!context) {


### PR DESCRIPTION
## Description

The `useSlateWithV` return object's `editor` property is currently typed as just a `ReactEditor`, which causes type errors in our app when we try to use it as the extended `Editor` type. This change brings `useSlateWithV`'s return type in line with those of `useSlate` and `useSlateStatic`.

## Checks

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

