### PR TITLE
Ignore `selectionchange` events originating from `<input>` and `<textarea>` elements

### DIFF
--- a/.changeset/empty-pillows-exercise.md
+++ b/.changeset/empty-pillows-exercise.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Ignore selectionchange events originating from input and textarea elements (addresses Chrome bug https://issues.chromium.org/issues/389368412)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -856,15 +856,25 @@ export const Editable = forwardRef(
     useIsomorphicLayoutEffect(() => {
       const window = ReactEditor.getWindow(editor)
 
+      // COMPAT: In Chrome, `selectionchange` events can fire when <input> and
+      // <textarea> elements are appended to the DOM, causing
+      // `editor.selection` to be overwritten in some circumstances.
+      // (2025/01/16) https://issues.chromium.org/issues/389368412
+      const onSelectionChange = ({ target }: Event) => {
+        const targetElement = target instanceof HTMLElement ? target : null
+        const targetTagName = targetElement?.tagName
+        if (targetTagName === 'INPUT' || targetTagName === 'TEXTAREA') {
+          return
+        }
+        scheduleOnDOMSelectionChange()
+      }
+
       // Attach a native DOM event handler for `selectionchange`, because React's
       // built-in `onSelect` handler doesn't fire for all selection changes. It's
       // a leaky polyfill that only fires on keypresses or clicks. Instead, we
       // want to fire for any change to the selection inside the editor.
       // (2019/11/04) https://github.com/facebook/react/issues/5785
-      window.document.addEventListener(
-        'selectionchange',
-        scheduleOnDOMSelectionChange
-      )
+      window.document.addEventListener('selectionchange', onSelectionChange)
 
       // Listen for dragend and drop globally. In Firefox, if a drop handler
       // initiates an operation that causes the originally dragged element to
@@ -876,9 +886,8 @@ export const Editable = forwardRef(
       window.document.addEventListener('drop', stoppedDragging)
 
       return () => {
-        window.document.removeEventListener(
-          'selectionchange',
-          scheduleOnDOMSelectionChange
+        window.document.removeEventListener('selectionchange',
+          onSelectionChange
         )
         window.document.removeEventListener('dragend', stoppedDragging)
         window.document.removeEventListener('drop', stoppedDragging)

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -886,7 +886,8 @@ export const Editable = forwardRef(
       window.document.addEventListener('drop', stoppedDragging)
 
       return () => {
-        window.document.removeEventListener('selectionchange',
+        window.document.removeEventListener(
+          'selectionchange',
           onSelectionChange
         )
         window.document.removeEventListener('dragend', stoppedDragging)


### PR DESCRIPTION
**Description**
In Chrome, `selectionchange` events can fire when `<input>` and `<textarea>` elements are appended to the DOM, causing `editor.selection` to be overwritten in some circumstances. This PR addresses this issue by ignoring `selectionchange` events originating from these elements.

**Issue**
Fixes: #5791

**Example**
Before:

https://github.com/user-attachments/assets/1e550014-0ece-4354-b768-13b23da8b93b

After:

https://github.com/user-attachments/assets/49113ad1-1046-4cfc-8b3f-94efb6ef3250

**Context**
Although Chrome's behaviour is apparently [compliant with the spec](https://issues.chromium.org/issues/389368412#comment9), other browsers do not behave this way, and the spec may at some point be changed to match other browsers' behaviour. See the [Chromium issue](https://issues.chromium.org/issues/389368412) for more information.

I'm fairly sure that ignoring `selectionchange` events from `<input>` and `<textarea>` elements will not cause other issues, since actual text selections in these elements do not affect `editor.selection`. However, if this PR causes a regression, feel free to revert it, since any bug it causes is likely to be more common than the one it fixes.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

