### PR TITLE
fix: Determine the higher version of WeChat browser for Windows

### DIFF
--- a/packages/slate-dom/src/utils/environment.ts
+++ b/packages/slate-dom/src/utils/environment.ts
@@ -52,8 +52,8 @@ export const IS_UC_MOBILE =
 export const IS_WECHATBROWSER =
   typeof navigator !== 'undefined' &&
   /.*Wechat/.test(navigator.userAgent) &&
-  !/.*MacWechat/.test(navigator.userAgent) // avoid lookbehind (buggy in safari < 16.4)
-
+  !/.*MacWechat/.test(navigator.userAgent) && // avoid lookbehind (buggy in safari < 16.4)
+  (IS_CHROME ? IS_CHROME_LEGACY : true) // wechat and low chrome is real wechat
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js
 export const CAN_USE_DOM = !!(

--- a/packages/slate-dom/src/utils/environment.ts
+++ b/packages/slate-dom/src/utils/environment.ts
@@ -53,7 +53,7 @@ export const IS_WECHATBROWSER =
   typeof navigator !== 'undefined' &&
   /.*Wechat/.test(navigator.userAgent) &&
   !/.*MacWechat/.test(navigator.userAgent) && // avoid lookbehind (buggy in safari < 16.4)
-  (IS_CHROME ? IS_CHROME_LEGACY : true) // wechat and low chrome is real wechat
+  (!IS_CHROME || IS_CHROME_LEGACY) // wechat and low chrome is real wechat
 // Check if DOM is available as React does internally.
 // https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js
 export const CAN_USE_DOM = !!(


### PR DESCRIPTION
**Description**
Now the latest WeChat browser for Windows has used a newer version of Chrome

**Issue**
Fixes: [https://github.com/ianstormtaylor/slate/issues/5912](url)

