### PR TITLE
Fix uncaught throws in withDOM apply and DOM range line detection

### DIFF
--- a/packages/slate-dom/src/utils/lines.ts
+++ b/packages/slate-dom/src/utils/lines.ts
@@ -12,10 +12,19 @@ const doRectsIntersect = (rect: DOMRect, compareRect: DOMRect) => {
 }
 
 const areRangesSameLine = (editor: DOMEditor, range1: Range, range2: Range) => {
-  const rect1 = DOMEditor.toDOMRange(editor, range1).getBoundingClientRect()
-  const rect2 = DOMEditor.toDOMRange(editor, range2).getBoundingClientRect()
+  try {
+    const domRange1 = DOMEditor.toDOMRange(editor, range1)
+    const domRange2 = DOMEditor.toDOMRange(editor, range2)
 
-  return doRectsIntersect(rect1, rect2) && doRectsIntersect(rect2, rect1)
+    if (!domRange1 || !domRange2) return false
+
+    const rect1 = domRange1.getBoundingClientRect()
+    const rect2 = domRange2.getBoundingClientRect()
+
+    return doRectsIntersect(rect1, rect2) && doRectsIntersect(rect2, rect1)
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -447,10 +447,11 @@ export const Editable = forwardRef(
         // but Slate's value is not being updated through any operation
         // and thus it doesn't transform selection on its own
         if (selection && !ReactEditor.hasRange(editor, selection)) {
-          editor.selection = ReactEditor.toSlateRange(editor, domSelection, {
-            exactMatch: false,
-            suppressThrow: true,
-          })
+          editor.selection =
+            ReactEditor.toSlateRange(editor, domSelection, {
+              exactMatch: false,
+              suppressThrow: true,
+            }) ?? null
           return
         }
 

--- a/packages/slate-react/src/components/string.tsx
+++ b/packages/slate-react/src/components/string.tsx
@@ -18,9 +18,16 @@ const String = (props: {
 }) => {
   const { isLast, leaf, parent, text } = props
   const editor = useSlateStatic()
-  const path = ReactEditor.findPath(editor, text)
-  const parentPath = Path.parent(path)
   const isMarkPlaceholder = Boolean(leaf[MARK_PLACEHOLDER_SYMBOL])
+
+  let path: Path
+  let parentPath: Path
+  try {
+    path = ReactEditor.findPath(editor, text)
+    parentPath = Path.parent(path)
+  } catch {
+    return <TextString text={leaf.text} />
+  }
 
   // COMPAT: Render text inside void nodes with a zero-width space.
   // So the node can contain selection but the text is not visible.


### PR DESCRIPTION
**Description**                                                                                                                                                                                                                    Two targeted crash fixes cherry-picked from https://github.com/ianstormtaylor/slate/pull/5407. No changes to public APIs or return types.
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  ---                                                                                                                                                                                                                
  packages/slate-dom/src/utils/lines.ts — areRangesSameLine crash on stale DOM                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                         
  ---                                                                                                                                                                                                                
  packages/slate-react/src/components/editable.tsx — editor.selection nullability
                                                                                                                                                                                                                                                                                            
  ---         
**Issue**
Fixes: #3878 #3723, #4323, #4485, #4564 , #4081 and #4561


**Checks**
- [X] The new code matches the existing patterns and styles.
- [X] The tests pass with `yarn test`.
- [X] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [X] The relevant examples still work. (Run examples with `yarn start`.)

