### PR TITLE
Add `Leaf` with `start` and `end` props

### DIFF
--- a/.changeset/slate-react.md
+++ b/.changeset/slate-react.md
@@ -2,4 +2,4 @@
 'slate-react': minor
 ---
 
-- Update `RenderLeafProps` to use the new `Leaf` type from `slate`, that includes `start` and `end` properties representing the offset range within the original `Text` node.
+- Update `RenderLeafProps` to receive the `Leaf` type from `slate`, which may include an optional nested `position: { start, end, isFirst, isLast }` property if the text node was split by decorations. Useful to render something only in a single leaf per text node.

--- a/.changeset/slate-react.md
+++ b/.changeset/slate-react.md
@@ -1,0 +1,5 @@
+---
+'slate-react': minor
+---
+
+- Update `RenderLeafProps` to use the new `Leaf` type from `slate`, that includes `start` and `end` properties representing the offset range within the original `Text` node.

--- a/.changeset/slate.md
+++ b/.changeset/slate.md
@@ -1,0 +1,6 @@
+---
+'slate': minor
+---
+
+- Update `Text.decorations` to return `Leaf[]` instead of `Text[]`.
+- Add new `Leaf` type, which includes `start` and `end` properties representing the offset range within the original `Text` node.

--- a/.changeset/slate.md
+++ b/.changeset/slate.md
@@ -2,5 +2,6 @@
 'slate': minor
 ---
 
-- Update `Text.decorations` to return `Leaf[]` instead of `Text[]`.
-- Add new `Leaf` type, which includes `start` and `end` properties representing the offset range within the original `Text` node.
+- Update `Text.decorations` to return `Leaf[]`.
+- Add `position?: { start, end, isFirst, isLast }` property to `Leaf` type.
+- The `position` property is only added if decorations cause the text node to be split into multiple leaves.

--- a/docs/api/nodes/text.md
+++ b/docs/api/nodes/text.md
@@ -26,9 +26,15 @@ If a `props.text` property is passed in, it will be ignored.
 
 If there are properties in `text` that are not in `props`, those will be ignored when it comes to testing for a match.
 
-#### `Text.decorations(node: Text, decorations: DecoratedRange[]) => Text[]`
+#### `Text.decorations(node: Text, decorations: DecoratedRange[]) => Leaf[]`
 
 Get the leaves for a text node, given `decorations`.
+
+Each `Leaf` object includes all properties of the original `Text` node, plus `start` and `end` properties indicating the offset range within the original `node.text` that the leaf represents.
+
+```typescript
+type Leaf = Text & { start: number; end: number }
+```
 
 ### Check methods
 

