### PR TITLE
docs: specify default value of `edge` in `Editor.point` as `start`

### DIFF
--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -165,7 +165,7 @@ Options: `{depth?: number, edge?: 'start' | 'end'}`
 
 #### `Editor.point(editor: Editor, at: Location, options?) => Point`
 
-Get the start or end point of a location.
+Get the `start` or `end` (default is `start`) point of a location.
 
 Options: `{edge?: 'start' | 'end'}`
 


### PR DESCRIPTION
Clarify in the documentation that the default value for `edge` in `Editor.point` is `start`. 

This is helpful for developers who are not deeply familiar with the framework but need to quickly use it for development. 

They no longer need to inspect the source code or experiment with sample code to understand the default behavior.

**Description**

**Issue**

**Example**

**Context**

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

