### PR TITLE
fix: Closing skip logic for some unit tests in slate history section

### DIFF
--- a/packages/slate-history/test/undo/delete_backward/custom-prop.tsx
+++ b/packages/slate-history/test/undo/delete_backward/custom-prop.tsx
@@ -18,5 +18,4 @@ export const input = (
     </block>
   </editor>
 )
-export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
 export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/delete_backward/inline-across.tsx
+++ b/packages/slate-history/test/undo/delete_backward/inline-across.tsx
@@ -26,5 +26,4 @@ export const input = (
     </block>
   </editor>
 )
-export const skip = true // TODO: see https://github.com/ianstormtaylor/slate/pull/4188
 export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/insert_fragment/basic.tsx
+++ b/packages/slate-history/test/undo/insert_fragment/basic.tsx
@@ -35,4 +35,3 @@ export const input = (
   </editor>
 )
 export const output = cloneDeep(input)
-export const skip = true


### PR DESCRIPTION
**Description**
After turning off the skip logic, the unit test can pass
![image](https://github.com/user-attachments/assets/0127f323-4443-4bde-8ce1-e31d366d5cf0)
