### PR TITLE
feat(docs): add another member for slate (#5838)

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -21,6 +21,8 @@ These extensions and plugins add additional features and capabilities to Slate:
 - [`slate-yjs`](https://github.com/BitPhinix/slate-yjs/) Collaborative editing utilities for Slate leveraging Yjs
 - [`slate-collaborative`](https://github.com/cudr/slate-collaborative) Collaborative editing utilities for Slate
   leveraging Automerge
+- [`slate-vue3`](https://github.com/Guan-Erjia/slate-vue3) Which is a useful supplement to
+  Slate for building a rich text editor using Vue3, integrated all functions in an npm package
 
 ## Products
 


### PR DESCRIPTION
Hi, I hope to add slate-vue3 to the documentation resources, which would be very useful for those who want to use slate in Vue projects. At present, the functionality of slate-vue3 has reached consistency with slate-react.

You can view demos in [slate-vue3](https://guan-erjia.github.io/slate-vue3/examples/rich-text)