### PR TITLE
fix: HistoryEditor helpers leaving flags stuck when fn throws, and nested withNewBatch losing the enclosing batch's split

### DIFF
--- a/.changeset/silver-scissors-attack.md
+++ b/.changeset/silver-scissors-attack.md
@@ -1,0 +1,5 @@
+---
+'slate-history': patch
+---
+
+fix: wrap withMerging, withNewBatch, and withoutMerging in try/finally to ensure state cleanup on error

--- a/.changeset/silver-scissors-attack.md
+++ b/.changeset/silver-scissors-attack.md
@@ -2,4 +2,4 @@
 'slate-history': patch
 ---
 
-fix: wrap withMerging, withNewBatch, and withoutMerging in try/finally to ensure state cleanup on error
+Fix `HistoryEditor.withMerging`, `HistoryEditor.withNewBatch` and `HistoryEditor.withoutMerging` leaving the history flags corrupted when `fn` throws, and a nested `withNewBatch` that applies no operation clearing the pending split of the enclosing `withNewBatch`.

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -82,8 +82,11 @@ export const HistoryEditor = {
   withMerging(editor: HistoryEditor, fn: () => void): void {
     const prev = HistoryEditor.isMerging(editor)
     MERGING.set(editor, true)
-    fn()
-    MERGING.set(editor, prev)
+    try {
+      fn()
+    } finally {
+      MERGING.set(editor, prev)
+    }
   },
 
   /**
@@ -95,9 +98,12 @@ export const HistoryEditor = {
     const prev = HistoryEditor.isMerging(editor)
     MERGING.set(editor, true)
     SPLITTING_ONCE.set(editor, true)
-    fn()
-    MERGING.set(editor, prev)
-    SPLITTING_ONCE.delete(editor)
+    try {
+      fn()
+    } finally {
+      MERGING.set(editor, prev)
+      SPLITTING_ONCE.delete(editor)
+    }
   },
 
   /**
@@ -108,8 +114,11 @@ export const HistoryEditor = {
   withoutMerging(editor: HistoryEditor, fn: () => void): void {
     const prev = HistoryEditor.isMerging(editor)
     MERGING.set(editor, false)
-    fn()
-    MERGING.set(editor, prev)
+    try {
+      fn()
+    } finally {
+      MERGING.set(editor, prev)
+    }
   },
 
   /**

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -96,13 +96,14 @@ export const HistoryEditor = {
    */
   withNewBatch(editor: HistoryEditor, fn: () => void): void {
     const prev = HistoryEditor.isMerging(editor)
+    const prevSplitting = HistoryEditor.isSplittingOnce(editor)
     MERGING.set(editor, true)
     SPLITTING_ONCE.set(editor, true)
     try {
       fn()
     } finally {
       MERGING.set(editor, prev)
-      SPLITTING_ONCE.delete(editor)
+      SPLITTING_ONCE.set(editor, prevSplitting)
     }
   },
 

--- a/packages/slate-history/src/history-editor.ts
+++ b/packages/slate-history/src/history-editor.ts
@@ -95,15 +95,17 @@ export const HistoryEditor = {
    * merged as usual.
    */
   withNewBatch(editor: HistoryEditor, fn: () => void): void {
-    const prev = HistoryEditor.isMerging(editor)
+    const prevMerging = HistoryEditor.isMerging(editor)
     const prevSplitting = HistoryEditor.isSplittingOnce(editor)
     MERGING.set(editor, true)
     SPLITTING_ONCE.set(editor, true)
     try {
       fn()
     } finally {
-      MERGING.set(editor, prev)
-      SPLITTING_ONCE.set(editor, prevSplitting)
+      MERGING.set(editor, prevMerging)
+      if (!prevSplitting) {
+        SPLITTING_ONCE.delete(editor)
+      }
     }
   },
 

--- a/packages/slate-history/test/history-editor.ts
+++ b/packages/slate-history/test/history-editor.ts
@@ -1,0 +1,42 @@
+import assert from 'assert'
+import { createEditor } from 'slate'
+import { HistoryEditor, withHistory } from '..'
+
+const boom = () => {
+  throw new Error('boom')
+}
+
+describe('HistoryEditor', () => {
+  describe('withMerging', () => {
+    it('restores the merging flag when fn throws', () => {
+      const editor = withHistory(createEditor())
+      assert.throws(() => HistoryEditor.withMerging(editor, boom), /boom/)
+      assert.strictEqual(HistoryEditor.isMerging(editor), undefined)
+    })
+  })
+
+  describe('withNewBatch', () => {
+    it('restores the merging and splitting flags when fn throws', () => {
+      const editor = withHistory(createEditor())
+      assert.throws(() => HistoryEditor.withNewBatch(editor, boom), /boom/)
+      assert.strictEqual(HistoryEditor.isMerging(editor), undefined)
+      assert.strictEqual(HistoryEditor.isSplittingOnce(editor), undefined)
+    })
+  })
+
+  describe('withoutMerging', () => {
+    it('restores the merging flag when fn throws', () => {
+      const editor = withHistory(createEditor())
+      assert.throws(() => HistoryEditor.withoutMerging(editor, boom), /boom/)
+      assert.strictEqual(HistoryEditor.isMerging(editor), undefined)
+    })
+  })
+
+  describe('withoutSaving', () => {
+    it('restores the saving flag when fn throws', () => {
+      const editor = withHistory(createEditor())
+      assert.throws(() => HistoryEditor.withoutSaving(editor, boom), /boom/)
+      assert.strictEqual(HistoryEditor.isSaving(editor), undefined)
+    })
+  })
+})

--- a/packages/slate-history/test/undo/with_new_batch/nested-empty.tsx
+++ b/packages/slate-history/test/undo/with_new_batch/nested-empty.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+import { HistoryEditor } from '../../..'
+
+export const run = editor => {
+  editor.insertText('x')
+  HistoryEditor.withNewBatch(editor, () => {
+    HistoryEditor.withNewBatch(editor, () => {})
+    editor.insertText('y')
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      one
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      onex
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate-history/test/undo/with_new_batch/nested-throws.tsx
+++ b/packages/slate-history/test/undo/with_new_batch/nested-throws.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import assert from 'assert'
+import { jsx } from '../..'
+import { HistoryEditor } from '../../..'
+
+export const run = editor => {
+  editor.insertText('x')
+  HistoryEditor.withNewBatch(editor, () => {
+    assert.throws(() => {
+      HistoryEditor.withNewBatch(editor, () => {
+        throw new Error('boom')
+      })
+    }, /boom/)
+    editor.insertText('y')
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      one
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      onex
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate-history/test/undo/with_new_batch/nested.tsx
+++ b/packages/slate-history/test/undo/with_new_batch/nested.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+import { jsx } from '../..'
+import { HistoryEditor } from '../../..'
+
+export const run = editor => {
+  editor.insertText('x')
+  HistoryEditor.withNewBatch(editor, () => {
+    HistoryEditor.withNewBatch(editor, () => {
+      editor.insertText('a')
+    })
+    editor.insertText('b')
+  })
+}
+export const input = (
+  <editor>
+    <block>
+      one
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = (
+  <editor>
+    <block>
+      onex
+      <cursor />
+    </block>
+  </editor>
+)

--- a/packages/slate-history/test/undo/with_new_batch/throws.tsx
+++ b/packages/slate-history/test/undo/with_new_batch/throws.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import assert from 'assert'
+import { jsx } from '../..'
+import { HistoryEditor } from '../../..'
+import { cloneDeep } from 'lodash'
+
+export const run = editor => {
+  editor.insertText('x')
+  assert.throws(() => {
+    HistoryEditor.withNewBatch(editor, () => {
+      throw new Error('boom')
+    })
+  }, /boom/)
+  editor.insertText('y')
+}
+export const input = (
+  <editor>
+    <block>
+      one
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = cloneDeep(input)

--- a/packages/slate-history/test/undo/without_merging/throws.tsx
+++ b/packages/slate-history/test/undo/without_merging/throws.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import assert from 'assert'
+import { jsx } from '../..'
+import { HistoryEditor } from '../../..'
+import { cloneDeep } from 'lodash'
+
+export const run = editor => {
+  assert.throws(() => {
+    HistoryEditor.withoutMerging(editor, () => {
+      throw new Error('boom')
+    })
+  }, /boom/)
+  editor.insertText('a')
+  editor.insertText('b')
+}
+export const input = (
+  <editor>
+    <block>
+      one
+      <cursor />
+    </block>
+  </editor>
+)
+export const output = cloneDeep(input)


### PR DESCRIPTION
### Description

`HistoryEditor.withMerging`, `HistoryEditor.withNewBatch` and `HistoryEditor.withoutMerging` set internal state flags (`MERGING`, `SPLITTING_ONCE`) on WeakMaps before calling the user-provided `fn()` and restore the previous state afterwards. If `fn()` throws, the restoration code is never reached and the editor is left permanently stuck in a corrupted state: every subsequent operation merges into a single undo batch, nothing merges, or the next operation is forced into a new batch.

This PR wraps the `fn()` call in `try/finally` so the flags are always restored, following the pattern `withoutSaving` already uses in the same file.

In `withNewBatch`, the cleanup also only clears `SPLITTING_ONCE` if this call armed it (`if (!prevSplitting) SPLITTING_ONCE.delete(editor)`). When `withNewBatch` is nested inside another `withNewBatch` that has not applied an operation yet, the flag belongs to the enclosing call: the inner call leaves it pending if nothing was applied, and leaves it consumed if the first operation already started the batch, so later operations of the enclosing batch merge as usual.

### Behaviour change vs `main`

Besides the throw cases, one non-throwing case changes: a nested `withNewBatch` that applies nothing, before the enclosing batch has applied anything.

```ts
editor.insertText('x')
HistoryEditor.withNewBatch(editor, () => {
  HistoryEditor.withNewBatch(editor, () => {}) // applies nothing
  editor.insertText('y')
})
```

On `main` the inner call's unconditional `delete` wipes the enclosing batch's pending split, so `y` merges into the `x` batch and one undo removes both, contrary to the [documented behaviour](https://github.com/ianstormtaylor/slate/blob/bd2441c86a2d5f7b3bafc3fba93c11037cd74bf9/packages/slate-history/src/history-editor.ts#L89-L93) ("ensuring that the first operation starts a new batch"). With this PR `y` starts a new batch. This is the same defect as the throw-before-any-operation case raised in review, reached via `return` instead of `throw`; the cleanup cannot distinguish the two without special-casing exceptions. Every other non-throwing sequence, nested or not, behaves exactly as on `main`.

### Issue

N/A — discovered via code inspection. Follows up on #5837, which fixed the same bug for `withoutSaving`.

### Context

`withoutSaving` in the same file ([history-editor.ts](https://github.com/ianstormtaylor/slate/blob/bd2441c86a2d5f7b3bafc3fba93c11037cd74bf9/packages/slate-history/src/history-editor.ts#L120-L128)) and `withoutNormalizing` in core ([without-normalizing.ts](https://github.com/ianstormtaylor/slate/blob/bd2441c86a2d5f7b3bafc3fba93c11037cd74bf9/packages/slate/src/editor/without-normalizing.ts)) already wrap `fn()` in `try/finally`; this applies the same pattern to the three remaining helpers.

### Tests

- `test/undo/with_new_batch/throws.tsx`, `test/undo/without_merging/throws.tsx`: flags restored after a throw (fail on `main`).
- `test/undo/with_new_batch/nested.tsx`: nested call whose first operation starts the batch; the enclosing batch's next operation merges.
- `test/undo/with_new_batch/nested-throws.tsx`, `nested-empty.tsx`: nested call that throws / returns without applying anything; the enclosing batch's first operation still starts a new batch (`nested-empty` fails on `main`).
- `test/history-editor.ts`: `isMerging` / `isSplittingOnce` / `isSaving` are `undefined` again after each helper throws.

### Checks

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with yarn test.
- [x] The linter passes with yarn lint. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)