### PR TITLE
fix: add translate=no attribute to Editable component to avoid DOM desynchronization

### DIFF
--- a/.changeset/warm-dolphins-rescue.md
+++ b/.changeset/warm-dolphins-rescue.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Adds translate='no' to Editable component to skip DOM from translation

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1030,6 +1030,7 @@ export const Editable = forwardRef(
               <Component
                 role={readOnly ? undefined : 'textbox'}
                 aria-multiline={readOnly ? undefined : true}
+                translate="no"
                 {...attributes}
                 // COMPAT: Certain browsers don't support the `beforeinput` event, so we'd
                 // have to use hacks to make these replacement-based features work.

--- a/packages/slate-react/test/editable.spec.tsx
+++ b/packages/slate-react/test/editable.spec.tsx
@@ -200,5 +200,42 @@ describe('slate-react', () => {
       expect(onChange).toHaveBeenCalled()
       expect(onSelectionChange).not.toHaveBeenCalled()
     })
+
+    describe('translate="no"', () => {
+      test('should have translate="no" attribute', () => {
+        const editor = withReact(createEditor())
+        const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+
+        const { container } = render(
+          <Slate
+            editor={editor}
+            initialValue={initialValue}
+            onChange={() => {}}
+          >
+            <Editable />
+          </Slate>
+        )
+
+        const editableElement = container.querySelector('[data-slate-editor]')
+        expect(editableElement?.getAttribute('translate')).toBe('no')
+      })
+      test('should allow override of translate attribute', () => {
+        const editor = withReact(createEditor())
+        const initialValue = [{ type: 'block', children: [{ text: 'test' }] }]
+
+        const { container } = render(
+          <Slate
+            editor={editor}
+            initialValue={initialValue}
+            onChange={() => {}}
+          >
+            <Editable translate="yes" />
+          </Slate>
+        )
+
+        const editableElement = container.querySelector('[data-slate-editor]')
+        expect(editableElement?.getAttribute('translate')).toBe('yes')
+      })
+    })
   })
 })


### PR DESCRIPTION
**Description**
This PR adds `translate='no'` to the Editable component to prevent textareas from getting desynced due to browser or extension-based translations. I’ve verified this behavior in Notion, Google Docs, and Lexical, all of which use either `notranslate` or `skiptranslate` class but `translate` attribute is now [widely](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate) supported across browsers.

**Issue**
Fixes: #5951 

**Example**
Before: 

https://github.com/user-attachments/assets/4b262e43-435d-43bd-9172-ecdae68f5819


After: 

https://github.com/user-attachments/assets/1cbe6b8a-5079-4473-bdb9-0f9491df1390



**Context**
This issue occurs because when the page is translated, all text content is replaced with its translated version. This can cause syncing issues between the DOM text and Slate’s internal state. In particular, when the translated text becomes longer than the original, it results in the `point.offset` exceeding the valid range in the `toDOMPoint` function, leading to the error:
`Cannot resolve a DOM point from Slate point`.

To address this, I checked how other editors handle translation, including Google Docs, Notion, and Lexical, and noticed that they exclude their editable regions from being translated. This approach makes sense since editable content should not be translated unless the translation can be synchronized with the editor’s internal state (`editor.children` in our case).
Please let me know if this approach works for us.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

