### PR TITLE
Fix rendering issues when both chunking and React's strict mode are enabled

### DIFF
--- a/.changeset/warm-months-hammer.md
+++ b/.changeset/warm-months-hammer.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix rendering issues when both chunking and React's strict mode are enabled

--- a/packages/slate-react/src/chunking/reconcile-children.ts
+++ b/packages/slate-react/src/chunking/reconcile-children.ts
@@ -31,8 +31,6 @@ export const reconcileChildren = (
     debug,
   }: ReconcileOptions
 ) => {
-  chunkTree.modifiedChunks.clear()
-
   const chunkTreeHelper = new ChunkTreeHelper(chunkTree, { chunkSize, debug })
   const childrenHelper = new ChildrenHelper(editor, children)
 

--- a/packages/slate-react/src/components/chunk-tree.tsx
+++ b/packages/slate-react/src/components/chunk-tree.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { ComponentProps, Fragment, useEffect } from 'react'
 import { Element } from 'slate'
 import { Key } from 'slate-dom'
 import { RenderChunkProps } from './editable'
@@ -51,7 +51,17 @@ const ChunkAncestor = <C extends TChunkAncestor>(props: {
   })
 }
 
-const ChunkTree = ChunkAncestor<TChunkTree>
+const ChunkTree = (props: ComponentProps<typeof ChunkAncestor<TChunkTree>>) => {
+  // Clear the set of modified chunks only when React finishes rendering. The
+  // timing of this is important in strict mode because if the chunks are
+  // cleared during rendering (such as in reconcileChildren), strict mode's
+  // second render won't include them.
+  useEffect(() => {
+    props.root.modifiedChunks.clear()
+  })
+
+  return <ChunkAncestor {...props} />
+}
 
 const MemoizedChunk = React.memo(
   ChunkAncestor<TChunk>,

--- a/site/examples/js/huge-document.jsx
+++ b/site/examples/js/huge-document.jsx
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { StrictMode, useCallback, useEffect, useState } from 'react'
 import { createEditor as slateCreateEditor, Editor } from 'slate'
 import { Editable, Slate, withReact, useSelected } from 'slate-react'
 
@@ -41,6 +41,7 @@ const initialConfig = {
     'chunk'
   ),
   showSelectedHeadings: parseBoolean('selected_headings', false),
+  strictMode: parseBoolean('strict', false),
 }
 const setSearchParams = config => {
   if (searchParams) {
@@ -54,6 +55,7 @@ const setSearchParams = config => {
       'selected_headings',
       config.showSelectedHeadings ? 'true' : 'false'
     )
+    searchParams.set('strict', config.strictMode ? 'true' : 'false')
     history.replaceState({}, '', `?${searchParams.toString()}`)
   }
 }
@@ -129,6 +131,24 @@ const HugeDocumentExample = () => {
     ),
     [config.contentVisibilityMode, config.chunkOutlines]
   )
+  const editable = rendering ? (
+    <div>Rendering&hellip;</div>
+  ) : (
+    <Slate key={editorVersion} editor={editor} initialValue={initialValue}>
+      <Editable
+        placeholder="Enter some text…"
+        renderElement={renderElement}
+        renderChunk={config.chunkDivs ? renderChunk : undefined}
+        spellCheck
+        autoFocus
+      />
+    </Slate>
+  )
+  const editableWithStrictMode = config.strictMode ? (
+    <StrictMode>{editable}</StrictMode>
+  ) : (
+    editable
+  )
   return (
     <>
       <PerformanceControls
@@ -137,19 +157,7 @@ const HugeDocumentExample = () => {
         setConfig={setConfig}
       />
 
-      {rendering ? (
-        <div>Rendering&hellip;</div>
-      ) : (
-        <Slate key={editorVersion} editor={editor} initialValue={initialValue}>
-          <Editable
-            placeholder="Enter some text…"
-            renderElement={renderElement}
-            renderChunk={config.chunkDivs ? renderChunk : undefined}
-            spellCheck
-            autoFocus
-          />
-        </Slate>
-      )}
+      {editableWithStrictMode}
     </>
   )
 }
@@ -392,6 +400,21 @@ const PerformanceControls = ({ editor, config, setConfig }) => {
               }
             />{' '}
             Call <code>useSelected</code> in each heading
+          </label>
+        </p>
+
+        <p>
+          <label>
+            <input
+              type="checkbox"
+              checked={config.strictMode}
+              onChange={event =>
+                setConfig({
+                  strictMode: event.target.checked,
+                })
+              }
+            />{' '}
+            React strict mode (only works in localhost)
           </label>
         </p>
       </details>

--- a/site/examples/js/richtext.jsx
+++ b/site/examples/js/richtext.jsx
@@ -194,10 +194,9 @@ const BlockButton = ({ format, icon }) => {
         format,
         isAlignType(format) ? 'align' : 'type'
       )}
-      onMouseDown={event => {
-        event.preventDefault()
-        toggleBlock(editor, format)
-      }}
+      onPointerDown={event => event.preventDefault()}
+      onClick={() => toggleBlock(editor, format)}
+      data-test-id={`block-button-${format}`}
     >
       <Icon>{icon}</Icon>
     </Button>
