### PR TITLE
Fix certain undos undoing more than they should

### DIFF
--- a/.changeset/friendly-socks-divide.md
+++ b/.changeset/friendly-socks-divide.md
@@ -1,0 +1,5 @@
+---
+'slate-history': patch
+---
+
+Fix certain undos undoing more than they should

--- a/packages/slate-history/src/with-history.ts
+++ b/packages/slate-history/src/with-history.ts
@@ -83,7 +83,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
       if (merge == null) {
         if (lastBatch == null) {
           merge = false
-        } else if (operations.length !== 0) {
+        } else if (operations.includes(lastOp)) {
           merge = true
         } else {
           merge = shouldMerge(op, lastOp)


### PR DESCRIPTION
**Description**
When the first operation in a frame is a `set_selection`, it causes each following operation to merge into the previous history step, no matter where or when it took place, causing some undos to undo more than expected.
This is a one-line change to fix that.

**Issue**
Fixes #5572, fixes #5773, fixes #5554
Might also affect #5364 and #5587, but unable to easily reproduce those circumstances in a testing environment to verify.
Edit: also seems to fix #3838, looks like @verngutz had this figured out two years before me lol

**Example**
https://github.com/user-attachments/assets/2f835fe5-16a0-4a60-823b-4d25636d8d0a

**Context**
Instead of just checking for the existence of previous operations this frame when considering a merge, `HistoryEditor#apply` now checks that one of those operations was actually the last saved operation--or in other words, checks whether the last operation in history happened this frame. ***This is a `obj === obj` comparison***, so won't match ie: two separately deserialized JSON objects, but since this is only about operations in a single frame I don't think it will be an issue.

There are other ways to change this line if this version isn't desired but this seems like it best matches the original intent and expected behavior.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

