### PR TITLE
Add `pass` option to `Editor.nodes`

### DIFF
--- a/.changeset/rotten-taxis-battle.md
+++ b/.changeset/rotten-taxis-battle.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Add `pass` option to `Editor.nodes`, which is passed through to `Node.nodes`.

--- a/docs/api/nodes/editor.md
+++ b/docs/api/nodes/editor.md
@@ -141,7 +141,7 @@ Options: `depth?: number, edge?: 'start' | 'end'`
 
 At any given `Location` or `Span` in the editor provided by `at` (default is the current selection), the method returns a Generator of `NodeEntry` objects that represent the nodes that include `at`. At the top of the hierarchy is the `Editor` object itself.
 
-Options: `{at?: Location | Span, match?: NodeMatch, mode?: 'all' | 'highest' | 'lowest', universal?: boolean, reverse?: boolean, voids?: boolean}`
+Options: `{at?: Location | Span, match?: NodeMatch, mode?: 'all' | 'highest' | 'lowest', universal?: boolean, reverse?: boolean, voids?: boolean, pass?: (node: NodeEntry => boolean), ignoreNonSelectable?: boolean}`
 
 `options.match`: Provide a value to the `match?` option to limit the `NodeEntry` objects that are returned.
 
@@ -150,6 +150,8 @@ Options: `{at?: Location | Span, match?: NodeMatch, mode?: 'all' | 'highest' | '
 - `'all'` (default): Return all matching nodes
 - `'highest'`: in a hierarchy of nodes, only return the highest level matching nodes
 - `'lowest'`: in a hierarchy of nodes, only return the lowest level matching nodes
+
+`options.pass`: Skip the descendants of certain nodes (but not the nodes themselves).
 
 #### `Editor.parent(editor: Editor, at: Location, options?) => NodeEntry<Ancestor>`
 

--- a/packages/slate/src/editor/nodes.ts
+++ b/packages/slate/src/editor/nodes.ts
@@ -15,6 +15,7 @@ export function* nodes<T extends Node>(
     universal = false,
     reverse = false,
     voids = false,
+    pass,
     ignoreNonSelectable = false,
   } = options
   let { match } = options
@@ -44,7 +45,8 @@ export function* nodes<T extends Node>(
     reverse,
     from,
     to,
-    pass: ([node]) => {
+    pass: ([node, path]) => {
+      if (pass && pass([node, path])) return true
       if (!Element.isElement(node)) return false
       if (
         !voids &&

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -244,6 +244,7 @@ export interface EditorNodesOptions<T extends Node> {
   universal?: boolean
   reverse?: boolean
   voids?: boolean
+  pass?: (entry: NodeEntry) => boolean
   ignoreNonSelectable?: boolean
 }
 

--- a/packages/slate/test/interfaces/Editor/nodes/pass/block.tsx
+++ b/packages/slate/test/interfaces/Editor/nodes/pass/block.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { Editor } from 'slate'
+import { jsx } from '../../../..'
+
+export const input = (
+  <editor>
+    <block pass>
+      <block match>one</block>
+    </block>
+    <block>
+      <block match>two</block>
+      <block pass match>
+        three
+      </block>
+    </block>
+  </editor>
+)
+export const test = editor => {
+  return Array.from(
+    Editor.nodes(editor, {
+      at: [],
+      match: n => !!n.match,
+      pass: ([n]) => !!n.pass,
+    })
+  )
+}
+export const output = [
+  [<block match>two</block>, [1, 0]],
+  [
+    <block pass match>
+      three
+    </block>,
+    [1, 1],
+  ],
+]

--- a/packages/slate/test/interfaces/Node/nodes/pass.tsx
+++ b/packages/slate/test/interfaces/Node/nodes/pass.tsx
@@ -5,27 +5,27 @@ import { jsx } from 'slate-hyperscript'
 export const input = (
   <editor>
     <element>
-      <element>
+      <element pass>
         <text key="a" />
       </element>
     </element>
   </editor>
 )
 export const test = value => {
-  return Array.from(Node.nodes(value, { pass: ([n, p]) => p.length > 1 }))
+  return Array.from(Node.nodes(value, { pass: ([n]) => !!n.pass }))
 }
 export const output = [
   [input, []],
   [
     <element>
-      <element>
+      <element pass>
         <text key="a" />
       </element>
     </element>,
     [0],
   ],
   [
-    <element>
+    <element pass>
       <text key="a" />
     </element>,
     [0, 0],


### PR DESCRIPTION
**Description**
Adds the `pass` option from `Node.nodes` to `Editor.nodes`, making it possible to skip the descendants of certain nodes while keeping the `match` predicate simple and efficient.

**Example**
```ts
const isUnmarkable = (node: Node) => Element.isElement(node) && node.type === 'code-block';

const markableLeaves = Array.from(Editor.nodes(editor, {
  at: [],
  match: Text.isText,
  // Skips all leaves inside unmarkable nodes
  pass: ([node]) => isUnmarkable(node),
}));
```

**Context**
As per the behaviour of `Node.nodes`, passed nodes may still be returned from `Editor.nodes` if none of their ancestors were passed. I've modified the test for `Node.nodes` to make it clearer from reading the test that this is the intended behaviour.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

