### PR TITLE
Increase `slate-react`'s minimum `slate` version to 0.114.0

### DIFF
--- a/.changeset/tough-actors-play.md
+++ b/.changeset/tough-actors-play.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Increase minimum `slate` version to 0.114.0 due to https://github.com/ianstormtaylor/slate/issues/5852

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "react": ">=18.2.0",
     "react-dom": ">=18.2.0",
-    "slate": ">=0.99.0",
+    "slate": ">=0.114.0",
     "slate-dom": ">=0.110.2"
   },
   "umdGlobals": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13440,7 +13440,7 @@ __metadata:
   peerDependencies:
     react: ">=18.2.0"
     react-dom: ">=18.2.0"
-    slate: ">=0.99.0"
+    slate: ">=0.114.0"
     slate-dom: ">=0.110.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
**Description**
`slate-react@0.114.0` and newer depends on `slate@0.144.0` or newer. This PR updates `slate-react`'s minimum peer dependency version for `slate` to reflect this.

**Issue**
Addresses one side of #5852. Unfortunately, the other side of that issue cannot be addressed using peer dependencies.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)