### PR TITLE
Add notice clarifying that we're unrelated to Slate CRM

### DIFF
--- a/docs/general/contributing.md
+++ b/docs/general/contributing.md
@@ -32,6 +32,8 @@ Here's a [JSFiddle template for Slate](https://jsfiddle.net/01pLxfzu/) to get yo
 
 ## Asking Questions
 
+**ℹ️ If you're looking for help with the [Slate CRM platform](https://slate.org/), that's an unrelated project to us.**
+
 We've also got a [Slate Slack team](https://join.slack.com/t/slate-js/shared_invite/zt-f8t986ip-7dA1DyiqPpzootz1snKXkw) where you can ask questions and get answers from other people using Slate:
 
 [![](../.gitbook/assets/slack.png)](https://join.slack.com/t/slate-js/shared_invite/zt-f8t986ip-7dA1DyiqPpzootz1snKXkw)


### PR DESCRIPTION
We occasionally get people on Slack asking about Slate CRM, which has a very similar domain name to us (slate.org).

This PR adds a note to the contributing page, just above the Slack invite link, clarifying that we're unrelated. I'm guessing this is the main place where people are finding the Slack link. The link is also present at the top of the README, but I haven't added a note there to avoid cluttering it up. The Slack link in the navbar is a broken link to https://slate-slack.herokuapp.com/.