### PR TITLE
`slate-history`, `slate-hyperscript`: Increase minimum `slate` version to 0.114.3

### DIFF
--- a/.changeset/silly-lamps-sing.md
+++ b/.changeset/silly-lamps-sing.md
@@ -1,0 +1,6 @@
+---
+'slate-hyperscript': patch
+'slate-history': patch
+---
+
+Increase minimum `slate` version to `0.114.3`

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -21,7 +21,7 @@
     "source-map-loader": "^4.0.1"
   },
   "peerDependencies": {
-    "slate": ">=0.65.3"
+    "slate": ">=0.114.3"
   },
   "umdGlobals": {
     "slate": "Slate"

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -19,7 +19,7 @@
     "source-map-loader": "^4.0.1"
   },
   "peerDependencies": {
-    "slate": ">=0.65.3"
+    "slate": ">=0.114.3"
   },
   "umdGlobals": {
     "slate": "Slate"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13307,7 +13307,7 @@ __metadata:
     slate-hyperscript: "npm:^0.100.0"
     source-map-loader: "npm:^4.0.1"
   peerDependencies:
-    slate: ">=0.65.3"
+    slate: ">=0.114.3"
   languageName: unknown
   linkType: soft
 
@@ -13319,7 +13319,7 @@ __metadata:
     slate: "npm:^0.114.0"
     source-map-loader: "npm:^4.0.1"
   peerDependencies:
-    slate: ">=0.65.3"
+    slate: ">=0.114.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Description**
Following #5859, `slate-history` and `slate-hyperscript` depend on a minimum `slate` version of 0.114.3 due to the `isObject` export.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

