### PR TITLE
Fix IME crash on iOS, but break capitalisation on iOS

### DIFF
--- a/.changeset/orange-ears-help.md
+++ b/.changeset/orange-ears-help.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix a crash on iOS when composing text using an IME at the start of a block, at the cost of breaking capitalization on iOS in an empty editor.

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -134,7 +134,7 @@ export const ZeroWidthString = (props: {
   // inserting any text using an IME at the start of a block. This appears to
   // be because accepting an IME suggestion when at the start of a block (no
   // preceding \uFEFF) removes one or more DOM elements that `toSlateRange`
-  // depends on. (https://github.com/ianstormtaylor/slate/issues/5762)
+  // depends on. (https://github.com/ianstormtaylor/slate/issues/5703)
   return (
     <span {...attributes}>
       {!IS_ANDROID || !isLineBreak ? '\uFEFF' : null}

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -3,7 +3,7 @@ import { Editor, Text, Path, Element, Node } from 'slate'
 
 import { ReactEditor, useSlateStatic } from '..'
 import { useIsomorphicLayoutEffect } from '../hooks/use-isomorphic-layout-effect'
-import { IS_ANDROID, IS_IOS } from 'slate-dom'
+import { IS_ANDROID } from 'slate-dom'
 import { MARK_PLACEHOLDER_SYMBOL } from 'slate-dom'
 
 /**
@@ -127,9 +127,17 @@ export const ZeroWidthString = (props: {
     attributes['data-slate-mark-placeholder'] = true
   }
 
+  // FIXME: Inserting the \uFEFF on iOS breaks capitalization at the start of an
+  // empty editor (https://github.com/ianstormtaylor/slate/issues/5199).
+  //
+  // However, not inserting the \uFEFF on iOS causes the editor to crash when
+  // inserting any text using an IME at the start of a block. This appears to
+  // be because accepting an IME suggestion when at the start of a block (no
+  // preceding \uFEFF) removes one or more DOM elements that `toSlateRange`
+  // depends on. (https://github.com/ianstormtaylor/slate/issues/5762)
   return (
     <span {...attributes}>
-      {!(IS_ANDROID || IS_IOS) || !isLineBreak ? '\uFEFF' : null}
+      {!IS_ANDROID || !isLineBreak ? '\uFEFF' : null}
       {isLineBreak ? <br /> : null}
     </span>
   )


### PR DESCRIPTION
**Description**
There are issues on iOS surrounding the `\uFEFF` character inserted into empty leaves by `ZeroWidthString`.

- With the `\uFEFF`, iOS does not automatically capitalise the first letter typed into an empty editor - #5199
- Without the `\uFEFF`, the editor crashes when inserting text with an IME at the start of a block - #5703

Ideally, we would find a way to resolve both issues at once. However, until we are able to find such a solution, I think fixing the IME crash should be a higher priority than fixing capitalisation. This PR reverts #5654, breaking capitalisation but fixing IME composition on iOS.

**Issue**
Fixes #5703
Fixes #5762
Reopens #5199 (this will need to be reopened manually after merging)

**Context**
See the comment in `string.tsx`

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

