### PR TITLE
fix(slate-react): prevent premature flush during composition for Andr…

### DIFF
--- a/.changeset/brave-dragons-write.md
+++ b/.changeset/brave-dragons-write.md
@@ -1,0 +1,10 @@
+---
+'slate-react': patch
+---
+
+Fix Android handwriting input where first stroke commits prematurely on empty lines (e.g., '我' becomes '一我').
+
+**Cause:** When writing the first character of an empty line, Android handwriting triggers childList mutations (creating new DOM structure). These mutations get restored by RestoreDOM during React re-render, which interrupts the IME composition session.
+
+**Fix:** Skip flush during composition only when at the first character of an empty line. This targeted fix preserves normal onChange behavior for other scenarios while preventing the handwriting issue.
+


### PR DESCRIPTION
## Description

On Android devices, using handwriting input (e.g., Sogou Input Method) causes the initial stroke of a character to be committed prematurely. For example, when writing "我", the first stroke "一" is inserted immediately, leading to a final incorrect result of "一我".

The root cause is that Android handwriting IME triggers `compositionStart`/`compositionEnd` events per stroke, unlike keyboard input which only fires these events at the beginning and end of the entire input session. During composition, multiple code paths (`handleInput()`, `scheduleAction()`, `handleUserSelect()`) were calling `flush()`, which applies pending diffs to the editor via `Editor.insertText()`. This DOM modification causes the browser to terminate the current composition session, and the next stroke starts a new composition that appends to the already-committed text rather than replacing it.

The fix adds `IS_COMPOSING` checks in `flush()`, `scheduleAction()`, and `handleInput()` to prevent flushing during an active composition session. The pending diffs now properly accumulate and are only flushed after `compositionEnd` fires.

## Issue

Fixes: https://github.com/ianstormtaylor/slate/issues/5979

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

