### PR TITLE
When removing the node containing the cursor, always prefer placing the cursor in a sibling text node

### DIFF
--- a/.changeset/stupid-ants-buy.md
+++ b/.changeset/stupid-ants-buy.md
@@ -1,0 +1,9 @@
+---
+'slate': minor
+---
+
+- When removing a text node containing the cursor, always perfer placing the cursor in a sibling text node if one exists.
+  - Previously, the selection would enter a sibling inline in some circumstances, even when a sibling text node was available.
+  - The most noticeable effect of this change occurs when pressing backspace at the start of line N when the last non-empty node in line N-1 is an inline.
+    - Before, the cursor would be placed inside the inline.
+    - Now, the cursor is placed outside the inline.

--- a/packages/slate/src/interfaces/transforms/general.ts
+++ b/packages/slate/src/interfaces/transforms/general.ts
@@ -246,8 +246,10 @@ export const GeneralTransforms: GeneralTransforms = {
 
               let preferNext = false
               if (prev && next) {
-                if (Path.equals(next[1], path)) {
-                  preferNext = !Path.hasPrevious(next[1])
+                if (Path.isSibling(prev[1], path)) {
+                  preferNext = false
+                } else if (Path.equals(next[1], path)) {
+                  preferNext = true
                 } else {
                   preferNext =
                     Path.common(prev[1], path).length <

--- a/packages/slate/test/operations/remove_node/cursor-aunt-text-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-aunt-text-after.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { jsx } from '../../'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+      <inline>
+        <text id="0">a</text>
+        <text id="1">
+          <cursor />
+        </text>
+      </inline>
+      <text>b</text>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 1, 1],
+    node: { text: '', id: '1' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text />
+      <inline>
+        <text id="0">
+          a<cursor />
+        </text>
+      </inline>
+      <text>b</text>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-aunt-text-before.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-aunt-text-before.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { jsx } from '../../'
+
+export const input = (
+  <editor>
+    <element>
+      <text>a</text>
+      <inline>
+        <text id="0">
+          <cursor />
+        </text>
+        <text id="1">b</text>
+      </inline>
+      <text />
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 1, 0],
+    node: { text: '', id: '0' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text>a</text>
+      <inline>
+        <text id="1">
+          <cursor />b
+        </text>
+      </inline>
+      <text />
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-inline-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-inline-after.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { jsx } from '../../'
+
+export const input = (
+  <editor>
+    <element>a</element>
+    <element>
+      <text>
+        <cursor />
+      </text>
+      <inline>b</inline>
+      <text />
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [1, 0],
+    node: { text: '' },
+  },
+]
+export const output = (
+  <editor>
+    <element>a</element>
+    <element>
+      {/* Recreated by normalizer */}
+      <text />
+      <inline>
+        <cursor />b
+      </inline>
+      <text />
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-inline-before-text-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-inline-before-text-after.tsx
@@ -24,10 +24,10 @@ export const output = (
   <editor>
     <element>
       <text />
-      <inline>
-        a<cursor />
-      </inline>
-      <text id="1">b</text>
+      <inline>a</inline>
+      <text id="1">
+        <cursor />b
+      </text>
     </element>
   </editor>
 )

--- a/packages/slate/test/operations/remove_node/cursor-sibling-inline-before-text-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-inline-before-text-after.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { jsx } from '../../'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+      <inline>a</inline>
+      <text id="0">
+        <cursor />
+      </text>
+      <text id="1">b</text>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 2],
+    node: { text: '', id: '0' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text />
+      <inline>
+        a<cursor />
+      </inline>
+      <text id="1">b</text>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-inline-before.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-inline-before.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { jsx } from '../../'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+      <inline>a</inline>
+      <text>
+        <cursor />
+      </text>
+    </element>
+    <element>b</element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 2],
+    node: { text: '' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text />
+      <inline>
+        a<cursor />
+      </inline>
+      {/* Recreated by normalizer */}
+      <text />
+    </element>
+    <element>b</element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-text-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-text-after.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>a</element>
+    <element>
+      <text id="0">
+        <cursor />
+      </text>
+      <text id="1">b</text>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [1, 0],
+    node: { text: '', id: '0' },
+  },
+]
+export const output = (
+  <editor>
+    <element>a</element>
+    <element>
+      <text id="1">
+        <cursor />b
+      </text>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-text-before-inline-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-text-before-inline-after.tsx
@@ -23,10 +23,10 @@ export const operations = [
 export const output = (
   <editor>
     <element>
-      <text id="0">a</text>
-      <inline>
-        <cursor />b
-      </inline>
+      <text id="0">
+        a<cursor />
+      </text>
+      <inline>b</inline>
       <text />
     </element>
   </editor>

--- a/packages/slate/test/operations/remove_node/cursor-sibling-text-before-inline-after.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-text-before-inline-after.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { jsx } from '../../'
+
+export const input = (
+  <editor>
+    <element>
+      <text id="0">a</text>
+      <text id="1">
+        <cursor />
+      </text>
+      <inline>b</inline>
+      <text />
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 1],
+    node: { text: '', id: '1' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text id="0">a</text>
+      <inline>
+        <cursor />b
+      </inline>
+      <text />
+    </element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-text-before.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-text-before.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text id="0">a</text>
+      <text id="1">
+        <cursor />
+      </text>
+    </element>
+    <element>b</element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 1],
+    node: { text: '', id: '1' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text id="0">
+        a<cursor />
+      </text>
+    </element>
+    <element>b</element>
+  </editor>
+)

--- a/packages/slate/test/operations/remove_node/cursor-sibling-text-both-sides.tsx
+++ b/packages/slate/test/operations/remove_node/cursor-sibling-text-both-sides.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text id="0">a</text>
+      <text id="1">
+        <cursor />
+      </text>
+      <text id="2">b</text>
+    </element>
+  </editor>
+)
+export const operations = [
+  {
+    type: 'remove_node',
+    path: [0, 1],
+    node: { text: '', id: '1' },
+  },
+]
+export const output = (
+  <editor>
+    <element>
+      <text id="0">
+        a<cursor />
+      </text>
+      <text id="2">b</text>
+    </element>
+  </editor>
+)

--- a/packages/slate/test/transforms/delete/point/inline-void-reverse.tsx
+++ b/packages/slate/test/transforms/delete/point/inline-void-reverse.tsx
@@ -25,10 +25,9 @@ export const output = (
     <block>
       <text />
       <inline void>
-        <text>
-          <cursor />
-        </text>
+        <text />
       </inline>
+      <cursor />
       word
     </block>
   </editor>


### PR DESCRIPTION
**Description**
Previously, when removing the node containing the cursor, the selection would enter a sibling inline in some circumstances, even when a sibling text node was available. This PR ensures that if a sibling text node is available, the cursor is always placed inside it.

**Example**
The most noticeable side-effect of this change occurs when pressing backspace at the start of line N when the last non-empty node in line N-1 is an inline.

Before:

https://github.com/user-attachments/assets/3aa335fb-48b2-4f07-9656-59bbd305ecb9

After:

https://github.com/user-attachments/assets/c87219ba-99b7-4e69-bfe2-9ccd4eb5ef8a

**Context**
The purpose of this change is to ensure that `editor.isSelectable` is respected when the default normalization rules remove an empty text node containing the cursor. Previously, the cursor could be placed inside a non-selectable inline if one was adjacent to the removed text node.

See this commit for the full set of tests whose output is affected by this change (including tests added in this PR): https://github.com/ianstormtaylor/slate/commit/71f21614660825d461a510ecea6d9700ca091f07

If this is too big of a change to merge, an alternative would be to check inside the `remove_node` handler whether either the `prev` or `next` text node is inside a non-selectable ancestor element and disqualify it if so.

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

