### PR TITLE
fix: context menu undo support

### DIFF
--- a/.changeset/fifty-walls-search.md
+++ b/.changeset/fifty-walls-search.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+add context menu undo support

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -53,7 +53,9 @@ const App = () => {
               Transforms.setNodes(
                 editor,
                 { type: match ? null : 'code' },
-                { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
+                {
+                  match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+                }
               )
               break
             }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -506,6 +506,7 @@ export const Editable = forwardRef(
     // https://github.com/facebook/react/issues/11211
     const onDOMBeforeInput = useCallback(
       (event: InputEvent) => {
+        handleNativeHistoryEvents(editor, event)
         const el = ReactEditor.toDOMNode(editor, editor)
         const root = el.getRootNode()
 
@@ -1077,22 +1078,10 @@ export const Editable = forwardRef(
                     // This means undo can be triggered even when the div is not focused,
                     // and it only triggers the input event for the node. (2024/10/09)
                     if (!ReactEditor.isFocused(editor)) {
-                      const native = event.nativeEvent as InputEvent
-                      const maybeHistoryEditor: any = editor
-                      if (
-                        native.inputType === 'historyUndo' &&
-                        typeof maybeHistoryEditor.undo === 'function'
-                      ) {
-                        maybeHistoryEditor.undo()
-                        return
-                      }
-                      if (
-                        native.inputType === 'historyRedo' &&
-                        typeof maybeHistoryEditor.redo === 'function'
-                      ) {
-                        maybeHistoryEditor.redo()
-                        return
-                      }
+                      handleNativeHistoryEvents(
+                        editor,
+                        event.nativeEvent as InputEvent
+                      )
                     }
                   },
                   [attributes.onInput, editor]
@@ -1975,4 +1964,22 @@ export const isDOMEventHandled = <E extends Event>(
   }
 
   return event.defaultPrevented
+}
+
+const handleNativeHistoryEvents = (editor: Editor, event: InputEvent) => {
+  const maybeHistoryEditor: any = editor
+  if (
+    event.inputType === 'historyUndo' &&
+    typeof maybeHistoryEditor.undo === 'function'
+  ) {
+    maybeHistoryEditor.undo()
+    return
+  }
+  if (
+    event.inputType === 'historyRedo' &&
+    typeof maybeHistoryEditor.redo === 'function'
+  ) {
+    maybeHistoryEditor.redo()
+    return
+  }
 }


### PR DESCRIPTION
**Description**
Added Context Menu Undo Support. 

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5188

**Example**
https://github.com/user-attachments/assets/e7ce42d0-1770-43d1-9356-427d4f4fcc8a

**Context**
To support context menu undo we needed to listen on `beforeinput` event as it provides historyUndo/historyRedo events.
Sadly today it only shows undo as changes undone by editors are not tracked by DOM so redo doesn't show up. This behaviour is consistent in across other editors which works like slate.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

