### PR TITLE
fix: supplement of (fix: Prevent ReactEditor.toDOMRange crash in setDomSelection #5741)

### DIFF
--- a/.changeset/gold-tomatoes-grab.md
+++ b/.changeset/gold-tomatoes-grab.md
@@ -1,0 +1,5 @@
+---
+'slate-dom': patch
+---
+
+fix: additional fix for previous fix: Prevent ReactEditor.toDOMRange crash in setDomSelection #5741

--- a/packages/slate-dom/src/plugin/with-dom.ts
+++ b/packages/slate-dom/src/plugin/with-dom.ts
@@ -215,7 +215,7 @@ export const withDOM = <T extends BaseEditor>(
       case 'remove_text':
       case 'set_selection': {
         // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED
-        // to better reflect reality, see #5792 
+        // to better reflect reality, see #5792
         IS_NODE_MAP_DIRTY.set(e, true)
       }
     }

--- a/packages/slate-dom/src/plugin/with-dom.ts
+++ b/packages/slate-dom/src/plugin/with-dom.ts
@@ -214,6 +214,7 @@ export const withDOM = <T extends BaseEditor>(
       case 'insert_text':
       case 'remove_text':
       case 'set_selection': {
+        // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED to better reflect reality, see #5792 
         IS_NODE_MAP_DIRTY.set(e, true)
       }
     }

--- a/packages/slate-dom/src/plugin/with-dom.ts
+++ b/packages/slate-dom/src/plugin/with-dom.ts
@@ -214,7 +214,7 @@ export const withDOM = <T extends BaseEditor>(
       case 'insert_text':
       case 'remove_text':
       case 'set_selection': {
-        // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED 
+        // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED
         // to better reflect reality, see #5792 
         IS_NODE_MAP_DIRTY.set(e, true)
       }

--- a/packages/slate-dom/src/plugin/with-dom.ts
+++ b/packages/slate-dom/src/plugin/with-dom.ts
@@ -210,7 +210,10 @@ export const withDOM = <T extends BaseEditor>(
       case 'remove_node':
       case 'merge_node':
       case 'move_node':
-      case 'split_node': {
+      case 'split_node':
+      case 'insert_text':
+      case 'remove_text':
+      case 'set_selection': {
         IS_NODE_MAP_DIRTY.set(e, true)
       }
     }

--- a/packages/slate-dom/src/plugin/with-dom.ts
+++ b/packages/slate-dom/src/plugin/with-dom.ts
@@ -214,7 +214,8 @@ export const withDOM = <T extends BaseEditor>(
       case 'insert_text':
       case 'remove_text':
       case 'set_selection': {
-        // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED to better reflect reality, see #5792 
+        // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED 
+        // to better reflect reality, see #5792 
         IS_NODE_MAP_DIRTY.set(e, true)
       }
     }


### PR DESCRIPTION
Sorry, ue to the problem of English writing ability, the following English content is translated from Chinese by claude3.5


**Description**
```任何会改变 selection 的 op 同步到 dom 之前，onDOMSelectionChange 都不应该执行```
onDOMSelectionChange should not be executed before any selection-changing operations are synchronized to the DOM

**Issue**
```所有出现”Cannot resolve a DOM point from Slate point“的 issue 可能都是，包括但不限于：```
Maybe all issues where 'Cannot resolve a DOM point from Slate point' occurs include but are not limited to:

Fixes: (link to issue)
https://github.com/ianstormtaylor/slate/issues/5694

**Example**
```
在协同场景下很常见，例如内容 ‘1234567'，光标在末尾
1. 当前用户光标 selection 在 path: [0,0], offset: 7
2. 收到一条 op ，删除 '7'，在相关处理中（applyToDraft），selection 的 offset 会变成6
3. 所有状态渲染至 dom ，在这之前，Editable.tsx 306 line 的 useIsomorphicLayoutEffect 会把 editor.selection 转变为 domSelection

上面的步骤是理想步骤，但是问题就出在 2 和 3 之间，可能会执行 onDOMSelectionChange （throttle 导致其执行时机不确定）
onDOMSelectionChange 做了下面的事情：
Line 279: Transforms.select(editor, range)
在此之前，editor.selection 由 [0,0], 7 变更为 [0,0], 6，但尚未同步至 domSelection 
然而在 onDOMSelectionChange 这里，会读取同步前旧的 domSelection，将其同步给 editor.selection，将 [0,0],6 又变回了 [0,0], 7

然而在删除'7'这个操作渲染到 dom 后，useIsomorphicLayoutEffect 又会同步一遍 editor.selection & domSelection。
此时页面 dom 上 '7' 已经不存在，导致 Cannot resolve a Slate point from DOM point: {path: [0,0], offset: 7}
```

This is common in collaborative scenarios. For example, with content '1234567' and cursor at the end:

1. Current user's selection is at path: [0,0], offset: 7
2. Receives an operation that deletes '7'. During processing (applyToDraft), the selection's offset changes to 6
3. All states are rendered to DOM. Before this, the useIsomorphicLayoutEffect at line 306 in Editable.tsx will convert editor.selection to domSelection

These are the ideal steps, but the issue occurs between steps 2 and 3, where onDOMSelectionChange might execute (timing is uncertain due to throttle).

onDOMSelectionChange performs the following:
Line 279: Transforms.select(editor, range)
Before this, editor.selection changed from [0,0], 7 to [0,0], 6, but hasn't been synchronized to domSelection yet.
However, onDOMSelectionChange reads the old domSelection before synchronization and syncs it back to editor.selection, changing [0,0], 6 back to [0,0], 7.

After the operation to delete '7' is rendered to DOM, useIsomorphicLayoutEffect will synchronize editor.selection & domSelection again.
At this point, '7' no longer exists in the page DOM, leading to "Cannot resolve a DOM point from Slate point: {path: [0,0], offset: 7}"

**Context**
thanks to
[Commit e97a9f8](https://github.com/ianstormtaylor/slate/commit/e97a9f8857b24d57c1386b2d01e9922360f98599)


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

