### PR TITLE
fix: 🐛 fix android soft keyboard dismisses when mark and input

### DIFF
--- a/.changeset/tough-kings-fail.md
+++ b/.changeset/tough-kings-fail.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+fix android soft keyboard dismisses when mark and input

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -698,15 +698,13 @@ export function createAndroidInputManager({
                 offset: start.offset + text.length,
               }
 
-              scheduleAction(
-                () => {
-                  Transforms.select(editor, {
-                    anchor: newPoint,
-                    focus: newPoint,
-                  })
-                },
-                { at: newPoint }
-              )
+              // `Editor.insertText` with `editor.marks` uses `insertNodes` (new text leaf) instead of
+              // extending the current leaf, so `newPoint` can be past the end of `start.path`.
+              // `performAction` already applies `normalizePoint` to `action.at` before `run()`;
+              // a second `Transforms.select` here with the raw point would overwrite that and leave
+              // an invalid selection (e.g. Android keyboard dismiss). Selection is set in
+              // `performAction` only.
+              scheduleAction(() => {}, { at: newPoint })
             }
             return
           }


### PR DESCRIPTION
**Description**
On Android, after toggling a mark (e.g. bold) with a collapsed selection, the next keystroke could dismiss the soft keyboard and break caret placement. The Android input manager scheduled a follow-up selection using a point computed as if the character were inserted inside the same text leaf (path unchanged, offset + text.length). When editor.marks is set, Editor.insertText uses insertNodes (a new marked text node) rather than extending the current leaf, so that computed point could lie beyond the leaf length and overwrite the valid selection that insertNodes had already applied.
This change stops scheduling a second Transforms.select with that raw point: performAction already normalizes action.at with normalizePoint and updates the selection; the previous run() callback duplicated the select with incorrect coordinates for the marks/insertNodes case.

**Issue**
Fixes: #6022 

**Example**

Before repair see #6022 

After repair:
https://github.com/user-attachments/assets/20d0d15a-687e-4816-9e8d-6b0de32fac05

**Context**
In handleDOMBeforeInput, after storeDiff for an insertion, the code called
`scheduleAction(() => Transforms.select(editor, { anchor: newPoint, focus: newPoint }), { at: newPoint })`. flush runs `Editor.insertText` for the diff; with active marks, Slate’s insertText inserts a new text node and sets the selection to the end of that node. performAction then runs: it first selects using `normalizePoint(editor, newPoint)`, which maps an “past end of leaf” offset onto the correct following text node. Immediately after, `action.run()` called `Transforms.select` again with the un-normalized newPoint, which is invalid when the insert was a sibling node. Replacing the callback with a no-op keeps selection handling solely in the normalizePoint path inside performAction.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

