### PR TITLE
Fix Firefox IME bug caused by placeholder

### DIFF
--- a/.changeset/mean-carpets-tap.md
+++ b/.changeset/mean-carpets-tap.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix IME issues in Firefox caused by placeholder

--- a/packages/slate-react/src/components/leaf.tsx
+++ b/packages/slate-react/src/components/leaf.tsx
@@ -144,8 +144,8 @@ const Leaf = (props: {
 
     children = (
       <React.Fragment>
-        {renderPlaceholder(placeholderProps)}
         {children}
+        {renderPlaceholder(placeholderProps)}
       </React.Fragment>
     )
   }


### PR DESCRIPTION
**Description**
When composition starts and the placeholder is showing, Slate hides the placeholder. Due to a [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1967203), this causes macOS's IME to receive outdated information about the start offset of the composition. This PR works around this issue by rendering the placeholder after the cursor instead of before.

**Issue**
Fixes #5766

**Example**

https://github.com/user-attachments/assets/41382b2f-6d0e-4f34-9727-c3f7daac64be

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

