### PR TITLE
Fix IME composition being ignored in the first character in a line

### DIFF
--- a/.changeset/shaggy-points-suffer.md
+++ b/.changeset/shaggy-points-suffer.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix IME composition being ignored in the first character in a line

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -688,6 +688,15 @@ export function createAndroidInputManager({
             insertPositionHint = false
           }
 
+          if (
+            type === 'insertCompositionText' ||
+            type === 'deleteCompositionText'
+          ) {
+            storeDiff(start.path, diff)
+            // Don't schedule selection updates during composition
+            return
+          }
+
           if (canStoreDiff) {
             const currentSelection = editor.selection
             storeDiff(start.path, diff)
@@ -761,7 +770,7 @@ export function createAndroidInputManager({
       insertPositionHint = false
     }
 
-    if (pathChanged || hasPendingDiffs()) {
+    if ((pathChanged || hasPendingDiffs()) && !IS_COMPOSING.get(editor)) {
       flushTimeoutId = setTimeout(flush, FLUSH_DELAY)
     }
   }


### PR DESCRIPTION
**Description**
When using an IME, the first character's composition gets interrupted.

**Root Cause:**
**1. Immediate Selection Updates During Composition**
When insertCompositionText events occurred, the code would:
1. ✅ Correctly store the composition text as a pending diff with storeDiff()
2. ❌ Immediately call `scheduleAction()` to update selection
3. ❌ `scheduleAction()` would set `actionTimeoutId = setTimeout(flush)`
4. ❌ This caused pending diffs to be flushed almost immediately


**2. Selection-Triggered Flush Timeouts**
During IME composition, selection changes are common as the cursor position updates. The handleUserSelect function would:
1. Detect selection changes during composition
2. Schedule a 200ms flush timeout with `setTimeout(flush, FLUSH_DELAY)`
3. This would "auto-accept" the composition before the user could continue typing

**Issue**
Fixes: #5883

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)