### PR TITLE
fix: selectionchange render when user trigger

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -861,7 +861,11 @@ export const Editable = forwardRef(
       // (2019/11/04) https://github.com/facebook/react/issues/5785
       window.document.addEventListener(
         'selectionchange',
-        scheduleOnDOMSelectionChange
+        ()=>{
+          if(mouseDown.current){
+            scheduleOnDOMSelectionChange()
+          }
+        }
       )
 
       // Listen for dragend and drop globally. In Firefox, if a drop handler

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -165,7 +165,7 @@ export const Editable = forwardRef(
       number | undefined
     >()
     const processing = useRef(false)
-
+    const mouseDown = useRef(false)
     const { onUserInput, receivedUserInput } = useTrackUserInput()
 
     const [, forceRender] = useReducer(s => s + 1, 0)
@@ -456,9 +456,7 @@ export const Editable = forwardRef(
         androidInputManagerRef.current?.isFlushing() === 'action'
 
       if (!IS_ANDROID || !ensureSelection) {
-        setTimeout(() => {
-          state.isUpdatingSelection = false
-        })
+        state.isUpdatingSelection = false
         return
       }
 
@@ -1162,8 +1160,9 @@ export const Editable = forwardRef(
                     attributes.onBlur,
                   ]
                 )}
-                onClick={useCallback(
+                onMouseDown={useCallback(
                   (event: React.MouseEvent<HTMLDivElement>) => {
+                    mouseDown.current = true
                     if (
                       ReactEditor.hasTarget(editor, event.target) &&
                       !isEventHandled(event, attributes.onClick) &&
@@ -1224,8 +1223,11 @@ export const Editable = forwardRef(
                       }
                     }
                   },
-                  [editor, attributes.onClick, readOnly]
+                  [editor, attributes.onMouseDown, readOnly]
                 )}
+                onMouseUp={useCallback(() => {
+                  mouseDown.current = false
+                }, [])}
                 onCompositionEnd={useCallback(
                   (event: React.CompositionEvent<HTMLDivElement>) => {
                     if (ReactEditor.hasSelectableTarget(editor, event.target)) {


### PR DESCRIPTION
The PR is to completely solve issue1 in https://github.com/ianstormtaylor/slate/issues/5771 by controlling the triggering behavior of users.

This PR is inherited from https://github.com/ianstormtaylor/slate/pull/5772 . Due to uncertainty about the side effects brought by this PR, it is temporarily submitted as a draft PR. In this https://github.com/ianstormtaylor/slate/pull/5772, in order to solve issue1 inside, I added a variable named `onDOMSelectionChangeThrottleTime`. 

Then, I found that when this variable is set to the extremely small value of 0, there is still a 20-30% probability that the selection area is invalid when the QPS is 50, and a second click is required to select the selection area. 

Therefore, referring to the event triggering of quill, https://github.com/slab/quill/blob/20f02f55e30ca87c0c539632b36c6c52ca4670eb/packages/quill/src/core/selection.ts#L54-L68

The onClick event was changed to onMouseUp and onMouseDown (the main reason is that the timing of the onClick event is too late. When the onClick event is triggered, the selection area has already changed). And these two events generate a variable mouseDown, which is used to control the triggering of selectionchange. This ensures that only user actions can trigger selectionchange, and API actions cannot actively trigger it. The `setTimeout` in https://github.com/ianstormtaylor/slate/blob/5a1c728c62bcc6bafe60b9598946bb3adde21cdf/packages/slate-react/src/components/editable.tsx#L459-L462 seems to cause abnormal behavior of the selection area. Changing it to synchronously call state.isUpdatingSelection as in the PR will not cause abnormalities. What is this design for?
