### PR TITLE
Fix Firefox contenteditable break from decoration forceUpdate

### DIFF
--- a/packages/slate-react/src/hooks/use-decorations.ts
+++ b/packages/slate-react/src/hooks/use-decorations.ts
@@ -61,18 +61,28 @@ export const useDecorateContext = (
 ) => {
   const [, forceUpdate] = useReducer(s => s + 1, 0)
   const eventListeners = useRef(new Set<Callback>())
+  const hasMounted = useRef(false)
 
   const latestDecorate = useRef(decorateProp)
 
   useIsomorphicLayoutEffect(() => {
     latestDecorate.current = decorateProp
     eventListeners.current.forEach(listener => listener())
-    // Force Editable to re-render in the same batch as the text components
-    // notified above, so its selection-restoration layout effect runs after
-    // the decoration-induced DOM changes are committed. Without this, the
-    // text components restructure the DOM in a separate pass where
-    // Editable's layout effect never fires, potentially leaving the caret
-    // at a wrong position.
+
+    // Skip the forced re-render on the initial mount: there is no committed
+    // DOM to restore the selection against yet, and forcing an extra render
+    // here breaks contenteditable input in Firefox. Only later decoration
+    // changes need to re-render Editable in the same batch as the text
+    // components notified above, so its selection-restoration layout effect
+    // runs after the decoration-induced DOM changes are committed. Without
+    // that, the text components restructure the DOM in a separate pass where
+    // Editable's layout effect never fires, potentially leaving the caret at
+    // a wrong position.
+    if (!hasMounted.current) {
+      hasMounted.current = true
+      return
+    }
+
     forceUpdate()
   }, [decorateProp])
 


### PR DESCRIPTION
#6033 added a forceUpdate() in useDecorateContext's layout effect to re-render Editable in the same batch as decoration-induced DOM changes, fixing caret jumps (#5987). But it also fires on the initial mount, where there is no committed DOM to restore against, and that extra forced render breaks contenteditable text input in Firefox — all firefox typing integration tests (richtext, markdown-shortcuts) failed.

Skip the forced re-render on initial mount; only real post-mount decoration changes now trigger it. The #5987 caret fix and its decorations-async test still pass; full chromium integration suite (42 tests) passes.