### PR TITLE
Allow `null` in the types for `Transforms.setNodes`

### DIFF
--- a/.changeset/rare-worms-worry.md
+++ b/.changeset/rare-worms-worry.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Broaden the types of `Transforms.setNodes` and `editor.setNodes` to allow setting optional node properties to null (which has the effect of unsetting them).

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -91,9 +91,9 @@ Unwrap nodes at the specified location. If necessary, the parent node is split. 
 
 Options supported: `NodeOptions & {split?: boolean}`. For `options.mode`, `'all'` is also supported.
 
-#### `Transforms.setNodes(editor: Editor, props: Partial<Node>, options?)`
+#### `Transforms.setNodes(editor: Editor, props: Partial<NullableProps<Node>>, options?)`
 
-Set properties of nodes at the specified location. If no location is specified, use the selection.
+Set properties of nodes at the specified location. If no location is specified, use the selection. Optional node properties can be set to `null` to unset them.
 
 If `props` contains `undefined` values, the node's corresponding property will also be set to `undefined` as opposed to ignored.
 

--- a/packages/slate/src/interfaces/editor.ts
+++ b/packages/slate/src/interfaces/editor.ts
@@ -98,7 +98,7 @@ export interface BaseEditor {
   removeNodes: OmitFirstArg<typeof Transforms.removeNodes>
   select: OmitFirstArg<typeof Transforms.select>
   setNodes: <T extends Node>(
-    props: Partial<T>,
+    props: Partial<NullableProps<T>>,
     options?: {
       at?: Location
       match?: NodeMatch<T>
@@ -988,3 +988,7 @@ export type NodeMatch<T extends Node> =
 
 export type PropsCompare = (prop: unknown, node: unknown) => boolean
 export type PropsMerge = (prop: unknown, node: unknown) => object
+
+export type NullableProps<T> = {
+  [K in keyof T]: undefined extends T[K] ? T[K] | null : T[K]
+}

--- a/packages/slate/src/interfaces/transforms/node.ts
+++ b/packages/slate/src/interfaces/transforms/node.ts
@@ -1,5 +1,5 @@
 import { Editor, Element, Location, Node, Path } from '../../index'
-import { NodeMatch, PropsCompare, PropsMerge } from '../editor'
+import { NodeMatch, NullableProps, PropsCompare, PropsMerge } from '../editor'
 import { MaximizeMode, RangeMode } from '../../types/types'
 
 export interface NodeInsertNodesOptions<T extends Node> {
@@ -85,7 +85,7 @@ export interface NodeTransforms {
    */
   setNodes: <T extends Node>(
     editor: Editor,
-    props: Partial<T>,
+    props: Partial<NullableProps<T>>,
     options?: {
       at?: Location
       match?: NodeMatch<T>

--- a/packages/slate/src/transforms-node/set-nodes.ts
+++ b/packages/slate/src/transforms-node/set-nodes.ts
@@ -1,5 +1,5 @@
 import { NodeTransforms } from '../interfaces/transforms/node'
-import { Editor } from '../interfaces/editor'
+import { Editor, NullableProps } from '../interfaces/editor'
 import { matchPath } from '../utils/match-path'
 import { Range } from '../interfaces/range'
 import { Transforms } from '../interfaces/transforms'
@@ -9,7 +9,7 @@ import { NON_SETTABLE_NODE_PROPERTIES } from '../interfaces/transforms/general'
 
 export const setNodes: NodeTransforms['setNodes'] = (
   editor,
-  props: Partial<Node>,
+  props: Partial<NullableProps<Node>>,
   options = {}
 ) => {
   Editor.withoutNormalizing(editor, () => {


### PR DESCRIPTION
**Description**
`Transforms.setNodes` already supports unsetting properties by setting them to null. However, this was not possible in TypeScript without type assertions because we were using `props: Partial<Node>`, which doesn't permit `null`. This PR broadens the types of `Transforms.setNodes` and `editor.setNodes` to allow setting optional node properties to null.

**Example**
```ts
export type BulletedListElement = {
  type: 'bulleted-list'
  align?: string
  children: Descendant[]
}

export type CheckListItemElement = {
  type: 'check-list-item'
  checked: boolean
  children: Descendant[]
}

// ✅ Types pass since `align` is optional
Transforms.setNodes<BulletedListElement>(editor, { align: null })

// ❌ Type error since `checked` is a required property
Transforms.setNodes<CheckListItemElement>(editor, { checked: null })
```

**Context**
The ability to unset properties using `Transforms.setNodes` rather than `Transforms.unsetNodes` is useful in some cases, such as when changing multiple properties at once.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

