### PR TITLE
fix(ci): restore GitHub Releases via changesets/action publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,21 +61,18 @@ jobs:
       - name: Prepare release
         run: yarn prerelease
 
-      - name: Create or update release PR
+      # Version PR when changesets exist; when none remain, publish runs here and
+      # changesets/action pushes tags + creates GitHub Releases (unlike plain `yarn changeset publish`).
+      - name: Create or update release PR / publish
         if: matrix.channel == 'latest'
         id: changesets
         uses: changesets/action@v1
         with:
           version: yarn changesetversion
+          publish: yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-      - name: Publish to npm (OIDC)
-        if: matrix.channel == 'latest' && steps.changesets.outputs.hasChangesets == 'false'
-        run: yarn changeset publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release to @dev channel
         if: matrix.channel == 'dev'


### PR DESCRIPTION
## Summary

Publishing was moved to a standalone `yarn changeset publish` step in [`20db84f3`](https://github.com/ianstormtaylor/slate/commit/20db84f3). That publishes to npm but **does not** run `changesets/action`'s publish path, which is what **pushes `package@version` tags** and **creates GitHub Releases** (with notes from `@changesets/changelog-github`).

This PR restores `publish: yarn changeset publish` on `changesets/action@v1` and removes the duplicate publish step so we do not double-publish.

## OIDC / npm

The job already has `id-token: write` and omits `NPM_TOKEN`; `changesets/action` uses npm trusted publishing when OIDC is available.

## Test plan

- [ ] After merge, the next `Version Packages` merge should run the action publish path and create GitHub Releases for newly published packages.