### PR TITLE
chore(deps): update lodash to version 4.17.23 across all packages to fix prototype pollution issue

### DIFF
--- a/.changeset/security-lodash-41723.md
+++ b/.changeset/security-lodash-41723.md
@@ -1,0 +1,8 @@
+---
+"slate": patch
+"slate-dom": patch
+"slate-history": patch
+"slate-react": patch
+---
+
+chore(deps): update lodash to `^4.17.23` to address prototype pollution in `_.unset` / `_.omit` ([CVE-2025-13465](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg), [lodash v4.17.23 changelog](https://github.com/lodash/lodash/wiki/Changelog#v41723)).

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "jest-environment-jsdom": "29.7.0",
     "lerna": "^7.4.1",
     "lint-staged": "^15.0.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "mocha": "^10.2.0",
     "next": "^14.2.32",
     "npm-run-all": "^4.1.5",

--- a/packages/slate-dom/package.json
+++ b/packages/slate-dom/package.json
@@ -18,7 +18,7 @@
     "direction": "^1.0.4",
     "is-hotkey": "^0.2.0",
     "is-plain-object": "^5.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "scroll-into-view-if-needed": "^3.1.0",
     "tiny-invariant": "1.3.1"
   },

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -15,7 +15,7 @@
   ],
   "devDependencies": {
     "@babel/runtime": "^7.23.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "slate": "^0.124.0",
     "slate-hyperscript": "^0.115.0",
     "source-map-loader": "^4.0.1"

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -17,7 +17,7 @@
     "@juggle/resize-observer": "^3.4.0",
     "direction": "^1.0.4",
     "is-hotkey": "^0.2.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "scroll-into-view-if-needed": "^3.1.0",
     "tiny-invariant": "1.3.1"
   },

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -15,7 +15,7 @@
   ],
   "devDependencies": {
     "@babel/runtime": "^7.23.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "slate-hyperscript": "^0.115.0",
     "source-map-loader": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10289,10 +10289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
+"lodash@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
   languageName: node
   linkType: hard
 
@@ -13721,7 +13721,7 @@ __metadata:
     direction: "npm:^1.0.4"
     is-hotkey: "npm:^0.2.0"
     is-plain-object: "npm:^5.0.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     scroll-into-view-if-needed: "npm:^3.1.0"
     slate: "npm:^0.124.0"
     slate-hyperscript: "npm:^0.115.0"
@@ -13737,7 +13737,7 @@ __metadata:
   resolution: "slate-history@workspace:packages/slate-history"
   dependencies:
     "@babel/runtime": "npm:^7.23.2"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     slate: "npm:^0.124.0"
     slate-hyperscript: "npm:^0.115.0"
     source-map-loader: "npm:^4.0.1"
@@ -13808,7 +13808,7 @@ __metadata:
     jest-environment-jsdom: "npm:29.7.0"
     lerna: "npm:^7.4.1"
     lint-staged: "npm:^15.0.1"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     mocha: "npm:^10.2.0"
     next: "npm:^14.2.32"
     npm-run-all: "npm:^4.1.5"
@@ -13861,7 +13861,7 @@ __metadata:
     "@types/resize-observer-browser": "npm:^0.1.8"
     direction: "npm:^1.0.4"
     is-hotkey: "npm:^0.2.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     scroll-into-view-if-needed: "npm:^3.1.0"
@@ -13883,7 +13883,7 @@ __metadata:
   resolution: "slate@workspace:packages/slate"
   dependencies:
     "@babel/runtime": "npm:^7.23.2"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     slate-hyperscript: "npm:^0.115.0"
     source-map-loader: "npm:^4.0.1"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -10289,7 +10289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.23":
+"lodash@npm:^4.17.21, lodash@npm:^4.17.23":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233


### PR DESCRIPTION
**Description**
This PR bumps lodash from 4.17.21 to 4.17.23 in the root workspace and in packages that declare it as a devDependency (slate, slate-dom, slate-history, slate-react).

### Why
4.17.23 includes a security fix for prototype pollution in _.unset and _.omit, tracked as [CVE-2025-13465](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) (GitHub advisory). It can also be seen in [Snyk Vulnerability Database](https://security.snyk.io/package/npm/lodash/4.17.21). Upgrade to 4.17.23 is needed to fix this.

Lodash’s own changelog documents this release:

[lodash wiki — v4.17.23](https://github.com/lodash/lodash/wiki/Changelog#v41723) — notes the _.unset / _.omit fix and links the advisory above.


**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

