### PR TITLE
fix: correct dirty path update for Text nodes

### DIFF
--- a/.changeset/clever-moose-exist.md
+++ b/.changeset/clever-moose-exist.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+fix: correct dirty path update for Text nodes

--- a/packages/slate/src/transforms-node/insert-nodes.ts
+++ b/packages/slate/src/transforms-node/insert-nodes.ts
@@ -120,7 +120,7 @@ export const insertNodes: NodeTransforms['insertNodes'] = (
             at = Path.next(at as Path)
 
             batchedOps.push(op)
-            if (!Text.isText) {
+            if (Text.isText(node)) {
               newDirtyPaths.push(path)
             } else {
               newDirtyPaths.push(


### PR DESCRIPTION

Previously, the condition used was "if (!Text.isText)" without passing the node, which always evaluated to false. This caused the code to always take the branch intended for non-Text nodes, even for Text nodes. The fix now correctly checks "if (Text.isText(node))" to determine if the node is a Text node. Text nodes, which have no children, will now correctly add only their own path, while non-Text nodes continue to have all their descendant paths added.



