### PR TITLE
Fix: `editor.selection` is sometimes replaced with a new object even if the selection did not change

### DIFF
--- a/.changeset/eleven-days-thank.md
+++ b/.changeset/eleven-days-thank.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix: `editor.selection` is sometimes replaced with a new object even if the selection did not change

--- a/packages/slate-react/CHANGELOG.md
+++ b/packages/slate-react/CHANGELOG.md
@@ -11,6 +11,10 @@
     - If this change impacts you, consider changing your `decorate` function to work on the node's parent instead.
     - For example, if your `decorate` function decorates a `code-line` based on the parent `code-block`'s language, decorate the `code-block` instead.
     - This is unlikely to result in any performance detriment, since in previous versions of `slate-react`, the decorations of all siblings were recomputed when one sibling was modified.
+  - **BREAKING CHANGE:** Elements no longer re-render due to selection changes.
+    - To re-render whenever an element becomes selected or deselected, subscribe to `useSelected`.
+    - To re-render whenever the selection changes anywhere in the editor, subscribe to `useSlateSelection`.
+    - To re-render whenever the intersection of the selection with an element changes (the previous behaviour), use `useSlateSelector` to compute this intersection using `Range.intersection`. Ensure you provide a suitable equality function using `Range.equals`.
   - Increase minimum `slate-dom` version to `0.116.0`.
   - Deprecate the `useSlateWithV` hook
   - PERF: Use subscribable pattern for `useSlate`, `useSelected` and decorations to reduce re-renders.

--- a/packages/slate/src/interfaces/transforms/general.ts
+++ b/packages/slate/src/interfaces/transforms/general.ts
@@ -265,7 +265,9 @@ export const GeneralTransforms: GeneralTransforms = {
             }
           }
 
-          editor.selection = selection
+          if (!selection || !Range.equals(selection, editor.selection)) {
+            editor.selection = selection
+          }
         }
 
         break
@@ -422,7 +424,9 @@ export const GeneralTransforms: GeneralTransforms = {
         selection[key] = Point.transform(point, op)!
       }
 
-      editor.selection = selection
+      if (!Range.equals(selection, editor.selection)) {
+        editor.selection = selection
+      }
     }
   },
 }


### PR DESCRIPTION
**Description**
Prior to #5871, `editor.selection` is only replaced with a new object when the selection changes. The changes #5871 made to operation handling unintentionally resulted in `editor.selection` sometimes being replaced even when the selection did not change. This PR restores the previous behaviour.

I've also retroactively documented an additional (intentional) breaking change from #5871, which I forgot to include in the changeset earlier:

>   - **BREAKING CHANGE:** Elements no longer re-render due to selection changes.
>     - To re-render whenever an element becomes selected or deselected, subscribe to `useSelected`.
>     - To re-render whenever the selection changes anywhere in the editor, subscribe to `useSlateSelection`.
>     - To re-render whenever the intersection of the selection with an element changes (the previous behaviour), use `useSlateSelector` to compute this intersection using `Range.intersection`. Ensure you provide a suitable equality function using `Range.equals`.

**Context**
I noticed the change in how `editor.selection` is replaced when looking into a Plate bug relating to table selection. Although the bug turned out to be because of the re-rendering change (hence why I documented it), I thought it best to revert this unintended change anyway.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

