### PR TITLE
Fix onValueChange was not triggered when replacing text after selecting it from right to left

### DIFF
--- a/.changeset/mean-pots-thank.md
+++ b/.changeset/mean-pots-thank.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix: `onValueChange` was not triggered when replacing text after selecting it from right to left.

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -692,8 +692,18 @@ export const Editable = forwardRef(
                 exactMatch: false,
                 suppressThrow: false,
               })
+              const flippedRange = {
+                anchor: range.focus,
+                focus: range.anchor,
+              }
 
-              if (!selection || !Range.equals(selection, range)) {
+              if (
+                !selection ||
+                !(
+                  Range.equals(selection, range) ||
+                  Range.equals(selection, flippedRange)
+                )
+              ) {
                 native = false
 
                 const selectionRef =


### PR DESCRIPTION
`onValueChange` was not triggered when replacing text after selecting it from right to left

**Description**

onValueChange was not triggered when replacing text after selecting it from right to left, while selecting text from left to right works as expected. This inconsistency occurs because getTargetRanges cannot detect the direction of the user's selection.


**Issue**
Fixes: #5955 

**Example**

https://github.com/user-attachments/assets/f261e051-ec64-41e1-af34-ecc1814c61f0



**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

