### PR TITLE
fix: unexpected table selection behavior

### DIFF
--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -53,7 +53,9 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
+                {
+                  match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+                }
               )
               break
             }

--- a/site/examples/js/tables.jsx
+++ b/site/examples/js/tables.jsx
@@ -8,6 +8,7 @@ import {
 } from 'slate'
 import { withHistory } from 'slate-history'
 import { Editable, Slate, withReact } from 'slate-react'
+import { css } from '@emotion/css'
 
 const TablesExample = () => {
   const renderElement = useCallback(props => <Element {...props} />, [])
@@ -83,7 +84,12 @@ const Element = ({ attributes, children, element }) => {
   switch (element.type) {
     case 'table':
       return (
-        <table>
+        <table
+          className={css`
+            // avoid unexpected selection behavior on both sides of the table
+            position: relative;
+          `}
+        >
           <tbody {...attributes}>{children}</tbody>
         </table>
       )

--- a/site/examples/ts/tables.tsx
+++ b/site/examples/ts/tables.tsx
@@ -16,6 +16,7 @@ import {
   withReact,
 } from 'slate-react'
 import { CustomEditor } from './custom-types.d'
+import { css } from '@emotion/css'
 
 const TablesExample = () => {
   const renderElement = useCallback(
@@ -114,7 +115,12 @@ const Element = ({ attributes, children, element }: RenderElementProps) => {
   switch (element.type) {
     case 'table':
       return (
-        <table>
+        <table
+          className={css`
+            // avoid unexpected selection behavior on both sides of the table
+            position: relative;
+          `}
+        >
           <tbody {...attributes}>{children}</tbody>
         </table>
       )


### PR DESCRIPTION
**Description**
There's some strange selection behavior on the sides of the table. The table should take up a whole line instead of being inline, so this behavior is a bit odd.


**Example**

Here are some examples of the abnormal behavior:

<img  src="https://github.com/user-attachments/assets/a6b55f70-8d71-413d-b975-e13524ffc598" width="600px" >

This is essentially a selection issue and should be corrected in `normalizeDOMPoint`. In fact, slate is implemented correctly, but it doesn't call `setBaseAndExtent` again when the selection changes. 

The browser selection is updated only in `useEffect`, but when you click again, the `slate` selection model isn't updated, so the browser selection doesn't get updated either(`useEffect` doesn't get triggered).

Although I want to fix this issue, I found that elements like Mention rely on this behavior to independently select text within the node. So, I've decided to try and hide these two cursor behaviors.

<img  src="https://github.com/user-attachments/assets/03e4ea8a-72ec-4ab1-925c-8793216fd52c" width="600px" >


**Context**

This is an interesting question, obviously caused by changes in the district boundaries. So, we can solve the problem by avoiding triggering these changes. 

Just use preventDefault to stop the default behavior, and make sure the cell events are handled properly.

```html
<style>table td { border: 1px solid #eee; }</style>
<div contenteditable style="outline: none; padding: 20px;" id="$1">
  <table style="border-collapse: collapse; border-spacing: 0; table-layout: fixed">
    <colgroup>
      <col width="100" />
      <col width="100" />
    </colgroup>
    <tbody>
      <tr><td>1</td><td>2</td></tr>
      <tr><td>3</td><td>4</td></tr>
    </tbody>
  </table>
</div>
<script>
  $1.addEventListener("mousedown", (e) => {
    if (e.currentTarget === e.target) {
      e.preventDefault();
    }
  });
</script>
```

In `plate`, an extra `100% col` element was defined. This aligns the behavior with Firefox, allowing clicks on blank areas to automatically focus on the corresponding cell.

```html
<style>table td { border: 1px solid #eee; }</style>
<div contenteditable style="outline: none; padding: 20px;" on>
  <table style="border-collapse: collapse; border-spacing: 0; table-layout: fixed;">
    <colgroup>
      <col width="100" />
      <col width="100" />
      <col style="100%" />
    </colgroup>
    <tbody>
      <tr><td>1</td><td>2</td></tr>
      <tr><td>3</td><td>4</td></tr>
    </tbody>
  </table>
</div>
```

By chance, I discovered that using `relative` can avoid the cursor display issue, which is the method to solve the problem mentioned above. 

Of course, this only visually avoids the problem and doesn't actually correct the browser's selection. However, this doesn't affect the selection maintained by `slate` internally and won't affect input.


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

