### PR TITLE
Check if editor is still mounted before trying to focus

### DIFF
--- a/.changeset/strong-humans-taste.md
+++ b/.changeset/strong-humans-taste.md
@@ -1,0 +1,5 @@
+---
+'slate-dom': patch
+---
+
+Do not retry focusing editor after it has been unmounted

--- a/packages/slate-dom/src/plugin/dom-editor.ts
+++ b/packages/slate-dom/src/plugin/dom-editor.ts
@@ -422,6 +422,12 @@ export const DOMEditor: DOMEditorInterface = {
       return
     }
 
+    // Return if no dom node is associated with the editor, which means the editor is not yet mounted
+    // or has been unmounted. This can happen especially, while retrying to focus the editor.
+    if (!EDITOR_TO_ELEMENT.get(editor)) {
+      return
+    }
+
     // Retry setting focus if the editor has pending operations.
     // The DOM (selection) is unstable while changes are applied.
     // Retry until retries are exhausted or editor is focused.


### PR DESCRIPTION
**Description**
The `DOMEditor.focus` method has a retry mechanism built in. It can happen, that while retrying to focus the dom node of the editor, meanwhile the editor has been unmounted, which will result in an error when calling `DOMEditor.toDOMNode(editor, editor)`.

This PR adds a check on top of the `DOMEditor.focus` method, to check if the editor is still mounted, if not return and do not retry to focus the editor dom node anymore.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5915

**Context**
This error happened in our unit tests. I guess it's hard to reconstruct in the browser, since it is happening in the milliseconds area.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

