### PR TITLE
Optimize editor#above and allow passing a location that doesnt exist as long as its parent exists

### DIFF
--- a/.changeset/popular-bags-relax.md
+++ b/.changeset/popular-bags-relax.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Optimize editor#above and allow passing a location that doesnt exist as long as its parent exists

--- a/packages/slate/src/editor/above.ts
+++ b/packages/slate/src/editor/above.ts
@@ -1,4 +1,5 @@
 import { Editor, EditorInterface } from '../interfaces/editor'
+import { Range } from '../interfaces'
 import { Path } from '../interfaces/path'
 
 export const above: EditorInterface['above'] = (editor, options = {}) => {
@@ -13,15 +14,18 @@ export const above: EditorInterface['above'] = (editor, options = {}) => {
     return
   }
 
-  const path = Editor.path(editor, at)
-  const reverse = mode === 'lowest'
+  let path = Editor.path(editor, at)
 
-  if (path.length === 0) {
-    return
+  // start with the direct ancestor -- unless its already the common ancestor of a cross-node range
+  if (!Range.isRange(at) || Path.equals(at.focus.path, at.anchor.path)) {
+    if (path.length === 0) return
+    path = Path.parent(path)
   }
 
+  const reverse = mode === 'lowest'
+
   for (const entry of Editor.levels(editor, {
-    at: Path.parent(path),
+    at: path,
     voids,
     match,
     reverse,

--- a/packages/slate/src/editor/above.ts
+++ b/packages/slate/src/editor/above.ts
@@ -25,6 +25,11 @@ export const above: EditorInterface['above'] = (editor, options = {}) => {
 
   const reverse = mode === 'lowest'
 
-  const [firstMatch] = Editor.levels(editor, { at: path, voids, match, reverse });
+  const [firstMatch] = Editor.levels(editor, {
+    at: path,
+    voids,
+    match,
+    reverse,
+  })
   return firstMatch // if nothing matches this returns undefined
 }

--- a/packages/slate/src/editor/above.ts
+++ b/packages/slate/src/editor/above.ts
@@ -25,12 +25,6 @@ export const above: EditorInterface['above'] = (editor, options = {}) => {
 
   const reverse = mode === 'lowest'
 
-  for (const entry of Editor.levels(editor, {
-    at: path,
-    voids,
-    match,
-    reverse,
-  })) {
-    return entry
-  }
+  const [firstMatch] = Editor.levels(editor, { at: path, voids, match, reverse });
+  return firstMatch // if nothing matches this returns undefined
 }

--- a/packages/slate/src/editor/above.ts
+++ b/packages/slate/src/editor/above.ts
@@ -1,6 +1,4 @@
 import { Editor, EditorInterface } from '../interfaces/editor'
-import { Text } from '../interfaces/text'
-import { Range } from '../interfaces/range'
 import { Path } from '../interfaces/path'
 
 export const above: EditorInterface['above'] = (editor, options = {}) => {
@@ -18,24 +16,16 @@ export const above: EditorInterface['above'] = (editor, options = {}) => {
   const path = Editor.path(editor, at)
   const reverse = mode === 'lowest'
 
-  for (const [n, p] of Editor.levels(editor, {
-    at: path,
+  if (path.length === 0) {
+    return
+  }
+
+  for (const entry of Editor.levels(editor, {
+    at: Path.parent(path),
     voids,
     match,
     reverse,
   })) {
-    if (Text.isText(n)) continue
-    if (Range.isRange(at)) {
-      if (
-        Path.isAncestor(p, at.anchor.path) &&
-        Path.isAncestor(p, at.focus.path)
-      ) {
-        return [n, p]
-      }
-    } else {
-      if (!Path.equals(path, p)) {
-        return [n, p]
-      }
-    }
+    return entry
   }
 }

--- a/packages/slate/src/editor/above.ts
+++ b/packages/slate/src/editor/above.ts
@@ -16,7 +16,8 @@ export const above: EditorInterface['above'] = (editor, options = {}) => {
 
   let path = Editor.path(editor, at)
 
-  // start with the direct ancestor -- unless its already the common ancestor of a cross-node range
+  // If `at` is a Range that spans mulitple nodes, `path` will be their common ancestor.
+  // Otherwise `path` will be a text node and/or the same as `at`, in which cases we want to start with its parent.
   if (!Range.isRange(at) || Path.equals(at.focus.path, at.anchor.path)) {
     if (path.length === 0) return
     path = Path.parent(path)

--- a/packages/slate/test/interfaces/Editor/above/potential-parent.tsx
+++ b/packages/slate/test/interfaces/Editor/above/potential-parent.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { Editor, Element } from 'slate'
+import { jsx } from '../../..'
+
+// `above` can never return the location passed into it, and shouldnt care if it exists, only if its parent exists.
+
+export const input = (
+  <editor>
+    <block>
+      <block>
+        <block>one</block>
+        {/* path points here */}
+      </block>
+      <block>two</block>
+    </block>
+  </editor>
+)
+
+const path = [0, 0, 1]
+
+export const test = editor => {
+  return Editor.above(editor, {
+    at: path,
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
+  })
+}
+
+export const output = [
+  <block>
+    <block>one</block>
+  </block>,
+  [0, 0],
+]


### PR DESCRIPTION
**Description**
Currently calling `Editor#above` will error if the node that its input argument resolves to doesn't exist--even though it can never return that node and doesn't depend on it at all.
This fixes that and also reduces the amount of repeated/wasted checks in the implementation. (its probably faster now; I didn't check)

**Issue**
(just a personal issue 🙂)
In my usecase I want to filter/modify certain operations in `Editor#apply` depending on whether they are within a certain kind of block. A problem arises with `insert_node` (and `move_node`) operations: if I call `editor.above(operation.path)`, it errors because there is no node at `operation.path` yet. This seems silly because `editor.above` can never return the node at `operation.path`, the lowest node it can return is its parent. I've had to use a cumbersome workaround:
```ts
let entry = editor.parent(operation.path);
if (!matchesWhatIWant(node)) { // manually check direct parent
  entry = editor.above({ at: entry[1], match: n => matchesWhatIWant(n) });
}
```

**Example**
```xml
<editor>
  <block>
    <block>some text</block>
    <!-- path points here -->
  </block>
</editor>
```
```ts
editor.above({ at: [0, 1], match: n => Element.isElement(n) && editor.isBlock(n) })
// Old -> Error: Cannot find a descendant at path [0,1] in node: {...}
// New -> [<block><block>some text</block></block>, [0]]
```

**Context**
I took all checks out of the for-loop:
- `Text.isText(n)`: we now always pass an ancestor into the iterator. (`Path.equals(at.focus.path, at.anchor.path)` is used to test whether it would be text without having to look up the node!)
- `Path.isAncestor(p, at.anchor.path) && Path.isAncestor(p, at.focus.path)`: Unless I'm missing something, this was always true even in the old implementation.
- `!Path.equals(path, p)`: we use `Path.parent` to always start above `editor.path(at)`.

Also I added a test to prevent regressions of this behavior.

Alternatively (or additionally) to this change I could see an argument for some sort of method like `atOrAbove`--a version of above that *can* return its original input, or even just an option on `above`. This way made more sense for my specific usecase but I wouldnt be against it, my workaround above is essentially `editor.atOrAbove(Path.parent(operation.path))`.

If there are any changes I should make or if I should go in another direction like mentioned above just let me know 😄

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

