### PR TITLE
Handle numbers and booleans in `slate-hyperscript`

### DIFF
--- a/.changeset/many-hounds-sin.md
+++ b/.changeset/many-hounds-sin.md
@@ -2,4 +2,4 @@
 'slate-hyperscript': patch
 ---
 
-Convert number literals to strings and ignore booleans, consistent with React JSX
+Convert numbers to strings and ignore booleans, consistent with React JSX

--- a/.changeset/many-hounds-sin.md
+++ b/.changeset/many-hounds-sin.md
@@ -1,0 +1,5 @@
+---
+'slate-hyperscript': patch
+---
+
+Convert number literals to strings and ignore booleans, consistent with React JSX

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -262,7 +262,7 @@ const CustomEditor = {
 
       return !!match
     },
-    
+
     toggleMark(editor: Editor, mark: string) {
       if (CustomEditor.isMarkActive(editor, mark)) {
         editor.removeMark(mark)

--- a/packages/slate-hyperscript/src/creators.ts
+++ b/packages/slate-hyperscript/src/creators.ts
@@ -19,18 +19,18 @@ import {
 
 const STRINGS: WeakSet<Text> = new WeakSet()
 
-function resolveDescendants(children: any[]): Descendant[] {
+function resolveDescendants(children: unknown[]): Descendant[] {
   const nodes: Node[] = []
 
-  function addChild(child: Node | Token | string) {
-    if (child == null) {
+  function addChild(child: unknown) {
+    if (child == null || typeof child === 'boolean') {
       return
     }
 
     const prev = nodes[nodes.length - 1]
 
-    if (typeof child === 'string') {
-      const text = { text: child }
+    if (typeof child === 'string' || typeof child === 'number') {
+      const text = { text: child.toString() }
       STRINGS.add(text)
       child = text
     }

--- a/packages/slate-hyperscript/test/fixtures/element-boolean.tsx
+++ b/packages/slate-hyperscript/test/fixtures/element-boolean.tsx
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = (
+  <element>
+    {true}
+    {true && 'if true'}
+    {false && 'if false'}
+  </element>
+)
+export const output = {
+  children: [
+    {
+      text: 'if true',
+    },
+  ],
+}

--- a/packages/slate-hyperscript/test/fixtures/element-number.tsx
+++ b/packages/slate-hyperscript/test/fixtures/element-number.tsx
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+export const input = <element>{4}</element>
+export const output = {
+  children: [
+    {
+      text: '4',
+    },
+  ],
+}

--- a/site/examples/js/android-tests.jsx
+++ b/site/examples/js/android-tests.jsx
@@ -177,7 +177,7 @@ const TEST_CASES = [
     id: 'autocorrect',
     name: 'Autocorrect',
     instructions:
-      'Type "Cant", then press space to autocorrect it. Make sure the cursor position is correct (after the autocorrected word)',
+      'Type "Cant" (make sure to misspell it), then press space to autocorrect it. Make sure the cursor position is correct (after the autocorrected word)',
     value: [
       {
         type: 'paragraph',


### PR DESCRIPTION
**Description**
Previously, trying to include a number or boolean as a child in `slate-hyperscript` resulted in an error like `Error: Unexpected hyperscript child object: <value>`.

This PR updates the child handling logic to make number and boolean handling consistent with React JSX. Numbers are converted to strings, and booleans are ignored.

**Example**
```jsx
<element>{4}</element> // Element containing { text: '4' }
<element>{true}{false}</element> // Empty element, since true and false are ignored
```

**Context**
Since JSX is not type-safe, it's quite common to accidentally pass a number instead of a string as a child of a JSX tag when creating JSX dynamically.

Ignoring booleans lets us safely use patterns like `{condition && <element />}`.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

