### PR TITLE
Fix delete line being out by 1 char

### DIFF
--- a/packages/slate-dom/src/utils/lines.ts
+++ b/packages/slate-dom/src/utils/lines.ts
@@ -71,5 +71,5 @@ export const findCurrentLineRange = (
     middle = Math.floor((left + right) / 2)
   }
 
-  return Editor.range(editor, positions[right], parentRangeBoundary)
+  return Editor.range(editor, positions[left], parentRangeBoundary)
 }


### PR DESCRIPTION
**Description**
Code was introduced [in this PR](https://github.com/ianstormtaylor/slate/pull/3364) that adds the ability to delete a line backwards using cmd + backspace. However, it is always short by one character. 

In standard paragraphs of text that span many lines without a break the issue is not immediately obvious as after deleting a line the character/word left over often jumps back to the available space on the previous line. We first noticed the issue in our Slate project in a code block element where it was more apparent.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5292

**Example**
You can see in this video that unless it's the first line of an element (in this case the range is returned before hitting the problem algorithm), deleting a line always misses the first character. (Note that as there is often a single character remaining it jumps to the space in the previous line, but is clearly not deleted):

https://github.com/user-attachments/assets/75e3ece9-d570-4f96-aac1-5ceae42e6b77

Here's the fix branch with the first character getting deleted:


https://github.com/user-attachments/assets/594a5829-4b5b-4752-8eb5-d8335acbe043



**Context**
[This algorithm](https://github.com/ianstormtaylor/slate/blob/main/packages/slate-dom/src/utils/lines.ts#L58-L74) always reduces the positions to within 1 character - `left` and `middle` are always the same value and `right` is always this value + 1. The returned range uses the position at the `right` index up to the parent boundary, but it should be using the `left` index.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

