### PR TITLE
Do not allow paths to contain strings when getting nodes

### DIFF
--- a/.changeset/early-suns-judge.md
+++ b/.changeset/early-suns-judge.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Do not allow paths to contain strings when getting nodes

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -430,6 +430,10 @@ export const Node: NodeInterface = {
     for (let i = 0; i < path.length; i++) {
       const p = path[i]
 
+      if (typeof p !== 'number') {
+        throw new Error('Got non-numeric path index')
+      }
+
       if (Node.isText(node) || !node.children[p]) {
         return
       }

--- a/packages/slate/test/interfaces/Node/getIf/proto.tsx
+++ b/packages/slate/test/interfaces/Node/getIf/proto.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx  */
+import { Node } from 'slate'
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <editor>
+    <element>
+      <text />
+    </element>
+  </editor>
+)
+export const test = value => {
+  try {
+    return Node.getIf(value, ['__proto__' as any])
+  } catch (error) {
+    return error.message
+  }
+}
+export const output = 'Got non-numeric path index'


### PR DESCRIPTION
**Description**
Prevent `Node.get` and `Node.getIf` from accessing string keys when these keys are present in the given path.

**Example**
Before:
```js
const myNode = Node.get(editor, ['__proto__'])
myNode[99] = 'Ninety nine is compromised.'
console.log([][99]) // => Ninety nine is compromised.
```

After:
```js
Node.get(editor, ['__proto__']) // Error: Got non-numeric path index
```

**Context**
As far as I know, this is not directly exploitable **unless** applications are mutating properties on nodes directly, which is strongly discouraged. Even then, it would only be high-risk if this could be instigated by a remote attacker, such as in collaborative editors or Slate code running on the server.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

