### PR TITLE
Passing `force` property from `normalize` to `normalizeNode` method

### DIFF
--- a/.changeset/olive-planes-work.md
+++ b/.changeset/olive-planes-work.md
@@ -1,0 +1,5 @@
+---
+'slate': minor
+---
+
+Added `force` property to `normalizeNode` passed from `normalize` method

--- a/packages/slate/src/editor/normalize.ts
+++ b/packages/slate/src/editor/normalize.ts
@@ -57,7 +57,7 @@ export const normalize: EditorInterface['normalize'] = (
           by definition adding children to an empty node can't cause other paths to change.
         */
         if (Node.isElement(node) && node.children.length === 0) {
-          editor.normalizeNode(entry, { operation })
+          editor.normalizeNode(entry, { operation, force })
         }
       }
     }
@@ -83,7 +83,7 @@ export const normalize: EditorInterface['normalize'] = (
       // If the node doesn't exist in the tree, it does not need to be normalized.
       if (Node.has(editor, dirtyPath)) {
         const entry = Editor.node(editor, dirtyPath)
-        editor.normalizeNode(entry, { operation })
+        editor.normalizeNode(entry, { operation, force })
       }
       iteration++
       dirtyPaths = getDirtyPaths(editor)

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -59,6 +59,7 @@ export interface BaseEditor {
     options?: {
       operation?: Operation
       fallbackElement?: () => Element
+      force?: boolean
     }
   ) => void
   onChange: (options?: { operation?: Operation }) => void


### PR DESCRIPTION
It might be helpful when you have custom normalizations and you need to react accordingly to `editor.normalize({ force: true })`