### PR TITLE
Add support for JSX components in `slate-hyperscript`

### DIFF
--- a/.changeset/eight-starfishes-tell.md
+++ b/.changeset/eight-starfishes-tell.md
@@ -1,0 +1,5 @@
+---
+'slate-hyperscript': minor
+---
+
+Add support for JSX components (the `slate-hyperscript` equivalent of React components)

--- a/docs/walkthroughs/05-executing-commands.md
+++ b/docs/walkthroughs/05-executing-commands.md
@@ -262,7 +262,7 @@ const CustomEditor = {
 
       return !!match
     },
-    
+
     toggleMark(editor: Editor, mark: string) {
       if (CustomEditor.isMarkActive(editor, mark)) {
         editor.removeMark(mark)

--- a/packages/slate-hyperscript/src/hyperscript.ts
+++ b/packages/slate-hyperscript/src/hyperscript.ts
@@ -73,10 +73,14 @@ const createHyperscript = (
 
 const createFactory = <T extends HyperscriptCreators>(creators: T) => {
   const jsx = <S extends keyof T & string>(
-    tagName: S,
+    tagName: S | Function,
     attributes?: Object,
     ...children: any[]
   ): ReturnType<T[S]> => {
+    if (typeof tagName === 'function') {
+      return tagName({ children, ...attributes })
+    }
+
     const creator = creators[tagName]
 
     if (!creator) {

--- a/packages/slate-hyperscript/test/fixtures/components.tsx
+++ b/packages/slate-hyperscript/test/fixtures/components.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { jsx } from 'slate-hyperscript'
+
+interface MentionProps {
+  id: string
+  children: unknown
+}
+
+function Mention(props: MentionProps) {
+  return (
+    <element inline id={props.id}>
+      {props.children}
+    </element>
+  )
+}
+
+export const input = (
+  <element>
+    This is <Mention id="alice-123">Alice</Mention>.
+  </element>
+)
+
+export const output = {
+  children: [
+    { text: 'This is ' },
+    {
+      inline: true,
+      id: 'alice-123',
+      children: [{ text: 'Alice' }],
+    },
+    { text: '.' },
+  ],
+}


### PR DESCRIPTION
**Description**
This PR adds support for JSX components in `slate-hyperscript`, analogous to React components.

**Example**
```tsx
interface MentionProps {
  id: string
  children: unknown
}

function Mention({ id, children }: MentionProps) {
  return <element inline id={id}>{children}</element>
}

const element = (
  <element>
    This is <Mention id="alice-123">Alice</Mention>.
  </element>
)
```

**Context**
Complex applications using Slate sometimes require repetitive, deeply nested JSX for their tests. Using components lets us refactor out this JSX into reusable, logical units.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

