### PR TITLE
Generic return type for `Node.fragment`

### DIFF
--- a/.changeset/pretty-cobras-sleep.md
+++ b/.changeset/pretty-cobras-sleep.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Use generics for the return type of `Node.fragment`

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -127,7 +127,10 @@ export interface NodeInterface {
   /**
    * Get the sliced fragment represented by a range inside a root node.
    */
-  fragment: (root: Node, range: Range) => Descendant[]
+  fragment: <T extends Ancestor = Editor>(
+    root: T,
+    range: Range
+  ) => T['children']
 
   /**
    * Get the descendant node referred to by a specific path. If the path is an
@@ -353,15 +356,7 @@ export const Node: NodeInterface = {
     return [n, p]
   },
 
-  fragment(root: Node, range: Range): Descendant[] {
-    if (Text.isText(root)) {
-      throw new Error(
-        `Cannot get a fragment starting from a root text node: ${Scrubber.stringify(
-          root
-        )}`
-      )
-    }
-
+  fragment<T extends Ancestor = Editor>(root: T, range: Range): T['children'] {
     const newRoot = produce({ children: root.children }, r => {
       const [start, end] = Range.edges(range)
       const nodeEntries = Node.nodes(r, {


### PR DESCRIPTION
**Description**
Use generics for the return type of `Node.fragment` so that it matches the `children` of the root you pass in.

**Example**
```ts
interface ParagraphElement extends BaseElement {
  type: 'paragraph'
  children: InlineNode[]
}

// Type of fragment is InlineNode[]
const fragment = Node.fragment(paragraph, range)
```

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

