### PR TITLE
Fix prettier formatting on main

### DIFF
--- a/.changeset/fix-decorate-caret-jump.md
+++ b/.changeset/fix-decorate-caret-jump.md
@@ -1,5 +1,5 @@
 ---
-"slate-react": patch
+'slate-react': patch
 ---
 
 Fix caret jumping to wrong position when the decorate prop changes asynchronously

--- a/playwright/integration/examples/decorations-async.test.ts
+++ b/playwright/integration/examples/decorations-async.test.ts
@@ -28,9 +28,7 @@ test.describe('decorations-async', () => {
     // the word we typed, not somewhere else in the document.
     await page.keyboard.type('!')
 
-    const lastParagraph = editor
-      .locator('[data-slate-node="element"]')
-      .last()
+    const lastParagraph = editor.locator('[data-slate-node="element"]').last()
     await expect(lastParagraph).toContainText('fox!')
   })
 })


### PR DESCRIPTION
Two files merged with #6033 were not prettier-formatted, failing the lint:prettier CI job (and fail-fast canceling the other jobs): .changeset/fix-decorate-caret-jump.md and
playwright/integration/examples/decorations-async.test.ts.

**Description**
A clear and concise description of what this pull request solves. (Please do not just link to a long issue thread. Instead include a clear description here or your pull request will likely not be reviewed as quickly.)

**Issue**
Fixes: (link to issue)

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

