### PR TITLE
Introduce `HyperscriptPointRef` and `HyperscriptRangeRef`

### DIFF
--- a/.changeset/small-zebras-draw.md
+++ b/.changeset/small-zebras-draw.md
@@ -1,0 +1,10 @@
+---
+'slate-hyperscript': minor
+---
+
+- Introduced new `HyperscriptPointRef` and `HyperscriptRangeRef` classes.
+  - A `HyperscriptPointRef` can passed to the `ref` prop of the new `<point />` tag to store any arbitrary point in the editor.
+  - To access the point, call the `point()` method on the `HyperscriptPointRef` instance.
+  - A `HyperscriptRangeRef` can be passed to the `ref` prop of an `<anchor />` or `<focus />` tag to construct an arbitrary range.
+  - `<anchor />` and `<focus />` tags used in this manner do not affect `editor.selection`.
+  - To access the range, call the `range()` method on the `HyperscriptRangeRef` instance.

--- a/packages/slate-hyperscript/src/creators.ts
+++ b/packages/slate-hyperscript/src/creators.ts
@@ -2,11 +2,14 @@ import { Element, Descendant, Node, Range, Text, Editor } from 'slate'
 import {
   AnchorToken,
   FocusToken,
+  PointToken,
   Token,
   addAnchorToken,
   addFocusToken,
-  getAnchorOffset,
-  getFocusOffset,
+  addPointToken,
+  getAnchors,
+  getFoci,
+  getPoints,
 } from './tokens'
 
 /**
@@ -16,10 +19,10 @@ import {
 
 const STRINGS: WeakSet<Text> = new WeakSet()
 
-const resolveDescendants = (children: any[]): Descendant[] => {
+function resolveDescendants(children: any[]): Descendant[] {
   const nodes: Node[] = []
 
-  const addChild = (child: Node | Token): void => {
+  function addChild(child: Node | Token | string) {
     if (child == null) {
       return
     }
@@ -59,6 +62,8 @@ const resolveDescendants = (children: any[]): Descendant[] => {
         addAnchorToken(n, child)
       } else if (child instanceof FocusToken) {
         addFocusToken(n, child)
+      } else if (child instanceof PointToken) {
+        addPointToken(n, child)
       }
     } else {
       throw new Error(`Unexpected hyperscript child object: ${child}`)
@@ -130,6 +135,18 @@ export function createFragment(
   children: any[]
 ): Descendant[] {
   return resolveDescendants(children)
+}
+
+/**
+ * Create a point token.
+ */
+
+export function createPoint(
+  tagName: string,
+  attributes: { [key: string]: any },
+  children: any[]
+): PointToken {
+  return new PointToken(attributes)
 }
 
 /**
@@ -236,17 +253,23 @@ export const createEditor =
     // Search the document's texts to see if any of them have tokens associated
     // that need incorporated into the selection.
     for (const [node, path] of Node.texts(editor)) {
-      const anchor = getAnchorOffset(node)
-      const focus = getFocusOffset(node)
-
-      if (anchor != null) {
-        const [offset] = anchor
-        selection.anchor = { path, offset }
+      for (const { ref = selection, offset } of getAnchors(node)) {
+        if (offset != null) {
+          ref.anchor = { path, offset }
+        }
       }
 
-      if (focus != null) {
-        const [offset] = focus
-        selection.focus = { path, offset }
+      for (const { ref = selection, offset } of getFoci(node)) {
+        if (offset != null) {
+          ref.focus = { path, offset }
+        }
+      }
+
+      for (const { ref, offset } of getPoints(node)) {
+        if (ref) {
+          ref.offset = offset
+          ref.path = path
+        }
       }
     }
 

--- a/packages/slate-hyperscript/src/hyperscript.ts
+++ b/packages/slate-hyperscript/src/hyperscript.ts
@@ -6,6 +6,7 @@ import {
   createElement,
   createFocus,
   createFragment,
+  createPoint,
   createSelection,
   createText,
 } from './creators'
@@ -21,6 +22,7 @@ const DEFAULT_CREATORS = {
   element: createElement,
   focus: createFocus,
   fragment: createFragment,
+  point: createPoint,
   selection: createSelection,
   text: createText,
 }

--- a/packages/slate-hyperscript/src/index.ts
+++ b/packages/slate-hyperscript/src/index.ts
@@ -4,6 +4,7 @@ import {
   HyperscriptShorthands,
 } from './hyperscript'
 import { createEditor, createText } from './creators'
+import { HyperscriptPointRef, HyperscriptRangeRef } from './refs'
 
 /**
  * The default hyperscript factory that ships with Slate, without custom tags.
@@ -17,5 +18,7 @@ export {
   createEditor,
   createText,
   HyperscriptCreators,
+  HyperscriptPointRef,
+  HyperscriptRangeRef,
   HyperscriptShorthands,
 }

--- a/packages/slate-hyperscript/src/refs.ts
+++ b/packages/slate-hyperscript/src/refs.ts
@@ -1,0 +1,51 @@
+import { Path, Point, Range } from 'slate'
+
+/**
+ * Hyperscript point refs can be used to construct arbitrary points using the
+ * ref prop of a <point /> tag.
+ */
+
+export class HyperscriptPointRef {
+  path?: Path
+  offset?: number
+
+  point(): Point {
+    const { path, offset } = this
+
+    if (path == null || offset == null) {
+      throw new Error(
+        'A HyperscriptPointRef must be passed as the ref prop of a <point /> tag that is used inside an <editor>.'
+      )
+    }
+
+    return { path, offset }
+  }
+}
+
+/**
+ * Hyperscript range refs can be used to construct arbitrary range using the ref
+ * props of <anchor /> and <focus /> tags.
+ */
+
+export class HyperscriptRangeRef {
+  anchor?: Point
+  focus?: Point
+
+  range(): Range {
+    const { anchor, focus } = this
+
+    if (anchor == null) {
+      throw new Error(
+        'A HyperscriptRangeRef must be passed as the ref prop of an <anchor /> tag that is used inside an <editor>.'
+      )
+    }
+
+    if (focus == null) {
+      throw new Error(
+        'A HyperscriptRangeRef must be passed as the ref prop of a <focus /> tag that is used inside an <editor>.'
+      )
+    }
+
+    return { anchor, focus }
+  }
+}

