### PR TITLE
Fix CI by pinning Node to 22.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           cache: yarn
 
       - name: Run ${{ matrix.command }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           cache: yarn
           registry-url: https://registry.npmjs.org
           key: node22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           cache: yarn
           registry-url: https://registry.npmjs.org
           key: node20


### PR DESCRIPTION
It looks like CI was broken with the [release of Node 22.18.0](https://versionlog.com/nodejs/22/).

This PR patches the issue by pinning to 22.17.1, but we should look into fixing compatibility with later Node versions.

```
file:///home/runner/work/slate/slate/packages/slate/test/interfaces/CustomTypes/custom-types.ts:2
  BaseEditor,
  ^^^^^^^^^^
SyntaxError: Named export 'BaseEditor' not found. The requested module 'slate' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'slate';
```