### PR TITLE
fix: Sync `NODE_TO_INDEX` and `NODE_TO_PARENT` on `apply` instead on render

### DIFF
--- a/packages/slate-dom/src/plugin/with-dom.ts
+++ b/packages/slate-dom/src/plugin/with-dom.ts
@@ -35,6 +35,8 @@ import {
   EDITOR_TO_USER_MARKS,
   EDITOR_TO_USER_SELECTION,
   NODE_TO_KEY,
+  NODE_TO_INDEX,
+  NODE_TO_PARENT,
 } from '../utils/weak-maps'
 import { DOMEditor } from './dom-editor'
 
@@ -222,6 +224,15 @@ export const withDOM = <T extends BaseEditor>(
 
     for (const [path, key] of matches) {
       const [node] = Editor.node(e, path)
+
+      NODE_TO_INDEX.set(node, path.length ? path[path.length - 1] : 0)
+
+      if (path.length) {
+        const [parent] = Editor.parent(e, path)
+
+        NODE_TO_PARENT.set(node, parent)
+      }
+
       NODE_TO_KEY.set(node, key)
     }
 

--- a/packages/slate-react/src/components/element.tsx
+++ b/packages/slate-react/src/components/element.tsx
@@ -9,8 +9,6 @@ import {
   EDITOR_TO_KEY_TO_ELEMENT,
   ELEMENT_TO_NODE,
   NODE_TO_ELEMENT,
-  NODE_TO_INDEX,
-  NODE_TO_PARENT,
 } from 'slate-dom'
 import {
   RenderChunkProps,
@@ -138,9 +136,6 @@ const Element = (props: {
         />
       </Tag>
     )
-
-    NODE_TO_INDEX.set(text, 0)
-    NODE_TO_PARENT.set(text, element)
   }
 
   return renderElement({ attributes, children, element })

--- a/packages/slate-react/src/hooks/use-children.tsx
+++ b/packages/slate-react/src/hooks/use-children.tsx
@@ -12,12 +12,7 @@ import {
 import ElementComponent from '../components/element'
 import TextComponent from '../components/text'
 import { ReactEditor } from '../plugin/react-editor'
-import {
-  IS_NODE_MAP_DIRTY,
-  NODE_TO_INDEX,
-  NODE_TO_PARENT,
-  splitDecorationsByChild,
-} from 'slate-dom'
+import { IS_NODE_MAP_DIRTY, splitDecorationsByChild } from 'slate-dom'
 import { useSlateStatic } from './use-slate-static'
 import { getChunkTreeForNode } from '../chunking'
 import ChunkTree from '../components/chunk-tree'
@@ -59,16 +54,6 @@ const useChildren = (props: {
     node,
     decorations
   )
-
-  // Update the index and parent of each child.
-  // PERF: If chunking is enabled, this is done while traversing the chunk tree
-  // instead to eliminate unnecessary weak map operations.
-  if (!chunking) {
-    node.children.forEach((n, i) => {
-      NODE_TO_INDEX.set(n, i)
-      NODE_TO_PARENT.set(n, node)
-    })
-  }
 
   const renderElementComponent = useCallback(
     (n: Element, i: number, cachedKey?: Key) => {
@@ -127,17 +112,6 @@ const useChildren = (props: {
     reconcile: {
       chunkSize,
       rerenderChildren: childrenToRedecorate,
-      onInsert: (n, i) => {
-        NODE_TO_INDEX.set(n, i)
-        NODE_TO_PARENT.set(n, node)
-      },
-      onUpdate: (n, i) => {
-        NODE_TO_INDEX.set(n, i)
-        NODE_TO_PARENT.set(n, node)
-      },
-      onIndexChange: (n, i) => {
-        NODE_TO_INDEX.set(n, i)
-      },
     },
   })
 


### PR DESCRIPTION
**Description**
This PR will keep `NODE_TO_INDEX` and `NODE_TO_PARENT` in sync right after applying operations, instead of on render. This will make the `DOMEditor.findPath` function more reliable.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5938

**Context**
Please have a look at the issue for more context.

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

