### PR TITLE
Harden property accessors against untrusted keys

### DIFF
--- a/.changeset/pink-jobs-kneel.md
+++ b/.changeset/pink-jobs-kneel.md
@@ -1,0 +1,7 @@
+---
+'slate-dom': patch
+'slate': patch
+---
+
+- Harden property accessors against untrusted keys
+- Fix incorrect argument types for the `compare` and `merge` options of `Transforms.setNodes`

--- a/packages/slate-dom/src/utils/dom.ts
+++ b/packages/slate-dom/src/utils/dom.ts
@@ -158,6 +158,10 @@ export const getEditableChildAndIndex = (
   index: number,
   direction: 'forward' | 'backward'
 ): [DOMNode, number] => {
+  if (typeof index !== 'number') {
+    throw new Error('Expected index to be a number')
+  }
+
   const { childNodes } = parent
   let child = childNodes[index]
   let i = index

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -986,5 +986,5 @@ export type NodeMatch<T extends Node> =
   | ((node: Node, path: Path) => node is T)
   | ((node: Node, path: Path) => boolean)
 
-export type PropsCompare = (prop: Partial<Node>, node: Partial<Node>) => boolean
-export type PropsMerge = (prop: Partial<Node>, node: Partial<Node>) => object
+export type PropsCompare = (prop: unknown, node: unknown) => boolean
+export type PropsMerge = (prop: unknown, node: unknown) => object

--- a/packages/slate/src/interfaces/node.ts
+++ b/packages/slate/src/interfaces/node.ts
@@ -273,6 +273,10 @@ export const Node: NodeInterface = {
       )
     }
 
