### PR TITLE
Fix caret jumping to wrong position when decorations restructure DOM #5987

### DIFF
--- a/.changeset/fix-decorate-caret-jump.md
+++ b/.changeset/fix-decorate-caret-jump.md
@@ -1,0 +1,5 @@
+---
+"slate-react": patch
+---
+
+Fix caret jumping to wrong position when the decorate prop changes asynchronously

--- a/packages/slate-react/src/hooks/use-decorations.ts
+++ b/packages/slate-react/src/hooks/use-decorations.ts
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useRef } from 'react'
+import { createContext, useCallback, useContext, useMemo, useReducer, useRef } from 'react'
 import { DecoratedRange, Descendant, Node, NodeEntry } from 'slate'
 import { isTextDecorationsEqual, isElementDecorationsEqual } from 'slate-dom'
 import { useSlateStatic } from './use-slate-static'
@@ -52,6 +52,7 @@ export const useDecorations = (
 export const useDecorateContext = (
   decorateProp: (entry: NodeEntry) => DecoratedRange[]
 ) => {
+  const [, forceUpdate] = useReducer(s => s + 1, 0)
   const eventListeners = useRef(new Set<Callback>())
 
   const latestDecorate = useRef(decorateProp)
@@ -59,6 +60,7 @@ export const useDecorateContext = (
   useIsomorphicLayoutEffect(() => {
     latestDecorate.current = decorateProp
     eventListeners.current.forEach(listener => listener())
+    forceUpdate()
   }, [decorateProp])
 
   const decorate = useCallback(

--- a/packages/slate-react/src/hooks/use-decorations.ts
+++ b/packages/slate-react/src/hooks/use-decorations.ts
@@ -1,4 +1,11 @@
-import { createContext, useCallback, useContext, useMemo, useReducer, useRef } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useReducer,
+  useRef,
+} from 'react'
 import { DecoratedRange, Descendant, Node, NodeEntry } from 'slate'
 import { isTextDecorationsEqual, isElementDecorationsEqual } from 'slate-dom'
 import { useSlateStatic } from './use-slate-static'

--- a/packages/slate-react/src/hooks/use-decorations.ts
+++ b/packages/slate-react/src/hooks/use-decorations.ts
@@ -67,6 +67,12 @@ export const useDecorateContext = (
   useIsomorphicLayoutEffect(() => {
     latestDecorate.current = decorateProp
     eventListeners.current.forEach(listener => listener())
+    // Force Editable to re-render in the same batch as the text components
+    // notified above, so its selection-restoration layout effect runs after
+    // the decoration-induced DOM changes are committed. Without this, the
+    // text components restructure the DOM in a separate pass where
+    // Editable's layout effect never fires, potentially leaving the caret
+    // at a wrong position.
     forceUpdate()
   }, [decorateProp])
 

--- a/playwright/integration/examples/decorations-async.test.ts
+++ b/playwright/integration/examples/decorations-async.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('decorations-async', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/examples/decorations-async')
+  })
+
+  test('highlights duplicate words on initial load', async ({ page }) => {
+    // The initial value contains "the" and "fox" more than once.
+    // Decorations are computed on mount so highlights should appear immediately.
+    await expect(page.locator('[data-cy="highlight"]')).not.toHaveCount(0)
+  })
+
+  test('caret does not jump when async decoration fires', async ({ page }) => {
+    const editor = page.getByRole('textbox')
+
+    // Move to the end of the editor and type a word that already exists
+    // in the first paragraph ("fox"), creating a new duplicate.
+    await editor.click()
+    await editor.press('ControlOrMeta+End')
+    await page.keyboard.type(' fox')
+
+    // Wait for the 600 ms debounce to fire and decorations to update.
+    await page.waitForTimeout(800)
+
+    // If the caret jumped, the next character would appear at the wrong
+    // position. Type a sentinel character and verify it lands right after
+    // the word we typed, not somewhere else in the document.
+    await page.keyboard.type('!')
+
+    const lastParagraph = editor
+      .locator('[data-slate-node="element"]')
+      .last()
+    await expect(lastParagraph).toContainText('fox!')
+  })
+})

--- a/site/constants/examples.ts
+++ b/site/constants/examples.ts
@@ -3,6 +3,7 @@ export const EXAMPLE_NAMES_AND_PATHS = [
   ['Checklists', 'check-lists'],
   ['Code Highlighting', 'code-highlighting'],
   ['Custom Placeholder', 'custom-placeholder'],
+  ['Decorations Async', 'decorations-async'],
   ['Editable Voids', 'editable-voids'],
   ['Embeds', 'embeds'],
   ['Forced Layout', 'forced-layout'],

--- a/site/examples/js/decorations-async.jsx
+++ b/site/examples/js/decorations-async.jsx
@@ -1,38 +1,28 @@
 import { css } from '@emotion/css'
 import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react'
-import { Descendant, Text, NodeEntry, Range, createEditor } from 'slate'
+import { Text, createEditor } from 'slate'
 import { withHistory } from 'slate-history'
-import {
-  Editable,
-  RenderLeafProps,
-  Slate,
-  withReact,
-  ReactEditor,
-} from 'slate-react'
-
+import { Editable, Slate, withReact } from 'slate-react'
 // Finds all words that appear more than once across the document and returns
 // their ranges. In a real app this work might come from a language server,
 // spell-checker, or search index — anything that produces results with latency.
-function findDuplicateRanges(editor: ReactEditor): Range[] {
-  const freq: Record<string, number> = {}
-
+function findDuplicateRanges(editor) {
+  const freq = {}
   for (const [node] of editor.nodes({ at: [], match: n => Text.isText(n) })) {
     if (!Text.isText(node)) continue
     for (const word of node.text.toLowerCase().match(/\b\w+\b/g) ?? []) {
       freq[word] = (freq[word] ?? 0) + 1
     }
   }
-
   const duplicates = new Set(Object.keys(freq).filter(w => freq[w] > 1))
-  const ranges: Range[] = []
-
+  const ranges = []
   for (const [node, path] of editor.nodes({
     at: [],
     match: n => Text.isText(n),
   })) {
     if (!Text.isText(node)) continue
     const wordRe = /\b\w+\b/g
-    let match: RegExpExecArray | null
+    let match
     while ((match = wordRe.exec(node.text)) !== null) {
       if (duplicates.has(match[0].toLowerCase())) {
         ranges.push({
@@ -42,28 +32,22 @@ function findDuplicateRanges(editor: ReactEditor): Range[] {
       }
     }
   }
-
   return ranges
 }
-
 const AsyncDecorationsExample = () => {
   const editor = useMemo(() => withHistory(withReact(createEditor())), [])
-
-  const [ranges, setRanges] = useState<Range[]>([])
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
+  const [ranges, setRanges] = useState([])
+  const timeoutRef = useRef(null)
   // Compute the initial decorations synchronously on mount.
   useEffect(() => {
     setRanges(findDuplicateRanges(editor))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
   useEffect(() => {
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
   }, [])
-
   // On every change, keep the existing ranges and schedule a recompute after
   // 600 ms. When the timeout fires, `setRanges` produces a new `ranges`
   // reference, which gives `decorate` a new identity and triggers a full
@@ -75,9 +59,8 @@ const AsyncDecorationsExample = () => {
       setRanges(findDuplicateRanges(editor))
     }, 600)
   }, [editor])
-
   const decorate = useCallback(
-    ([node, path]: NodeEntry): Range[] => {
+    ([node, path]) => {
       if (!Text.isText(node)) return []
       return ranges
         .filter(r => r.anchor.path[0] === path[0])
@@ -85,7 +68,6 @@ const AsyncDecorationsExample = () => {
     },
     [ranges]
   )
-
   return (
     <div>
       <p
@@ -113,7 +95,7 @@ const AsyncDecorationsExample = () => {
       >
         <Editable
           decorate={decorate}
-          renderLeaf={(props: RenderLeafProps) => <Leaf {...props} />}
+          renderLeaf={props => <Leaf {...props} />}
           className={css`
             min-height: 140px;
             padding: 12px;
@@ -127,18 +109,11 @@ const AsyncDecorationsExample = () => {
     </div>
   )
 }
-
-interface HighlightLeaf {
-  highlight?: boolean
-  text: string
-}
-
-const Leaf = ({ attributes, children, leaf }: RenderLeafProps) => {
-  const hLeaf = leaf as HighlightLeaf
+const Leaf = ({ attributes, children, leaf }) => {
+  const hLeaf = leaf
   return (
     <span
       {...attributes}
-      {...(hLeaf.highlight && { 'data-cy': 'highlight' })}
       className={css`
         background-color: ${hLeaf.highlight ? '#ffe58f' : 'transparent'};
         border-radius: ${hLeaf.highlight ? '2px' : '0'};
@@ -148,8 +123,7 @@ const Leaf = ({ attributes, children, leaf }: RenderLeafProps) => {
     </span>
   )
 }
-
-const initialValue: Descendant[] = [
+const initialValue = [
   {
     type: 'paragraph',
     children: [
@@ -167,5 +141,4 @@ const initialValue: Descendant[] = [
     ],
   },
 ]
-
 export default AsyncDecorationsExample

--- a/site/examples/ts/decorations-async.tsx
+++ b/site/examples/ts/decorations-async.tsx
@@ -1,0 +1,157 @@
+import { css } from '@emotion/css'
+import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react'
+import { Descendant, Text, NodeEntry, Range, createEditor } from 'slate'
+import { withHistory } from 'slate-history'
+import { Editable, RenderLeafProps, Slate, withReact, ReactEditor } from 'slate-react'
+
+// Finds all words that appear more than once across the document and returns
+// their ranges. In a real app this work might come from a language server,
+// spell-checker, or search index — anything that produces results with latency.
+function findDuplicateRanges(editor: ReactEditor): Range[] {
+  const freq: Record<string, number> = {}
+
+  for (const [node] of editor.nodes({ at: [], match: n => Text.isText(n) })) {
+    if (!Text.isText(node)) continue
+    for (const word of node.text.toLowerCase().match(/\b\w+\b/g) ?? []) {
+      freq[word] = (freq[word] ?? 0) + 1
+    }
+  }
+
+  const duplicates = new Set(Object.keys(freq).filter(w => freq[w] > 1))
+  const ranges: Range[] = []
+
+  for (const [node, path] of editor.nodes({ at: [], match: n => Text.isText(n) })) {
+    if (!Text.isText(node)) continue
+    const wordRe = /\b\w+\b/g
+    let match: RegExpExecArray | null
+    while ((match = wordRe.exec(node.text)) !== null) {
+      if (duplicates.has(match[0].toLowerCase())) {
+        ranges.push({
+          anchor: { path, offset: match.index },
+          focus: { path, offset: match.index + match[0].length },
+        })
+      }
+    }
+  }
+
+  return ranges
+}
+
+const AsyncDecorationsExample = () => {
+  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+
+  const [ranges, setRanges] = useState<Range[]>([])
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Compute the initial decorations synchronously on mount.
+  useEffect(() => {
+    setRanges(findDuplicateRanges(editor))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  // On every change, keep the existing ranges and schedule a recompute after
+  // 600 ms. When the timeout fires, `setRanges` produces a new `ranges`
+  // reference, which gives `decorate` a new identity and triggers a full
+  // re-decoration pass across all Text components — the scenario where the
+  // caret previously jumped.
+  const handleChange = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => {
+      setRanges(findDuplicateRanges(editor))
+    }, 600)
+  }, [editor])
+
+  const decorate = useCallback(
+    ([node, path]: NodeEntry): Range[] => {
+      if (!Text.isText(node)) return []
+      return ranges
+        .filter(r => r.anchor.path[0] === path[0])
+        .map(r => ({ ...r, highlight: true }))
+    },
+    [ranges]
+  )
+
+  return (
+    <div>
+      <p
+        className={css`
+          font-size: 0.85em;
+          color: #555;
+          margin-bottom: 8px;
+          padding: 8px 12px;
+          background: #fffbe6;
+          border: 1px solid #ffe58f;
+          border-radius: 4px;
+        `}
+      >
+        Words that appear <strong>more than once</strong> are highlighted.
+        Highlights are kept while you type and updated{' '}
+        <strong>600 ms after you stop</strong>, simulating an async source
+        such as a spell-checker or language server. Place the caret after the
+        text and type a word that already exists — the caret should stay put
+        when the new highlight appears.
+      </p>
+      <Slate editor={editor} initialValue={initialValue} onChange={handleChange}>
+        <Editable
+          decorate={decorate}
+          renderLeaf={(props: RenderLeafProps) => <Leaf {...props} />}
+          className={css`
+            min-height: 140px;
+            padding: 12px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 16px;
+            line-height: 1.6;
+          `}
+        />
+      </Slate>
+    </div>
+  )
+}
+
+interface HighlightLeaf {
+  highlight?: boolean
+  text: string
+}
+
+const Leaf = ({ attributes, children, leaf }: RenderLeafProps) => {
+  const hLeaf = leaf as HighlightLeaf
+  return (
+    <span
+      {...attributes}
+      className={css`
+        background-color: ${hLeaf.highlight ? '#ffe58f' : 'transparent'};
+        border-radius: ${hLeaf.highlight ? '2px' : '0'};
+      `}
+    >
+      {children}
+    </span>
+  )
+}
+
+const initialValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: 'The fox jumped over the fence and the fox ran away.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: 'Type a word that already appears above, then wait. The new occurrence will be highlighted after a short delay.',
+      },
+    ],
+  },
+]
+
+export default AsyncDecorationsExample


### PR DESCRIPTION
**Description**

When decorate changes asynchronously, the caret jumps to the wrong position.

Root cause: Text components re-render in a separate React commit from Editable. When decorations restructure the DOM, Editable's selection-restoration useLayoutEffect has already run and never re-fires, leaving the browser selection pointing at a stale node.

A forceUpdate() in useDecorateContext forces Editable to re-render in the same commit as the Text components, so the layout effect runs after the updated DOM is in place.

Example and integration test added: Decorations Async — an editor where duplicate words are highlighted 600 ms after each edit, demonstrating that the caret stays put when the async decoration update fires.

Closes #5987

**Checks**
- [x ] The new code matches the existing patterns and styles.
- [ x] The tests pass with `yarn test`.
- [ x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ x] The relevant examples still work. (Run examples with `yarn start`.)
- [x ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

