### PR TITLE
fix(slate-dom): respect `suppressThrow` in `toSlatePoint` when `findPath` fails

### DIFF
--- a/.changeset/fix-find-path-throws-after-unmount.md
+++ b/.changeset/fix-find-path-throws-after-unmount.md
@@ -1,0 +1,9 @@
+---
+'slate-dom': patch
+---
+
+Fix `findPath` throwing "Unable to find the path for Slate node" after component unmount
+
+When `toSlatePoint` is called with `suppressThrow: true` (e.g., from `toSlateRange` during selection change handling), it should not throw errors. However, the internal `findPath` calls were not respecting this option, causing errors to be thrown when the component was unmounting and node references became stale.
+
+This fix wraps the `findPath` calls in `toSlatePoint` with try-catch blocks that respect the `suppressThrow` option, returning `null` instead of throwing when the option is enabled.

--- a/packages/slate-dom/src/plugin/dom-editor.ts
+++ b/packages/slate-dom/src/plugin/dom-editor.ts
@@ -888,10 +888,16 @@ export const DOMEditor: DOMEditorInterface = {
 
       if (node && DOMEditor.hasDOMNode(editor, node, { editable: true })) {
         const slateNode = DOMEditor.toSlateNode(editor, node)
-        let { path, offset } = Editor.start(
-          editor,
-          DOMEditor.findPath(editor, slateNode)
-        )
+        let nodePath
+        try {
+          nodePath = DOMEditor.findPath(editor, slateNode)
+        } catch (e) {
+          if (suppressThrow) {
+            return null as T extends true ? Point | null : Point
+          }
+          throw e
+        }
+        let { path, offset } = Editor.start(editor, nodePath)
 
         if (!node.querySelector('[data-slate-leaf]')) {
           offset = nearestOffset
@@ -914,7 +920,15 @@ export const DOMEditor: DOMEditorInterface = {
     // the select event fires twice, once for the old editor's `element`
     // first, and then afterwards for the correct `element`. (2017/03/03)
     const slateNode = DOMEditor.toSlateNode(editor, textNode!)
-    const path = DOMEditor.findPath(editor, slateNode)
+    let path
+    try {
+      path = DOMEditor.findPath(editor, slateNode)
+    } catch (e) {
+      if (suppressThrow) {
+        return null as T extends true ? Point | null : Point
+      }
+      throw e
+    }
     return { path, offset } as T extends true ? Point | null : Point
   },
 


### PR DESCRIPTION
When `toSlatePoint` is called with `suppressThrow: true`, internal calls to `findPath` should not cause errors to propagate. This is particularly important during component unmount when node references may become stale.

The throttled selection change handler in slate-react uses `toSlateRange` with `suppressThrow: true`, but if `findPath` throws during unmount, the error was not being caught, causing "Unable to find the path for Slate node" errors after the component unmounts.

This fix wraps the two `findPath` calls in `toSlatePoint` with try-catch blocks that respect the `suppressThrow` option.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

