### PR TITLE
Add changeset for Firefox decoration input fix (#6078)

### DIFF
--- a/.changeset/fix-firefox-decoration-input.md
+++ b/.changeset/fix-firefox-decoration-input.md
@@ -1,0 +1,5 @@
+---
+'slate-react': patch
+---
+
+Fix Firefox contenteditable text input breaking on editor mount, caused by a forced re-render added in `useDecorateContext` for decoration-driven caret restoration (#6078)


### PR DESCRIPTION
The fix in #6078 merged without a changeset, so it would not trigger a release. Add a slate-react patch changeset so it ships.