### PR TITLE
fix: add try/finally block in withoutSaving method to ensure state re…

### DIFF
--- a/.changeset/rotten-poems-collect.md
+++ b/.changeset/rotten-poems-collect.md
@@ -1,0 +1,5 @@
+---
+'slate-history': patch
+---
+
+fix: add try/finally block in withoutSaving method to ensure state restoration

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -120,7 +120,10 @@ export const HistoryEditor = {
   withoutSaving(editor: HistoryEditor, fn: () => void): void {
     const prev = HistoryEditor.isSaving(editor)
     SAVING.set(editor, false)
-    fn()
-    SAVING.set(editor, prev)
+    try {
+      fn()
+    } finally {
+      SAVING.set(editor, prev)
+    }
   },
 }


### PR DESCRIPTION
…storation

**Description**
When i perform some operations and put them in the history stack, then perform some other operations without putting them into the history stack, and then trigger an undo action, this action might fail - for example, it can not find the previous element.The error can cause the restoration of the `SAVING` state to fail, which in turn leads to the failure of subsequent historyEditor operations to record history.

**Issue**
Fixes: (link to issue)

**Example**
![image](https://github.com/user-attachments/assets/1db3bbe8-1d8f-4b2c-946c-22f88fbc15d3)

**Context**
I think we should  catch the error from the callback of `withoutSaving`, make it won't affect the restoration of the saving state.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

