### PR TITLE
fix(slate-dom): propagate suppressThrow to toSlateNode in toSlatePoint

### DIFF
--- a/.changeset/fix-toSlatePoint-suppress-throw.md
+++ b/.changeset/fix-toSlatePoint-suppress-throw.md
@@ -1,5 +1,5 @@
 ---
-"slate-dom": patch
+'slate-dom': patch
 ---
 
-Fix `toSlatePoint` not respecting `suppressThrow` when `toSlateNode` throws. Previously only errors from `findPath` were guarded; errors from the preceding `toSlateNode` call would propagate unconditionally even with `suppressThrow: true`.
+Fix `toSlatePoint` not respecting `suppressThrow` when `toSlateNode` throws. Only errors from `findPath` were guarded; errors from the preceding `toSlateNode` propagated unconditionally even with `suppressThrow: true`.

--- a/.changeset/fix-toSlatePoint-suppress-throw.md
+++ b/.changeset/fix-toSlatePoint-suppress-throw.md
@@ -1,0 +1,5 @@
+---
+"slate-dom": patch
+---
+
+Fix `toSlatePoint` not respecting `suppressThrow` when `toSlateNode` throws. Previously only errors from `findPath` were guarded; errors from the preceding `toSlateNode` call would propagate unconditionally even with `suppressThrow: true`.

--- a/packages/slate-dom/src/plugin/dom-editor.ts
+++ b/packages/slate-dom/src/plugin/dom-editor.ts
@@ -920,7 +920,15 @@ export const DOMEditor: DOMEditorInterface = {
     // COMPAT: If someone is clicking from one Slate editor into another,
     // the select event fires twice, once for the old editor's `element`
     // first, and then afterwards for the correct `element`. (2017/03/03)
-    const slateNode = DOMEditor.toSlateNode(editor, textNode!)
+    let slateNode
+    try {
+      slateNode = DOMEditor.toSlateNode(editor, textNode!)
+    } catch (e) {
+      if (suppressThrow) {
+        return null as T extends true ? Point | null : Point
+      }
+      throw e
+    }
     let path
     try {
       path = DOMEditor.findPath(editor, slateNode)


### PR DESCRIPTION
## Problem

`toSlatePoint` accepts a `suppressThrow` option that is supposed to prevent it from throwing when a DOM node cannot be resolved to a Slate point. However, the implementation only suppresses errors from `findPath` — errors thrown by `toSlateNode` (called on the line immediately before) are **not** guarded.

This means that callers passing `suppressThrow: true` can still receive an unhandled `Error: Cannot resolve a Slate node from DOM node` exception thrown by `toSlateNode`, defeating the purpose of the option.

### Affected code path

In `packages/slate-dom/src/plugin/dom-editor.ts`, the `toSlatePoint` implementation:

```ts
// BEFORE (buggy)
const slateNode = DOMEditor.toSlateNode(editor, textNode!)  // throws unconditionally
let path
try {
  path = DOMEditor.findPath(editor, slateNode)  // only this is guarded
} catch (e) {
  if (suppressThrow) {
    return null
  }
  throw e
}
```

A common trigger: the document-level `selectionchange` listener in `slate-react` calls `toSlatePoint` with `suppressThrow: true`, but receives the error anyway because `toSlateNode` is not guarded. This produces high-volume Sentry noise for applications using Slate in a React portal or with multiple editors on the page.

## Relationship to PR #6004

PR #6004 added `suppressThrow` handling to `findPath` inside `toSlatePoint`. This fix applies the same pattern one step earlier, to the `toSlateNode` call that precedes it.

## Fix

Wrap the `toSlateNode` call in the same `try/catch` pattern already used for `findPath`:

```ts
// AFTER (fixed)
let slateNode
try {
  slateNode = DOMEditor.toSlateNode(editor, textNode!)
} catch (e) {
  if (suppressThrow) {
    return null
  }
  throw e
}
let path
try {
  path = DOMEditor.findPath(editor, slateNode)
} catch (e) {
  if (suppressThrow) {
    return null
  }
  throw e
}
```

## Testing

The change is minimal and mirrors the existing pattern in the same function. The behavior when `suppressThrow` is `false` (or omitted) is unchanged — errors still propagate as before.
