### PR TITLE
Export `defaultScrollSelectionIntoView`

### DIFF
--- a/.changeset/fifty-shirts-tap.md
+++ b/.changeset/fifty-shirts-tap.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Export `defaultScrollSelectionIntoView`

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1929,7 +1929,7 @@ export const defaultDecorate: (entry: NodeEntry) => DecoratedRange[] = () => []
  * A default implement to scroll dom range into view.
  */
 
-const defaultScrollSelectionIntoView = (
+export const defaultScrollSelectionIntoView = (
   editor: ReactEditor,
   domRange: DOMRange
 ) => {

--- a/packages/slate-react/src/index.ts
+++ b/packages/slate-react/src/index.ts
@@ -6,6 +6,7 @@ export {
   RenderLeafProps,
   RenderPlaceholderProps,
   DefaultPlaceholder,
+  defaultScrollSelectionIntoView,
 } from './components/editable'
 
 export { DefaultElement } from './components/element'


### PR DESCRIPTION
**Description**
Exports `defaultScrollSelectionIntoView` from `slate-react`, making it easier to extend rather than replace the default `scrollSelectionIntoView` behaviour.

**Example**
```ts
const SCROLLING = new WeakMap<Editor, boolean | undefined>()

// Custom scroll handler
const scrollSelectionIntoView = (editor: ReactEditor, domRange: DOMRange) => {
  if (SCROLLING.get(editor) ?? true) {
    defaultScrollSelectionIntoView(editor, domRange)
  }
}

const withoutScrolling = (editor: Editor, fn: () => void) => {
  const value = SCROLLING.get(editor) ?? true
  SCROLLING.set(editor, false)
  try {
    fn()
  } finally {
    SCROLLING.set(editor, value)
  }
}
```

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