@@ -208,10 +207,8 @@ const MarkButton = ({ format, icon }) => {
   return (
     <Button
       active={isMarkActive(editor, format)}
-      onMouseDown={event => {
-        event.preventDefault()
-        toggleMark(editor, format)
-      }}
+      onPointerDown={event => event.preventDefault()}
+      onClick={() => toggleMark(editor, format)}
     >
       <Icon>{icon}</Icon>
     </Button>

--- a/site/examples/ts/huge-document.tsx
+++ b/site/examples/ts/huge-document.tsx
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import React, {
   CSSProperties,
   Dispatch,
+  StrictMode,
   useCallback,
   useEffect,
   useState,
@@ -33,6 +34,7 @@ interface Config {
   chunkOutlines: boolean
   contentVisibilityMode: 'none' | 'element' | 'chunk'
   showSelectedHeadings: boolean
+  strictMode: boolean
 }
 
 const blocksOptions = [
@@ -78,6 +80,7 @@ const initialConfig: Config = {
     'chunk'
   ),
   showSelectedHeadings: parseBoolean('selected_headings', false),
+  strictMode: parseBoolean('strict', false),
 }
 
 const setSearchParams = (config: Config) => {
@@ -92,6 +95,7 @@ const setSearchParams = (config: Config) => {
       'selected_headings',
       config.showSelectedHeadings ? 'true' : 'false'
     )
+    searchParams.set('strict', config.strictMode ? 'true' : 'false')
     history.replaceState({}, '', `?${searchParams.toString()}`)
   }
 }
@@ -183,6 +187,26 @@ const HugeDocumentExample = () => {
     [config.contentVisibilityMode, config.chunkOutlines]
   )
 
+  const editable = rendering ? (
+    <div>Rendering&hellip;</div>
+  ) : (
+    <Slate key={editorVersion} editor={editor} initialValue={initialValue}>
+      <Editable
+        placeholder="Enter some text…"
+        renderElement={renderElement}
+        renderChunk={config.chunkDivs ? renderChunk : undefined}
+        spellCheck
+        autoFocus
+      />
+    </Slate>
+  )
+
+  const editableWithStrictMode = config.strictMode ? (
+    <StrictMode>{editable}</StrictMode>
+  ) : (
+    editable
+  )
+
   return (
     <>
       <PerformanceControls
@@ -191,19 +215,7 @@ const HugeDocumentExample = () => {
         setConfig={setConfig}
       />
 
-      {rendering ? (
-        <div>Rendering&hellip;</div>
-      ) : (
-        <Slate key={editorVersion} editor={editor} initialValue={initialValue}>
-          <Editable
-            placeholder="Enter some text…"
-            renderElement={renderElement}
-            renderChunk={config.chunkDivs ? renderChunk : undefined}
-            spellCheck
-            autoFocus
-          />
-        </Slate>
-      )}
+      {editableWithStrictMode}
     </>
   )
 }
@@ -481,6 +493,21 @@ const PerformanceControls = ({
               }
             />{' '}
             Call <code>useSelected</code> in each heading
+          </label>
+        </p>
+
+        <p>
+          <label>
+            <input
+              type="checkbox"
+              checked={config.strictMode}
+              onChange={event =>
+                setConfig({
+                  strictMode: event.target.checked,
+                })
+              }
+            />{' '}
+            React strict mode (only works in localhost)
           </label>
         </p>
       </details>


### PR DESCRIPTION
**Description**
If React's strict mode and the experimental chunking optimisation are both enabled, this caused rendering issues inside chunks that prevented `slate-react` from synchronising changes to the editor value with the DOM. This PR resolves these issues by adjusting the timing of when the chunk tree's `modifiedChunks` set is cleared.

**Example**
Recording of the bug as reported by z2devil on Slack:

> When the editor chunk is initialized in React StrictMode, text input inside this chunk stops working and the cursor disappears.

https://github.com/user-attachments/assets/a3f6db85-c7b6-4a61-997f-89d5e2219172

**Context**
The chunking optimisation works by iteratively mutating a nested "chunk tree" object as part of `useChildren` every time the parent element renders. On each iteration, the new children array is "reconciled" with the chunk tree, analogous to how React reconciles the DOM with its virtual DOM. This reconciliation can result in chunks being added, removed or modified.

Since each individual chunk in the chunk tree is mutable, React cannot automatically determine whether the component corresponding to each chunk needs to be re-rendered. For this reason, the chunk tree maintains a set of `modifiedChunks`, which are chunks that have been modified since the last render. If a given chunk appears in this set, we bypass React's memoisation and re-render the chunk's component.

Prior to this PR, this `modifiedChunks` set was cleared at the start of each iteration (i.e. at the start of each render), so that the set included only those chunks that were modified as part of the current iteration. However, this caused issues with React's strict mode, in which each component's render function is called twice prior to that component actually being rendered.

This meant that on the first render pass, `modifiedChunks` was correct but unused. On the second render pass (caused by strict mode), `modifiedChunks` had already been cleared, and the chunk tree had already been updated. This meant that `modifiedChunk` was empty when `React.memo` checked whether each chunk component needed to be re-rendered, resulting in the chunk component failing to update in response to changes to the editor value.

This PR fixes this by only clearing `modifiedChunks` inside a `useEffect`, by which time its value has already been used.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

