### PR TITLE
Fix: Ensure block transformation works in the example

### DIFF
--- a/docs/walkthroughs/04-applying-custom-formatting.md
+++ b/docs/walkthroughs/04-applying-custom-formatting.md
@@ -39,7 +39,7 @@ const App = () => {
             Transforms.setNodes(
               editor,
               { type: match ? 'paragraph' : 'code' },
-              { match: n => Editor.isBlock(editor, n) }
+              { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
             )
           }
         }}
@@ -90,7 +90,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { type: match ? 'paragraph' : 'code' },
-                { match: n => Editor.isBlock(editor, n) }
+                { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
               )
               break
             }
@@ -178,7 +178,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: n => Editor.isBlock(editor, n) }
+                { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
               )
               break
             }


### PR DESCRIPTION
**Description**
I noticed that the current example for toggling a code block using the backtick key doesn't work as expected. The issue occurs because `Editor.nodes()` can return text nodes instead of block elements, causing`Transforms.setNodes()` to fail.

To fix this, I added an extra check using `Element.isElement(n)`, ensuring that only block elements are transformed.

**Issue**
[Slate docs - Applying Custom Formatting](https://docs.slatejs.org/walkthroughs/04-applying-custom-formatting)

**Example**
Before the fix: 
Pressing the backtick key sometimes fails to toggle a code block due to Transforms.setNodes() being applied to text nodes - [demo](https://codesandbox.io/p/sandbox/ph86gf).

After the fix:
The backtick key now correctly toggles a code block, as the logic ensures only block elements are transformed - [demo](https://codesandbox.io/p/sandbox/9dnlcn)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

