### PR TITLE
test: fix `select.test.ts` after button component styling updates

### DIFF
--- a/playwright/integration/examples/select.test.ts
+++ b/playwright/integration/examples/select.test.ts
@@ -12,11 +12,7 @@ test.describe('selection', () => {
     for (let i = 0; i < 3; i++) {
       await page.locator(slateEditor).nth(1).click()
     }
-    await page.pause()
-
-    // .css-1vdn1ty is the gray, unselected button
-    expect(await page.locator('.css-1vdn1ty').nth(6).textContent()).toBe(
-      'format_quote'
-    )
+    const quoteButton = page.getByTestId('block-button-block-quote')
+    await expect(quoteButton).toHaveCSS('color', 'rgb(204, 204, 204)')
   })
 })

--- a/site/examples/ts/richtext.tsx
+++ b/site/examples/ts/richtext.tsx
@@ -251,6 +251,7 @@ const BlockButton = ({ format, icon }: BlockButtonProps) => {
         event.preventDefault()
       }
       onClick={() => toggleBlock(editor, format)}
+      data-test-id={`block-button-${format}`}
     >
       <Icon>{icon}</Icon>
     </Button>


### PR DESCRIPTION
**Description**
The `select.test.ts` was using a dynamically generated CSS class selector (`.css-1vdn1ty`) from Emotion CSS-in-JS library, which broke after recent button component updates in PR #5946 .

**Context**
- The button component uses `@emotion/css` which generates hash-based class names
- When the button styling was updated, the CSS class hash changed from `.css-1vdn1ty` to a new value
- The test continued to reference the old, non-existent class name

Updates:
- Updated `richtext.tsx` to add test-id for BlockButton.
- Updated `select.test.ts` to use `page.getByTestId()` instead of CSS class selector.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] The relevant e2e test cases are passing.
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

**Apologies for missing this E2E update in the original PR. This ensures our test suite remains stable against future styling changes.**
<img width="1552" height="987" alt="Screenshot 2025-08-28 at 1 29 12 PM" src="https://github.com/user-attachments/assets/f04cafe4-3c02-4059-a4b7-106ae3015d75" />
