### PR TITLE
fix(slate): performance issues caused by ultra-long nodes(#5992)

### DIFF
--- a/packages/slate/src/utils/modify.ts
+++ b/packages/slate/src/utils/modify.ts
@@ -8,18 +8,15 @@ import {
   Text,
 } from '../interfaces'
 
-export const insertChildren = <T>(
-  xs: T[],
-  index: number,
-  ...newValues: T[]
-) => [...xs.slice(0, index), ...newValues, ...xs.slice(index)]
+export const insertChildren = <T>(xs: T[], index: number, ...newValues: T[]) =>
+  xs.slice(0, index).concat(newValues, xs.slice(index))
 
 export const replaceChildren = <T>(
   xs: T[],
   index: number,
   removeCount: number,
   ...newValues: T[]
-) => [...xs.slice(0, index), ...newValues, ...xs.slice(index + removeCount)]
+) => xs.slice(0, index).concat(newValues, xs.slice(index + removeCount))
 
 export const removeChildren = replaceChildren
 


### PR DESCRIPTION
**Description**
Calling `Node.fragment` incurs additional performance overhead due to array destructuring. Consider replacing it with `slice` and `contact` to achieve the same functionality.

**Issue**
Fixes: https://github.com/ianstormtaylor/slate/issues/5992

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

