### PR TITLE
fix（docs）: correct block matching condition in `Executing Commands` e…

### DIFF
--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -53,7 +53,7 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: n => Editor.isBlock(editor, n) }
+                { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
               )
               break
             }
@@ -105,7 +105,7 @@ const CustomEditor = {
     Transforms.setNodes(
       editor,
       { type: isActive ? null : 'code' },
-      { match: n => Editor.isBlock(editor, n) }
+      { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
     )
   },
 }


### PR DESCRIPTION
**Description**
Fix a problem in the `Executing Commands` section of the documentation where the Generate Block command lacks judgement on the element, causing the code not to work.

**Context**
[Applying Custom Formatting](https://docs.slatejs.org/walkthroughs/04-applying-custom-formatting)
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/94cb3713-5d49-4501-a879-0982b89423df" />

[Applying Custom Formatting](https://docs.slatejs.org/walkthroughs/05-executing-commands)
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/2457bd61-b259-4b41-a35d-f56e80c0259f" />


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

