### PR TITLE
fix: add missing `RenderTextProps` export

### DIFF
--- a/.changeset/spicy-chefs-relate.md
+++ b/.changeset/spicy-chefs-relate.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix: add missing `RenderTextProps` export

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -3,6 +3,7 @@ export {
   Editable,
   RenderElementProps,
   RenderLeafProps,
+  RenderTextProps,
   RenderPlaceholderProps,
   DefaultPlaceholder,
 } from './components/editable'


### PR DESCRIPTION
`renderText` was introduced in #5850, but the prop types didn't get exported with it.
