### PR TITLE
Fix hasDOMNode throwing error when editor is not mounted

### DIFF
--- a/packages/slate-dom/src/plugin/dom-editor.ts
+++ b/packages/slate-dom/src/plugin/dom-editor.ts
@@ -475,7 +475,14 @@ export const DOMEditor: DOMEditorInterface = {
 
   hasDOMNode: (editor, target, options = {}) => {
     const { editable = false } = options
-    const editorEl = DOMEditor.toDOMNode(editor, editor)
+
+    let editorEl
+    try {
+      editorEl = DOMEditor.toDOMNode(editor, editor)
+    } catch {
+      // Editor not mounted - target cannot be part of this editor
+      return false
+    }
     let targetEl
 
     // COMPAT: In Firefox, reading `target.nodeType` will throw an error if


### PR DESCRIPTION
Wrap the toDOMNode call in a try-catch to gracefully handle the case where the editor is not yet mounted. In this case, the target cannot be part of the editor, so returning false is the correct behavior.

**Description**
A clear and concise description of what this pull request solves. (Please do not just link to a long issue thread. Instead include a clear description here or your pull request will likely not be reviewed as quickly.)

**Issue**
Fixes: (link to issue)

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