+    if (typeof index !== 'number') {
+      throw new Error('Expected index to be a number')
+    }
+
     const c = root.children[index] as Descendant
 
     if (c == null) {
@@ -449,6 +453,10 @@ export const Node: NodeInterface = {
 
     for (let i = 0; i < path.length; i++) {
       const p = path[i]
+
+      if (typeof p !== 'number') {
+        throw new Error('Got non-numeric path index')
+      }
 
       if (Node.isText(node) || !node.children[p]) {
         return false

--- a/packages/slate/src/interfaces/path.ts
+++ b/packages/slate/src/interfaces/path.ts
@@ -199,6 +199,10 @@ export const Path: PathInterface = {
       const av = path[i]
       const bv = another[i]
 
+      if (typeof av !== 'number' || typeof bv !== 'number') {
+        throw new Error('Got non-numeric path index')
+      }
+
       if (av !== bv) {
         break
       }

--- a/packages/slate/src/interfaces/transforms/general.ts
+++ b/packages/slate/src/interfaces/transforms/general.ts
@@ -21,6 +21,23 @@ import {
   replaceChildren,
 } from '../../utils/modify'
 
+/**
+ * The set of properties that cannot be set using set_node.
+ */
+export const NON_SETTABLE_NODE_PROPERTIES = [
+  'children',
+  'text',
+  // Do not allow overriding any property on the Object prototype
+  ...Object.getOwnPropertyNames(Object.prototype),
+]
+
+/**
+ * The set of properties that cannot be set using set_selection.
+ */
+export const NON_SETTABLE_SELECTION_PROPERTIES = Object.getOwnPropertyNames(
+  Object.prototype
+)
+
 export interface GeneralTransforms {
   /**
    * Transform the editor by an operation.
@@ -76,6 +93,16 @@ export const GeneralTransforms: GeneralTransforms = {
         const index = path[path.length - 1]
         const prevPath = Path.previous(path)
         const prevIndex = prevPath[prevPath.length - 1]
+
+        if (path.length === 0) {
+          throw new Error(
+            `Cannot apply a "merge_node" operation at path [${path}] because the root node cannot be merged.`
+          )
+        }
+
+        // Defend against malicious paths containing strings
+        if (typeof index !== 'number' || typeof prevIndex !== 'number')
+          throw new Error('Index must be number')
 
         modifyChildren(editor, Path.parent(path), children => {
           const node = children[index]
@@ -225,11 +252,23 @@ export const GeneralTransforms: GeneralTransforms = {
           const newNode = { ...node }
 
           for (const key in newProperties) {
-            if (key === 'children' || key === 'text') {
+            if (NON_SETTABLE_NODE_PROPERTIES.includes(key)) {
               throw new Error(`Cannot set the "${key}" property of nodes!`)
             }
 
-            const value = newProperties[<keyof Node>key]
+            const value = Object.hasOwn(newProperties, key)
+              ? newProperties[<keyof Node>key]
+              : undefined
+
+            // Make sure we're not setting `then` to a function, since this will
+            // cause the node to be treated as a Promise-like object, which can
+            // cause unexpected behaviour when returning the node from async
+            // functions.
+            if (key === 'then' && typeof value === 'function') {
+              throw new Error(
+                'Cannot set the "then" property of a node to a function'
+              )
+            }
 
             if (value == null) {
               delete newNode[<keyof Node>key]
@@ -240,7 +279,7 @@ export const GeneralTransforms: GeneralTransforms = {
 
           // properties that were previously defined, but are now missing, must be deleted
           for (const key in properties) {
-            if (!newProperties.hasOwnProperty(key)) {
+            if (!Object.hasOwn(newProperties, key)) {
               delete newNode[<keyof Node>key]
             }
           }
@@ -275,7 +314,23 @@ export const GeneralTransforms: GeneralTransforms = {
         const selection = { ...editor.selection }
 
         for (const key in newProperties) {
+          if (NON_SETTABLE_SELECTION_PROPERTIES.includes(key)) {
+            throw new Error(
+              `Cannot set the "${key}" property of the selection!`
+            )
+          }
+
           const value = newProperties[<keyof Range>key]
+
+          // Make sure we're not setting `then` to a function, since this will
+          // cause the selection to be treated as a Promise-like object, which
+          // can cause unexpected behaviour when returning the selection from
+          // async functions.
+          if (key === 'then' && typeof value === 'function') {
+            throw new Error(
+              'Cannot set the "then" property of the selection to a function'
+            )
+          }
 
           if (value == null) {
             if (key === 'anchor' || key === 'focus') {
@@ -302,6 +357,9 @@ export const GeneralTransforms: GeneralTransforms = {
             `Cannot apply a "split_node" operation at path [${path}] because the root node cannot be split.`
           )
         }
+
+        // Defend against malicious paths containing strings
+        if (typeof index !== 'number') throw new Error('Index must be number')
 
         modifyChildren(editor, Path.parent(path), children => {
           const node = children[index]

--- a/packages/slate/src/transforms-node/set-nodes.ts
+++ b/packages/slate/src/transforms-node/set-nodes.ts
@@ -5,6 +5,7 @@ import { Range } from '../interfaces/range'
 import { Transforms } from '../interfaces/transforms'
 import { Node } from '../interfaces/node'
 import { Location } from '../interfaces'
+import { NON_SETTABLE_NODE_PROPERTIES } from '../interfaces/transforms/general'
 
 export const setNodes: NodeTransforms['setNodes'] = (
   editor,
@@ -79,9 +80,8 @@ export const setNodes: NodeTransforms['setNodes'] = (
       mode,
       voids,
     })) {
-      const properties: Partial<Node> = {}
-      // FIXME: is this correct?
-      const newProperties: Partial<Node> & { [key: string]: unknown } = {}
+      const properties: Record<string, unknown> = {}
+      const newProperties: Record<string, unknown> = {}
 
       // You can't set properties on the editor node.
       if (path.length === 0) {
@@ -91,25 +91,25 @@ export const setNodes: NodeTransforms['setNodes'] = (
       let hasChanges = false
 
       for (const k in props) {
-        if (k === 'children' || k === 'text') {
+        if (NON_SETTABLE_NODE_PROPERTIES.includes(k)) {
           continue
         }
 
-        if (compare(props[<keyof Node>k], node[<keyof Node>k])) {
+        const value: unknown = Object.hasOwn(node, k)
+          ? node[<keyof Node>k]
+          : undefined
+
+        const newValue: unknown = props[<keyof Node>k]
+
+        if (compare(newValue, value)) {
           hasChanges = true
           // Omit new properties from the old properties list
-          if (node.hasOwnProperty(k))
-            properties[<keyof Node>k] = node[<keyof Node>k]
+          if (Object.hasOwn(node, k)) properties[k] = value
           // Omit properties that have been removed from the new properties list
           if (merge) {
-            if (props[<keyof Node>k] != null)
-              newProperties[<keyof Node>k] = merge(
-                node[<keyof Node>k],
-                props[<keyof Node>k]
-              )
+            if (newValue != null) newProperties[k] = merge(value, newValue)
           } else {
-            if (props[<keyof Node>k] != null)
-              newProperties[<keyof Node>k] = props[<keyof Node>k]
+            if (newValue != null) newProperties[k] = newValue
           }
         }
       }

--- a/packages/slate/src/transforms-selection/set-selection.ts
+++ b/packages/slate/src/transforms-selection/set-selection.ts
@@ -1,13 +1,14 @@
 import { SelectionTransforms } from '../interfaces/transforms/selection'
 import { Range } from '../interfaces/range'
 import { Point } from '../interfaces/point'
+import { NON_SETTABLE_SELECTION_PROPERTIES } from '../interfaces/transforms/general'
 
 export const setSelection: SelectionTransforms['setSelection'] = (
   editor,
   props
 ) => {
   const { selection } = editor
-  const oldProps: Partial<Range> | null = {}
+  const oldProps: Partial<Range> = {}
   const newProps: Partial<Range> = {}
 
   if (!selection) {
@@ -15,17 +16,17 @@ export const setSelection: SelectionTransforms['setSelection'] = (
   }
 
   for (const k in props) {
-    if (
-      (k === 'anchor' &&
-        props.anchor != null &&
-        !Point.equals(props.anchor, selection.anchor)) ||
-      (k === 'focus' &&
-        props.focus != null &&
-        !Point.equals(props.focus, selection.focus)) ||
-      (k !== 'anchor' &&
-        k !== 'focus' &&
-        props[<keyof Range>k] !== selection[<keyof Range>k])
-    ) {
+    if (NON_SETTABLE_SELECTION_PROPERTIES.includes(k)) {
+      continue
+    }
+
+    const value = Object.hasOwn(selection, k)
+      ? selection[<keyof Range>k]
+      : undefined
+
+    const newValue = props[<keyof Range>k]
+
+    if (compareSelectionProps(<keyof Range>k, value, newValue)) {
       oldProps[<keyof Range>k] = selection[<keyof Range>k]
       newProps[<keyof Range>k] = props[<keyof Range>k]
     }
@@ -38,4 +39,15 @@ export const setSelection: SelectionTransforms['setSelection'] = (
       newProperties: newProps,
     })
   }
+}
+
+function compareSelectionProps(
+  key: keyof Range,
+  value: unknown,
+  newValue: unknown
+) {
+  if (key === 'anchor' || key === 'focus') {
+    return !Point.equals(<Point>value, <Point>newValue)
+  }
+  return value !== newValue
 }

--- a/packages/slate/src/transforms-selection/set-selection.ts
+++ b/packages/slate/src/transforms-selection/set-selection.ts
@@ -46,8 +46,12 @@ function compareSelectionProps(
   value: unknown,
   newValue: unknown
 ) {
-  if (key === 'anchor' || key === 'focus') {
-    return !Point.equals(<Point>value, <Point>newValue)
+  if (
+    (key === 'anchor' || key === 'focus') &&
+    Point.isPoint(value) &&
+    Point.isPoint(newValue)
+  ) {
+    return !Point.equals(value, newValue)
   }
   return value !== newValue
 }

--- a/packages/slate/src/utils/deep-equal.ts
+++ b/packages/slate/src/utils/deep-equal.ts
@@ -15,8 +15,8 @@ export const isDeepEqual = (
   another: Record<string, any>
 ): boolean => {
   for (const key in node) {
-    const a = node[key]
-    const b = another[key]
+    const a = Object.hasOwn(node, key) ? node[key] : undefined
+    const b = Object.hasOwn(another, key) ? another[key] : undefined
     if (Array.isArray(a) && Array.isArray(b)) {
       if (a.length !== b.length) return false
       for (let i = 0; i < a.length; i++) {


### PR DESCRIPTION
**Description**
It's sometimes possible to cause mischief in JavaScript by supplying unexpected keys to square bracket property accessors. These unexpected keys can come from unexpected places. For example, `path.length` might be a non-number if a user is able to supply a path of `{ length: 'Untrusted value' }` as part of JSON input, such as serialised  operations.

I've gone through and hardened every property accessor I could find where it's remotely possible that an untrusted key might be used with harmful consequences.

As part of this, I've banned `set_node` operations from shadowing any property on the Object prototype (e.g. `__proto__`, `toString`, `hasOwnProperty`), since overwriting these default properties may cause unexpected behaviour.

The list of banned properties is currently: `toString`, `toLocaleString`, `valueOf`, `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`, `__defineGetter__`, `__defineSetter__`, `__lookupGetter__`, `__lookupSetter__`, `__proto__`, `constructor`. This list is subject to change automatically as new properties are added to `Object.prototype`, but I think the risk of a collision between a future prototype property and a genuine user-supplied property name is very small.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

