### PR TITLE
fix: Fixed with pasting a void block in a paragraph middle path

### DIFF
--- a/packages/slate/test/transforms/insertFragment/of-blocks/block-middle-void.tsx
+++ b/packages/slate/test/transforms/insertFragment/of-blocks/block-middle-void.tsx
@@ -1,0 +1,34 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const run = (editor, options = {}) => {
+  Transforms.insertFragment(
+    editor,
+    <fragment>
+      <block void />
+    </fragment>,
+    options
+  )
+}
+export const input = (
+  <editor>
+    <block>
+      wo
+      <cursor />
+      rd
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>wo</block>
+    <block void>
+      <text />
+    </block>
+    <block>
+      <cursor />
+      rd
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
Inserting a void block (such as an image) in the middle of a paragraph would incorrectly insert it before or after the paragraph. This change will cause it to be inserted at the cursor or selection position.

**Issue**
Fixes: (link to issue)

**Example**
befor:

https://github.com/user-attachments/assets/978db57c-1960-48d8-ba35-29e16755c64e

after:

https://github.com/user-attachments/assets/f8ce025f-ec71-4a54-847a-e0241ddd445e



**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

