### PR TITLE
Deeply compare nested array data structures

### DIFF
--- a/.changeset/funny-shoes-allow.md
+++ b/.changeset/funny-shoes-allow.md
@@ -1,0 +1,5 @@
+---
+'slate': patch
+---
+
+Deeply compare nested data structures inside array properties on nodes for the purpose of merging identical text nodes. Previously, items in array properties were shallowly compared using `===`.

--- a/packages/slate/src/utils/deep-equal.ts
+++ b/packages/slate/src/utils/deep-equal.ts
@@ -1,45 +1,39 @@
 import { isObject } from './is-object'
 
-/*
-  Custom deep equal comparison for Slate nodes.
-
-  We don't need general purpose deep equality;
-  Slate only supports plain values, Arrays, and nested objects.
-  Complex values nested inside Arrays are not supported.
-
-  Slate objects are designed to be serialised, so
-  missing keys are deliberately normalised to undefined.
+/**
+ * Custom deep equal comparison for Slate nodes. Since Slate only supports plain
+ * values, arrays and nested objects, we don't need a general purpose deep
+ * equality check.
+ *
+ * Slate objects are designed to be serialised, so missing keys are deliberately
+ * normalised to undefined.
  */
-export const isDeepEqual = (
-  node: Record<string, any>,
-  another: Record<string, any>
-): boolean => {
-  for (const key in node) {
-    const a = Object.hasOwn(node, key) ? node[key] : undefined
-    const b = Object.hasOwn(another, key) ? another[key] : undefined
-    if (Array.isArray(a) && Array.isArray(b)) {
-      if (a.length !== b.length) return false
-      for (let i = 0; i < a.length; i++) {
-        if (a[i] !== b[i]) return false
-      }
-    } else if (isObject(a) && isObject(b)) {
-      if (!isDeepEqual(a, b)) return false
-    } else if (a !== b) {
-      return false
+export const isDeepEqual = (a: unknown, b: unknown): boolean => {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!isDeepEqual(a[i], b[i])) return false
     }
+    return true
   }
 
-  /*
-    Deep object equality is only necessary in one direction; in the reverse direction
-    we are only looking for keys that are missing.
-    As above, undefined keys are normalised to missing.
-  */
-
-  for (const key in another) {
-    if (node[key] === undefined && another[key] !== undefined) {
-      return false
+  if (isObject(a) && isObject(b)) {
+    for (const key in a) {
+      const valueA = Object.hasOwn(a, key) ? a[key] : undefined
+      const valueB = Object.hasOwn(b, key) ? b[key] : undefined
+      if (!isDeepEqual(valueA, valueB)) return false
     }
+
+    // Deep object equality is only necessary in one direction; in the reverse
+    // direction we are only looking for keys that are missing. As above,
+    // undefined keys treated the same as missing keys.
+
+    for (const key in b) {
+      if (a[key] === undefined && b[key] !== undefined) return false
+    }
+
+    return true
   }
 
-  return true
+  return a === b
 }

--- a/packages/slate/src/utils/is-object.ts
+++ b/packages/slate/src/utils/is-object.ts
@@ -1,2 +1,2 @@
-export const isObject = (value: any) =>
+export const isObject = (value: any): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null

--- a/packages/slate/test/utils/deep-equal/deep-equals-with-array.js
+++ b/packages/slate/test/utils/deep-equal/deep-equals-with-array.js
@@ -3,12 +3,12 @@ import { isDeepEqual } from '../../../src/utils/deep-equal'
 export const input = {
   objectA: {
     text: 'same text',
-    array: ['array-content'],
+    array: ['array-content', { active: true }],
     bold: true,
   },
   objectB: {
     text: 'same text',
-    array: ['array-content'],
+    array: ['array-content', { active: true }],
     bold: true,
   },
 }

--- a/packages/slate/test/utils/deep-equal/deep-not-equals-with-array.js
+++ b/packages/slate/test/utils/deep-equal/deep-not-equals-with-array.js
@@ -3,13 +3,13 @@ import { isDeepEqual } from '../../../src/utils/deep-equal'
 export const input = {
   objectA: {
     text: 'same text',
-    array: ['array-content'],
+    array: ['array-content', { active: true, inactive: false }],
     bold: true,
   },
   objectB: {
     text: 'same text',
-    array: ['array-content'],
-    bold: false,
+    array: ['array-content', { active: true }],
+    bold: true,
   },
 }
 


### PR DESCRIPTION
**Description**
This PR extends the logic for `isDeepEqual` to deeply compare array structures. Previously, although objects were compared to unlimited depth, any arrays were only compared shallowly using `===` on their items.

**Example**
Before, these two text nodes would not have been merged:

```js
{ text: 'a', data: [{}] },
{ text: 'b', data: [{}] },
```

Now, they're treated as identical by `Text.equals(a, b, { loose: true })`, and therefore will be merged by Slate's built-in normalisation.

**Context**
Here's the history of how the text node comparison logic has changed up until now:

1. Initially, top-level node properties were shallowly compared using `===`
2. #3532 - @timbuckley added a deep equality check using Lodash
3. #4245 - @JonasKruckenberg replaced the Lodash dependency with `fast-deep-equal` to reduce the bundle size
4. #4276 - @TheSpyder replaced `fast-deep-equal` with a specialised custom equality check to fix a [regression](https://github.com/ianstormtaylor/slate/pull/3532#issuecomment-844461006) and avoid a third-party dependency
   - This is when support for deeply comparing array contents was dropped.
   - According to the comment added at this time, this was intentional, but I'm unable to find a documented reason for this in any code comment, GitHub conversation or unit test.

**Performance**
I haven't tested the performance of the new code, but I believe in simple cases where there are no nested data structures, this will only add one extra `isArray` check and two extra `isObject` checks to per `Text.equals` call. This is because `isDeepEqual` no longer assumes that its arguments are objects in order to simplify recursion.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

