### PR TITLE
doc: add missing APIs in the doc

### DIFF
--- a/docs/api/locations/path-ref.md
+++ b/docs/api/locations/path-ref.md
@@ -10,8 +10,15 @@ interface PathRef {
 }
 ```
 
+- [Instance methods](path-ref.md#instance-methods)
 - [Static methods](path-ref.md#static-methods)
   - [Transform methods](path-ref.md#trasnform-methods)
+
+## Instance methods
+
+#### `unref() => Path | null`
+
+Free the resources used by the PathRef. This should be called when you no longer need to track the path. Returns the final path value before being unrefed, or null if the path was already invalid.
 
 ## Static methods
 

--- a/docs/api/locations/path.md
+++ b/docs/api/locations/path.md
@@ -115,6 +115,10 @@ Check is a value implements the `Path` interface.
 
 Check if a path is a sibling of another.
 
+#### `Path.operationCanTransformPath(operation: Operation) => operation is InsertNodeOperation | RemoveNodeOperation | MergeNodeOperation | SplitNodeOperation | MoveNodeOperation`
+
+Returns whether this operation can affect paths or not.
+
 ### Transform method
 
 #### `Path.transform(path: Path, operation: Operation, options?) => Path | null`

--- a/docs/api/locations/point-ref.md
+++ b/docs/api/locations/point-ref.md
@@ -16,7 +16,7 @@ interface PointRef {
 
 ## Instance methods
 
-#### `unRef() => Point`
+#### `unref() => Point | null`
 
 Call this when you no longer need to sync this point.
 It also returns the current value.

--- a/docs/api/locations/range-ref.md
+++ b/docs/api/locations/range-ref.md
@@ -27,7 +27,7 @@ Transforms.select(editor, selectionRef.unref())
 
 ## Instance methods
 
-#### `unref() => Range`
+#### `unref() => Range | null`
 
 Call this when you no longer need to sync this range.
 It also returns the current value.

--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -246,6 +246,10 @@ Delete the content in the current selection.
 
 Insert a block break at the current selection.
 
+#### `Editor.insertSoftBreak(editor: Editor) => void`
+
+Insert a soft break at the current selection.
+
 #### `Editor.insertFragment(editor: Editor, fragment: Node[], options?) => void`
 
 Inserts a fragment at the specified location or (if not defined) the current selection or (if not defined) the end of the document.
@@ -444,7 +448,7 @@ Remove a custom property from the leaf text nodes within non-void nodes or void 
 
 ### getFragment method
 
-#### `getFragment() => Descendant`
+#### `getFragment() => Descendant[]`
 
 Returns the fragment at the current selection. Used when cutting or copying, as an example, to get the fragment at the current selection.
 

--- a/docs/api/nodes/node.md
+++ b/docs/api/nodes/node.md
@@ -58,10 +58,10 @@ Extract all properties from a Node except for its content-related fields (`child
 ```typescript
 // For an Element node
 const element = {
-    type: 'paragraph',
-    align: 'center',
-    children: [{ text: 'Try it out for yourself!' }],
-  }
+  type: 'paragraph',
+  align: 'center',
+  children: [{ text: 'Try it out for yourself!' }],
+}
 const props = Node.extractProps(element)
 // Returns: { type: 'paragraph', align: "center" }
 

--- a/docs/api/nodes/node.md
+++ b/docs/api/nodes/node.md
@@ -51,6 +51,26 @@ Return a generator of all the element nodes inside a root node. Each iteration w
 
 Options: `{from?: Path, to?: Path, reverse?: boolean, pass?: (node: NodeEntry => boolean)}`
 
+#### `Node.extractProps(node: Node) => NodeProps`
+
+Extract all properties from a Node except for its content-related fields (`children` for Element nodes and `text` for Text nodes).
+
+```typescript
+// For an Element node
+const element = {
+    type: 'paragraph',
+    align: 'center',
+    children: [{ text: 'Try it out for yourself!' }],
+  }
+const props = Node.extractProps(element)
+// Returns: { type: 'paragraph', align: "center" }
+
+// For a Text node
+const text = { text: 'Hello', bold: true }
+const props = Node.extractProps(text)
+// Returns: { bold: true }
+```
+
 #### `Node.first(root: Node, path: Path) => NodeEntry`
 
 Get the first node entry in a root node from a `path`.
@@ -62,6 +82,19 @@ Get the sliced fragment represented by the `range`.
 #### `Node.get(root: Node, path: Path) => Node`
 
 Get the descendant node referred to by a specific `path`. If the path is an empty array, get the root node itself.
+
+#### `Node.getIf(root: Node, path: Path) => Node | undefined`
+
+Get a descendant node at a specific path, returning `undefined` if the node does not exist. This is a safer alternative to `Node.get()` as it won't throw an error if the path is invalid.
+
+```typescript
+const node = Node.getIf(root, [0, 1])
+if (node) {
+  // node exists at path [0, 1]
+} else {
+  // no node exists at path [0, 1]
+}
+```
 
 #### `Node.last(root: Node, path: Path) => NodeEntry`
 


### PR DESCRIPTION
**Description**

I was going through the API references, and I found that there are some APIs that aren't documented yet, such as the newly added `getIf()` method. I have documented those missing APIs.

I am unsure if some of the APIs written years ago are intentionally left in the documentation. I have tried to cover all the missing changes I could. If some of them are intentionally left out, I will remove those changes from the PR.

**Issue**
Fixes: #5834 

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

