### PR TITLE
Issue 5782

### DIFF
--- a/docs/libraries/slate-react/editable.md
+++ b/docs/libraries/slate-react/editable.md
@@ -165,13 +165,21 @@ An example usage might look like:
 
 ```jsx
 <Editable
-  renderPlaceholder={({ attributes, children }) => (
-    <div {...attributes} style={{ fontStyle: 'italic', color: 'gray' }}>
-      {children}
-    </div>
-  )}
+  placeholder="Enter text here..."
+  renderPlaceholder={({ attributes, children }) => {
+    const styledAttributes = {
+      ...attributes,
+      style: {
+        ...attributes.style,
+        color: 'gray',
+      },
+    };
+    return <div {...styledAttributes}>{children}</div>;
+  }}
 />
 ```
+
+Note that the `attributes` prop that comes in will contain a `style` object already. This object contains important styling properties which will make the placeholder behave like a placeholder. As such, it is advisible to extend styles and to focus on things like changing colors, opacity etc. Changing positioning, for example, could cause undesirable behavior.
 
 #### `scrollSelectionIntoView?: (editor: ReactEditor, domRange: DOMRange) => void`
 


### PR DESCRIPTION
**Description**
Fixes issue where instructions for renderProps in the react-slate documentation, if followed properly, produce an undesirable effect. This PR updates instructions such that a user can re-style the placeholder while still maintaining desirable default behavior

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5782

**Example**
```
<Editable
  placeholder="Enter text here..."
  renderPlaceholder={({ attributes, children }) => {
    const styledAttributes = {
      ...attributes,
      style: {
        ...attributes.style,
        color: 'gray',
      },
    };
    return <div {...styledAttributes}>{children}</div>;
  }}
/>
```

**Context**
It was noticed that, when following the docs exactly, for renderProps within react-slate that the placeholder was behaving strangely. It was then noticed that in the docs the style prop that came in from `attributes` was being completely overridden. This was creating a situation where the placeholder exhibited some strange and undesirable behavior. The documentation has been updated so that the `attributes` prop that comes in is extended upon instead of overwritten entirely. This allows a user to do things like change the color, opacity, etc without overwriting critical style related props.

**Checks**
No checks necessary; only a documentation change

