### PR TITLE
Fix release workflow changeset install immutability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           version: yarn changesetversion
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Publish to npm (OIDC)
         if: matrix.channel == 'latest' && steps.changesets.outputs.hasChangesets == 'false'


### PR DESCRIPTION
## Summary
- allow the release PR versioning step to run with `YARN_ENABLE_IMMUTABLE_INSTALLS=false`
- keep normal install and CI behavior unchanged; only the `changesets/action` version step is made mutable
- fix the release workflow failure where `yarn changesetversion` tries to update `yarn.lock` after package versions are bumped

## Context
The release workflow is currently failing in the `Create or update release PR` step.

Relevant failing run:
- https://github.com/ianstormtaylor/slate/actions/runs/22678163418/job/65740660422#step:10:132

Root cause:
- `package.json` defines `changesetversion` as `yarn changeset version && yarn install && git add .`
- after Changesets bumps internal package ranges, `yarn install` needs to update `yarn.lock`
- in GitHub Actions, Yarn is running with immutable installs enabled, so the step fails with `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.`

This PR makes only that release-PR generation step mutable, which matches what the step is expected to do.

## Test plan
- [x] inspect the failing GitHub Actions run and confirm the failure happens in `yarn changesetversion`
- [x] verify this branch is based on `main`
- [ ] wait for the release workflow to run on this PR