### PR TITLE
Fix backspace for Bengali grapheme clusters

### DIFF
--- a/.changeset/grumpy-walls-look.md
+++ b/.changeset/grumpy-walls-look.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Handle backspace correctly for grapheme clusters in Bengali

--- a/packages/slate/src/transforms-text/delete-text.ts
+++ b/packages/slate/src/transforms-text/delete-text.ts
@@ -169,15 +169,17 @@ export const deleteText: TextTransforms['delete'] = (editor, options = {}) => {
       })
     }
 
-    // For Thai script, deleting N character(s) backward should delete
+    // For certain scripts, deleting N character(s) backward should delete
     // N code point(s) instead of an entire grapheme cluster.
     // Therefore, the remaining code points should be inserted back.
+    // Bengali: \u0980-\u09FF
+    // Thai: \u0E00-\u0E7F
     if (
       isCollapsed &&
       reverse &&
       unit === 'character' &&
       removedText.length > 1 &&
-      removedText.match(/[\u0E00-\u0E7F]+/)
+      removedText.match(/[\u0980-\u09FF\u0E00-\u0E7F]+/)
     ) {
       Transforms.insertText(
         editor,


### PR DESCRIPTION
**Description**
This PR adds Bengali to the range of Unicode characters for which backspace should delete a single code point, similar to Thai.

**Issue**
Fixes: #5886 

**Example**

https://github.com/user-attachments/assets/461cda1c-575d-4db6-9d60-4988c5f02785

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

