### PR TITLE
Fix Netlify builds for PRs

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -15,4 +15,8 @@ module.exports = {
     })
     return config
   },
+  // https://answers.netlify.com/t/basic-nextjs-website-failing-to-build-with-exit-code-129/120273/2
+  experimental: {
+    cpus: 1,
+  },
 }

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -15,8 +15,4 @@ module.exports = {
     })
     return config
   },
-  // https://answers.netlify.com/t/basic-nextjs-website-failing-to-build-with-exit-code-129/120273/2
-  experimental: {
-    cpus: 1,
-  },
 }


### PR DESCRIPTION
**Description**
The Netlify build workflows have been failing for some time. The error message `Command failed with exit code 129: yarn build` might indicate a problem with memory usage; if so, [this forum thread](https://answers.netlify.com/t/basic-nextjs-website-failing-to-build-with-exit-code-129/120273/2) indicates that limiting the number of CPUs during the build might address the problem.

<details>
<summary>Full error message</summary>
<pre>
8:18:01 PM:    Generating static pages (0/27) ...
8:18:27 PM: ​
8:18:27 PM: "build.command" failed                                        
8:18:27 PM: ────────────────────────────────────────────────────────────────
8:18:27 PM: ​
8:18:27 PM:   Error message
8:18:27 PM:   Command failed with exit code 129: yarn build (https://ntl.fyi/exit-code-129)
8:18:27 PM: ​
8:18:27 PM:   Error location
8:18:27 PM:   In Build command from Netlify app:
8:18:27 PM:   yarn build
8:18:27 PM: ​
8:18:27 PM:   Resolved config
8:18:27 PM:   build:
8:18:27 PM:     command: yarn build
8:18:27 PM:     commandOrigin: ui
8:18:27 PM:     environment:
8:18:27 PM:       - NODE_VERSION
8:18:27 PM:       - REVIEW_ID
8:18:27 PM:     publish: /opt/build/repo/site/out
8:18:27 PM:     publishOrigin: ui
8:18:28 PM: Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
8:18:28 PM: Build failed due to a user error: Build script returned non-zero exit code: 2
8:18:28 PM: Failing build: Failed to build site
8:18:28 PM: Finished processing build request in 1m43.368s
</pre>
</details>

**Context**
Prior attempts: #5785 (addressing linter errors), #5809 (addressing stale browserlist). ~~I'm not sure which of these potential issues is the root cause, or if multiple of them are.~~ Setting the CPU limit fixed the problem. 🎉 