### PR TITLE
[codex] Fix brittle code-highlighting integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage
 !/.yarn/sdks/**/lib/
 !.yarn/versions
 .pnp.*
+.omx/

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ coverage
 !/.yarn/sdks/**/lib/
 !.yarn/versions
 .pnp.*
-.omx/

--- a/playwright/integration/examples/code-highlighting.test.ts
+++ b/playwright/integration/examples/code-highlighting.test.ts
@@ -32,8 +32,11 @@ test.describe('code highlighting', () => {
 async function setText(page: Page, text: string, language: string) {
   await page.locator('[data-slate-editor]').selectText()
   await page.keyboard.press('Backspace') // clear editor
-  await page.getByTestId('code-block-button').click() // convert first and the only one paragraph to code block
-  await page.getByTestId('language-select').selectOption({ value: language }) // select the language option
+  await page.getByTestId('code-block-button').click() // convert the first paragraph to a code block
+  await page
+    .locator('[data-slate-editor] [data-test-id="language-select"]')
+    .first()
+    .selectOption({ value: language }) // select the language option for the code block we just created
 
   await page.keyboard.type(text) // type text
 }


### PR DESCRIPTION
## What changed
- scope the code-highlighting integration test to the first code block language selector inside the editor

## Why
The failing GitHub Actions job `24355317831` showed `getByTestId('language-select')` matching 3 elements in `playwright/integration/examples/code-highlighting.test.ts` on the mobile project. The page already renders multiple code blocks, so the test was using an ambiguous selector.

This is not a new regression from PR #6043. The same failure already appeared on `main` in run `24288370171` on April 11, 2026.

## Impact
- removes a brittle Playwright selector that could fail intermittently on CI
- keeps the test focused on the code block created by the test itself

## Validation
- `PLAYWRIGHT_RETRIES=0 yarn playwright playwright/integration/examples/code-highlighting.test.ts --project=mobile --grep "code highlighting html"`
- `PLAYWRIGHT_RETRIES=0 yarn playwright playwright/integration/examples/code-highlighting.test.ts --project=mobile`
- `yarn exec prettier --check playwright/integration/examples/code-highlighting.test.ts`
- `yarn exec eslint playwright/integration/examples/code-highlighting.test.ts`