### PR TITLE
Fix backspace for more grapheme clusters

### DIFF
--- a/packages/slate/src/transforms-text/delete-text.ts
+++ b/packages/slate/src/transforms-text/delete-text.ts
@@ -169,17 +169,25 @@ export const deleteText: TextTransforms['delete'] = (editor, options = {}) => {
       })
     }
 
-    // For certain scripts, deleting N character(s) backward should delete
+// For certain scripts, deleting N character(s) backward should delete
     // N code point(s) instead of an entire grapheme cluster.
     // Therefore, the remaining code points should be inserted back.
     // Bengali: \u0980-\u09FF
     // Thai: \u0E00-\u0E7F
+    // Burmese (Myanmar): \u1000-\u109F
+    // Hindi (Devanagari): \u0900-\u097F
+    // Khmer: \u1780-\u17FF
+    // Malayalam: \u0D00-\u0D7F
+    // Oriya: \u0B00-\u0B7F
+    // Punjabi (Gurmukhi): \u0A00-\u0A7F
+    // Tamil: \u0B80-\u0BFF
+    // Telugu: \u0C00-\u0C7F
     if (
       isCollapsed &&
       reverse &&
       unit === 'character' &&
       removedText.length > 1 &&
-      removedText.match(/[\u0980-\u09FF\u0E00-\u0E7F]+/)
+      removedText.match(/[\u0980-\u09FF\u0E00-\u0E7F\u1000-\u109F\u0900-\u097F\u1780-\u17FF\u0D00-\u0D7F\u0B00-\u0B7F\u0A00-\u0A7F\u0B80-\u0BFF\u0C00-\u0C7F]+/)
     ) {
       Transforms.insertText(
         editor,

--- a/packages/slate/src/transforms-text/delete-text.ts
+++ b/packages/slate/src/transforms-text/delete-text.ts
@@ -169,7 +169,7 @@ export const deleteText: TextTransforms['delete'] = (editor, options = {}) => {
       })
     }
 
-// For certain scripts, deleting N character(s) backward should delete
+    // For certain scripts, deleting N character(s) backward should delete
     // N code point(s) instead of an entire grapheme cluster.
     // Therefore, the remaining code points should be inserted back.
     // Bengali: \u0980-\u09FF


### PR DESCRIPTION
**Description**
This PR further resolves the problem detailed in issue #5886.

That issue records behavior wherein the user might create a grapheme cluster using multiple characters, but then when backspacing the entire grapheme cluster would be removed rather than just the last character that was input.

PR #5887 resolved this issue for Bengali. This PR resolves this for a wider set of languages where this would also be problematic.

The changes in this PR are specifically for the following languages:
- Burmese
- Hindi
- Khmer
- Malayalam
- Oriya
- Punjabi
- Tamil
- Telugu

**Issue**
Fixes: #5886.

**Example**
https://github.com/user-attachments/assets/255d7056-8d78-4b8a-afcf-a6c68ec96f46

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

