### PR TITLE
docs: add Velt to Extensions and Plugins

### DIFF
--- a/docs/general/resources.md
+++ b/docs/general/resources.md
@@ -22,6 +22,7 @@ These extensions and plugins add additional features and capabilities to Slate:
 - [`slate-collaborative`](https://github.com/cudr/slate-collaborative) Collaborative editing utilities for Slate
   leveraging Automerge
 - [`slate-vue3`](https://github.com/Guan-Erjia/slate-vue3) Which is a useful supplement to Slate for building a rich text editor using Vue3, integrated all functions in an npm package
+- [Velt](https://velt.dev/docs/async-collaboration/comments/setup/slatejs) Collaboration SDK adding comments, presence, live cursors and CRDT to Slate
 
 ## Products
 


### PR DESCRIPTION
Adds [Velt](https://velt.dev) to the **Extensions and Plugins** list on the docs Resources page.

Velt is a collaboration SDK that adds comments, presence, live cursors and CRDT (Yjs) real-time editing to Slate.

- Live demo: https://sample-apps-slatejs-comments-demo.vercel.app
- Slate setup docs: https://velt.dev/docs/async-collaboration/comments/setup/slatejs
- Source (sample app): https://github.com/velt-js/sample-apps/tree/main/apps/react/comments/text-editors/slatejs/slatejs-comments-demo

Docs-only change — a single list entry, appended to the end of the section to match the existing formatting (link + space + description, no trailing period).