### PR TITLE
Fix normalization hanging under non-selectable elements

### DIFF
--- a/.changeset/fair-lobsters-thank.md
+++ b/.changeset/fair-lobsters-thank.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Fix normalization hanging when merging text under non-selectable elements

--- a/packages/slate/src/transforms-node/merge-nodes.ts
+++ b/packages/slate/src/transforms-node/merge-nodes.ts
@@ -31,8 +31,12 @@ export const mergeNodes: NodeTransforms['mergeNodes'] = (
       return
     }
 
+    const isPathMerge = Location.isPath(at)
+    const pathAt = isPathMerge ? (at as Path) : null
+    const usesDefaultSiblingMatch = match == null && isPathMerge
+
     if (match == null) {
-      if (Location.isPath(at)) {
+      if (isPathMerge) {
         const [parent] = Editor.parent(editor, at)
         match = n => parent.children.includes(n)
       } else {
@@ -60,7 +64,13 @@ export const mergeNodes: NodeTransforms['mergeNodes'] = (
     }
 
     const [current] = Editor.nodes(editor, { at, match, voids, mode })
-    const prev = Editor.previous(editor, { at, match, voids, mode })
+    const previousPath =
+      usesDefaultSiblingMatch && pathAt && Path.hasPrevious(pathAt)
+        ? Path.previous(pathAt)
+        : null
+    const prev = previousPath
+      ? Editor.node(editor, previousPath)
+      : Editor.previous(editor, { at, match, voids, mode })
 
     if (!current || !prev) {
       return

--- a/packages/slate/test/normalization/text/merge-adjacent-non-selectable-ancestor.ts
+++ b/packages/slate/test/normalization/text/merge-adjacent-non-selectable-ancestor.ts
@@ -1,0 +1,74 @@
+import { createEditor } from 'slate'
+
+export const input = createEditor() as any
+
+const { isSelectable, shouldNormalize } = input
+
+input.isSelectable = (element: any) => {
+  return element.type === 'collapsible-content' ? false : isSelectable(element)
+}
+
+input.shouldNormalize = (options: any) => {
+  if (options.iteration > 20) {
+    throw new Error(
+      'Normalization likely stalled while merging text under a non-selectable element.'
+    )
+  }
+
+  return shouldNormalize(options)
+}
+
+input.children = [
+  {
+    type: 'paragraph',
+    children: [{ text: 'Before the collapsible.' }],
+  },
+  {
+    type: 'collapsible',
+    children: [
+      {
+        type: 'collapsible-summary',
+        children: [{ text: 'Summary' }],
+      },
+      {
+        type: 'collapsible-content',
+        children: [
+          {
+            type: 'paragraph',
+            children: [{ text: 'is' }, { text: ' here' }],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+input.selection = null
+
+export const output = {
+  children: [
+    {
+      type: 'paragraph',
+      children: [{ text: 'Before the collapsible.' }],
+    },
+    {
+      type: 'collapsible',
+      children: [
+        {
+          type: 'collapsible-summary',
+          children: [{ text: 'Summary' }],
+        },
+        {
+          type: 'collapsible-content',
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ text: 'is here' }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  selection: null,
+} as any

--- a/packages/slate/test/transforms/mergeNodes/path/non-selectable-ancestor.ts
+++ b/packages/slate/test/transforms/mergeNodes/path/non-selectable-ancestor.ts
@@ -1,0 +1,70 @@
+import { createEditor, Transforms } from 'slate'
+
+export const input = createEditor() as any
+
+export const run = editor => {
+  const { isSelectable } = editor
+
+  editor.isSelectable = (element: any) => {
+    return element.type === 'collapsible-content'
+      ? false
+      : isSelectable(element)
+  }
+
+  editor.children = [
+    {
+      type: 'paragraph',
+      children: [{ text: 'Before the collapsible.' }],
+    },
+    {
+      type: 'collapsible',
+      children: [
+        {
+          type: 'collapsible-summary',
+          children: [{ text: 'Summary' }],
+        },
+        {
+          type: 'collapsible-content',
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ text: 'is' }, { text: ' here' }],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+
+  editor.selection = null
+
+  Transforms.mergeNodes(editor, { at: [1, 1, 0, 1], voids: true })
+}
+
+export const output = {
+  children: [
+    {
+      type: 'paragraph',
+      children: [{ text: 'Before the collapsible.' }],
+    },
+    {
+      type: 'collapsible',
+      children: [
+        {
+          type: 'collapsible-summary',
+          children: [{ text: 'Summary' }],
+        },
+        {
+          type: 'collapsible-content',
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ text: 'is here' }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  selection: null,
+} as any


### PR DESCRIPTION
**Description**
Fix a Slate core regression where normalization can hang while merging adjacent text nodes under a non-selectable element.

**Issue**
Fixes: #6023

**Example**
Minimal repro:

```ts
const editor = createEditor()
const originalIsSelectable = editor.isSelectable

editor.isSelectable = element =>
  element.type === 'collapsible-content'
    ? false
    : originalIsSelectable(element)

editor.children = [
  {
    type: 'paragraph',
    children: [{ text: 'Before the collapsible.' }],
  },
  {
    type: 'collapsible',
    children: [
      {
        type: 'collapsible-summary',
        children: [{ text: 'Summary' }],
      },
      {
        type: 'collapsible-content',
        children: [
          {
            type: 'paragraph',
            children: [{ text: 'is' }, { text: ' here' }],
          },
        ],
      },
    ],
  },
]

editor.selection = null
Editor.normalize(editor, { force: true })
```

This PR also adds:
- a normalization regression test that reproduces the hang
- a narrower `Transforms.mergeNodes` test covering the structural merge path directly

**Context**
The regression comes from `Editor.positions` honoring `editor.isSelectable`, while `mergeNodes` was using cursor-style traversal to find the previous merge partner even in the default path-based merge case.

For structural merges, that traversal is the wrong abstraction: when `mergeNodes` is called with the default sibling match at a concrete path, it should use the direct previous sibling path instead of `Editor.previous`. This keeps normalization from skipping non-selectable subtrees while still preserving the `isSelectable` behavior in cursor movement APIs.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

Targeted checks run locally:
- `yarn build:rollup`
- `yarn test:custom --grep "(merge-adjacent-non-selectable-ancestor|non-selectable-ancestor)"`
- `yarn test:custom --grep "text-across"`