--- a/docs/libraries/slate-react/editable.md
+++ b/docs/libraries/slate-react/editable.md
@@ -117,7 +117,7 @@ The `renderLeaf` function receives an object of type `RenderLeafProps` as its ar
 ```typescript
 export interface RenderLeafProps {
   children: any
-  leaf: Text
+  leaf: Leaf
   text: Text
   attributes: {
     'data-slate-leaf': true

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -108,7 +108,6 @@ export interface RenderLeafProps {
   children: any
   leaf: Leaf
   text: Text
-  isLast: boolean
   attributes: {
     'data-slate-leaf': true
   }

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1830,7 +1830,6 @@ export const Editable = forwardRef(
                 <Children
                   decorations={decorations}
                   node={editor}
-                  path={[]}
                   renderElement={renderElement}
                   renderPlaceholder={renderPlaceholder}
                   renderLeaf={renderLeaf}

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -23,6 +23,7 @@ import {
   Text,
   Transforms,
   DecoratedRange,
+  Leaf,
 } from 'slate'
 import { useAndroidInputManager } from '../hooks/android-input-manager/use-android-input-manager'
 import useChildren from '../hooks/use-children'
@@ -105,8 +106,9 @@ export interface RenderElementProps {
 
 export interface RenderLeafProps {
   children: any
-  leaf: Text
+  leaf: Leaf
   text: Text
+  isLast: boolean
   attributes: {
     'data-slate-leaf': true
   }
@@ -1828,6 +1830,7 @@ export const Editable = forwardRef(
                 <Children
                   decorations={decorations}
                   node={editor}
+                  path={[]}
                   renderElement={renderElement}
                   renderPlaceholder={renderPlaceholder}
                   renderLeaf={renderLeaf}

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
 } from 'react'
 import { JSX } from 'react'
-import { Element, Text } from 'slate'
+import { Element, Leaf as LeafType, Text } from 'slate'
 import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer'
 import String from './string'
 import {
@@ -48,7 +48,7 @@ function clearTimeoutRef(timeoutRef: MutableRefObject<TimerId>) {
  */
 const Leaf = (props: {
   isLast: boolean
-  leaf: Text
+  leaf: LeafType
   parent: Element
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
@@ -157,7 +157,7 @@ const Leaf = (props: {
     'data-slate-leaf': true,
   }
 
-  return renderLeaf({ attributes, children, leaf, text })
+  return renderLeaf({ attributes, children, leaf, text, isLast })
 }
 
 const MemoizedLeaf = React.memo(Leaf, (prev, next) => {

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -157,7 +157,7 @@ const Leaf = (props: {
     'data-slate-leaf': true,
   }
 
-  return renderLeaf({ attributes, children, leaf, text, isLast })
+  return renderLeaf({ attributes, children, leaf, text })
 }
 
 const MemoizedLeaf = React.memo(Leaf, (prev, next) => {

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, memo, useRef, useState } from 'react'
-import { Editor, Text, Path, Element, Node } from 'slate'
+import { Editor, Text, Path, Element, Node, Leaf } from 'slate'
 
 import { ReactEditor, useSlateStatic } from '..'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
@@ -12,7 +12,7 @@ import { MARK_PLACEHOLDER_SYMBOL } from 'slate-dom'
 
 const String = (props: {
   isLast: boolean
-  leaf: Text
+  leaf: Leaf
   parent: Element
   text: Text
 }) => {

--- a/packages/slate/test/interfaces/Text/decorations/adjacent.js
+++ b/packages/slate/test/interfaces/Text/decorations/adjacent.js
@@ -33,19 +33,27 @@ export const output = [
   {
     text: 'a',
     mark: 'mark',
+    start: 0,
+    end: 1,
   },
   {
     text: 'b',
     mark: 'mark',
     decoration1: 'decoration1',
+    start: 1,
+    end: 2,
   },
   {
     text: 'c',
     mark: 'mark',
     decoration2: 'decoration2',
+    start: 2,
+    end: 3,
   },
   {
     text: 'd',
     mark: 'mark',
+    start: 3,
+    end: 4,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/collapse.js
+++ b/packages/slate/test/interfaces/Text/decorations/collapse.js
@@ -55,11 +55,15 @@ export const output = [
   {
     text: 'a',
     mark: 'mark',
+    start: 0,
+    end: 1,
   },
   {
     text: 'b',
     mark: 'mark',
     decoration1: 'decoration1',
+    start: 1,
+    end: 2,
   },
   {
     text: '',
@@ -67,19 +71,27 @@ export const output = [
     decoration1: 'decoration1',
     decoration2: 'decoration2',
     decoration3: 'decoration3',
+    start: 2,
+    end: 2,
   },
   {
     text: 'c',
     mark: 'mark',
     decoration3: 'decoration3',
+    start: 2,
+    end: 3,
   },
   {
     text: 'd',
     mark: 'mark',
+    start: 3,
+    end: 4,
   },
   {
     text: '',
     mark: 'mark',
     decoration4: 'decoration4',
+    start: 4,
+    end: 4,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/end.tsx
+++ b/packages/slate/test/interfaces/Text/decorations/end.tsx
@@ -20,10 +20,14 @@ export const output = [
   {
     text: 'ab',
     mark: 'mark',
+    start: 0,
+    end: 2,
   },
   {
     text: 'c',
     mark: 'mark',
     decoration: 'decoration',
+    start: 2,
+    end: 3,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/intersect.js
+++ b/packages/slate/test/interfaces/Text/decorations/intersect.js
@@ -55,12 +55,16 @@ export const output = [
   {
     text: 'a',
     mark: 'mark',
+    start: 0,
+    end: 1,
   },
   {
     text: 'b',
     mark: 'mark',
     decoration1: 'decoration1',
     decoration2: 'decoration2',
+    start: 1,
+    end: 2,
   },
   {
     text: '',
@@ -69,6 +73,8 @@ export const output = [
     decoration2: 'decoration2',
     decoration3: 'decoration3',
     decoration4: 'decoration4',
+    start: 2,
+    end: 2,
   },
   {
     text: 'c',
@@ -76,20 +82,28 @@ export const output = [
     decoration1: 'decoration1',
     decoration2: 'decoration2',
     decoration4: 'decoration4',
+    start: 2,
+    end: 3,
   },
   {
     text: 'd',
     mark: 'mark',
     decoration1: 'decoration1',
     decoration4: 'decoration4',
+    start: 3,
+    end: 4,
   },
   {
     text: 'e',
     mark: 'mark',
     decoration1: 'decoration1',
+    start: 4,
+    end: 5,
   },
   {
     text: 'f',
     mark: 'mark',
+    start: 5,
+    end: 6,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/merge.ts
+++ b/packages/slate/test/interfaces/Text/decorations/merge.ts
@@ -40,15 +40,21 @@ export const output = [
     text: 'a',
     mark: 'mark',
     decoration: [1, 2, 3],
+    start: 0,
+    end: 1,
   },
   {
     text: 'b',
     mark: 'mark',
     decoration: [1, 2, 3, 4, 5, 6],
+    start: 1,
+    end: 2,
   },
   {
     text: 'c',
     mark: 'mark',
     decoration: [4, 5, 6],
+    start: 2,
+    end: 3,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/middle.tsx
+++ b/packages/slate/test/interfaces/Text/decorations/middle.tsx
@@ -20,14 +20,20 @@ export const output = [
   {
     text: 'a',
     mark: 'mark',
+    start: 0,
+    end: 1,
   },
   {
     text: 'b',
     mark: 'mark',
     decoration: 'decoration',
+    start: 1,
+    end: 2,
   },
   {
     text: 'c',
     mark: 'mark',
+    start: 2,
+    end: 3,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/overlapping.tsx
+++ b/packages/slate/test/interfaces/Text/decorations/overlapping.tsx
@@ -32,16 +32,22 @@ export const output = [
     text: 'a',
     mark: 'mark',
     decoration2: 'decoration2',
+    start: 0,
+    end: 1,
   },
   {
     text: 'b',
     mark: 'mark',
     decoration1: 'decoration1',
     decoration2: 'decoration2',
+    start: 1,
+    end: 2,
   },
   {
     text: 'c',
     mark: 'mark',
     decoration2: 'decoration2',
+    start: 2,
+    end: 3,
   },
 ]

--- a/packages/slate/test/interfaces/Text/decorations/start.tsx
+++ b/packages/slate/test/interfaces/Text/decorations/start.tsx
@@ -21,9 +21,13 @@ export const output = [
     text: 'a',
     mark: 'mark',
     decoration: 'decoration',
+    start: 0,
+    end: 1,
   },
   {
     text: 'bc',
     mark: 'mark',
+    start: 1,
+    end: 3,
   },
 ]


### PR DESCRIPTION
**Description**
Add optional `position` property to leaves returned by `Text.decorations()`. This makes it easier to track the exact position and boundary of each leaf within its parent text node, especially useful when you need to render elements relative to text nodes that have been split by decorations.

**Example**
Before:
```js
Text.decorations({ text: 'abc', mark: 'bold' }, [...])
// Returns:
[
  { text: 'a', mark: 'bold' },
  { text: 'b', mark: 'bold', decoration: 'highlight' },
  { text: 'c', mark: 'bold' }
]
```

After:
```js
Text.decorations({ text: 'abc', mark: 'bold' }, [...])
// Returns leaves with position info only when split by decorations:
[
  { 
    text: 'a', 
    mark: 'bold',
    position: { start: 0, end: 1, isFirst: true, isLast: false }
  },
  { 
    text: 'b', 
    mark: 'bold', 
    decoration: 'highlight',
    position: { start: 1, end: 2, isFirst: false, isLast: false }
  },
  { 
    text: 'c', 
    mark: 'bold',
    position: { start: 2, end: 3, isFirst: false, isLast: true }
  }
]

// Single leaf = no position info needed:
[{ text: 'abc', mark: 'bold' }]
```

**Context**
When working with decorated text nodes, it's often necessary to know the exact position of each leaf within the original text. A common use case is rendering an element exactly once after a text node, even when that text node has been split into multiple leaves by decorations.

For example, if you want to render a tooltip after a text node, using `renderLeaf` directly would cause the tooltip to render multiple times (once per leaf) because `renderLeaf` is called for each decorated segment. With the new `position` property, you can now reliably check:

```jsx
const renderLeaf = ({ leaf, text, ...props }) => {
  return (
    <>
      <span {...props.attributes}>{props.children}</span>
      {/* Render tooltip only once, after the last leaf of this text node */}
      {leaf.position?.isLast && <Tooltip />}
    </>
  )
}
```

The `position` property is only added when a text node is actually split by decorations, keeping the leaf objects clean and simple in the common case where no splitting occurs. Potential naming conflicts with user-defined `position` mark could be resolved by referring to the `Text` node instead.