--- a/packages/slate-hyperscript/src/tokens.ts
+++ b/packages/slate-hyperscript/src/tokens.ts
@@ -1,99 +1,159 @@
-import { Node, Path, Text } from 'slate'
+import { Node, Path, Point, Text } from 'slate'
+import { HyperscriptPointRef, HyperscriptRangeRef } from './refs'
 
 /**
  * A weak map to hold anchor tokens.
  */
 
-const ANCHOR: WeakMap<Node, [number, AnchorToken]> = new WeakMap()
+const ANCHORS: WeakMap<Node, Set<[number, AnchorToken]>> = new WeakMap()
 
 /**
  * A weak map to hold focus tokens.
  */
 
-const FOCUS: WeakMap<Node, [number, FocusToken]> = new WeakMap()
+const FOCI: WeakMap<Node, Set<[number, FocusToken]>> = new WeakMap()
+
+/**
+ * A weak map to hold point tokens.
+ */
+
+const POINTS: WeakMap<Node, Set<[number, PointToken]>> = new WeakMap()
 
 /**
  * All tokens inherit from a single constructor for `instanceof` checking.
  */
 
-export class Token {}
+export class Token<Ref = unknown> {
+  offset?: number
+  path?: Path
+  ref?: Ref
+
+  constructor(
+    props: {
+      offset?: number
+      path?: Path
+      ref?: Ref
+    } = {}
+  ) {
+    const { offset, path, ref } = props
+    this.offset = offset
+    this.path = path
+
+    if (ref) {
+      if (path != null) {
+        throw new Error(
+          'The ref prop of a token cannot be used with the path prop.'
+        )
+      }
+      this.ref = ref
+    }
+  }
+}
 
 /**
  * Anchor tokens represent the selection's anchor point.
  */
 
