### PR TITLE
Use equalityFn in useSlateSelector during render

### DIFF
--- a/.changeset/tough-falcons-itch.md
+++ b/.changeset/tough-falcons-itch.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+Use equalityFn in useSlateSelector during render as well

--- a/packages/slate-react/src/hooks/use-slate-selector.tsx
+++ b/packages/slate-react/src/hooks/use-slate-selector.tsx
@@ -57,7 +57,13 @@ export function useSlateSelector<T>(
       selector !== latestSelector.current ||
       latestSubscriptionCallbackError.current
     ) {
-      selectedState = selector(getSlate())
+      const selectorResult = selector(getSlate())
+
+      if (equalityFn(latestSelectedState.current, selectorResult)) {
+        selectedState = latestSelectedState.current
+      } else {
+        selectedState = selectorResult
+      }
     } else {
       selectedState = latestSelectedState.current
     }

--- a/packages/slate-react/test/use-slate-selector.test.tsx
+++ b/packages/slate-react/test/use-slate-selector.test.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+import React, { useEffect } from 'react'
+import { createEditor, Editor, Text, Transforms } from 'slate'
+import { act, render, renderHook } from '@testing-library/react'
+import {
+  Slate,
+  withReact,
+  Editable,
+  ReactEditor,
+  useSlateSelector,
+} from '../src'
+import _ from 'lodash'
+
+describe('useSlateSelector', () => {
+  test('should use equality function when selector changes', async () => {
+    const editor = withReact(createEditor())
+    const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+
+    const callback1 = jest.fn(() => [])
+    const callback2 = jest.fn(() => [])
+
+    const { result, rerender } = renderHook(
+      ({ callback }) => useSlateSelector(callback, _.isEqual),
+      {
+        initialProps: {
+          callback: callback1,
+        },
+        wrapper: ({ children }) => (
+          <Slate editor={editor} initialValue={initialValue}>
+            <Editable />
+            {children}
+          </Slate>
+        ),
+      }
+    )
+
+    // One call in the render body, and one call in the effect
+    expect(callback1).toBeCalledTimes(2)
+
+    const firstResult = result.current
+
+    await act(async () => {
+      Transforms.insertText(editor, '!', { at: { path: [0, 0], offset: 4 } })
+    })
+
+    // The new call is from the effect
+    expect(callback1).toBeCalledTimes(3)
+
+    // Return values should have referential equality because of the custom equality function
+    expect(firstResult).toBe(result.current)
+
+    // Callback 2 has not been used yet
+    expect(callback2).toBeCalledTimes(0)
+
+    // Re-render with new function identity
+    rerender({ callback: callback2 })
+
+    // Callback 1 is not called
+    expect(callback1).toBeCalledTimes(3)
+
+    // Callback 2 is used instead
+    expect(callback2).toBeCalledTimes(1)
+
+    // Return values should have referential equality because of the custom equality function
+    expect(firstResult).toBe(result.current)
+  })
+})


### PR DESCRIPTION
**Description**
Currently, `useSlateSelector` only uses `equalityFn` when recalculating the value after the editor updates, but not when recalculating it after the selector function changes. That by itself doesn't cause any extra re-renders, but it means that the result can be referentially unstable. That can cause issues if used in dependency arrays later, or passed as a prop to a memoized component. This is surprising behavior if `equalityFn` checks deep equality.

This PR improves referential stability in these cases by only returning the new value if it differs according to `equalityFn`.

**Issue**
I didn't find an existing GitHub issue, but we've encountered this in our code base at work.

**Example**
```
// Pointless selector for demonstration purposes
const state = useSlateSelector(editor => [], _.isEqual)

useEffect(() => {
  // Before this PR, triggering a re-render here caused an infinite render loop.
}, [state])
```

**Context**

See description.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

