### PR TITLE
docs: Fix link references to examples in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,15 +103,15 @@ Check out the [**live demo**](http://slatejs.org) of all of the examples!
 
 To get a sense for how you might use Slate, check out a few of the examples:
 
-- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/plaintext.tsx) — showing the most basic case: a glorified `<textarea>`.
-- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/richtext.tsx) — showing the features you'd expect from a basic editor.
-- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/markdown-preview.tsx) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Inlines**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/inlines.tsx) — showing how wrap text in inline nodes with associated data.
-- [**Images**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/images.tsx) — showing how to use void (text-less) nodes to add images.
-- [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/hovering-toolbar.tsx) — showing how a hovering toolbar can be implemented.
-- [**Tables**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/tables.tsx) — showing how to nest blocks to render more advanced components.
-- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/paste-html.tsx) — showing how to use an HTML serializer to handle pasted HTML.
-- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/mentions.tsx) — showing how to use inline void nodes for simple @-mentions.
+- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/plaintext.tsx) — showing the most basic case: a glorified `<textarea>`.
+- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/richtext.tsx) — showing the features you'd expect from a basic editor.
+- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/markdown-preview.tsx) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Inlines**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/inlines.tsx) — showing how wrap text in inline nodes with associated data.
+- [**Images**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/images.tsx) — showing how to use void (text-less) nodes to add images.
+- [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/hovering-toolbar.tsx) — showing how a hovering toolbar can be implemented.
+- [**Tables**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/tables.tsx) — showing how to nest blocks to render more advanced components.
+- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/paste-html.tsx) — showing how to use an HTML serializer to handle pasted HTML.
+- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/ts/mentions.tsx) — showing how to use inline void nodes for simple @-mentions.
 - [**See all the examples...**](https://github.com/ianstormtaylor/slate/tree/main/site/examples/)
 
 If you have an idea for an example that shows a common use case, pull request it!


### PR DESCRIPTION
**Description**
I noticed that the link references in the Readme for examples were broken, I updated them to the correct references.
