### PR TITLE
Fix `Transforms.wrapNodes` where `split: true` at text node start or end

### DIFF
--- a/.changeset/heavy-pants-cover.md
+++ b/.changeset/heavy-pants-cover.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix: The `split: true` option on `Transforms.wrapNodes` does not work correctly when one or more points is at the start or end of a text node.

--- a/packages/slate/src/transforms-node/wrap-nodes.ts
+++ b/packages/slate/src/transforms-node/wrap-nodes.ts
@@ -15,6 +15,7 @@ export const wrapNodes: NodeTransforms['wrapNodes'] = (
   Editor.withoutNormalizing(editor, () => {
     const { mode = 'lowest', split = false, voids = false } = options
     let { match, at = editor.selection } = options
+    const isInline = editor.isInline(element)
 
     if (!at) {
       return
@@ -23,7 +24,7 @@ export const wrapNodes: NodeTransforms['wrapNodes'] = (
     if (match == null) {
       if (Path.isPath(at)) {
         match = matchPath(editor, at)
-      } else if (editor.isInline(element)) {
+      } else if (isInline) {
         match = n =>
           (Element.isElement(n) && Editor.isInline(editor, n)) || Text.isText(n)
       } else {
@@ -36,8 +37,13 @@ export const wrapNodes: NodeTransforms['wrapNodes'] = (
       const rangeRef = Editor.rangeRef(editor, at, {
         affinity: 'inward',
       })
-      Transforms.splitNodes(editor, { at: end, match, voids })
-      Transforms.splitNodes(editor, { at: start, match, voids })
+      Transforms.splitNodes(editor, { at: end, match, voids, always: isInline })
+      Transforms.splitNodes(editor, {
+        at: start,
+        match,
+        voids,
+        always: isInline,
+      })
       at = rangeRef.unref()!
 
       if (options.at == null) {

--- a/packages/slate/test/transforms/wrapNodes/split-block/block-mark.tsx
+++ b/packages/slate/test/transforms/wrapNodes/split-block/block-mark.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block old>
+      <text>
+        one
+        <anchor />
+      </text>
+      <text bold>two</text>
+      <text>
+        <focus />
+        three
+      </text>
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.wrapNodes(editor, <block new />, { split: true })
+}
+export const output = (
+  <editor>
+    <block old>one</block>
+    <block new>
+      <block old>
+        <text bold>
+          <anchor />
+          two
+          <focus />
+        </text>
+      </block>
+    </block>
+    <block old>
+      <text>three</text>
+    </block>
+  </editor>
+)

--- a/packages/slate/test/transforms/wrapNodes/split-inline/inline-mark.tsx
+++ b/packages/slate/test/transforms/wrapNodes/split-inline/inline-mark.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { Transforms } from 'slate'
+import { jsx } from '../../..'
+
+export const input = (
+  <editor>
+    <block>
+      <text>
+        one
+        <anchor />
+      </text>
+      <text bold>two</text>
+      <text>
+        <focus />
+        three
+      </text>
+    </block>
+  </editor>
+)
+export const run = editor => {
+  Transforms.wrapNodes(editor, <inline new />, { split: true })
+}
+export const output = (
+  <editor>
+    <block>
+      <text>one</text>
+      <inline new>
+        <text bold>
+          <anchor />
+          two
+          <focus />
+        </text>
+      </inline>
+      <text>three</text>
+    </block>
+  </editor>
+)


### PR DESCRIPTION
**Description**
Previously `Transforms.wrapNodes`, when called with `split: true`, did not split at the start or end of the selection correctly if that point was at the start or end of a text node. This could result in adjacent text nodes being inadvertently wrapped.

**Issue**
Fixes #5942

**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)
- [X] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

