### PR TITLE
fix: Search backward and forward for leaf nodes in non contenteditable elements

### DIFF
--- a/.changeset/real-clouds-accept.md
+++ b/.changeset/real-clouds-accept.md
@@ -1,0 +1,5 @@
+---
+'slate-dom': patch
+---
+
+Search backward and forward for leaf nodes in non contenteditable elements inside `toSlatePoint`

--- a/packages/slate-dom/src/plugin/dom-editor.ts
+++ b/packages/slate-dom/src/plugin/dom-editor.ts
@@ -697,7 +697,7 @@ export const DOMEditor: DOMEditorInterface = {
       searchDirection?: 'forward' | 'backward'
     }
   ): T extends true ? Point | null : Point => {
-    const { exactMatch, suppressThrow, searchDirection = 'backward' } = options
+    const { exactMatch, suppressThrow, searchDirection } = options
     const [nearestNode, nearestOffset] = exactMatch
       ? domPoint
       : normalizeDOMPoint(domPoint)
@@ -812,20 +812,32 @@ export const DOMEditor: DOMEditorInterface = {
           '[data-slate-node="element"]'
         )
 
-        if (searchDirection === 'forward') {
-          const leafNodes = [
-            ...getLeafNodes(elementNode),
-            ...getLeafNodes(elementNode?.nextElementSibling),
-          ]
-          leafNode =
-            leafNodes.find(leaf => isAfter(nonEditableNode, leaf)) ?? null
-        } else {
+        if (searchDirection === 'backward' || !searchDirection) {
           const leafNodes = [
             ...getLeafNodes(elementNode?.previousElementSibling),
             ...getLeafNodes(elementNode),
           ]
+
           leafNode =
             leafNodes.findLast(leaf => isBefore(nonEditableNode, leaf)) ?? null
+
+          if (leafNode) {
+            searchDirection === 'backward'
+          }
+        }
+
+        if (searchDirection === 'forward' || !searchDirection) {
+          const leafNodes = [
+            ...getLeafNodes(elementNode),
+            ...getLeafNodes(elementNode?.nextElementSibling),
+          ]
+
+          leafNode =
+            leafNodes.find(leaf => isAfter(nonEditableNode, leaf)) ?? null
+
+          if (leafNode) {
+            searchDirection === 'forward'
+          }
         }
 
         if (leafNode) {


### PR DESCRIPTION
**Description**
This PR change the `toSlatePoint` function in a way, that if the selection is within a `contentEditable={false}` node, it will search backward and forward for valid slate leafs. Before it was only looking backward by default.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5932

**Example**
You can find a GIF and a codesandbox link in the linked issue. Here you can see how it behaves after the fix:
![slate-drop](https://github.com/user-attachments/assets/a59522eb-c541-4dcc-85c6-b87aa184aa9d)

**Context**
I am aware, that this is a very sensible spot to make changes. Help appreciated!

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

