### PR TITLE
feat: add optional merge method to decoration object

### DIFF
--- a/.changeset/tiny-cheetahs-ring.md
+++ b/.changeset/tiny-cheetahs-ring.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Add `merge` optional function to decorations and change related type signatures to `DecoratedRange`. Now developers can specify how two decoration object with the same key but different value are merged together if they overlap"

--- a/docs/api/nodes/text.md
+++ b/docs/api/nodes/text.md
@@ -26,7 +26,7 @@ If a `props.text` property is passed in, it will be ignored.
 
 If there are properties in `text` that are not in `props`, those will be ignored when it comes to testing for a match.
 
-#### `Text.decorations(node: Text, decorations: Range[]) => Text[]`
+#### `Text.decorations(node: Text, decorations: DecoratedRange[]) => Text[]`
 
 Get the leaves for a text node, given `decorations`.
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -22,6 +22,7 @@ import {
   Range,
   Text,
   Transforms,
+  DecoratedRange,
 } from 'slate'
 import { useAndroidInputManager } from '../hooks/android-input-manager/use-android-input-manager'
 import useChildren from '../hooks/use-children'
@@ -116,7 +117,7 @@ export interface RenderLeafProps {
  */
 
 export type EditableProps = {
-  decorate?: (entry: NodeEntry) => Range[]
+  decorate?: (entry: NodeEntry) => DecoratedRange[]
   onDOMBeforeInput?: (event: InputEvent) => void
   placeholder?: string
   readOnly?: boolean
@@ -1876,7 +1877,7 @@ export const DefaultPlaceholder = ({
  * A default memoized decorate function.
  */
 
-export const defaultDecorate: (entry: NodeEntry) => Range[] = () => []
+export const defaultDecorate: (entry: NodeEntry) => DecoratedRange[] = () => []
 
 /**
  * A default implement to scroll dom range into view.

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -1,7 +1,13 @@
 import getDirection from 'direction'
 import React, { useCallback } from 'react'
 import { JSX } from 'react'
-import { Editor, Element as SlateElement, Node, Range } from 'slate'
+import {
+  Editor,
+  Element as SlateElement,
+  Node,
+  Range,
+  DecoratedRange,
+} from 'slate'
 import { ReactEditor, useReadOnly, useSlateStatic } from '..'
 import useChildren from '../hooks/use-children'
 import { isElementDecorationsEqual } from 'slate-dom'
@@ -25,7 +31,7 @@ import Text from './text'
  */
 
 const Element = (props: {
-  decorations: Range[]
+  decorations: DecoratedRange[]
   element: SlateElement
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element

--- a/packages/slate-react/src/components/text.tsx
+++ b/packages/slate-react/src/components/text.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react'
-import { Element, Range, Text as SlateText } from 'slate'
+import { Element, DecoratedRange, Text as SlateText } from 'slate'
 import { ReactEditor, useSlateStatic } from '..'
 import { isTextDecorationsEqual } from 'slate-dom'
 import {
@@ -15,7 +15,7 @@ import Leaf from './leaf'
  */
 
 const Text = (props: {
-  decorations: Range[]
+  decorations: DecoratedRange[]
   isLast: boolean
   parent: Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { Ancestor, Descendant, Editor, Element, Range } from 'slate'
+import {
+  Ancestor,
+  Descendant,
+  Editor,
+  Element,
+  Range,
+  DecoratedRange,
+} from 'slate'
 import {
   RenderElementProps,
   RenderLeafProps,
@@ -19,7 +26,7 @@ import { useSlateStatic } from './use-slate-static'
  */
 
 const useChildren = (props: {
-  decorations: Range[]
+  decorations: DecoratedRange[]
   node: Ancestor
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element

--- a/packages/slate-react/src/hooks/use-decorate.ts
+++ b/packages/slate-react/src/hooks/use-decorate.ts
@@ -1,18 +1,18 @@
 import { createContext, useContext } from 'react'
-import { Range, NodeEntry } from 'slate'
+import { DecoratedRange, NodeEntry } from 'slate'
 
 /**
  * A React context for sharing the `decorate` prop of the editable.
  */
 
-export const DecorateContext = createContext<(entry: NodeEntry) => Range[]>(
-  () => []
-)
+export const DecorateContext = createContext<
+  (entry: NodeEntry) => DecoratedRange[]
+>(() => [])
 
 /**
  * Get the current `decorate` prop of the editable.
  */
 
-export const useDecorate = (): ((entry: NodeEntry) => Range[]) => {
+export const useDecorate = (): ((entry: NodeEntry) => DecoratedRange[]) => {
   return useContext(DecorateContext)
 }

--- a/packages/slate/test/interfaces/Text/decorations/merge.ts
+++ b/packages/slate/test/interfaces/Text/decorations/merge.ts
@@ -1,0 +1,54 @@
+import { Text } from 'slate'
+
+const merge = (leaf: Text, dec: { decoration: number[] }) => {
+  const { decoration, ...rest } = dec
+  leaf.decoration = [...(leaf.decoration ?? []), ...decoration]
+  Object.assign(leaf, rest)
+}
+
+export const input = [
+  {
+    anchor: {
+      path: [0],
+      offset: 0,
+    },
+    focus: {
+      path: [0],
+      offset: 2,
+    },
+    merge,
+    decoration: [1, 2, 3],
+  },
+  {
+    anchor: {
+      path: [0],
+      offset: 1,
+    },
+    focus: {
+      path: [0],
+      offset: 3,
+    },
+    merge,
+    decoration: [4, 5, 6],
+  },
+]
+export const test = decorations => {
+  return Text.decorations({ text: 'abc', mark: 'mark' }, decorations)
+}
+export const output = [
+  {
+    text: 'a',
+    mark: 'mark',
+    decoration: [1, 2, 3],
+  },
+  {
+    text: 'b',
+    mark: 'mark',
+    decoration: [1, 2, 3, 4, 5, 6],
+  },
+  {
+    text: 'c',
+    mark: 'mark',
+    decoration: [4, 5, 6],
+  },
+]


### PR DESCRIPTION
**Description**
Currently, when decorations overlap with each other and they are merging with each other, `Object.assign` is used.
However, if two decorations with the same key has different values, one of the decoration will overwrite the other.

``` js
// text content: `them are happy`
// decoration 1:
{
  anchor: {
    path: [0],
    offset: 0,
  },
  focus: {
    path: [0],
    offset: 1,
  },
  message: '`t` should be upper case.'
}

// decoration 2:
{
  anchor: {
    path: [0],
    offset: 0,
  },
  focus: {
    path: [0],
    offset: 4,
  },
  message: 'The correct word is `they`.'
}
```

In this example, two messages cannot be shown together due to `Object.assign` overwriting behavior.


**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

After adding a function `merge` to the decoration, two messages can be merged together:

``` js
// text content: `them are happy`

const merge = (leaf, decoration) => {
  const { messages, ...rest } = decoration;
  leaf.messages = [...(leaf.messages ?? []), ...messages];
  Object.assign(leaf, rest);
}

// decoration 1:
{
  anchor: {
    path: [0],
    offset: 0,
  },
  focus: {
    path: [0],
    offset: 1,
  },
  merge,
  messages: ['`t` should be upper case.']
}

// decoration 2:
{
  anchor: {
    path: [0],
    offset: 0,
  },
  focus: {
    path: [0],
    offset: 4,
  },
  merge,
  messages: ['The correct word is `they`.']
}
```

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

