### PR TITLE
Prevent `split_node` operation from setting disallowed properties

### DIFF
--- a/packages/slate/src/interfaces/transforms/general.ts
+++ b/packages/slate/src/interfaces/transforms/general.ts
@@ -256,9 +256,7 @@ export const GeneralTransforms: GeneralTransforms = {
               throw new Error(`Cannot set the "${key}" property of nodes!`)
             }
 
-            const value = Object.hasOwn(newProperties, key)
-              ? newProperties[<keyof Node>key]
-              : undefined
+            const value = newProperties[<keyof Node>key]
 
             // Make sure we're not setting `then` to a function, since this will
             // cause the node to be treated as a Promise-like object, which can
@@ -374,7 +372,6 @@ export const GeneralTransforms: GeneralTransforms = {
               text: before,
             }
             nextNode = {
-              ...(properties as Partial<Text>),
               text: after,
             }
           } else {
@@ -385,8 +382,29 @@ export const GeneralTransforms: GeneralTransforms = {
               children: before,
             }
             nextNode = {
-              ...(properties as Partial<Element>),
               children: after,
+            }
+          }
+
+          for (const key in properties) {
+            if (NON_SETTABLE_NODE_PROPERTIES.includes(key)) {
+              throw new Error(`Cannot set the "${key}" property of nodes!`)
+            }
+
+            const value = properties[<keyof Node>key]
+
+            // Make sure we're not setting `then` to a function, since this will
+            // cause the node to be treated as a Promise-like object, which can
+            // cause unexpected behaviour when returning the node from async
+            // functions.
+            if (key === 'then' && typeof value === 'function') {
+              throw new Error(
+                'Cannot set the "then" property of a node to a function'
+              )
+            }
+
+            if (value != null) {
+              nextNode[<keyof Node>key] = value
             }
           }
 


### PR DESCRIPTION
**Description**
Follow-up of #6040. I forgot to handle disallowed properties in `split_node`.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) - This can be released under the same changeset as #6040. If that gets released before this is merged, I'll add a separate changeset for this change.