-export class AnchorToken extends Token {
-  offset?: number
-  path?: Path
-
-  constructor(
-    props: {
-      offset?: number
-      path?: Path
-    } = {}
-  ) {
-    super()
-    const { offset, path } = props
-    this.offset = offset
-    this.path = path
-  }
-}
+export class AnchorToken extends Token<HyperscriptRangeRef> {}
 
 /**
  * Focus tokens represent the selection's focus point.
  */
 
-export class FocusToken extends Token {
-  offset?: number
-  path?: Path
+export class FocusToken extends Token<HyperscriptRangeRef> {}
 
-  constructor(
-    props: {
-      offset?: number
-      path?: Path
-    } = {}
-  ) {
-    super()
-    const { offset, path } = props
-    this.offset = offset
-    this.path = path
-  }
-}
+/**
+ * Point tokens represent arbitrary points.
+ */
+
+export class PointToken extends Token<HyperscriptPointRef> {}
 
 /**
  * Add an anchor token to the end of a text node.
  */
 
-export const addAnchorToken = (text: Text, token: AnchorToken) => {
+export function addAnchorToken(text: Text, token: AnchorToken) {
   const offset = text.text.length
-  ANCHOR.set(text, [offset, token])
+
+  let anchors = ANCHORS.get(text)
+  if (!anchors) {
+    anchors = new Set()
+    ANCHORS.set(text, anchors)
+  }
+
+  anchors.add([offset, token])
 }
 
 /**
- * Get the offset if a text node has an associated anchor token.
+ * Get the associated anchor tokens for a text node.
  */
 
-export const getAnchorOffset = (
-  text: Text
-): [number, AnchorToken] | undefined => {
-  return ANCHOR.get(text)
+export function getAnchors(text: Text): AnchorToken[] {
+  const anchors = ANCHORS.get(text)
+  if (!anchors) return []
+
+  return Array.from(
+    anchors.values(),
+    ([offset, token]) => new AnchorToken({ ...token, offset })
+  )
 }
 
 /**
  * Add a focus token to the end of a text node.
  */
 
-export const addFocusToken = (text: Text, token: FocusToken) => {
+export function addFocusToken(text: Text, token: FocusToken) {
   const offset = text.text.length
-  FOCUS.set(text, [offset, token])
+
+  let foci = FOCI.get(text)
+  if (!foci) {
+    foci = new Set()
+    FOCI.set(text, foci)
+  }
+
+  foci.add([offset, token])
 }
 
 /**
- * Get the offset if a text node has an associated focus token.
+ * Get the associated focus tokens for a text node.
  */
 
-export const getFocusOffset = (
-  text: Text
-): [number, FocusToken] | undefined => {
-  return FOCUS.get(text)
+export function getFoci(text: Text): FocusToken[] {
+  const foci = FOCI.get(text)
+  if (!foci) return []
+
+  return Array.from(
+    foci.values(),
+    ([offset, token]) => new FocusToken({ ...token, offset })
+  )
+}
+
+/**
+ * Add a point token to the end of a text node.
+ */
+
+export function addPointToken(text: Text, token: PointToken) {
+  const offset = text.text.length
+
+  let points = POINTS.get(text)
+  if (!points) {
+    points = new Set()
+    POINTS.set(text, points)
+  }
+
+  points.add([offset, token])
+}
+
+/**
+ * Get the associated point tokens for a text node.
+ */
+
+export function getPoints(text: Text): PointToken[] {
+  const points = POINTS.get(text)
+  if (!points) return []
+
+  return Array.from(
+    points.values(),
+    ([offset, token]) => new PointToken({ ...token, offset })
+  )
 }

--- a/packages/slate-hyperscript/test/fixtures/point-ref.tsx
+++ b/packages/slate-hyperscript/test/fixtures/point-ref.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+import assert from 'assert'
+import { HyperscriptPointRef, jsx } from 'slate-hyperscript'
+
+const afterOneRef = new HyperscriptPointRef()
+const afterTwoRef = new HyperscriptPointRef()
+
+export const input = (
+  <editor>
+    <element>
+      one
+      <point ref={afterOneRef} />
+      two
+      <point ref={afterTwoRef} />
+      three
+    </element>
+  </editor>
+)
+
+const afterOne = afterOneRef.point()
+const afterTwo = afterTwoRef.point()
+
+export const output = {
+  children: [
+    {
+      children: [
+        {
+          text: 'onetwothree',
+        },
+      ],
+    },
+  ],
+  selection: null,
+}
+
+export function test() {
+  assert.deepEqual(afterOne, { path: [0, 0], offset: 3 })
+  assert.deepEqual(afterTwo, { path: [0, 0], offset: 6 })
+}

--- a/packages/slate-hyperscript/test/fixtures/range-ref.tsx
+++ b/packages/slate-hyperscript/test/fixtures/range-ref.tsx
@@ -1,0 +1,50 @@
+/** @jsx jsx */
+import assert from 'assert'
+import {
+  HyperscriptPointRef,
+  HyperscriptRangeRef,
+  jsx,
+} from 'slate-hyperscript'
+
+const rangeRef = new HyperscriptRangeRef()
+
+export const input = (
+  <editor>
+    <element>
+      one
+      <anchor />
+      two
+      <anchor ref={rangeRef} />
+      three
+      <focus />
+      four
+      <focus ref={rangeRef} />
+      five
+    </element>
+  </editor>
+)
+
+const range = rangeRef.range()
+
+export const output = {
+  children: [
+    {
+      children: [
+        {
+          text: 'onetwothreefourfive',
+        },
+      ],
+    },
+  ],
+  selection: {
+    anchor: { path: [0, 0], offset: 3 },
+    focus: { path: [0, 0], offset: 11 },
+  },
+}
+
+export function test() {
+  assert.deepEqual(range, {
+    anchor: { path: [0, 0], offset: 6 },
+    focus: { path: [0, 0], offset: 15 },
+  })
+}

--- a/packages/slate-hyperscript/test/index.js
+++ b/packages/slate-hyperscript/test/index.js
@@ -4,7 +4,7 @@ import { fixtures } from '../../../support/fixtures'
 
 describe('slate-hyperscript', () => {
   fixtures(resolve(__dirname, 'fixtures'), ({ module }) => {
-    const { input, output } = module
+    const { input, output, test } = module
     let actual = {}
 
     if (Array.isArray(output)) {
@@ -16,5 +16,6 @@ describe('slate-hyperscript', () => {
     }
 
     assert.deepEqual(actual, output)
+    test?.()
   })
 })


### PR DESCRIPTION
**Description**
This PR adds two new concepts to `slate-hyperscript`: `HyperscriptPointRef` and `HyperscriptRangeRef`. These can be used to reduce the need for hardcoded points and ranges in tests.

**Example**
A `HyperscriptPointRef` can be used with the newly introduced `<point />` tag to construct any arbitrary point in the editor, similar to `<cursor />` but without affecting the selection.

```tsx
const pointRef = new HyperscriptPointRef()

<editor>
  <paragraph>
    Hello, <point ref={pointRef} />world!
  </paragraph>
</editor>

// Throws an error if the point hasn't been defined yet
const point = pointRef.point()

console.log(point) // => { path: [0, 0], offset: 7 }
```

A `HyperscriptRangeRef` can be used with the existing `<anchor />` and `<focus />` tags to construct any arbitrary range in the editor. `<anchor />` and `<focus />` tags do not affect `editor.selection` when used in this manner.

```tsx
const rangeRef = new HyperscriptRangeRef()

<editor>
  <paragraph>
    Hello, <anchor ref={rangeRef} />world!</focus ref={rangeRef} />
  </paragraph>
</editor>

// Throws an error if the range ref hasn't been used with both <anchor /> and <focus /> yet
const range = rangeRef.range()

console.log(range) // => {
//   anchor: { path: [0, 0], offset: 7 }
//   focus: { path: [0, 0], offset: 13 }
// }
```

**Context**
I wanted to add a `HyperscriptPathRef` too that could be used with the `ref` prop of any node's JSX tag, but this is less trivial since elements don't have their own token objects to add metadata to without polluting the node itself. Perhaps associating the node and the ref using a weak map as part of `createElement` would work best?

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)