### PR TITLE
fix issue #5814. onValueChange not triggered when selecting text from right to left then

### DIFF
--- a/packages/slate/src/core/apply.ts
+++ b/packages/slate/src/core/apply.ts
@@ -1,7 +1,7 @@
 import { PathRef } from '../interfaces/path-ref'
 import { PointRef } from '../interfaces/point-ref'
 import { RangeRef } from '../interfaces/range-ref'
-import { FLUSHING } from '../utils/weak-maps'
+import { FLUSHING, FLUSHING_SELECTION } from '../utils/weak-maps'
 import { Path } from '../interfaces/path'
 import { Transforms } from '../interfaces/transforms'
 import { WithEditorFirstArg } from '../utils/types'
@@ -41,11 +41,13 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
     editor.marks = null
   }
 
-  if (!FLUSHING.get(editor)) {
-    FLUSHING.set(editor, true)
+  const flushing = op.type === 'set_selection' ? FLUSHING_SELECTION : FLUSHING
+
+  if (!flushing.get(editor)) {
+    flushing.set(editor, true)
 
     Promise.resolve().then(() => {
-      FLUSHING.set(editor, false)
+      flushing.set(editor, false)
       editor.onChange({ operation: op })
       editor.operations = []
     })

--- a/packages/slate/src/utils/weak-maps.ts
+++ b/packages/slate/src/utils/weak-maps.ts
@@ -3,6 +3,7 @@ import { Editor, Path, PathRef, PointRef, RangeRef } from '..'
 export const DIRTY_PATHS: WeakMap<Editor, Path[]> = new WeakMap()
 export const DIRTY_PATH_KEYS: WeakMap<Editor, Set<string>> = new WeakMap()
 export const FLUSHING: WeakMap<Editor, boolean> = new WeakMap()
+export const FLUSHING_SELECTION: WeakMap<Editor, boolean> = new WeakMap()
 export const NORMALIZING: WeakMap<Editor, boolean> = new WeakMap()
 export const PATH_REFS: WeakMap<Editor, Set<PathRef>> = new WeakMap()
 export const POINT_REFS: WeakMap<Editor, Set<PointRef>> = new WeakMap()


### PR DESCRIPTION
onValueChange not triggered when selecting text from right to left

✅ Closes: #5814

**Description**
when selecting text from right to left, it will trigger set_selection, remove_text, insert_text at the same time, cause onValueChange not trigger.

**Issue**
Fixes: [(link to issue)](https://github.com/ianstormtaylor/slate/issues/5814)

**Example**
![image](https://github.com/user-attachments/assets/73360075-44d0-4817-abcf-51876083d758)


