### PR TITLE
Fix `normalizeNode` to keep text/inline nodes when removing blocks

### DIFF
--- a/.changeset/large-cars-itch.md
+++ b/.changeset/large-cars-itch.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Keep data in normalization when blocks are not allowed

--- a/packages/slate/src/core/normalize-node.ts
+++ b/packages/slate/src/core/normalize-node.ts
@@ -53,7 +53,11 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     // other inline nodes, or parent blocks that only contain inlines and
     // text.
     if (isInlineOrText !== shouldHaveInlines) {
-      Transforms.removeNodes(editor, { at: path.concat(n), voids: true })
+      if (isInlineOrText) {
+        Transforms.removeNodes(editor, { at: path.concat(n), voids: true })
+      } else {
+        Transforms.unwrapNodes(editor, { at: path.concat(n), voids: true })
+      }
       n--
     } else if (Element.isElement(child)) {
       // Ensure that inline nodes are surrounded by text nodes.

--- a/packages/slate/test/normalization/block/remove-block.tsx
+++ b/packages/slate/test/normalization/block/remove-block.tsx
@@ -12,7 +12,7 @@ export const input = (
 export const output = (
   <editor>
     <block>
-      <text>one</text>
+      <text>onetwo</text>
     </block>
   </editor>
 )

--- a/packages/slate/test/normalization/inline/remove-block.tsx
+++ b/packages/slate/test/normalization/inline/remove-block.tsx
@@ -20,7 +20,7 @@ export const output = (
     <block>
       <text />
       <inline>
-        <text>twofour</text>
+        <text>onetwothreefour</text>
       </inline>
       <text />
     </block>


### PR DESCRIPTION
**Description**
`normalizeNode` ensures that all children of a node are either all blocks or inline/text nodes.
When blocks need to be removed, we can at least unwrap the nodes instead of removing them altogether and thus prevent data loss.
(As normalization is called again on changes, this recursively ensures that the inline/text nodes contained in a block eventually remain.
The other way round, i.e. when inline/text nodes need to be removed, is not fixable, since we do not know which block element to use to wrap the inline/text nodes.)

**Issue**
Fixes: no issue created yet

**Example**
See the changed unit tests. Instead of throwing away text nodes contained in a block, the inner text nodes are added to the parent node (and then merged).

**Context**
This change improves resiliency on invalid documents, e.g. if documents can be changed manually, uploaded by an API, another normalization function ill-behaves, or some other way exists to create invalid documents.
Without the change, on the first edit action in the editor, the document would be normalized and data is lost without an easy way for a user to cope with the behavior (you cannot copy & paste part of the editor because this would by default result in the same problem, the pasted part would be normalized and thrown away).

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

